### PR TITLE
feat(#9): vragenlijst niveau B — ontwerp, migratie en frontend-uitrolbesluit

### DIFF
--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -42,6 +42,14 @@ UC2 ontbrak volledig in het ontwerp en raakte het datamodel, niet alleen de teks
 
 Volledig ontwerp: `docs/superpowers/specs/2026-07-28-vragenlijst-ontwerp.md` — status **BOUWBAAR**, bouwvolgorde in §10.
 
+**MVM_V2 is functioneel leidend voor de vragenlijst** (besluit 2026-07-29). Dat betekent: MVM_V2 bepaalt wát de gebruiker ziet en kan — schermen, vraagtypen, categorieën, naamgeving, workflow. MCM2 bepaalt hóé het onder water werkt — tokens, RLS, constraints, audit. Op dat tweede punt is MVM_V2 juist achterlopend: daar staan tokens onversleuteld in een `Map` in het geheugen, terwijl MCM2 ze SHA-256-hasht.
+
+Uit de vergelijking (ontwerp §1a-bis) kwam dat beide modellen onafhankelijk grotendeels overeenkomen. Drie besluiten:
+
+- **Categorieën gaan erin** — MVM_V2's interne beoordeling heeft er vijf met 29 vragen (Duidelijkheid, Behoefte, Kwaliteit, Kosten, Besturing). Nieuwe tabel `survey_category`; `category_id` op `survey_question` is **nullable**, want UC1 heeft geen categorieën. Inclusief `min_answers`: onder die drempel is de categoriescore `null` in plaats van een gemiddelde over te weinig punten.
+- **`frameworkRef` niet** — koppelt een vraag aan een normartikel en loopt vooruit op meerdere compliance-frameworks. Nu bouwen we NIS2. De tool is al framework-agnostisch; een tweede framework is straks een tweede import.
+- **`date` als negende vraagtype niet** — geen van beide use cases gebruikt het.
+
 **Nog open in het ontwerp (voorstellen, niet bevestigd, geen van alle blokkerend):** dat een gestarte ronde de vragenlijst bevriest (§2), dat een toelichting ook verplicht is bij "I do not confirm" (§3), en wat er gebeurt bij een geïmporteerd e-mailadres zonder bekende vendor (§2c — advies: weigeren, niet automatisch aanmaken).
 
 **Drie dingen raken bestaande, groene code** en verdienen aandacht bij het bouwen: `survey_run` krijgt drie kolommen (`status`, `is_test`, `survey_kind`), `survey_response` krijgt er drie (`subject_vendor_id`, `respondent_user_id`, `respondent_label`) waarbij `vendor_id` **nullable** wordt, en de bestaande guard moet de ronde-status meewegen naast `closes_at`/`revoked_at`. Die nullable-wijziging is een versoepeling op een tabel die vanochtend gemerged is — de UC1-garantie wordt overgenomen door een partiële unieke index plus twee CHECK-constraints, en testpunten 41 t/m 43 horen te bewijzen dat er niets weglekt.

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,7 +1,7 @@
 # MCM2 — actuele status
 
 ## Laatst bijgewerkt
-2026-07-28, einde sessie (Issue #7 spoor 2 gebouwd en groen in CI; koerswijziging op de vragenlijst — alles hieronder is geverifieerd, niet uit gespreksgeheugen)
+2026-07-29 (PR #32 gemerged, Issue #31 gesloten; vragenlijst-scope vastgesteld op niveau B — alles hieronder is geverifieerd, niet uit gespreksgeheugen)
 
 ## Voor een nieuwe sessie: lees dit eerst
 
@@ -9,29 +9,27 @@
 2. Lees dit document (`docs/STATUS.md`) volledig — het is de enige actuele waarheid over fase en blockers.
 3. Verifieer git-status zelf (`git status`, `git branch -a`) tegen wat hieronder staat — vertrouw niet blind op deze snapshot.
 4. Check de open GitHub Issues (`gh issue list --repo AlingAdvies/MCM2 --state open`) voor de actuele backlog — dit document verwijst naar issue-nummers, maar de Issues zelf zijn de bron van waarheid over wat daadwerkelijk nog open staat.
-5. **Eerste concrete vervolgstap: PR #32 mergen** (CI groen op alle drie de jobs, commit `b29e2ad`, geverifieerd met `gh pr checks 32` op 2026-07-28). Daarna is de eerstvolgende inhoudelijke stap **het beantwoorden van één ontwerpvraag over de vragenlijst-tool** — zie "Openstaand besluit" hieronder. Issue #30 (geen backups) blijft de zwaarste openstaande blokkade voor alles wat de productiedatabase raakt (#19, #25, #29), maar vraagt nu alleen nog uitvoering door de eigenaar, geen besluit.
+5. **Eerste concrete vervolgstap: het bouwen van de vragenlijst-tool kan beginnen.** Het ontwerp is op 2026-07-29 bouwbaar geworden (niveau B vastgesteld); de bouwvolgorde staat in §10 van het ontwerp. Issue #30 (geen backups) blijft de zwaarste openstaande blokkade voor alles wat de productiedatabase raakt (#19, #25, #29), maar vraagt nu alleen nog uitvoering door de eigenaar, geen besluit — en de vragenlijst-tool loopt daar niet op vast, want die bouwt tegen wegwerpcontainers.
 
-## Openstaand besluit — blokkeert het bouwen van de vragenlijst-tool
+## Vragenlijst-tool — scope vastgesteld op 2026-07-29, ontwerp is bouwbaar
 
-Op 2026-07-28 is de scope van de vragenlijst **gecorrigeerd door de opdrachtgever**. Dit is de belangrijkste inhoudelijke wijziging van deze sessie en een nieuwe sessie moet hem kennen vóór er iets gebouwd wordt.
+Op 2026-07-28 is de scope **gecorrigeerd door de opdrachtgever**: wat er gebouwd moet worden is **een tool waarmee een tenant zélf vragen opstelt**. De acht Transdev-vragen (`Transdev Annual Vendor IT Risk SurveyV1_0.md`) zijn de **eerste vulling en de PoC-casus** — niet de scope.
 
-Wat er gebouwd moet worden is **een tool waarmee een tenant zélf vragen opstelt**. De acht Transdev-vragen (`Transdev Annual Vendor IT Risk SurveyV1_0.md`, aangeleverd op 2026-07-28) zijn de **eerste vulling en de PoC-casus** — niet de scope.
+Op 2026-07-29 is het openstaande niveau-besluit genomen: **niveau B**. Aanleiding was `VendorComply Help en Manual.md` (in OneDrive, `Bizaline/Producten/VendorComply/`) — de handleiding van een bestaand, werkend product. Dat leverde geen wensenlijst maar keuzes die de praktijk al hebben overleefd. Het eerdere advies (niveau A) rustte op het argument dat er nog geen tweede vraagvorm was om tegen te ontwerpen; dat verviel zodra er acht bewezen vraagtypen op tafel lagen.
 
-Een eerdere ontwerpversie ging ervan uit dat die acht vragen *de* vragenlijst waren en legde ze vast in code. Dat was een verkeerde lezing en is herschreven; de vragen horen in de database, met beheer eromheen.
+**Wat niveau B betekent:** de tenant kiest per vraag een antwoordtype uit acht — `instruction` (leesblok), `confirmation`, `open_text`, `yes_no`, `single_choice`, `multi_choice`, `rating`, `number`, `file_upload`.
 
-**De vraag die openstaat, en die de omvang bepaalt:** hoeveel vrijheid krijgt de tenant?
+**Overgenomen uit VendorComply:** de acht vraagtypen, de lifecycle Draft → Active → Finished/Archived, Test Mode vóór publicatie, drie manieren om deelnemers toe te voegen, deadline met overdue-markering, en import/export als JSON-schema.
 
-| | Niveau | Wat de tenant kan |
-|---|---|---|
-| **A** | Vaste vraagvorm, vrije tekst | Vraagteksten schrijven, volgorde bepalen, per vraag een upload aan/uit. Eén antwoordtype. |
-| **B** | Meerdere antwoordtypen | Als A, plus per vraag kiezen: bevestiging, meerkeuze, vrije tekst, ja/nee, datum. |
-| **C** | Volledige formulierbouwer | Als B, plus voorwaardelijke logica, secties, herhaalbare blokken. |
+**Bewust uitgesteld:** logic jumps (voorwaardelijke logica — dat is niveau C), AI-beoordeling via Gemini, EFQM KPI-sync, Marketing Mode (publieke anonieme surveys) en radar/spider charts.
 
-Advies aan de eigenaar was **A voor de PoC**, met een datamodel dat B mogelijk maakt zonder verbouwing. Onderbouwing in het ontwerp, §1.
+**Bewust níét gebouwd — en dit is de belangrijkste:** auto-save en "request revisions". Beide zouden vragen dat indienen terugdraaibaar wordt, en dat is precies de garantie die de zojuist gemergde tokenlaag levert. **De tokenlaag blijft daarmee ongewijzigd.** Expliciet concept opslaan blijft wél bestaan — dat is nodig omdat acht vragen met verplichte toelichtingen niet in één keer ingevuld worden en het token gehasht is, dus niet opnieuw te versturen.
 
-Twee voorstellen in datzelfde ontwerp zijn eveneens nog niet bevestigd: dat een gestarte ronde de vragenlijst **bevriest** (§2) en dat een toelichting ook verplicht is bij "I do not confirm" (§3).
+Volledig ontwerp: `docs/superpowers/specs/2026-07-28-vragenlijst-ontwerp.md` — status **BOUWBAAR**, bouwvolgorde in §10.
 
-Volledig ontwerp: `docs/superpowers/specs/2026-07-28-vragenlijst-ontwerp.md` — status **ONVOLLEDIG, niet bouwen** tot niveau A/B/C gekozen is.
+**Nog open in het ontwerp (voorstellen, niet bevestigd, geen van alle blokkerend):** dat een gestarte ronde de vragenlijst bevriest (§2), dat een toelichting ook verplicht is bij "I do not confirm" (§3), en wat er gebeurt bij een geïmporteerd e-mailadres zonder bekende vendor (§2c — advies: weigeren, niet automatisch aanmaken).
+
+**Twee dingen raken bestaande, groene code** en verdienen aandacht bij het bouwen: `survey_run` krijgt twee kolommen (`status`, `is_test`), en de bestaande guard moet de ronde-status meewegen naast `closes_at`/`revoked_at`.
 
 ## Doel
 Transdev Vendor IT Compliance Survey als eerste verticale MVP-slice.
@@ -44,7 +42,7 @@ Transdev Vendor IT Compliance Survey als eerste verticale MVP-slice.
 
   Issue #7 vraagt om **twee gescheiden mechanismen**, met verschillende voortgang:
   - **Interne beheerder (spoor 1)** — identity-infrastructuur staat en werkt. Besluit: Microsoft Entra External ID als CIAM-laag (ADR-006, herzien op 2026-07-27; AWS Cognito losgelaten vóór er resources waren aangemaakt, dus geen opruimwerk). De federatie-PoC is geslaagd: tenant `mcm2ciam.onmicrosoft.com`, federatie met `alingadvies.nl`, end-to-end doorlopen tot een geldige authorization code (`?code=...`, geen error). Volledige configuratie — tenant-ID's, client-ID's, endpoints — plus een gedocumenteerde tijdelijke blokkade die zonder configuratiewijziging verdween: `docs/architecture-review/2026-07-27/01-entra-external-id-poc-bevindingen.md`. **Nog te bouwen:** authorization code server-to-server inwisselen, claims inspecteren, NestJS-guard die de tenantcontext uit het geverifieerde ID-token afleidt. **Niet gestart.**
-  - **Externe leverancier (spoor 2)** — tokengebaseerde, accountloze survey-linktoegang. **Gebouwd op 2026-07-28, CI groen, wacht op merge in PR #32.** Zie het blok "Aantoonbaar werkend" hieronder voor wat precies bewezen is.
+  - **Externe leverancier (spoor 2)** — tokengebaseerde, accountloze survey-linktoegang. **Gebouwd op 2026-07-28, CI groen, gemerged op 2026-07-29 (PR #32).** Zie het blok "Aantoonbaar werkend" hieronder voor wat precies bewezen is.
 
   Het tijdelijke AWS-account `727732213368` is niet langer nodig voor identity.
 - **ZWAARSTE BLOKKADE (Issue #30): er zijn géén backups van de productiedatabase.** Op 2026-07-28 in het dashboard vastgesteld: `clm-enterprise` draait op het **Supabase Free Plan**, dat letterlijk meldt *"Free Plan does not include project backups"*. Niet "beperkte backups" — **geen**. Bij verlies van het project is alles weg. Free-projecten worden bovendien na circa **7 dagen inactiviteit gepauzeerd**, met verwijdering na langere inactiviteit; voor een surveylink die 30 dagen geldig moet zijn is dat op zichzelf al onwerkbaar.
@@ -120,8 +118,8 @@ Transdev Vendor IT Compliance Survey als eerste verticale MVP-slice.
 
 ## Huidige branch en Git-status
 
-- **Actieve branch: `feat/issue-7-leveranciertoken`, met openstaande PR #32.** Laatste commit `b29e2ad`. CI groen op alle drie de jobs; `mergeable=MERGEABLE`, `mergeStateStatus=CLEAN` — geverifieerd op 2026-07-28 met `gh pr checks 32` en `gh pr view 32`. **Klaar om te mergen; wacht alleen op akkoord van de eigenaar.** Drie commits: de tokenlaag, de HTTP-routes met logmaskering en auditregels, en de fix op `maskeerDiep`.
-- **Niet-gecommitteerde bestanden in de working tree** (bewust, aan het eind van de sessie): `Transdev Annual Vendor IT Risk SurveyV1_0.md` in de repo-root (klantaanlevering) en `docs/superpowers/specs/2026-07-28-vragenlijst-ontwerp.md` (het herschreven, nog onvolledige ontwerp). Beide horen bij de vragenlijst-tool, niet bij PR #32 — daarom niet meegecommit.
+- **`feat/issue-7-leveranciertoken` is op 2026-07-29 via PR #32 gemerged naar `main`** (merge-commit `7f0cc01`) en daarna lokaal én op GitHub verwijderd. CI groen op alle drie de jobs vóór de merge, opnieuw geverifieerd met `gh pr checks 32` op de laatste commit. Vijf commits: de tokenlaag, de HTTP-routes met logmaskering en auditregels, de fix op `maskeerDiep`, plus twee documentatiecommits. **Issue #31 is bij die merge gesloten** — migratie `0004` loste hem op. Let op: die migratie is bewezen in CI, **niet toegepast op `clm-enterprise`** — net als #29 en #25 wacht dat op #30.
+- **Actieve branch: `feat/issue-9-vragenlijst-ontwerp`** — bevat uitsluitend documentatie: het bijgewerkte vragenlijst-ontwerp (niveau B) en deze statusbijwerking. Geen code.
 - `chore/supabase-verificatie` is op 2026-07-28 via PR #28 gemerged naar `main` en daarna lokaal én op GitHub verwijderd. Zes commits: Supabase read-only verificatie, schemacontrole die uit het schema meegroeit, ADR-011 (backupeisen per fase), de #29-fix, en het runbook met beproefde commando's en opruimprocedure. CI groen op alle drie de jobs vóór de merge.
 - `feat/issue-5-drizzle-omzetting` is op 2026-07-28 via PR #26 gemerged naar `main` (merge-commit `f0806f8`) en daarna lokaal én op GitHub verwijderd. Bevatte de volledige Drizzle-omzetting; CI groen op alle drie de jobs vóór de merge.
 - `docs/issue-7-leveranciertoken-ontwerp` is op 2026-07-28 via PR #27 gemerged naar `main` (merge-commit `c8f896a`) en daarna lokaal én op GitHub verwijderd. Bevatte uitsluitend het ontwerpdocument voor het leverancierstokenspoor.
@@ -137,10 +135,13 @@ Transdev Vendor IT Compliance Survey als eerste verticale MVP-slice.
 
 ## Eerstvolgende goedgekeurde stap
 
-De databaselaag is omgezet (ADR-010), en spoor 2 van Issue #7 is gebouwd en groen. **Bij de start van een nieuwe sessie:**
+De databaselaag is omgezet (ADR-010), spoor 2 van Issue #7 zit in `main`, en het vragenlijst-ontwerp is bouwbaar.
 
-0. **PR #32 mergen** — CI groen, geen conflicten, wacht alleen op akkoord. Daarna de branch lokaal én op GitHub verwijderen (git-ritueel).
-0b. **Het openstaande besluit over de vragenlijst-tool voorleggen** — niveau A, B of C (zie het blok bovenaan dit document). Zonder dat antwoord is het ontwerp niet af en kan er niet gebouwd worden. Dit is nu de kortste weg naar een werkende pilot, want de tokenlaag eronder staat.
+**De eerstvolgende inhoudelijke stap is het bouwen van de vragenlijst-tool** (ontwerp §10). Dat is nu de kortste weg naar een werkende pilot: de toegangslaag eronder staat en is bewezen, en het bouwen ervan raakt de productiedatabase niet — de hele e2e-keten draait tegen wegwerpcontainers, dus #30 blokkeert dit spoor niet.
+
+Eerste twee stappen uit die volgorde, omdat ze bestaande groene code raken en dus de meeste aandacht vragen:
+1. Migratie met `survey_question`, `survey_answer`, `survey_attachment`, plus `status` en `is_test` op `survey_run` — inclusief RLS, policies, CHECK-constraints en de samengestelde foreign key. Handwerk: drizzle-kit genereert hiervan niets.
+2. De bestaande guard uitbreiden met de ronde-statuscontrole.
 
 Daarna, in volgorde van afhankelijkheid:
 
@@ -148,8 +149,8 @@ Daarna, in volgorde van afhankelijkheid:
 2. **Issue #19** — restore-test van de dashboard-backup. Kan pas ná #30: zonder plan zijn er geen backups om te herstellen. Runbook stap 1, vereist dashboardtoegang.
 3. **Issue #29** — de vijf ontbrekende UUID-defaults toepassen op de productiedatabase. Migratie ligt klaar en is bewezen tegen een productiekopie; wacht op een vangnet uit #30/#19.
 4. **Issue #25** — Drizzle-migratiestand initialiseren op de bestaande Supabase-database. Idem: raakt productie, wacht op #30/#19. Schema-afdrijving is al uitgesloten.
-5. **Issue #7** — spoor 2 (leverancierstoken) is **gebouwd en groen**, wacht op merge van PR #32. Spoor 1 (Entra-guard) vraagt nog om het inwisselen van de authorization code en het bouwen van de JWKS-guard; **niet gestart**. Beide sporen kunnen zonder de productiedatabase — de e2e-keten draait tegen wegwerpcontainers.
-5b. **Vragenlijst-tool** — ontwerp ligt er, wacht op het besluit uit §1 (niveau A/B/C). Bouwvolgorde staat in het ontwerp, §10. Dit is wat de leverancierskant van een werkende toegangslaag naar een werkende pilot brengt.
+5. **Issue #7** — spoor 2 (leverancierstoken) is **gebouwd, groen en gemerged** (PR #32). Spoor 1 (Entra-guard) vraagt nog om het inwisselen van de authorization code en het bouwen van de JWKS-guard; **niet gestart**. Spoor 1 blokkeert de leverancierskant niet, maar wél de beheer-UI van de vragenlijst-tool (ontwerp §10, stap 10). Beide sporen kunnen zonder de productiedatabase — de e2e-keten draait tegen wegwerpcontainers.
+5b. **Vragenlijst-tool** — ontwerp is **bouwbaar** (niveau B, vastgesteld 2026-07-29). Bouwvolgorde in het ontwerp, §10. Dit is wat de leverancierskant van een werkende toegangslaag naar een werkende pilot brengt, en het is nu het actieve spoor.
 5c. **Issue #9 (certificaat-upload)** — meegenomen in datzelfde ontwerp, §4/§6. Twee punten die daaruit voortkomen en nog geen issue hebben: **een virusscan** (OV-7 onbeantwoord, ontwerp bouwt er geen) en **backup van geüploade bestanden** (die vallen buiten `npm run backup:dump` en zijn daarmee het enige onderdeel zonder vangnet — raakt #30).
 6. **Issue #1** — wachtwoordrotatie van de `postgres`-beheerrol (P0, niet aangeraakt door de databaserol-fix van 2026-07-27).
 7. **Issue #3** — `tsconfig.json` naar strict-mode, module-systeem-inconsistentie oplossen (P0, klein). De eerdere kanttekening hierbij ("kan typefouten blootleggen die per ORM verschillen") is vervallen nu de databaselaag vastligt.
@@ -169,7 +170,8 @@ Volledige backlog (alle 24 items, incl. Before production en Later): `gh issue l
 - **Backlog/roadmap: GitHub Issues** (`https://github.com/AlingAdvies/MCM2/issues`), gelabeld met type (`bug`/`enhancement`/`chore`) en prioriteit (`priority:p0`/`priority:before-pilot`/`priority:before-production`/`priority:later`). Vervangt de losse Markdown-roadmap sinds 2026-07-27 (zie `docs/archive/06-prioritized-roadmap-2026-07-24-pre-issues.md` voor de migratieverantwoording en issue-nummer-mapping).
 - **Ontwerpen (`docs/superpowers/specs/`):**
   - `2026-07-28-leveranciertoken-ontwerp.md` — toegangslaag voor leveranciers. **Uitgevoerd**, zie PR #32. Blijft de referentie voor waarom de guard doet wat hij doet.
-  - `2026-07-28-vragenlijst-ontwerp.md` — vragenlijst-tool, antwoorden en certificaat-upload. **Status: onvolledig, niet bouwen** tot het besluit over niveau A/B/C er is. §0 legt uit waarom dit document herschreven is.
+  - `2026-07-28-vragenlijst-ontwerp.md` — vragenlijst-tool, antwoorden en certificaat-upload. **Status: bouwbaar** (niveau B, vastgesteld 2026-07-29). §0 legt de twee scopewijzigingen uit; §10 bevat de bouwvolgorde.
+- **Externe referentie:** `VendorComply Help en Manual.md` (OneDrive, `Bizaline/Producten/VendorComply/`) — handleiding van een bestaand, werkend product. Bron van de acht vraagtypen en de lifecycle. **Referentie, geen compatibiliteitseis:** geen gedeelde database, geen migratiepad. Wat is overgenomen en wat niet, staat in het ontwerp §1a.
 - **Klantaanlevering:** `Transdev Annual Vendor IT Risk SurveyV1_0.md` (repo-root) — de acht vragen die de eerste vulling van de tool vormen.
 - Architectuurreview: `docs/architecture-review/2026-07-24/` (00, 02-05, 07-09 — 06 is verplaatst naar `docs/archive/`, zie hierboven)
 - Actieve ADR's: `docs/adr/`, inclusief ADR-006 (CIAM-laag: Microsoft Entra External ID — herzien op 2026-07-27, AWS Cognito verworpen; bestand heette eerder `ADR-006-cognito-als-federatielaag.md`), ADR-007 (CI-platform: GitHub Actions; eerste CI-scope: format/lint/typecheck, test/build bewust uitgesteld tot na de ORM-spike), ADR-008 (P0-databaserolherstel: clm_api_runtime, ontbrekende schema-grants, tijdelijke clm_admin=clm_api-gelijkstelling), ADR-009 (migration-rol clm_migrator, rollenbootstrap, geautomatiseerde RLS-test in CI via ephemere testdatabase) ADR-010 (databaselaag Drizzle, Prisma verwijderd; inclusief de toetsing van de zeven §5-criteria) en ADR-011 (backup- en hersteleisen per fase: hoeveel dataverlies en hersteltijd acceptabel zijn tijdens ontwikkeling, pilot en productie). ADR-002 is op 2026-07-28 bijgewerkt met de werkelijke stand van de vier openstaande controls.

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -21,15 +21,17 @@ Op 2026-07-29 is het openstaande niveau-besluit genomen: **niveau B**. Aanleidin
 
 **Scopegrens van de MVP, verduidelijkt op 2026-07-29: twee use cases, niets daarbuiten.**
 
-| | Use case | Wie vult in | Over wie gaat het |
+| | Use case | Wie vult in | Over welke leverancier |
 |---|---|---|---|
-| **UC1** | Vendor compliance (bv. IT) | externe leverancier | zichzelf |
-| **UC2** | Interne beoordeling van een dienstverlener | Transdev-collega | een andere partij |
+| **UC1** | Vendor compliance (bv. IT) | de leverancier zelf | zichzelf |
+| **UC2** | Interne beoordeling | een Transdev-collega | dezelfde leverancier |
 
-UC2 ontbrak volledig in het ontwerp en raakte het datamodel, niet alleen de tekst: `survey_response.vendor_id` was `NOT NULL` met een foreign key naar `vendor`, en een interne collega is geen leverancier. Drie besluiten van de eigenaar bepalen hoe UC2 werkt:
+"Leverancier" en "dienstverlener" zijn hetzelfde: dezelfde partij, dezelfde `clm.vendor`-rij, alleen bekeken vanuit een andere kant. Bij UC1 is de leverancier de **deelnemer**, bij UC2 het **onderwerp** — hij vult daar niets in, er wordt over hem ingevuld. Omdat `subject_vendor_id` bij beide gevuld is, staan de zelfverklaring en de praktijkscore over dezelfde partij automatisch naast elkaar.
+
+UC2 ontbrak volledig in het ontwerp en raakte het datamodel, niet alleen de tekst: `survey_response.vendor_id` was `NOT NULL` met een foreign key naar `vendor`, en de invuller is bij UC2 een collega, geen leverancier. Drie besluiten van de eigenaar bepalen hoe UC2 werkt:
 
 - **Toegang ook via token-link** — daarmee blijft de toegangslaag ongewijzigd en wacht de MVP niet op de Entra-guard.
-- **Meerdere collega's mogen dezelfde dienstverlener beoordelen** — `UNIQUE (run_id, vendor_id)` wordt partieel, zodat UC1's garantie "één leverancier, één respons" wél overeind blijft.
+- **Meerdere collega's mogen dezelfde leverancier beoordelen** — `UNIQUE (run_id, vendor_id)` wordt partieel, zodat UC1's garantie "één leverancier, één respons" wél overeind blijft.
 - **De interne score is niet zichtbaar voor de leverancier.** Dat volgt al uit de architectuur: een leverancier heeft geen toegang tot de Transdev-tenant, alleen één token voor één respons. Vastgelegd als testpunt 39, omdat het de garantie is die sneuvelt zodra iemand een route bouwt die op `subject_vendor_id` filtert in plaats van op `response_id`.
 
 **Overgenomen uit VendorComply:** de acht vraagtypen, de lifecycle Draft → Active → Finished/Archived, Test Mode vóór publicatie, drie manieren om deelnemers toe te voegen, deadline met overdue-markering, en import/export als JSON-schema.

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -19,6 +19,19 @@ Op 2026-07-29 is het openstaande niveau-besluit genomen: **niveau B**. Aanleidin
 
 **Wat niveau B betekent:** de tenant kiest per vraag een antwoordtype uit acht — `instruction` (leesblok), `confirmation`, `open_text`, `yes_no`, `single_choice`, `multi_choice`, `rating`, `number`, `file_upload`.
 
+**Scopegrens van de MVP, verduidelijkt op 2026-07-29: twee use cases, niets daarbuiten.**
+
+| | Use case | Wie vult in | Over wie gaat het |
+|---|---|---|---|
+| **UC1** | Vendor compliance (bv. IT) | externe leverancier | zichzelf |
+| **UC2** | Interne beoordeling van een dienstverlener | Transdev-collega | een andere partij |
+
+UC2 ontbrak volledig in het ontwerp en raakte het datamodel, niet alleen de tekst: `survey_response.vendor_id` was `NOT NULL` met een foreign key naar `vendor`, en een interne collega is geen leverancier. Drie besluiten van de eigenaar bepalen hoe UC2 werkt:
+
+- **Toegang ook via token-link** — daarmee blijft de toegangslaag ongewijzigd en wacht de MVP niet op de Entra-guard.
+- **Meerdere collega's mogen dezelfde dienstverlener beoordelen** — `UNIQUE (run_id, vendor_id)` wordt partieel, zodat UC1's garantie "één leverancier, één respons" wél overeind blijft.
+- **De interne score is niet zichtbaar voor de leverancier.** Dat volgt al uit de architectuur: een leverancier heeft geen toegang tot de Transdev-tenant, alleen één token voor één respons. Vastgelegd als testpunt 39, omdat het de garantie is die sneuvelt zodra iemand een route bouwt die op `subject_vendor_id` filtert in plaats van op `response_id`.
+
 **Overgenomen uit VendorComply:** de acht vraagtypen, de lifecycle Draft → Active → Finished/Archived, Test Mode vóór publicatie, drie manieren om deelnemers toe te voegen, deadline met overdue-markering, en import/export als JSON-schema.
 
 **Bewust uitgesteld:** logic jumps (voorwaardelijke logica — dat is niveau C), AI-beoordeling via Gemini, EFQM KPI-sync, Marketing Mode (publieke anonieme surveys) en radar/spider charts.
@@ -29,7 +42,7 @@ Volledig ontwerp: `docs/superpowers/specs/2026-07-28-vragenlijst-ontwerp.md` —
 
 **Nog open in het ontwerp (voorstellen, niet bevestigd, geen van alle blokkerend):** dat een gestarte ronde de vragenlijst bevriest (§2), dat een toelichting ook verplicht is bij "I do not confirm" (§3), en wat er gebeurt bij een geïmporteerd e-mailadres zonder bekende vendor (§2c — advies: weigeren, niet automatisch aanmaken).
 
-**Twee dingen raken bestaande, groene code** en verdienen aandacht bij het bouwen: `survey_run` krijgt twee kolommen (`status`, `is_test`), en de bestaande guard moet de ronde-status meewegen naast `closes_at`/`revoked_at`.
+**Drie dingen raken bestaande, groene code** en verdienen aandacht bij het bouwen: `survey_run` krijgt drie kolommen (`status`, `is_test`, `survey_kind`), `survey_response` krijgt er drie (`subject_vendor_id`, `respondent_user_id`, `respondent_label`) waarbij `vendor_id` **nullable** wordt, en de bestaande guard moet de ronde-status meewegen naast `closes_at`/`revoked_at`. Die nullable-wijziging is een versoepeling op een tabel die vanochtend gemerged is — de UC1-garantie wordt overgenomen door een partiële unieke index plus twee CHECK-constraints, en testpunten 41 t/m 43 horen te bewijzen dat er niets weglekt.
 
 ## Doel
 Transdev Vendor IT Compliance Survey als eerste verticale MVP-slice.

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,7 +1,7 @@
 # MCM2 — actuele status
 
 ## Laatst bijgewerkt
-2026-07-29 (PR #32 gemerged, Issue #31 gesloten; vragenlijst-scope vastgesteld op niveau B — alles hieronder is geverifieerd, niet uit gespreksgeheugen)
+2026-07-29 (PR #32 en #33 gemerged; vragenlijst niveau B gebouwd t/m stap 2, frontend-repository aangemaakt — alles hieronder is geverifieerd, niet uit gespreksgeheugen)
 
 ## Voor een nieuwe sessie: lees dit eerst
 
@@ -9,7 +9,7 @@
 2. Lees dit document (`docs/STATUS.md`) volledig — het is de enige actuele waarheid over fase en blockers.
 3. Verifieer git-status zelf (`git status`, `git branch -a`) tegen wat hieronder staat — vertrouw niet blind op deze snapshot.
 4. Check de open GitHub Issues (`gh issue list --repo AlingAdvies/MCM2 --state open`) voor de actuele backlog — dit document verwijst naar issue-nummers, maar de Issues zelf zijn de bron van waarheid over wat daadwerkelijk nog open staat.
-5. **Eerste concrete vervolgstap: het bouwen van de vragenlijst-tool kan beginnen.** Het ontwerp is op 2026-07-29 bouwbaar geworden (niveau B vastgesteld); de bouwvolgorde staat in §10 van het ontwerp. Issue #30 (geen backups) blijft de zwaarste openstaande blokkade voor alles wat de productiedatabase raakt (#19, #25, #29), maar vraagt nu alleen nog uitvoering door de eigenaar, geen besluit — en de vragenlijst-tool loopt daar niet op vast, want die bouwt tegen wegwerpcontainers.
+5. **Eerste concrete vervolgstap: stap 3 uit de bouwvolgorde** (import/export van het JSON-schema, ontwerp §10). Stap 1 (migratie) en stap 2 (guard weegt de ronde-status mee) zijn op 2026-07-29 gebouwd en gemerged. Issue #30 (geen backups) blijft de zwaarste openstaande blokkade voor alles wat de productiedatabase raakt (#19, #25, #29), maar vraagt nu alleen nog uitvoering door de eigenaar, geen besluit — en de vragenlijst-tool loopt daar niet op vast, want die bouwt tegen wegwerpcontainers.
 
 ## Vragenlijst-tool — scope vastgesteld op 2026-07-29, ontwerp is bouwbaar
 
@@ -54,9 +54,21 @@ Uit de vergelijking (ontwerp §1a-bis) kwam dat beide modellen onafhankelijk gro
 
 **Drie dingen raken bestaande, groene code** en verdienen aandacht bij het bouwen: `survey_run` krijgt drie kolommen (`status`, `is_test`, `survey_kind`), `survey_response` krijgt er drie (`subject_vendor_id`, `respondent_user_id`, `respondent_label`) waarbij `vendor_id` **nullable** wordt, en de bestaande guard moet de ronde-status meewegen naast `closes_at`/`revoked_at`. Die nullable-wijziging is een versoepeling op een tabel die vanochtend gemerged is — de UC1-garantie wordt overgenomen door een partiële unieke index plus twee CHECK-constraints, en testpunten 41 t/m 43 horen te bewijzen dat er niets weglekt.
 
-## Frontend — besloten op 2026-07-29 (ADR-012), nog niet gebouwd
+## Frontend — repository aangemaakt op 2026-07-29 (ADR-012), nog geen schermen
 
-MCM2 heeft **geen frontend**. Op 2026-07-29 is besloten hoe die eruit gaat zien en hoe hij wordt uitgerold.
+**`https://github.com/AlingAdvies/MCM2-frontend`** (privé, onder AlingAdvies). Fundament staat, CI groen op beide jobs. **Nog geen schermen** — het leverancierportaal is de volgende stap.
+
+Wat er staat: Next.js 15 + Tailwind 3 (**bewust dezelfde majors als MVM_V2**, niet de nieuwste — Next 16/Tailwind 4 zouden het overnemen van MVM_V2-componenten juist duurder maken), versies exact gepind conform MCM2-CLAUDE.md §11, TypeScript meteen op `strict` (in de backend is dat nog Issue #3; achteraf strict maken kost meer).
+
+De **design tokens** zijn gekopieerd met bronvermelding; Tailwind leest zijn thema eruit, zodat `bg-brand-primary` en `tokens.brandPrimary` niet uit elkaar kunnen lopen. De **mock/live-schakelaar** werkt: zonder `NEXT_PUBLIC_API_URL` draait alles op mock data, en de startpagina toont welke bron actief is.
+
+**Twee CI-poorten dwingen af wat anders alleen op papier staat:** geen leveranciersspecifieke imports (de draagbaarheidsregel), en nooit een tenant in een URL. Beide zijn geverifieerd door een overtreding uit te lokken — waarbij bleek dat de tweede poort afging op een codevoorbeeld in het commentaar van `client.ts` zelf. Dat voorbeeld is herschreven naar een beschrijving.
+
+**Geverifieerd:** image bouwt, container serveert HTTP 200, draait als non-root. De Docker-poort controleert niet alleen dát het image start maar dat het een pagina *serveert* — een Next.js-server met een kapotte build start namelijk wel en geeft een 500.
+
+**Let op bij het uitrollen:** `NEXT_PUBLIC_*`-variabelen worden **tijdens de build** in de bundel gebakken, niet bij het starten gelezen. Een image dat de echte backend moet gebruiken heeft die waarde nodig als build-argument. Dat is een eigenschap van Next.js, geen keuze.
+
+### Het uitrolbesluit zelf
 
 **Besluit: Next.js in een eigen repository, uitgerold als containerimage — de enige uitrolweg.** Tot de golive draait dat lokaal via `docker compose` naast de bestaande backend-stack. **Kosten: nul.** Bij golive is AWS de beoogde doelplek, met **App Runner** als voorkeursdienst (indicatie $25–40/mnd, *niet op de bron geverifieerd*).
 
@@ -122,6 +134,26 @@ Transdev Vendor IT Compliance Survey als eerste verticale MVP-slice.
 
 ## Aantoonbaar werkend
 
+- **Vragenlijst-datamodel niveau B (2026-07-29, PR #33, migratie `0005_vragenlijst_niveau_b.sql`).** Vier nieuwe tabellen (`survey_category`, `survey_question`, `survey_answer`, `survey_attachment`) plus `survey_kind`/`status`/`is_test` op `survey_run` en drie respondentkolommen op `survey_response`. 459 regels, waarvan ongeveer een derde gegenereerd — de rest handwerk, precies zoals ADR-010 voorspelt.
+
+  **Geverifieerd tegen een verse Postgres 17.6-container, niet beredeneerd.** Volledige keten 0000 t/m 0006 via `clm_migrator`. Daarna is elke garantie uitgelokt; alle acht werden geweigerd door de database: categorie van een andere template, verplicht leesblok, afwijkend `answer_type`, rating in het tekstveld, toelichting van drie spaties, dezelfde leverancier twee keer in een UC1-ronde, wijzigen van een bevroren template, bestand boven 5 MB. De tegenproef slaagt wél: **twee collega's die dezelfde leverancier beoordelen in een UC2-ronde**, wat bewijst dat de partiële unieke index UC1 beschermt zonder UC2 te blokkeren.
+
+  **Twee dingen die drizzle-kit niet kon en die handmatig zijn opgelost:**
+  - Het gegenereerde `ADD COLUMN subject_vendor_id uuid NOT NULL` slaagt alleen op een lege tabel en **zou op `clm-enterprise` falen**. Vervangen door kolom toevoegen → backfillen vanuit `vendor_id` → dan pas `NOT NULL`.
+  - De rolverdeling per use case kon niet als CHECK: `survey_kind` staat op `survey_run` en een CHECK mag geen subquery bevatten. Opgelost met een trigger in plaats van `survey_kind` te dupliceren — dupliceren zou een derde plek opleveren waar de waarde kan afwijken.
+
+  Alle zeven survey-tabellen hebben RLS met zowel `USING` als `WITH CHECK`.
+
+- **De guard weegt de lifecycle van de ronde mee (2026-07-29, migratie `0006_ronde_status_in_guard.sql`).** Vóór deze stap was een ronde in `draft` — aangemaakt maar niet opengesteld — via een token gewoon bereikbaar; `revoked_at` en `closes_at` zeggen niets over een ronde die nog niet begonnen is. `draft` krijgt een eigen melding ("nog niet opengesteld"), want dat is voor een leverancier iets anders dan "gesloten".
+
+  De controle staat **ook in het `UPDATE`-statement van `dienIn()`**, niet alleen in de guard: die beschermt het HTTP-pad, de voorwaarde beschermt de methode zelf.
+
+  **Bevinding om te onthouden:** PostgreSQL weigert een `CREATE OR REPLACE` die de `RETURNS TABLE` wijzigt — geverifieerd, niet aangenomen. Daarom `DROP` + `CREATE`. Gevolg: **na een `DROP` zijn de rechten weg**, want die hangen aan het functie-object en niet aan de naam. Zonder de herhaalde `GRANT` zou geen enkele leverancierslink meer werken.
+
+  **De testwaarde is geverifieerd door de controle tijdelijk te verwijderen:** vijf van de zes nieuwe tests vielen om. Zonder die proef bewijzen groene tests niets — de eerste poging mislukte overigens stil (een regex die niet matchte), waardoor de "proef" niets toetste.
+
+  53 van 53 e2e-tests groen.
+
 - **Leverancierstoegang via token, spoor 2 van Issue #7 (2026-07-28, PR #32, commit `b29e2ad`).** CI groen op alle drie de jobs, geverifieerd met `gh pr checks 32`. 46 tests groen. Wat er staat:
   - `clm.resolve_survey_token()` — `SECURITY DEFINER` met `SET search_path = clm, pg_temp`. De enige route naar een responserij zonder tenantcontext, met een minimale returnwaarde (geen namen, geen e-mailadressen, geen antwoorden). Lost de kip-en-ei op: de tenant is niet bekend vóór de lookup.
   - **De tenantcontext komt uitsluitend uit die lookup**, nooit uit een header, query-parameter of body. Er bestáát geen veld waarin een leverancier een andere tenant kan benoemen. Dit is precies het patroon dat de verwijderde branch `feat/fase0-skeleton-vendors` fout deed.
@@ -163,7 +195,8 @@ Transdev Vendor IT Compliance Survey als eerste verticale MVP-slice.
 ## Huidige branch en Git-status
 
 - **`feat/issue-7-leveranciertoken` is op 2026-07-29 via PR #32 gemerged naar `main`** (merge-commit `7f0cc01`) en daarna lokaal én op GitHub verwijderd. CI groen op alle drie de jobs vóór de merge, opnieuw geverifieerd met `gh pr checks 32` op de laatste commit. Vijf commits: de tokenlaag, de HTTP-routes met logmaskering en auditregels, de fix op `maskeerDiep`, plus twee documentatiecommits. **Issue #31 is bij die merge gesloten** — migratie `0004` loste hem op. Let op: die migratie is bewezen in CI, **niet toegepast op `clm-enterprise`** — net als #29 en #25 wacht dat op #30.
-- **Actieve branch: `feat/issue-9-vragenlijst-ontwerp`** — bevat uitsluitend documentatie: het bijgewerkte vragenlijst-ontwerp (niveau B) en deze statusbijwerking. Geen code.
+- **`feat/issue-9-vragenlijst-ontwerp` is op 2026-07-29 via PR #33 gemerged naar `main`** en daarna lokaal én op GitHub verwijderd. Negen commits: het vragenlijst-ontwerp (niveau B, twee use cases, categorieën), ADR-012, de migratie 0005, de guard-uitbreiding 0006 en deze statusbijwerking. CI groen op alle drie de jobs vóór de merge.
+- **Tweede repository sinds 2026-07-29: `AlingAdvies/MCM2-frontend`** (privé). Eigen CI, eigen releasecyclus — bewust geen map in deze repo, zodat een tekstwijziging in een scherm niet wacht op een databasemigratie. Zie ADR-012.
 - `chore/supabase-verificatie` is op 2026-07-28 via PR #28 gemerged naar `main` en daarna lokaal én op GitHub verwijderd. Zes commits: Supabase read-only verificatie, schemacontrole die uit het schema meegroeit, ADR-011 (backupeisen per fase), de #29-fix, en het runbook met beproefde commando's en opruimprocedure. CI groen op alle drie de jobs vóór de merge.
 - `feat/issue-5-drizzle-omzetting` is op 2026-07-28 via PR #26 gemerged naar `main` (merge-commit `f0806f8`) en daarna lokaal én op GitHub verwijderd. Bevatte de volledige Drizzle-omzetting; CI groen op alle drie de jobs vóór de merge.
 - `docs/issue-7-leveranciertoken-ontwerp` is op 2026-07-28 via PR #27 gemerged naar `main` (merge-commit `c8f896a`) en daarna lokaal én op GitHub verwijderd. Bevatte uitsluitend het ontwerpdocument voor het leverancierstokenspoor.
@@ -183,9 +216,20 @@ De databaselaag is omgezet (ADR-010), spoor 2 van Issue #7 zit in `main`, en het
 
 **De eerstvolgende inhoudelijke stap is het bouwen van de vragenlijst-tool** (ontwerp §10). Dat is nu de kortste weg naar een werkende pilot: de toegangslaag eronder staat en is bewezen, en het bouwen ervan raakt de productiedatabase niet — de hele e2e-keten draait tegen wegwerpcontainers, dus #30 blokkeert dit spoor niet.
 
-Eerste twee stappen uit die volgorde, omdat ze bestaande groene code raken en dus de meeste aandacht vragen:
-1. Migratie met `survey_question`, `survey_answer`, `survey_attachment`, plus `status` en `is_test` op `survey_run` — inclusief RLS, policies, CHECK-constraints en de samengestelde foreign key. Handwerk: drizzle-kit genereert hiervan niets.
-2. De bestaande guard uitbreiden met de ronde-statuscontrole.
+~~1. Migratie met de vier nieuwe tabellen en de kolommen op `survey_run`/`survey_response`~~ — **afgerond 2026-07-29** (migratie 0005).
+~~2. De bestaande guard uitbreiden met de ronde-statuscontrole~~ — **afgerond 2026-07-29** (migratie 0006).
+
+**Nu aan de beurt — stap 3 t/m 9 uit ontwerp §10:**
+
+3. **Import/export van het JSON-schema** (ontwerp §2d). Bewust vóór de seed: die is gewoon zo'n bestand, dus als import eerst werkt bestaat er geen apart seed-script dat later uit de pas loopt met het echte importpad.
+4. **Seed:** de acht Transdev-vragen (UC1) plus een korte interne beoordelingsvragenlijst (UC2), beide via stap 3.
+5. `GET /survey/respond/questions` — vragen ophalen inclusief `config` per type.
+6. Validatie- en indienlogica; `POST /survey/respond` uitbreiden met de antwoordbody (ontwerp §5).
+7. `PUT /survey/respond/answers` — concept opslaan, expliciet (geen auto-save).
+8. Bestandsupload met inhoudscontrole (ontwerp §6, Issue #9).
+9. Tests 14 t/m 48.
+
+**Parallel spoor, blokkeert het bovenstaande niet:** het leverancierportaal in `MCM2-frontend` op mock data. Dat kan vooruit omdat de mock/live-schakelaar niet op werkende endpoints wacht.
 
 Daarna, in volgorde van afhankelijkheid:
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -54,6 +54,27 @@ Uit de vergelijking (ontwerp §1a-bis) kwam dat beide modellen onafhankelijk gro
 
 **Drie dingen raken bestaande, groene code** en verdienen aandacht bij het bouwen: `survey_run` krijgt drie kolommen (`status`, `is_test`, `survey_kind`), `survey_response` krijgt er drie (`subject_vendor_id`, `respondent_user_id`, `respondent_label`) waarbij `vendor_id` **nullable** wordt, en de bestaande guard moet de ronde-status meewegen naast `closes_at`/`revoked_at`. Die nullable-wijziging is een versoepeling op een tabel die vanochtend gemerged is — de UC1-garantie wordt overgenomen door een partiële unieke index plus twee CHECK-constraints, en testpunten 41 t/m 43 horen te bewijzen dat er niets weglekt.
 
+## Frontend — besloten op 2026-07-29 (ADR-012), nog niet gebouwd
+
+MCM2 heeft **geen frontend**. Op 2026-07-29 is besloten hoe die eruit gaat zien en hoe hij wordt uitgerold.
+
+**Besluit: Next.js in een eigen repository, uitgerold als containerimage — de enige uitrolweg.** Tot de golive draait dat lokaal via `docker compose` naast de bestaande backend-stack. **Kosten: nul.** Bij golive is AWS de beoogde doelplek, met **App Runner** als voorkeursdienst (indicatie $25–40/mnd, *niet op de bron geverifieerd*).
+
+Doorslaggevend criterium van de eigenaar: **robuust en eenvoudig deployen** — één manier van uitrollen die overal hetzelfde werkt, niet de snelste weg naar een deelbare link.
+
+**Vercel is overwogen en afgewezen.** Het geeft gratis een preview-URL per PR (de acceptatiestap uit OTAP), maar introduceert een tweede uitrolweg naast de containeraanpak van de backend — die zou bij de overstap naar AWS weer afgeleerd moeten worden.
+
+**Wat dit kost, expliciet:** iets laten zien aan de klant wordt een handeling in plaats van een link. Dat raakt precies de vraag die tot deze ADR leidde (schermen zien om het backend-ontwerp te toetsen). Het blijft mogelijk, maar lokaal.
+
+**MVM_V2 levert drie dingen** (`C:\dev\Work\MVM_V2`, Next.js 15 / React 19):
+- `src/shared/design-tokens.ts` — de huisstijl die de klant kent. **Kopiëren, niet koppelen**: een gedeeld npm-pakket is afgewezen als overhead voor twee producten met één onderhouder.
+- `src/app/portal/survey/[token]/` — een leverancierportaal op token; precies MCM2's route.
+- De **mock/live-schakelaar**: staat `NEXT_PUBLIC_API_URL` leeg, dan mock data; gezet, dan de echte API. Daarmee zijn schermen te beoordelen vóórdat de backend af is.
+
+**Eén ding gaat er expliciet uit bij overname:** MVM_V2 stuurt de tenant mee in het webadres (`?tenant=demo`). Dat is exact het patroon dat MCM2-CLAUDE.md §6 verbiedt en waarom `feat/fase0-skeleton-vendors` is weggegooid. In MCM2 komt de tenant uit het token; **de API accepteert geen `tenant`-parameter.**
+
+Raakt **#12** (acceptatieomgeving — wordt zwaarder: twee containers), **#18** (OTAP-doorloop moet front- én backend omvatten) en **#20** (base-image pinnen geldt ook voor de frontend).
+
 ## Doel
 Transdev Vendor IT Compliance Survey als eerste verticale MVP-slice.
 
@@ -197,7 +218,7 @@ Volledige backlog (alle 24 items, incl. Before production en Later): `gh issue l
 - **Externe referentie:** `VendorComply Help en Manual.md` (OneDrive, `Bizaline/Producten/VendorComply/`) — handleiding van een bestaand, werkend product. Bron van de acht vraagtypen en de lifecycle. **Referentie, geen compatibiliteitseis:** geen gedeelde database, geen migratiepad. Wat is overgenomen en wat niet, staat in het ontwerp §1a.
 - **Klantaanlevering:** `Transdev Annual Vendor IT Risk SurveyV1_0.md` (repo-root) — de acht vragen die de eerste vulling van de tool vormen.
 - Architectuurreview: `docs/architecture-review/2026-07-24/` (00, 02-05, 07-09 — 06 is verplaatst naar `docs/archive/`, zie hierboven)
-- Actieve ADR's: `docs/adr/`, inclusief ADR-006 (CIAM-laag: Microsoft Entra External ID — herzien op 2026-07-27, AWS Cognito verworpen; bestand heette eerder `ADR-006-cognito-als-federatielaag.md`), ADR-007 (CI-platform: GitHub Actions; eerste CI-scope: format/lint/typecheck, test/build bewust uitgesteld tot na de ORM-spike), ADR-008 (P0-databaserolherstel: clm_api_runtime, ontbrekende schema-grants, tijdelijke clm_admin=clm_api-gelijkstelling), ADR-009 (migration-rol clm_migrator, rollenbootstrap, geautomatiseerde RLS-test in CI via ephemere testdatabase) ADR-010 (databaselaag Drizzle, Prisma verwijderd; inclusief de toetsing van de zeven §5-criteria) en ADR-011 (backup- en hersteleisen per fase: hoeveel dataverlies en hersteltijd acceptabel zijn tijdens ontwikkeling, pilot en productie). ADR-002 is op 2026-07-28 bijgewerkt met de werkelijke stand van de vier openstaande controls.
+- Actieve ADR's: `docs/adr/`, inclusief ADR-012 (frontend-uitrol: Docker als enige weg, AWS App Runner beoogd, Vercel afgewezen), ADR-006 (CIAM-laag: Microsoft Entra External ID — herzien op 2026-07-27, AWS Cognito verworpen; bestand heette eerder `ADR-006-cognito-als-federatielaag.md`), ADR-007 (CI-platform: GitHub Actions; eerste CI-scope: format/lint/typecheck, test/build bewust uitgesteld tot na de ORM-spike), ADR-008 (P0-databaserolherstel: clm_api_runtime, ontbrekende schema-grants, tijdelijke clm_admin=clm_api-gelijkstelling), ADR-009 (migration-rol clm_migrator, rollenbootstrap, geautomatiseerde RLS-test in CI via ephemere testdatabase) ADR-010 (databaselaag Drizzle, Prisma verwijderd; inclusief de toetsing van de zeven §5-criteria) en ADR-011 (backup- en hersteleisen per fase: hoeveel dataverlies en hersteltijd acceptabel zijn tijdens ontwikkeling, pilot en productie). ADR-002 is op 2026-07-28 bijgewerkt met de werkelijke stand van de vier openstaande controls.
 - Runbooks: `docs/runbooks/` — bevat sinds 2026-07-28 `supabase-verificatie-en-restoretest.md`: vijf stappen (backupinventarisatie, restore-test, tier/garanties, Drizzle-migratiestand, provider-toets), met beproefde `pg_dump`/`pg_restore`-commando's, zes gedocumenteerde valkuilen en een meetregister voor hersteltijden.
 - Historisch projectcontextdocument: `docs/context/PROJECT-HISTORY-2026-07-24.md`
 - Volledig gearchiveerd, vervangen instructiebestand: `docs/archive/MCM2-CLAUDE-2026-07-24-pre-restructure.md`

--- a/docs/adr/ADR-012-frontend-uitrol-docker.md
+++ b/docs/adr/ADR-012-frontend-uitrol-docker.md
@@ -1,0 +1,267 @@
+# ADR-012 — Frontend: Docker als enige uitrolweg, AWS als beoogde doelplek
+
+**Datum:** 2026-07-29
+**Status:** besloten, nog niet uitgevoerd
+**Raakt:** Issue #12 (acceptatieomgeving), Issue #18 (OTAP-doorloop), Issue #20 (Dockerfile hardenen)
+**Bouwt voort op:** ADR-001 (TypeScript als enige taal), ADR-008/009 (draagbaarheid als bewezen principe)
+
+---
+
+## Context
+
+MCM2 heeft tot 2026-07-29 **geen frontend**. De backend is een NestJS-applicatie met twee
+survey-routes; er is geen scherm, geen framework-keuze en geen uitrolbesluit. ADR-001 noemt Next.js
+terloops als context ("sluit aan bij de frontend (Next.js/MVM_V2)"), maar dat is geen besluit.
+
+De aanleiding voor deze ADR is een vraag van de eigenaar: **wanneer zien we de verbinding met de
+frontend, want dat geeft veel beter zicht op de juistheid van het backend-ontwerp.** Die vraag is
+terecht — een datamodel beoordeel je op papier als abstractie, aan een scherm zie je meteen of het
+klopt. Diezelfde sessie leverde daar al bewijs voor: de vergelijking met MVM_V2 legde drie gaten in
+het vragenlijst-ontwerp bloot die in het document zelf niet zichtbaar waren.
+
+### Wat er al ligt
+
+**MVM_V2** (`C:\dev\Work\MVM_V2`) is een Next.js 15 / React 19-applicatie met werkende
+surveyschermen op mock data, die de klant heeft gezien. Relevant hier:
+
+- `src/shared/design-tokens.ts` — 57 regels, expliciet "ENIGE bron van waarheid voor kleuren en
+  typografie"
+- `src/app/portal/survey/[token]/` — een leverancierportaal op token, precies MCM2's route
+- Een mock/live-schakelaar op de branch `feat/transdev-backend-koppeling`: staat
+  `NEXT_PUBLIC_API_URL` gezet, dan haalt de service echte data op; zo niet, dan mock data
+
+MVM_V2 heeft géén `vercel.json`, `netlify.toml` of Dockerfile — daar is dus ook nog geen
+uitrolbesluit genomen. De CI daar is één job (lint + build).
+
+**MCM2** heeft een multi-stage Dockerfile met een `development`-stage voor hot reload en een
+`runtime`-stage die het gecompileerde resultaat draait, plus een CI-job die het image bouwt **én
+start**. Die job bestaat omdat de oorspronkelijke Dockerfile de applicatie niet eens bouwde
+(`npm install` + `start:dev`) en dat pas aan het licht kwam toen er een poort op kwam.
+
+---
+
+## Besluit
+
+De frontend wordt een **Next.js-applicatie in een eigen repository**, uitgerold als
+**containerimage — de enige uitrolweg**, zowel lokaal als in productie.
+
+Tot de golive draait die container **lokaal via `docker compose`**, naast de bestaande
+backend-stack. Kosten: nul.
+
+Bij golive is **AWS de beoogde doelplek**, met **App Runner** als voorkeursdienst. Dat is een
+richting, geen definitief besluit — zie "Beoogde doelplek".
+
+---
+
+## Onderbouwing
+
+Het doorslaggevende criterium is door de eigenaar expliciet gesteld: **robuust en eenvoudig
+deployen.** Dat is een operationeel criterium, geen gemakscriterium — het gaat om één manier van
+uitrollen die begrepen wordt en overal hetzelfde werkt, niet om de snelste weg naar een deelbare
+link.
+
+| Wat het oplevert | Waarom dat hier telt |
+|---|---|
+| Eén patroon in plaats van twee | De backend zit al in Docker, met dezelfde CI-poort. Eén manier van uitrollen, terugdraaien en logs lezen. |
+| Nul kosten tot golive | Lokaal draaien kost niets. Tweede randvoorwaarde van de eigenaar. |
+| Geen externe partij in de keten | Bij een NIS2-instrument is "wie kan mijn dienst platleggen" een gerechtvaardigde vraag. |
+| Eén omgeving om aan te tonen | Voor NIS2/ISO27001 aanzienlijk eenvoudiger dan de helft bij een externe partij. |
+| Consistent met ADR-008/009 | Geen leveranciersspecifieke diensten. Dat principe maakte de overstap naar Neon gratis. |
+| Elke dag bewezen | De CI-poort "bouwt én start" vanaf dag één, niet pas bij de eerste uitrol. |
+
+Dat laatste punt is zwaarder dan het lijkt. De backend-Dockerfile was aanvankelijk fout en werd
+betrapt door de CI-poort. Diezelfde poort direct voor de frontend inbouwen voorkomt dat een tweede
+keer — en het is goedkoop, want het patroon ligt er al.
+
+---
+
+## Wat dit kost
+
+Deze afwegingen horen hier vastgelegd, want over drie maanden zijn het terechte vragen.
+
+**Iets laten zien aan de klant wordt een handeling.** Bij een gehoste optie zoals Vercel krijgt elke
+pull request automatisch een eigen webadres — de acceptatiestap uit OTAP, gratis. Met Docker en
+lokaal draaien is dat: zelf starten en het scherm delen, of tijdelijk iets online zetten.
+
+Dat is een reële beperking en raakt precies de vraag die deze ADR aanleiding gaf. Het blijft
+mogelijk om schermen te beoordelen, maar op de eigen machine in plaats van via een link.
+
+**De acceptatieomgeving (Issue #12) kan niet worden overgeslagen.** Met een gehoste optie had de
+frontend de acceptatiestap eerder kunnen waarmaken dan de backend. Nu delen ze dezelfde
+afhankelijkheid.
+
+**Next.js in een container vraagt eenmalig aandacht:** `output: 'standalone'` in `next.config.ts`,
+en de ingebouwde afbeeldingsoptimalisatie werkt niet vanzelf zoals bij een gehost platform. Voor
+MCM2 is dat waarschijnlijk klein — een logo, mogelijk een certificaat-preview — maar het is het
+enige punt waar het uiterlijk kan afwijken als het over het hoofd gezien wordt.
+
+**Wat níét verschilt:** de HTML, CSS en JavaScript zijn identiek. Een gehost platform voert onder
+water hetzelfde `next build` uit. Er bestaat geen platformspecifieke versie van Next.js.
+
+---
+
+## Beoogde doelplek: AWS
+
+De eigenaar geeft aan dat golive **met grote waarschijnlijkheid op AWS** gebeurt. Dat is hier
+vastgelegd als richting, niet als besluit — het definitieve besluit hoeft pas te vallen wanneer de
+pilot daadwerkelijk live gaat.
+
+| Dienst | Wat het is | Beheerlast | Oordeel |
+|---|---|---|---|
+| **App Runner** | Neemt een image, levert een draaiende dienst met HTTPS | vrijwel geen | **voorkeur** |
+| ECS/Fargate | Containers met volledige controle | netwerk, load balancer, taakdefinities | te veel voor deze schaal |
+| EC2 | Zelf beheerde server | updates, patches, certificaten | het meeste werk |
+| Amplify | Gehost platform van AWS | weinig | **afgeraden** — niet containergebaseerd, levert alsnog twee uitrolwegen op |
+
+App Runner regelt HTTPS, schaling en herstarten zelf. Dat is de AWS-dienst die het dichtst bij het
+gemak van een gehost platform komt zonder een tweede uitrolweg te introduceren.
+
+> **Kosten, niet op de bron geverifieerd:** App Runner heeft geen gratis laag. Indicatie voor een
+> kleine, continu draaiende dienst: **$25–40 per maand**. Dit cijfer is niet bij AWS geverifieerd en
+> moet gecontroleerd worden vóór de golive-beslissing. Het is een kost bij golive, niet nu.
+
+---
+
+## De draagbaarheidsregel
+
+**Geen aannames over waar de container draait.** Alle configuratie via omgevingsvariabelen, geen
+AWS-specifieke code, geen platformspecifieke functies — ook niet van de eigen omgeving.
+
+Dit is dezelfde regel die de database-overstap goedkoop maakte. MCM2 bleek zonder één regel
+codewijziging op Neon te draaien, en dat was geen toeval maar een gevolg van ADR-008/009: geen
+Supabase Auth, Storage, Edge Functions of `supabase-js`.
+
+Concreet voor de frontend:
+
+| Regel | Waarom |
+|---|---|
+| API-adres uit `NEXT_PUBLIC_API_URL` | Zelfde patroon als MVM_V2's mock/live-schakelaar |
+| Geen platformspecifieke build-functies | Anders is verhuizen later duur |
+| Geen aanname over het domein | Het adres verschilt per omgeving |
+| Bestandsopslag via de backend, nooit rechtstreeks | De backend bewaakt de tokencontrole (vragenlijst-ontwerp §6) |
+
+Daarmee is App Runner straks een keuze en geen huwelijk: blijkt een MSP of Azure beter, dan verhuist
+hetzelfde image.
+
+---
+
+## De mock/live-schakelaar
+
+Het patroon uit MVM_V2 wordt **overgenomen, niet overgeërfd**: het is een idee van enkele regels,
+geen bestand om te kopiëren. Er wordt niet gewacht op het mergen van
+`feat/transdev-backend-koppeling` in MVM_V2 — dat is een aangelegenheid van dat project.
+
+```
+NEXT_PUBLIC_API_URL leeg    → schermen draaien op mock data, geen backend nodig
+NEXT_PUBLIC_API_URL gezet   → dezelfde schermen op de echte MCM2-API
+```
+
+Dit levert precies wat de aanleiding van deze ADR vroeg: schermen zijn te beoordelen vóórdat de
+backend af is, en services gaan één voor één over zodra het endpoint bestaat. Geen big bang.
+
+### Eén ding gaat er expliciet uit
+
+De MVM_V2-code stuurt de tenant mee in het webadres:
+
+```typescript
+const res = await fetch(`${API_URL}/api/v2/contracts?tenant=demo`)
+```
+
+**Dat mag in MCM2 niet.** Het is exact het patroon dat MCM2-CLAUDE.md §6 verbiedt en de kern van
+Issue #7 — het is de reden dat de branch `feat/fase0-skeleton-vendors` is weggegooid zonder te
+mergen. In MVM_V2 is het verdedigbaar (demo-code tegen de C#-pilot), maar bij overname komt het
+patroon mee als niemand oplet.
+
+In MCM2 komt de tenant uit het token (leverancierskant) of uit het geverifieerde ID-token
+(beheerderskant, spoor 1). **De API accepteert geen `tenant`-parameter.**
+
+---
+
+## Huisstijl: kopiëren, niet koppelen
+
+`design-tokens.ts` wordt **gekopieerd** naar de MCM2-frontend, met een verwijzing naar de bron in
+het bestand. Wijzigt MVM_V2 de huisstijl, dan is dat één bestand bijwerken — een handeling van
+minuten, hooguit enkele keren per jaar.
+
+**Een gedeeld npm-pakket is overwogen en afgewezen.** Technisch netter, maar het betekent een derde
+repository, een publicatiestap en versiebeheer voor twee producten die door één persoon onderhouden
+worden. De overhead is groter dan het probleem.
+
+De regel uit MVM_V2 wordt meegenomen: **nooit kleuren hardcoderen in componenten.** Dan blijft een
+huisstijlwijziging altijd één bestand.
+
+---
+
+## Gevolgen
+
+### Nieuwe structuur
+
+| Onderdeel | Waar |
+|---|---|
+| Frontend | eigen repository (`MCM2-frontend` of vergelijkbaar) |
+| Uitrolartefact | containerimage, gebouwd uit een Dockerfile in die repo |
+| Lokaal draaien | `docker compose up`, frontend toegevoegd aan de bestaande stack |
+| CI-poort | image bouwen **én starten**, gemodelleerd naar de `docker-build`-job van de backend |
+
+**Eigen repository, geen map in MCM2.** Frontend en backend hebben verschillende releasecycli: een
+tekstwijziging in een scherm moet niet wachten op een databasemigratie, en een frontendwijziging
+hoort niet de RLS-isolatietests te draaien.
+
+### OTAP
+
+Het bestaande document `docs/otap-en-security-voor-eigenaar.md` beschrijft OTAP backend-only en is
+op onderdelen verouderd (het noemt Prisma en twee CI-controles; er zijn er nu drie). Het moet
+bijgewerkt worden met de frontend erin.
+
+| Fase | Backend | Frontend |
+|---|---|---|
+| Ontwikkel | branch, lokaal | branch, `docker compose up` op mock data |
+| Test | CI: 3 jobs | CI: typecheck, build, image start |
+| Acceptatie | Issue #12 | Issue #12 — **gedeelde afhankelijkheid** |
+| Productie | AWS (beoogd) | AWS App Runner (beoogd) |
+
+### Issues die geraakt worden
+
+- **#12** (acceptatieomgeving) — wordt zwaarder: nu twee containers in plaats van één.
+- **#18** (OTAP-doorloop) — de doorloop moet frontend én backend omvatten.
+- **#20** (Dockerfile hardenen) — de openstaande eis "base-image op exacte patchversie pinnen" geldt
+  vanaf het begin ook voor de frontend-Dockerfile.
+
+---
+
+## Overwogen alternatieven
+
+**Vercel.** Gemaakt door de makers van Next.js, gratis voor deze fase, en het geeft automatisch een
+preview-URL per pull request — precies de acceptatiestap die nu handwerk wordt. **Afgewezen op het
+criterium "robuust en eenvoudig deployen":** het introduceert een tweede uitrolweg naast de
+containeraanpak van de backend, en die zou bij de overstap naar AWS weer afgeleerd moeten worden.
+Daarnaast is het een Amerikaanse partij in de keten, wat bij een NIS2-instrument uitleg vraagt.
+
+**Vercel nu, Docker later.** Overwogen als tussenvorm, met de Dockerfile vanaf dag één in CI zodat
+beide wegen bewezen blijven. **Afgewezen:** twee uitrolwegen onderhouden is per definitie niet
+eenvoudig — twee plekken waar het misgaat, twee verhalen bij een incident.
+
+**Azure Static Web Apps / Container Apps.** Serieuze kandidaat, want identity ligt al bij Microsoft
+(ADR-006). **Afgewezen omdat die koppeling hier niet bestaat:** de frontend praat niet met Entra,
+dat doet de backend. En golive gaat naar verwachting naar AWS.
+
+**Een map in de MCM2-repo.** Eén repository, één pull request voor front- en backend samen.
+**Afgewezen:** verschillende releasecycli, en elke frontendwijziging zou de volledige backend-CI
+draaien.
+
+**Gedeeld npm-pakket voor de huisstijl.** Zie hierboven — overhead groter dan het probleem.
+
+---
+
+## Reviewmoment
+
+Herzien wanneer:
+
+- **de pilot live gaat** — dan valt het definitieve besluit over de AWS-dienst, met geverifieerde
+  kosten in plaats van de indicatie hierboven;
+- **een klant EU-hosting of eigen infrastructuur eist** — dan is de draagbaarheidsregel de reden
+  dat dit een verhuizing is en geen verbouwing;
+- **er een tweede ontwikkelaar bijkomt** — dan verandert de afweging tussen beheerlast en gemak,
+  en wordt een preview-omgeving per pull request waardevoller;
+- **het handmatig tonen van schermen aan de klant in de praktijk knelt** — dat is de bekende prijs
+  van dit besluit en het is legitiem om hem opnieuw te wegen.

--- a/docs/superpowers/specs/2026-07-28-vragenlijst-ontwerp.md
+++ b/docs/superpowers/specs/2026-07-28-vragenlijst-ontwerp.md
@@ -1,14 +1,18 @@
 # Ontwerp — vragenlijst-tool, antwoorden en certificaat-upload
 
-**Datum:** 2026-07-28
-**Status:** ⚠️ **ONVOLLEDIG — herschreven na koerswijziging, wacht op één antwoord.** Niet bouwen.
+**Datum:** 2026-07-28, scope vastgesteld 2026-07-29
+**Status:** ✅ **BOUWBAAR — niveau B vastgesteld door de opdrachtgever op 2026-07-29.**
 **Issues:** #9 (certificaat-upload, AC13), en het inhoudelijke deel van #7 dat OV-6/OV-8 blokkeerde
 **Bron:** `Transdev Annual Vendor IT Risk SurveyV1_0.md` (aangeleverd 2026-07-28)
+**Referentie:** `VendorComply Help en Manual.md` §2.1–2.3, §3.1–3.4 — een bestaand, werkend product
+waarvan de vraagtypen en lifecycle zijn overgenomen (zie §1a)
 **Bouwt voort op:** `2026-07-28-leveranciertoken-ontwerp.md` (toegang), dat hier als gegeven geldt
 
 ---
 
-## 0. Lees dit eerst — de scope is op 2026-07-28 gecorrigeerd
+## 0. Lees dit eerst — twee scopewijzigingen, op 2026-07-28 en 2026-07-29
+
+**Wijziging 1 (2026-07-28) — de vragen horen in de database, niet in code.**
 
 De eerste versie van dit document ging ervan uit dat de acht Transdev-vragen **de** vragenlijst
 waren, en legde ze daarom vast in code met een uitgebreide onderbouwing waarom een beheerscherm
@@ -24,35 +28,97 @@ vulling en de PoC-casus — niet de scope. De vragen horen daarmee in de **datab
 eromheen, niet in de codebase.
 
 Alles hieronder is op die correctie herschreven. Wat uit de eerste versie ongewijzigd overeind
-blijft: de antwoordopslag (§4), de toelichtingsregels (§3), de bestandsvalidatie (§6) en de
-RLS-garanties. Alleen de herkomst van de vragen verschuift.
+blijft: de toelichtingsregels (§3), de bestandsvalidatie (§6) en de RLS-garanties.
 
-**Dit ontwerp is nog niet af.** Eén vraag aan de opdrachtgever staat open en bepaalt de omvang —
-zie §1. Zonder dat antwoord is §2 (het schema voor de vragen) niet definitief in te vullen.
+**Wijziging 2 (2026-07-29) — niveau B in plaats van A.**
+
+Aanleiding was `VendorComply Help en Manual.md`, de handleiding van een bestaand, werkend product.
+Dat document leverde geen wensenlijst maar keuzes die de praktijk al hebben overleefd. Het eerdere
+advies in dit document (niveau A) rustte op het argument dat er nog geen tweede vraagvorm was om
+tegen te ontwerpen; dat argument verviel zodra er acht bewezen vraagtypen op tafel lagen. Zie §1.
+
+**Wat door wijziging 2 wél herzien is ten opzichte van 2026-07-28:** het antwoordschema (§4) is
+ingrijpend veranderd — één `answer TEXT`-kolom volstaat niet meer voor acht typen. Nieuw zijn §2a
+(de typen), §2b (lifecycle), §2c (deelnemers) en §2d (import/export). Wie de vorige versie kent,
+moet in elk geval §2a en §4 opnieuw lezen.
 
 ---
 
-## 1. OPENSTAAND — hoeveel vrijheid krijgt de tenant?
+## 1. Niveau B — vastgesteld op 2026-07-29
 
-Dit is de vraag die de omvang bepaalt en die vóór het bouwen beantwoord moet zijn.
+De vraag die de omvang bepaalde, was hoeveel vrijheid de tenant krijgt:
 
-| | Niveau | Wat de tenant kan | Dekt de 8 vragen? |
+| | Niveau | Wat de tenant kan | Besluit |
 |---|---|---|---|
-| **A** | Vaste vraagvorm, vrije tekst | Vraagteksten schrijven, volgorde bepalen, per vraag aangeven of er een upload bij hoort. Antwoordtype is altijd het bevestigingstype uit §3. | ja, volledig |
-| **B** | Meerdere antwoordtypen | Als A, plus per vraag kiezen: bevestiging, meerkeuze, vrije tekst, ja/nee, datum. | ja, ruim |
-| **C** | Volledige formulierbouwer | Als B, plus voorwaardelijke logica ("als vraag 3 = nee, toon 3a"), secties, herhaalbare blokken. | ja, zeer ruim |
+| **A** | Vaste vraagvorm, vrije tekst | Vraagteksten, volgorde, upload aan/uit. Eén antwoordtype. | te krap |
+| **B** | Meerdere antwoordtypen | Als A, plus per vraag een antwoordtype kiezen uit acht. | ✅ **gekozen** |
+| **C** | Volledige formulierbouwer | Als B, plus voorwaardelijke logica, secties, herhaalbare blokken. | uitgesteld |
 
-**Advies: A voor de PoC, met een datamodel dat B mogelijk maakt zonder verbouwing.**
+Het eerdere advies in dit document was A, met als onderbouwing dat alle acht Transdev-vragen
+hetzelfde antwoordtype hebben en er dus geen tweede vraagvorm was om tegen te ontwerpen.
 
-Onderbouwing: alle acht vragen hebben exact hetzelfde antwoordtype. Er is nog geen tweede vraagvorm
-om tegen te ontwerpen. Een abstractie bouwen voor variatie die je nog niet gezien hebt, levert
-doorgaans de verkeerde abstractie op — die kost later meer dan hij nu bespaart.
+**Die onderbouwing is vervallen.** VendorComply §2.1 levert acht vraagtypen die zich in de praktijk
+bewezen hebben. Het bezwaar tegen vooruitbouwen — dat je de verkeerde abstractie kiest als je de
+variatie nog niet gezien hebt — geldt niet meer wanneer een werkend product je precies laat zien
+welke variatie er in de praktijk nodig blijkt.
 
-Het datamodel in §2 is bewust zo gekozen dat B erbij past: `answer_type` staat al als kolom in
-`survey_question`, met voorlopig één toegestane waarde. Uitbreiden naar B is dan een nieuwe waarde
-plus de bijbehorende validatie, geen migratie van bestaande gegevens.
+### 1a. Wat uit VendorComply is overgenomen, en wat niet
 
-C is een apart product en zou ik niet in dit spoor halen.
+VendorComply is een **referentie, geen compatibiliteitseis**. Er is geen gedeelde database, geen
+gedeeld schema en geen migratiepad tussen beide producten. Wat overgenomen is, is overgenomen omdat
+het een goede keuze is — niet om ergens op aan te sluiten.
+
+**Overgenomen (§2.1, §2.2, §3.3):**
+
+| Onderdeel | Waar het landt |
+|---|---|
+| De acht vraagtypen | §2, `answer_type` |
+| Lifecycle Draft → Active → Finished/Archived | §2b |
+| Test Mode vóór publicatie | §2b |
+| Drie manieren om deelnemers toe te voegen | §2c |
+| Deadline met overdue-markering | §2b |
+| Import/export als JSON-schema | §2d |
+
+Import/export verdient een aparte opmerking: het lijkt een gemaksfunctie, maar het levert
+"template klonen" en "template delen tussen tenants" er vrijwel gratis bij, en het geeft een
+leesbaar exportformaat voor de vragenlijststructuur. Dat is meer waarde dan de omvang doet vermoeden.
+
+**Uitgesteld — bewust niet in dit ontwerp:**
+
+| Onderdeel | Reden |
+|---|---|
+| Logic jumps (voorwaardelijke logica) | Niveau C. Verandert "welke vragen zie je" van een lijst in een berekening, en raakt daarmee validatie, voortgang, export en verplichtstelling tegelijk. Eigen bouwstap ná een werkende B. |
+| AI-beoordeling (Gemini) | Externe dienst. Brengt bovendien een verwerkersvraag mee: leverancierscertificaten en compliance-antwoorden naar een externe AI-dienst sturen is een AVG/NIS2-besluit, geen technische keuze. |
+| EFQM KPI-sync | Externe koppeling, niet nodig voor de pilot. |
+| Marketing Mode (publieke anonieme surveys) | Tweede product. Botst met het hele tokenontwerp, dat uitgaat van één link per vendor per ronde. |
+| Radar/spider charts | Rapportage, volgt op werkende data. |
+
+### 1b. Draft/auto-save en "request revisions" — bewust niet
+
+VendorComply §3.4 beschrijft antwoorden die in Draft staan met auto-save, en §2.2 fase 4 laat een
+owner een ingediende response terugzetten naar Draft voor revisie.
+
+**Besluit opdrachtgever 2026-07-29: geen van beide, niet voor nu.**
+
+Dat is een belangrijke bevestiging, want het betekent dat de tokenlaag die op 2026-07-29 in `main`
+is gemerged **ongewijzigd blijft**. Die laag is bewust éénmalig: één atomair
+`UPDATE … WHERE status = 'pending'`, en een 410 zodra er is ingediend. Auto-save en "request
+revisions" hadden allebei gevraagd dat indienen terugdraaibaar wordt — een wijziging in de laag die
+net groen is geworden, niet een uitbreiding erop.
+
+**Wat dit betekent voor §7 van dit ontwerp:** het conceptopslag-mechanisme dat daar beschreven staat
+(`PUT /survey/respond/answers`) blijft wél bestaan, maar in de smalle vorm. Het verschil:
+
+| | Wel | Niet |
+|---|---|---|
+| Antwoorden opslaan vóór indienen, expliciet door de leverancier | ✅ | |
+| Automatisch opslaan tijdens typen (auto-save) | | ❌ |
+| Herzien ná indienen | | ❌ |
+| Owner zet response terug naar Draft | | ❌ |
+
+Concept opslaan blijft nodig om een praktische reden die niets met auto-save te maken heeft: acht
+vragen met verplichte toelichtingen vul je niet in één keer in, en het token is gehasht en dus niet
+opnieuw te versturen. Zonder opslaan verliest iemand die een tabblad sluit alles, onherstelbaar.
 
 ---
 
@@ -70,7 +136,9 @@ position        INTEGER NOT NULL           → volgorde, 1-based
 question_key    TEXT NOT NULL              → 'q1' … 'q8', stabiel over versies heen
 title           TEXT NOT NULL              → korte kop ("ISO 27001 Certification Evidence")
 body            TEXT NOT NULL              → de volledige vraagtekst
-answer_type     TEXT NOT NULL              → nu alleen 'confirmation' (zie §1)
+answer_type     TEXT NOT NULL              → een van de acht typen uit §2a
+config          JSONB NOT NULL DEFAULT '{}' → typespecifieke instellingen, zie §2a
+is_required     BOOLEAN NOT NULL DEFAULT true
 allows_upload   BOOLEAN NOT NULL DEFAULT false
 max_files       SMALLINT NOT NULL DEFAULT 0
 created_at      TIMESTAMPTZ NOT NULL
@@ -80,9 +148,10 @@ created_at      TIMESTAMPTZ NOT NULL
 |---|---|
 | `UNIQUE (template_id, question_key)` | Eén vraag per key binnen een versie |
 | `UNIQUE (template_id, position)` | Geen twee vragen op dezelfde plek |
-| `CHECK (answer_type IN ('confirmation'))` | Uitbreidbaar naar B door de lijst te verlengen |
+| `CHECK (answer_type IN (…acht waarden…))` | Alleen bekende typen |
 | `CHECK (allows_upload = false OR max_files BETWEEN 1 AND 5)` | Een upload zonder maximum kan niet bestaan |
 | `CHECK (allows_upload = true OR max_files = 0)` | Een maximum zonder upload evenmin |
+| `CHECK (answer_type <> 'instruction' OR is_required = false)` | Een leesblok kan niet verplicht zijn |
 | `template_id → survey_template ON DELETE RESTRICT` | Vragen verdwijnen niet stilzwijgend |
 
 `question_key` is bewust een stabiele tekstsleutel naast de UUID. Bij een nieuwe templateversie
@@ -90,7 +159,54 @@ krijgt vraag 4 een nieuwe `question_id`, maar behoudt `question_key = 'q4'` — 
 over versies heen vergelijkbaar. Zonder dat is een jaar-op-jaar-vergelijking niet te maken, en dat
 is bij een jaarlijkse compliance-survey precies het punt.
 
-Voor Transdev vraag 1: `allows_upload = true`, `max_files = 2`.
+Voor Transdev vraag 1: `answer_type = 'confirmation'`, `allows_upload = true`, `max_files = 2`.
+
+### 2a. De acht antwoordtypen
+
+Overgenomen uit VendorComply §2.1/§3.3, met één toevoeging: `confirmation` bestaat daar niet en is
+het type dat de acht Transdev-vragen nodig hebben (zie §3).
+
+| `answer_type` | Wat de leverancier doet | `config` bevat | Antwoord landt in |
+|---|---|---|---|
+| `instruction` | niets — leesblok, kop of toelichting | — | *geen antwoordrij* |
+| `confirmation` | I confirm / do not confirm / n.v.t. / kan niet uploaden | — | `answer_code` |
+| `open_text` | vrije tekst | `min_length`, `max_length` | `answer_text` |
+| `yes_no` | ja of nee | — | `answer_code` (`yes`/`no`) |
+| `single_choice` | één optie kiezen | `options[]` | `answer_code` |
+| `multi_choice` | meerdere opties kiezen | `options[]`, `min_select`, `max_select` | `answer_codes[]` |
+| `rating` | een getal op een schaal | `min`, `max`, `min_label`, `max_label` | `answer_number` |
+| `number` | getal, bedrag of percentage | `format` (`plain`/`eur`/`usd`/`pct`), `decimals`, `min`, `max` | `answer_number` |
+| `file_upload` | alleen bestanden, geen keuze | — | *geen waarde, alleen bijlagen* |
+
+Twee typen zijn bijzonder en verdienen aandacht bij het bouwen:
+
+**`instruction` levert geen antwoord op.** Het is een leesblok. Het telt niet mee in de voortgang,
+kan niet verplicht zijn (CHECK hierboven), en er hoort geen rij in `survey_answer` bij. Bij het
+valideren van "alle vragen beantwoord?" moeten deze vragen worden overgeslagen — anders is een
+vragenlijst met een inleidend tekstblok nooit compleet in te dienen. Dit is de meest waarschijnlijke
+bug bij het bouwen van §5 stap 2.
+
+**`file_upload` heeft geen antwoordwaarde**, alleen bijlagen. Dat is iets anders dan `confirmation`
+met `allows_upload = true`, waar de leverancier zowel een keuze maakt *als* een bestand levert.
+
+### Waarom `config` een JSONB is en geen twintig kolommen
+
+De alternatieven waren: een kolom per instelling (`rating_min`, `rating_max`, `number_format`, …),
+of een aparte tabel per vraagtype. Beide zijn slechter.
+
+Kolommen per instelling geeft een tabel waarin bij elke rij het merendeel van de kolommen `NULL` is,
+en waarbij elk nieuw vraagtype een migratie kost. Een tabel per type geeft acht tabellen die
+grotendeels hetzelfde doen, met acht keer RLS en acht keer policies — en RLS is in dit project
+handwerk (ADR-010).
+
+`config` is bewust **niet** de plek waar het antwoord landt, alleen waar de vraag beschreven staat.
+Een verkeerd gevulde `config` levert een onbruikbare vraag op; hij kan nooit een antwoord vervalsen
+of RLS omzeilen.
+
+**De prijs: de database bewaakt de inhoud van `config` niet.** Een `rating` met `min = 5` en
+`max = 1` is voor Postgres een geldige rij. Dat moet in de servicelaag gevalideerd worden bij het
+opslaan van de vraag, en het is een testpunt (§8, punt 29). Dit is een bewuste afweging: de garanties
+die er echt toe doen — tenantisolatie, toelichtingsplicht, éénmaligheid — zitten wél in de database.
 
 ### Een lopende ronde bevriest de vragenlijst
 
@@ -133,7 +249,159 @@ Dat maakt de beheer-UI een afgebakende volgende stap in plaats van een blokkade 
 
 ---
 
-## 3. Het antwoordmodel
+## 2b. Lifecycle van een vragenlijst
+
+Overgenomen uit VendorComply §2.2. De statussen horen op `survey_run` (de ronde), niet op
+`survey_template` (de vragenlijst) — een template kan meerdere rondes hebben die elk hun eigen
+status doorlopen.
+
+```
+draft ──→ active ──→ finished ──→ archived
+  │                      ↑
+  └──────────────────────┘  (sluiten zonder ooit actief te zijn geweest)
+```
+
+| Status | Vendor ziet de survey | Indienen mag | Wijzigen van de template |
+|---|---|---|---|
+| `draft` | nee | nee | ja |
+| `active` | ja | ja | **nee — bevroren** |
+| `finished` | nee | nee | nee |
+| `archived` | nee | nee | nee |
+
+**`survey_run` krijgt hiervoor een `status`-kolom.** Nu heeft die tabel alleen `started_at`,
+`closes_at` en `revoked_at` — de status is daar impliciet uit af te leiden, en dat is precies het
+soort afleiding dat bij de eerste uitzondering misgaat.
+
+**Dit sluit aan op de bestaande guard.** Die weegt `closes_at` en `revoked_at` al mee en geeft 410
+bij een gesloten ronde. De statuskolom maakt dat expliciet in plaats van afgeleid; de guard moet
+uitgebreid worden zodat alles behalve `active` een 410 oplevert. Dat is een wijziging in bestaande,
+geteste code — testpunt 30.
+
+### Deadline en overdue
+
+`survey_run.closes_at` bestaat al en fungeert als deadline. VendorComply markeert verlopen surveys
+rood op beide dashboards; dat is een presentatiekwestie zonder schemawijziging — `closes_at < now()`
+bij status `active` is de volledige definitie.
+
+**Let op de bestaande asymmetrie:** de guard hanteert de striktste van `expires_at` (per token) en
+`closes_at` (per ronde). Een deadline verlengen op de ronde verlengt daarmee niet automatisch de
+tokens. Dat is verdedigbaar, maar het moet in de beheer-UI zichtbaar zijn, anders verlengt iemand de
+deadline en werkt de helft van de links alsnog niet.
+
+### Test Mode
+
+VendorComply §2.2 laat een owner een survey in een sandbox doorlopen vóór publicatie, met omzeiling
+van de normale login. Dat is waardevol — een vragenlijst met acht vragen en verplichte toelichtingen
+wil je één keer zelf doorlopen hebben.
+
+**Hoe dit hier moet werken, en waarom niet zoals VendorComply het doet:** "bypassing normal login
+requirements" is in MCM2 geen optie. De hele tokenlaag bestaat omdat toegang nooit uit
+client-invoer mag komen (MCM2-CLAUDE.md §6, Issue #7).
+
+**Voorstel: Test Mode is een echte run met een echt token, gemarkeerd als test.**
+
+```
+survey_run.is_test  BOOLEAN NOT NULL DEFAULT false
+```
+
+Een testrun gebruikt exact hetzelfde pad als een echte run — dezelfde guard, dezelfde validatie,
+dezelfde `resolve_survey_token()`. Het verschil zit uitsluitend in wat erna gebeurt: testruns tellen
+niet mee in rapportages, en de beheerder kan ze zonder bezwaar verwijderen (de enige survey-data die
+géén `ON DELETE RESTRICT` nodig heeft, want het is geen bewijsmateriaal).
+
+Dat is aantoonbaar beter dan een sandbox-route die de guard omzeilt: je test dan namelijk het
+werkelijke pad, niet een nabootsing ervan. Een sandbox die de guard overslaat, bewijst niet dat de
+echte flow werkt — en dat is nu juist wat je wilt weten vóór je twaalf leveranciers uitnodigt.
+
+---
+
+## 2c. Deelnemers toevoegen — drie routes
+
+Overgenomen uit VendorComply §2.2 fase 2. Alle drie leiden tot hetzelfde eindpunt: een
+`survey_response`-rij met een token, precies zoals de bestaande tokenlaag die aanmaakt.
+
+| Manier | Invoer | Bijzonderheid |
+|---|---|---|
+| Entity mapping | Selectie uit bestaande `vendor` / `vendor_contact` | Enige die aan een bekende vendor koppelt |
+| Quick paste | Plaktekst met e-mailadressen, komma of regeleinde gescheiden | Moet vendors aanmaken of matchen |
+| CSV-import | `.csv` met contactgegevens | Idem, plus foutrapportage per regel |
+
+**Het knelpunt zit niet in het inlezen maar in de koppeling.** `survey_response.vendor_id` is
+`NOT NULL` met een foreign key. Een geplakt e-mailadres heeft geen vendor. Er zijn twee opties, en
+dit is een besluit dat vóór het bouwen van §2c genomen moet worden:
+
+1. **Automatisch een vendor aanmaken** bij een onbekend e-mailadres, met het domein als naam.
+   Snel, maar vervuilt het vendorbestand met halve records.
+2. **Weigeren en terugmelden** welke adressen geen bekende vendor hebben, met een expliciete
+   "aanmaken"-stap. Meer handelingen, schoner bestand.
+
+Advies: **optie 2.** Het vendorbestand is bij een compliance-instrument geen bijzaak — het is de
+lijst waar de rapportage op leunt. Automatisch aanmaken levert binnen een jaar dubbele vendors op
+(`transdev.nl` en `Transdev Nederland` als twee records), en dat is achteraf duur op te ruimen.
+
+De uniciteitsregel die er al ligt, helpt hierbij: `UNIQUE (run_id, vendor_id)` op `survey_response`
+betekent dat dezelfde vendor niet twee keer in dezelfde ronde kan zitten. Een import die een vendor
+dubbel bevat, moet dus sowieso een nette fout geven in plaats van een databaseconflict.
+
+---
+
+## 2d. Import/export van de vragenlijststructuur
+
+Overgenomen uit VendorComply §2.1. Eén JSON-bestand dat de volledige structuur van een template
+beschrijft: de vragen, hun volgorde, typen en `config`.
+
+```json
+{
+  "schema_version": 1,
+  "name": "transdev-annual-vendor-it-risk",
+  "version": 1,
+  "questions": [
+    {
+      "question_key": "q1",
+      "position": 1,
+      "title": "ISO 27001 Certification Evidence",
+      "body": "…",
+      "answer_type": "confirmation",
+      "is_required": true,
+      "allows_upload": true,
+      "max_files": 2,
+      "config": {}
+    }
+  ]
+}
+```
+
+Dit levert vier dingen op waarvan er maar één expliciet gevraagd is:
+
+- **Template klonen** — exporteren en weer importeren
+- **Nieuwe versie afsplitsen** van een bevroren template (§2) is dezelfde operatie
+- **Delen tussen tenants** — met `tenant_id` die bij import opnieuw wordt gezet, nooit uit het bestand
+- **De seed van de acht Transdev-vragen** is gewoon zo'n bestand, geen apart migratiescript
+
+Die laatste is de reden om dit vroeg te bouwen in plaats van laat: het vervangt werk dat anders
+tweemaal gedaan wordt.
+
+**Drie regels die bij import hard moeten zijn:**
+
+| Regel | Waarom |
+|---|---|
+| `tenant_id` komt **nooit** uit het bestand, altijd uit de sessiecontext | Een importbestand mag geen tenantgrens kunnen oversteken |
+| `question_id` staat **niet** in het export en wordt bij import nieuw gegenereerd | Anders importeer je een verwijzing naar andermans rij |
+| `schema_version` wordt gecontroleerd | Een later formaat moet herkenbaar weigeren in plaats van half inlezen |
+
+De eerste is de belangrijkste en is precies het patroon waar Issue #7 over gaat: een veld uit
+client-invoer dat de tenant bepaalt. Een importbestand is client-invoer. Testpunt 31.
+
+---
+
+## 3. Het `confirmation`-type
+
+Dit is één van de acht typen uit §2a, en het type dat alle acht Transdev-vragen gebruiken. Het staat
+apart beschreven omdat de toelichtingsregels eromheen door de opdrachtgever zijn bevestigd en op
+databaseniveau worden afgedwongen.
+
+De regels in deze paragraaf gelden **alleen voor `confirmation`**. Voor de andere zeven typen geldt
+§3a.
 
 ### Drie opties, plus één bij een uploadvraag
 
@@ -152,8 +420,10 @@ Waarom de optie bestaat: een upload kan mislukken om redenen die niets met compl
 hebben — bestand te groot, certificaat bij een andere afdeling, NDA-beperking. Zonder deze optie
 moet een leverancier kiezen tussen een onjuist antwoord en helemaal niet indienen.
 
-De labels zijn Engels en staan vast in de code; alleen de vraagteksten komen uit de database. Dat
-is een bewuste beperking van niveau A (§1).
+De labels zijn Engels en staan vast in de code; alleen de vraagteksten komen uit de database. Dat is
+bewust: bij `confirmation` hoort de betekenis van de vier opties vast te liggen, anders is een
+jaar-op-jaar-vergelijking niet te maken. Een tenant die andere keuzeteksten wil, gebruikt
+`single_choice` — dáár komen de opties wél uit `config`.
 
 ### Wanneer een toelichting verplicht is
 
@@ -192,6 +462,55 @@ die hoort bij de opdrachtgever, niet bij een validatieregel.
 
 ---
 
+## 3a. De andere zeven typen
+
+Bij `confirmation` is de toelichtingsplicht inhoudelijk bepaald: een niet-bevestiging vraagt uitleg.
+Die redenering laat zich niet zomaar overzetten. Wat is bij een `rating` van 2 uit 5 het equivalent
+van "niet bevestigd"?
+
+**Voorstel: geen automatische toelichtingsplicht bij de andere typen. Wel per vraag instelbaar.**
+
+```
+survey_question.config.comment = "none" | "optional" | "required"
+```
+
+Standaard `optional`. De tenant die bij een rating onder een drempel uitleg wil, kan dat aanzetten —
+maar dan voor de hele vraag, niet voorwaardelijk op de gegeven waarde. Voorwaardelijke
+toelichtingsplicht is voorwaardelijke logica, en dat is niveau C.
+
+Wat wél per type geldt:
+
+| Type | Verplicht betekent | Aanvullende validatie |
+|---|---|---|
+| `instruction` | n.v.t. — kan niet verplicht zijn | geen antwoordrij toegestaan |
+| `open_text` | niet-lege tekst na `btrim` | `min_length` / `max_length` uit `config` |
+| `yes_no` | een van beide gekozen | waarde is `yes` of `no` |
+| `single_choice` | één optie gekozen | code moet in `config.options[]` voorkomen |
+| `multi_choice` | ≥ 1 optie gekozen | elke code in `options[]`; aantal binnen `min_select`/`max_select`; geen duplicaten |
+| `rating` | een waarde gekozen | geheel getal, binnen `min`…`max` |
+| `number` | een waarde ingevuld | binnen `min`…`max`; decimalen conform `config.decimals`; bij `pct` tussen 0 en 100 |
+| `file_upload` | ≥ 1 bestand geüpload | aantal ≤ `max_files` |
+
+**De ondergrens van 10 tekens geldt alleen waar een toelichting verplicht is** — dus bij
+`confirmation` altijd bij een niet-bevestiging, en elders alleen bij `comment = "required"`. Bij
+`open_text` is de tekst het antwoord zelf, niet de toelichting; daar geldt `min_length` uit `config`
+en die staat standaard op 1.
+
+**Wat de database hier wél en niet kan afdwingen.** Dit is het punt waar niveau B duurder is dan A:
+
+| Regel | Waar afgedwongen |
+|---|---|
+| Toelichtingsplicht bij `confirmation` | ✅ CHECK-constraint (§4) |
+| Waarde landt in de juiste kolom voor het type | ✅ CHECK-constraint (§4) |
+| Gekozen optie bestaat in `config.options[]` | ❌ servicelaag — vereist een blik op de vraagrij |
+| Rating binnen `min`…`max` | ❌ servicelaag — idem |
+| `multi_choice` binnen `min_select`/`max_select` | ❌ servicelaag — idem |
+
+Een CHECK kan geen andere tabel raadplegen. Deze drie regels leunen daarmee op de servicelaag, en
+dat is een reëel verschil met de garanties die dit project elders hanteert. **Wie ze in de database
+wil, heeft een trigger nodig** — uitvoerbaar, maar dat is werk dat pas de moeite waard is als blijkt
+dat de servicelaag hier daadwerkelijk faalt. Voor nu: expliciet benoemd, met testpunten 33 t/m 35.
+
 ## 4. Schema voor de antwoorden
 
 Twee tabellen naast `survey_question`, beide tenantgebonden, beide met RLS en `USING` + `WITH CHECK`
@@ -204,30 +523,90 @@ answer_id       UUID PK
 tenant_id       UUID NOT NULL              → RLS-kolom
 response_id     UUID NOT NULL              → clm.survey_response, ON DELETE RESTRICT
 question_id     UUID NOT NULL              → clm.survey_question, ON DELETE RESTRICT
-answer          TEXT NOT NULL              → confirmed | not_confirmed | not_applicable | cannot_upload
+answer_type     TEXT NOT NULL              → gekopieerd van de vraag, zie hieronder
+answer_code     TEXT NULL                  → confirmation, yes_no, single_choice
+answer_codes    TEXT[] NULL                → multi_choice
+answer_text     TEXT NULL                  → open_text
+answer_number   NUMERIC NULL               → rating, number
 comment         TEXT NULL
 created_at      TIMESTAMPTZ NOT NULL
 updated_at      TIMESTAMPTZ NULL           → concept mag bijgewerkt worden (§7)
 ```
 
+**Aparte kolommen per waardesoort, geen `answer JSONB` en geen `answer TEXT` voor alles.** Dat is de
+belangrijkste ontwerpkeuze van niveau B, en de reden is bruikbaarheid achteraf: een rating in een
+`NUMERIC` is te sorteren, te middelen en in een rapportage te aggregeren. Dezelfde waarde als tekst
+in een JSONB is dat niet — daar moet elke query eerst casten, en één niet-numerieke waarde laat de
+hele query klappen. Bij een compliance-instrument waarvan de uitkomst jaar op jaar vergeleken wordt,
+is dat het verschil tussen bruikbare en onbruikbare data.
+
+De prijs is vier kolommen die meestal `NULL` zijn. Dat is in Postgres vrijwel gratis (een NULL kost
+één bit in de row header) en het levert typering en aggregeerbaarheid op.
+
+**`answer_type` staat gedupliceerd op de antwoordrij.** Dat is bewust redundant. Het maakt de
+onderstaande CHECK-constraint mogelijk — zonder die kolom zou de constraint de vraagtabel moeten
+raadplegen, en dat kan een CHECK niet. De consistentie tussen beide wordt afgedwongen met een
+samengestelde foreign key:
+
+```sql
+-- survey_question krijgt hiervoor UNIQUE (question_id, answer_type)
+FOREIGN KEY (question_id, answer_type)
+    REFERENCES clm.survey_question (question_id, answer_type)
+```
+
+Daarmee kan `answer_type` op de antwoordrij nooit afwijken van die op de vraag — de database bewaakt
+het, niet de code.
+
 | Constraint | Dwingt af |
 |---|---|
 | `UNIQUE (response_id, question_id)` | Eén antwoord per vraag per response |
-| `CHECK (answer IN (...))` | Geen ongeldige waarde door een bug |
-| `CHECK (answer = 'confirmed' OR length(btrim(comment)) >= 10)` | Toelichtingsplicht op databaseniveau |
+| `CHECK (answer_type IN (…zeven waarden…))` | `instruction` uitgesloten: leesblok krijgt geen antwoordrij |
+| **Vormconstraint per type** (hieronder) | Waarde staat in de juiste kolom, andere kolommen leeg |
+| `CHECK (answer_type <> 'confirmation' OR answer_code = 'confirmed' OR length(btrim(comment)) >= 10)` | Toelichtingsplicht op databaseniveau |
+| `FOREIGN KEY (question_id, answer_type)` | Type van het antwoord matcht het type van de vraag |
 | `question_id → survey_question ON DELETE RESTRICT` | Antwoorden verdwijnen niet stilzwijgend |
+
+De vormconstraint zorgt dat elk type precies één waardekolom vult en de rest leeg laat:
+
+```sql
+CHECK (
+  CASE answer_type
+    WHEN 'confirmation'   THEN answer_code  IS NOT NULL AND answer_codes IS NULL
+                               AND answer_text IS NULL AND answer_number IS NULL
+    WHEN 'yes_no'         THEN answer_code  IN ('yes','no') AND answer_codes IS NULL
+                               AND answer_text IS NULL AND answer_number IS NULL
+    WHEN 'single_choice'  THEN answer_code  IS NOT NULL AND answer_codes IS NULL
+                               AND answer_text IS NULL AND answer_number IS NULL
+    WHEN 'multi_choice'   THEN answer_codes IS NOT NULL AND array_length(answer_codes,1) >= 1
+                               AND answer_code IS NULL AND answer_text IS NULL
+                               AND answer_number IS NULL
+    WHEN 'open_text'      THEN answer_text  IS NOT NULL AND length(btrim(answer_text)) >= 1
+                               AND answer_code IS NULL AND answer_codes IS NULL
+                               AND answer_number IS NULL
+    WHEN 'rating'         THEN answer_number IS NOT NULL AND answer_number = trunc(answer_number)
+                               AND answer_code IS NULL AND answer_codes IS NULL
+                               AND answer_text IS NULL
+    WHEN 'number'         THEN answer_number IS NOT NULL
+                               AND answer_code IS NULL AND answer_codes IS NULL
+                               AND answer_text IS NULL
+    WHEN 'file_upload'    THEN answer_code IS NULL AND answer_codes IS NULL
+                               AND answer_text IS NULL AND answer_number IS NULL
+  END
+)
+```
+
+Zonder deze constraint kan een bug een rating als tekst wegschrijven of een keuzecode in
+`answer_number` proppen. Dat merk je pas maanden later bij de eerste rapportage, wanneer de data
+niet meer te repareren is omdat niemand weet wat er oorspronkelijk bedoeld was.
 
 **Verschil met de eerste versie:** `question_id` als echte foreign key, niet `question_key` als
 losse tekst. Nu de vragen in de database staan, is er een tabel om naar te verwijzen — en dan hoort
 de koppeling ook door de database bewaakt te worden.
 
-De derde constraint is de kern: dezelfde regel als §3, maar afgedwongen door de database. Een fout
-in de validatiecode levert dan een databasefout op, geen halfleeg compliance-antwoord dat er
-volledig uitziet.
-
 **Wat de database niet kan afdwingen:** dat `cannot_upload` alleen voorkomt bij een vraag met
-`allows_upload = true`. Dat vereist een blik op een andere tabel, wat een CHECK niet kan. Dit hoort
-in de validatie én in een trigger — zie testpunt 17 in §8.
+`allows_upload = true`, en dat een gekozen optie daadwerkelijk in `config.options[]` staat (§3a).
+Beide vereisen een blik op de vraagrij, wat een CHECK niet kan. Dit hoort in de validatie én in een
+trigger — zie testpunten 17 en 33 in §8.
 
 ### `clm.survey_attachment`
 
@@ -281,25 +660,51 @@ aanval maar normaal gedrag van iemand met een script.
 
 ```
 1.  Tokencontrole (bestaand, ontwerp §5 + §5a)          → 404 / 410
-2.  Alle vragen van deze template beantwoord?           → 422, met de ontbrekende keys
+1b. Ronde heeft status 'active'? (§2b)                  → 410
+2.  Alle verplichte vragen beantwoord?                  → 422, met de ontbrekende keys
+    → vragen met answer_type = 'instruction' overslaan
+    → vragen met is_required = false overslaan
 3.  Onbekende question_id meegestuurd?                  → 422
 4.  Hoort de question_id bij de template van deze run?  → 422
-5.  Antwoordwaarde geldig voor déze vraag?              → 422  (cannot_upload alleen bij upload)
-6.  Toelichting verplicht en aanwezig, ≥ 10 tekens?     → 422, per vraag benoemd
-7.  Toelichting ≤ 2.000 tekens?                         → 422
-8.  Bij confirmed op een uploadvraag: ≥ 1 bestand?      → 422
-9.  Aantal bestanden ≤ max_files van die vraag?         → 422
-10. Atomair indienen (bestaand, ontwerp §5)             → 410 bij tweede poging
+5.  answer_type in het antwoord = dat van de vraag?     → 422
+6.  Waarde geldig voor dít type? (§3a-tabel)            → 422
+    → single/multi_choice: code bestaat in config.options[]
+    → multi_choice: aantal binnen min_select/max_select, geen duplicaten
+    → rating: geheel getal binnen min…max
+    → number: binnen min…max, decimalen conform config, pct tussen 0 en 100
+    → open_text: lengte binnen min_length…max_length
+    → confirmation: cannot_upload alleen bij allows_upload = true
+7.  Toelichting verplicht en aanwezig, ≥ 10 tekens?     → 422, per vraag benoemd
+    → confirmation: verplicht bij alles behalve 'confirmed'
+    → overige typen: alleen bij config.comment = 'required'
+8.  Toelichting ≤ 2.000 tekens?                         → 422
+9.  Bij confirmed op een uploadvraag: ≥ 1 bestand?      → 422
+9b. Bij answer_type = 'file_upload': ≥ 1 bestand?       → 422
+10. Aantal bestanden ≤ max_files van die vraag?         → 422
+11. Atomair indienen (bestaand, ontwerp §5)             → 410 bij tweede poging
 ```
 
-Stap 4 is nieuw ten opzichte van de eerste versie en is niet cosmetisch: nu vragen per tenant
-verschillen, moet gecontroleerd worden dat een meegestuurde `question_id` daadwerkelijk bij de
-template van *deze* run hoort. Zonder die controle kan een `question_id` van een andere template
-meeliften. RLS beschermt tegen een andere *tenant*, niet tegen een andere template binnen dezelfde
-tenant.
+Vier stappen verdienen toelichting.
 
-**Stap 2 t/m 9 vóór stap 10.** Eerst alles valideren, dan pas de status op `submitted` zetten. Bij
-een fout in stap 6 mag de response niet half ingediend achterblijven — dan is de link verbruikt
+**Stap 1b is nieuw** en volgt uit de statuskolom op `survey_run` (§2b). De bestaande guard weegt
+`closes_at` en `revoked_at`; die moet nu ook de status meewegen.
+
+**Stap 2 heeft twee uitzonderingen die makkelijk vergeten worden.** Een `instruction` is een leesblok
+en levert nooit een antwoord op; een vraag met `is_required = false` mag leeg blijven. Wie beide
+vergeet, bouwt een vragenlijst die met een inleidend tekstblok nooit in te dienen is. Dit is de
+waarschijnlijkste bug in deze paragraaf — testpunt 32.
+
+**Stap 4 is niet cosmetisch:** nu vragen per tenant verschillen, moet gecontroleerd worden dat een
+meegestuurde `question_id` daadwerkelijk bij de template van *deze* run hoort. Zonder die controle
+kan een `question_id` van een andere template meeliften. RLS beschermt tegen een andere *tenant*,
+niet tegen een andere template binnen dezelfde tenant.
+
+**Stap 5 is nieuw bij niveau B.** De client stuurt een antwoord met een type mee; dat type moet
+overeenkomen met wat de vraag voorschrijft. De samengestelde foreign key uit §4 vangt dit ook af,
+maar dan als databasefout in plaats van een leesbare 422.
+
+**Stap 2 t/m 10 vóór stap 11.** Eerst alles valideren, dan pas de status op `submitted` zetten. Bij
+een fout in stap 7 mag de response niet half ingediend achterblijven — dan is de link verbruikt
 terwijl er niets bruikbaars staat, en dat is onherstelbaar omdat het token gehasht is.
 
 Alles gebeurt in één transactie: antwoorden, statuswijziging en auditregel. Faalt er iets, dan
@@ -407,8 +812,13 @@ Achter de Entra-guard uit spoor 1, dus **nog niet te bouwen** (§2). Voor de vol
 | `GET/POST/PUT /admin/survey/templates` | Vragenlijsten beheren |
 | `POST /admin/survey/templates/:id/copy` | Nieuwe versie afsplitsen van een bevroren template |
 | `GET/POST/PUT/DELETE /admin/survey/templates/:id/questions` | Vragen beheren |
+| `GET /admin/survey/templates/:id/export` | JSON-schema exporteren (§2d) |
+| `POST /admin/survey/templates/import` | JSON-schema importeren (§2d) |
+| `POST /admin/survey/runs/:id/participants` | Deelnemers toevoegen, drie manieren (§2c) |
+| `POST /admin/survey/runs/:id/status` | Lifecycle-overgang (§2b) |
+| `POST /admin/survey/runs/test` | Testrun starten met `is_test = true` (§2b) |
 
-### Concept opslaan
+### Concept opslaan — expliciet, niet automatisch
 
 Acht vragen met verplichte toelichtingen vul je niet in één keer in. Iemand die bij vraag 6 moet
 nazoeken of dat incident wel binnen 48 uur gemeld is, verliest bij het sluiten van het tabblad
@@ -418,6 +828,13 @@ Daarom: **antwoorden mogen opgeslagen worden vóór het indienen.** `survey_answ
 terwijl de response nog `pending` is; indienen zet alleen de status. Dat werkt zonder extra
 tabellen, mits het schrijven geblokkeerd wordt zodra de status `submitted` is — anders is de
 éénmaligheid uit AC12 alsnog omzeilbaar.
+
+**Geen auto-save** (besluit 2026-07-29, §1b). De leverancier slaat expliciet op met een knop; er
+wordt niet tijdens het typen weggeschreven. Dat scheelt een aanzienlijke hoeveelheid werk aan
+conflictafhandeling en debounce-logica, en het houdt het aantal schrijfacties op de database laag.
+
+**Geen herziening na indienen** (idem). Zodra de status `submitted` is, ligt alles vast. De
+`WITH CHECK`-policy hieronder is precies wat dat afdwingt.
 
 Die blokkade hoort in de RLS-policy, niet alleen in code:
 
@@ -434,11 +851,20 @@ EXISTS (
 
 Hetzelfde geldt voor `survey_attachment`: na indienen geen uploads meer.
 
-**Let op bij een concept:** de CHECK-constraint op de toelichtingsplicht (§4) geldt óók tijdens het
-opslaan van een concept. Iemand die vraag 4 alvast op `not_confirmed` zet zonder toelichting, kan
-dat concept niet bewaren. Dat is streng maar verdedigbaar; het alternatief (de constraint pas bij
-indienen afdwingen) betekent dat de database de garantie niet meer draagt. Als dit in de praktijk
-knelt, is de oplossing een aparte conceptstatus per antwoord — niet het weghalen van de constraint.
+**Let op bij een concept:** de CHECK-constraints uit §4 gelden óók tijdens het opslaan van een
+concept. Iemand die vraag 4 alvast op `not_confirmed` zet zonder toelichting, kan dat concept niet
+bewaren. Hetzelfde geldt voor de vormconstraint: een half ingevuld antwoord past er niet in.
+
+Dat is streng maar verdedigbaar; het alternatief (de constraints pas bij indienen afdwingen)
+betekent dat de database de garantie niet meer draagt. **De praktische vorm is dat een concept
+alleen volledig ingevulde antwoorden bevat** — een vraag is af of hij staat er niet in. Dat is
+werkbaar: de leverancier vult vraag 1 t/m 3 in, slaat op, en gaat later verder met 4 t/m 8.
+
+Wat dit uitsluit is het halverwege bewaren van één vraag ("ik heb `not_confirmed` gekozen maar de
+toelichting nog niet geschreven"). Als dat in de praktijk knelt, is de oplossing een aparte
+conceptkolom of een conceptstatus per antwoord — niet het weghalen van de constraint. Zonder
+auto-save (§1b) is de kans dat dit knelt aanzienlijk kleiner, want de leverancier bepaalt zelf
+wanneer er opgeslagen wordt.
 
 ---
 
@@ -464,14 +890,36 @@ Aanvullend op de 13 punten uit het tokenontwerp §6:
 | 27 | Een vraag van een template met een lopende run is niet te wijzigen — op databaseniveau |
 | 28 | Kopiëren naar een nieuwe versie laat lopende responses ongemoeid |
 
-Punt 15, 23 en 27 zijn de belangrijkste: die toetsen dat de garantie in de database zit en niet
-alleen in de applicatiecode. Alle drie moeten getest worden met directe SQL die de applicatielaag
-overslaat — anders test je je eigen validatiecode en niet de garantie.
+Aanvullend uit niveau B (§1) en de VendorComply-overname (§1a):
+
+| # | Bewijs |
+|---|---|
+| 29 | Een `rating` met `min > max` in `config` wordt geweigerd bij het opslaan van de vraag |
+| 30 | Een ronde met status ≠ `active` levert 410 op, ook binnen `closes_at` (§2b) |
+| 31 | Een importbestand met een vreemde `tenant_id` importeert in de eigen tenant, nooit die uit het bestand (§2d) |
+| 32 | Een vragenlijst met een `instruction`-blok is in te dienen zonder antwoord op dat blok (§5 stap 2) |
+| 33 | Een `single_choice` met een code die niet in `config.options[]` staat, wordt geweigerd |
+| 34 | Een `rating` buiten `min`…`max` wordt geweigerd; een niet-geheel getal eveneens |
+| 35 | `multi_choice` met duplicaten of buiten `min_select`/`max_select` wordt geweigerd |
+| 36 | Een antwoord met een `answer_type` dat afwijkt van de vraag faalt — op de foreign key, niet op code |
+| 37 | Een `rating`-waarde in `answer_text` faalt op de vormconstraint (§4) |
+| 38 | Een testrun (`is_test = true`) doorloopt exact hetzelfde guardpad als een echte run |
+
+Punt 15, 23, 27, 36 en 37 zijn de belangrijkste: die toetsen dat de garantie in de database zit en
+niet alleen in de applicatiecode. Alle vijf moeten getest worden met directe SQL die de
+applicatielaag overslaat — anders test je je eigen validatiecode en niet de garantie.
 
 Punt 25 sluit het risico af waar §5 voor waarschuwt: een half verbruikte link is onherstelbaar.
 
-Punt 26, 27 en 28 zijn nieuw en vloeien rechtstreeks voort uit de koerswijziging: zodra de tenant
-zelf vragen opstelt, ontstaan fouten die bij een vaste vragenlijst niet konden bestaan.
+Punt 26, 27 en 28 vloeien voort uit de koerswijziging: zodra de tenant zelf vragen opstelt, ontstaan
+fouten die bij een vaste vragenlijst niet konden bestaan.
+
+Punt 32 is de meest waarschijnlijke bug van het hele ontwerp. Een `instruction`-blok dat meetelt als
+onbeantwoorde vraag maakt de vragenlijst onindienbaar, en dat merk je pas bij de eerste template die
+er een gebruikt — niet bij de acht Transdev-vragen, want die hebben er geen.
+
+Punt 31 is de zwaarste in beveiligingstermen: een importbestand is client-invoer, en `tenant_id`
+daaruit overnemen is exact het patroon dat Issue #7 verbiedt.
 
 ---
 
@@ -479,46 +927,92 @@ zelf vragen opstelt, ontstaan fouten die bij een vaste vragenlijst niet konden b
 
 | Onderwerp | Reden |
 |---|---|
-| Antwoordtypen naast bevestiging | Niveau B uit §1; datamodel is erop voorbereid |
-| Voorwaardelijke logica, secties | Niveau C uit §1; apart product |
+| Voorwaardelijke logica (logic jumps), secties | Niveau C. Uitgesteld op 2026-07-29 (§1a). Eigen bouwstap ná een werkende B. |
+| AI-beoordeling (Gemini) | Uitgesteld op 2026-07-29 (§1a). Externe dienst plus een openstaande verwerkersvraag. |
+| EFQM KPI-sync | Uitgesteld op 2026-07-29 (§1a) |
+| Marketing Mode (publieke anonieme surveys) | Uitgesteld op 2026-07-29 (§1a). Botst met één-link-per-vendor. |
+| Radar/spider charts, rapportage | Uitgesteld op 2026-07-29 (§1a). Volgt op werkende data. |
+| Auto-save tijdens typen | Uitgesteld op 2026-07-29 (§1b). Expliciet opslaan blijft wel. |
+| Herzien na indienen / "request revisions" | Uitgesteld op 2026-07-29 (§1b). Zou de éénmaligheid van het token doorbreken. |
 | Virusscan | OV-7 onbeantwoord; risico en haakpunt benoemd in §6. Aparte issue. |
 | Nederlandse vertaling | Alleen Engels, zoals besloten. Structuur belet een latere vertaling niet. |
 | Objectopslag | Fase 2; `storage_key` is er al op voorbereid |
 | Beheer-UI | Wacht op spoor 1 (Entra-guard); datamodel en validatie kunnen vooruit |
 | Herinneringsmails | Wacht op OV-9 (SMTP) |
-| Export van ingediende antwoorden | OV-4, apart spoor |
+| Export van ingediende antwoorden | OV-4, apart spoor. **Niet te verwarren met §2d**, dat de vragenlijst*structuur* exporteert, niet de antwoorden. |
 
 ---
 
-## 10. Volgorde (na goedkeuring van §1)
+## 10. Bouwvolgorde
 
-1. Migratie: `survey_question`, `survey_answer`, `survey_attachment` — met RLS, policies,
-   CHECK-constraints en de bevriezingstrigger uit §2
-2. Seed met de acht Transdev-vragen als template `transdev-annual-vendor-it-risk` v1
-3. Validatie- en indienlogica; `POST /survey/respond` uitbreiden met de antwoordbody
-4. `GET /survey/respond/questions` en `PUT /survey/respond/answers` (concept)
-5. Bestandsupload met inhoudscontrole
-6. Tests 14 t/m 28
-7. Issue aanmaken voor de virusscan; backup van bestanden meenemen in #30
-8. Beheerroutes zodra spoor 1 (Entra-guard) er is
+De volgorde is zo gekozen dat er na elke stap iets werkt dat te testen is, en dat de stappen die de
+bestaande, groene tokenlaag raken zo vroeg mogelijk komen — daar is de kans op verrassingen het
+grootst.
 
-Stap 1 is de plek waar het misgaat als het misgaat: drizzle-kit genereert geen RLS, geen
+| # | Stap | Levert op |
+|---|---|---|
+| 1 | Migratie: `survey_question`, `survey_answer`, `survey_attachment`, plus `status` en `is_test` op `survey_run` — met RLS, policies, CHECK-constraints, de samengestelde FK uit §4 en de bevriezingstrigger uit §2 | Het datamodel staat |
+| 2 | Guard uitbreiden met de statuscontrole (§2b, stap 1b) | Bestaande laag blijft groen — testpunt 30 |
+| 3 | Import/export van het JSON-schema (§2d) | Nodig voor stap 4; levert klonen en versioneren mee |
+| 4 | Seed: de acht Transdev-vragen als template `transdev-annual-vendor-it-risk` v1, via stap 3 | De PoC-vulling |
+| 5 | `GET /survey/respond/questions` — vragen ophalen incl. `config` per type | Leverancier ziet de vragenlijst |
+| 6 | Validatie- en indienlogica (§5); `POST /survey/respond` uitbreiden met de antwoordbody | De kern |
+| 7 | `PUT /survey/respond/answers` (concept, expliciet opslaan) | Bruikbaar bij acht vragen |
+| 8 | Bestandsupload met inhoudscontrole (§6) | Issue #9 |
+| 9 | Tests 14 t/m 38 | Bewijs |
+| 10 | Beheerroutes: lifecycle, deelnemers, templatebeheer — zodra spoor 1 (Entra-guard) er is | Tenant beheert zelf |
+
+**Stap 3 vóór stap 4 is bewust.** De seed is gewoon een importbestand; als import eerst werkt,
+bestaat er geen apart seed-script dat later uit de pas loopt met het echte importpad.
+
+**Stap 1 is de plek waar het misgaat als het misgaat:** drizzle-kit genereert geen RLS, geen
 CHECK-constraints en geen triggers — die zijn handwerk, zoals in ADR-010 vastgelegd en bij migratie
-0003 al gebleken.
+0003 al gebleken. De vormconstraint uit §4 en de samengestelde foreign key zijn hier de twee stukken
+die met de hand geschreven en met directe SQL getoetst moeten worden.
+
+**Stap 10 blokkeert de rest niet.** Tot spoor 1 er is, komt de vragenlijst via import (stap 3) in de
+database. De leverancierskant werkt dan volledig.
 
 ---
 
 ## 11. Openstaande punten
 
-- **BLOKKEREND — niveau A, B of C** (§1). Zonder dit antwoord is §2 niet definitief.
-- **Bevriezing van een lopende ronde** (§2) is mijn voorstel, niet bevestigd. Het is de regel die
-  bepaalt of antwoorden achteraf nog interpreteerbaar zijn.
-- **Verplichte toelichting bij `not_confirmed`** is mijn afleiding, niet bevestigd (§3).
+**Beslist op 2026-07-29, niet langer open:**
+
+- ~~Niveau A, B of C~~ → **B** (§1)
+- ~~Auto-save en "request revisions"~~ → **beide niet** (§1b)
+- ~~Welke VendorComply-features overnemen~~ → zie de twee tabellen in §1a
+
+**Nog open — voorstellen van mij, niet bevestigd:**
+
+- **Bevriezing van een lopende ronde** (§2). Het is de regel die bepaalt of antwoorden achteraf nog
+  interpreteerbaar zijn. Ik zou hem aanhouden, maar hij is niet expliciet bevestigd.
+- **Verplichte toelichting bij `not_confirmed`** (§3). Mijn afleiding uit de bevestigde regels voor
+  `not_applicable` en `cannot_upload`.
+- **Onbekend e-mailadres bij import: weigeren of vendor aanmaken** (§2c). Advies: weigeren. Dit moet
+  vóór stap 10 beslist zijn, niet eerder.
+- **Toelichting bij de andere zeven typen is per vraag instelbaar en staat standaard op optioneel**
+  (§3a). Alternatief zou zijn: nooit een toelichting buiten `confirmation`.
+
+**Bekende beperkingen, bewust geaccepteerd:**
+
+- **Drie validatieregels leunen op de servicelaag, niet op de database** (§3a): geldige optiecode,
+  rating binnen bereik, `multi_choice`-aantallen. Een CHECK kan de vraagrij niet raadplegen. Een
+  trigger zou dit oplossen; dat is werk dat pas loont als de servicelaag hier aantoonbaar faalt.
+- **`config` wordt door de database niet inhoudelijk bewaakt** (§2a). Een `rating` met `min > max`
+  is voor Postgres een geldige rij. Validatie zit in de servicelaag, testpunt 29.
 - **5 MB per bestand, niet totaal.** Bij twee bestanden is de bovengrens dus 10 MB. Zo gelezen uit
   "files not larger than 5MB".
 - **Geen virusscan** (§6). Risico benoemd; de keuze om zonder te gaan is aan de opdrachtgever.
 - **Bestanden vallen buiten de huidige backup** (§6, raakt #30).
+- **Conceptopslag vereist volledig ingevulde antwoorden** (§7). Een half ingevulde vraag past niet
+  in de constraints. Werkbaar, maar het is een echte beperking.
+
+**Werk dat niet vergeten mag worden:**
+
 - **De bestaande `POST /survey/respond`-test** verwacht een lege body en moet aangepast worden.
-  Geen ontwerpkwestie, wel werk dat niet vergeten mag worden.
-- **Conceptopslag botst met de toelichting-constraint** (§7). Verdedigbaar, maar het kan in de
-  praktijk knellen.
+- **De bestaande guard krijgt een statuscontrole** (§2b). Dat is een wijziging in code die nu groen
+  is; testpunt 30 hoort daarbij geschreven te worden vóór de wijziging.
+- **`survey_run` krijgt twee kolommen** (`status`, `is_test`) die er nu niet zijn.
+- **`survey_question` krijgt `UNIQUE (question_id, answer_type)`** — nodig voor de samengestelde
+  foreign key uit §4, en niet vanzelfsprekend op een kolom die al primary key is.

--- a/docs/superpowers/specs/2026-07-28-vragenlijst-ontwerp.md
+++ b/docs/superpowers/specs/2026-07-28-vragenlijst-ontwerp.md
@@ -308,6 +308,7 @@ De template bestaat al (`clm.survey_template`, met `name` en `version`); die kri
 question_id     UUID PK
 tenant_id       UUID NOT NULL              → RLS-kolom
 template_id     UUID NOT NULL              → clm.survey_template, ON DELETE RESTRICT
+category_id     UUID NULL                  → clm.survey_category; leeg = platte lijst
 position        INTEGER NOT NULL           → volgorde, 1-based
 question_key    TEXT NOT NULL              → 'q1' … 'q8', stabiel over versies heen
 title           TEXT NOT NULL              → korte kop ("ISO 27001 Certification Evidence")
@@ -329,6 +330,13 @@ created_at      TIMESTAMPTZ NOT NULL
 | `CHECK (allows_upload = true OR max_files = 0)` | Een maximum zonder upload evenmin |
 | `CHECK (answer_type <> 'instruction' OR is_required = false)` | Een leesblok kan niet verplicht zijn |
 | `template_id → survey_template ON DELETE RESTRICT` | Vragen verdwijnen niet stilzwijgend |
+| `category_id → survey_category ON DELETE RESTRICT` | Een categorie met vragen is niet te verwijderen |
+
+**De categorie moet bij dezelfde template horen als de vraag.** Een `category_id` van een andere
+template mag niet meeliften — hetzelfde risico als §5 stap 4 bij `question_id`. Dat vraagt een
+samengestelde foreign key: `survey_category` krijgt `UNIQUE (category_id, template_id)`, waarna
+`survey_question` verwijst met `FOREIGN KEY (category_id, template_id)`. Zo bewaakt de database het
+in plaats van de servicelaag. Testpunt 45.
 
 `question_key` is bewust een stabiele tekstsleutel naast de UUID. Bij een nieuwe templateversie
 krijgt vraag 4 een nieuwe `question_id`, maar behoudt `question_key = 'q4'` — zo blijven antwoorden
@@ -336,6 +344,53 @@ over versies heen vergelijkbaar. Zonder dat is een jaar-op-jaar-vergelijking nie
 is bij een jaarlijkse compliance-survey precies het punt.
 
 Voor Transdev vraag 1: `answer_type = 'confirmation'`, `allows_upload = true`, `max_files = 2`.
+
+### `clm.survey_category`
+
+Toegevoegd op 2026-07-29, nadat MVM_V2 functioneel leidend werd verklaard voor de vragenlijst. De
+interne beoordeling daar (`transdevSurveyTemplate`) heeft **vijf categorieën met 29 vragen**:
+Duidelijkheid, Behoefte, Kwaliteit, Kosten en Besturing. Dat is geen placeholder maar een
+uitgewerkte vragenlijst die de klant gezien heeft.
+
+```
+category_id     UUID PK
+tenant_id       UUID NOT NULL              → RLS-kolom
+template_id     UUID NOT NULL              → clm.survey_template, ON DELETE RESTRICT
+position        INTEGER NOT NULL           → volgorde van de categorieën
+name            TEXT NOT NULL              → 'Duidelijkheid', 'Kwaliteit', …
+min_answers     SMALLINT NOT NULL DEFAULT 0 → minimaal ingevuld voor een geldige score
+created_at      TIMESTAMPTZ NOT NULL
+```
+
+| Constraint | Dwingt af |
+|---|---|
+| `UNIQUE (template_id, position)` | Geen twee categorieën op dezelfde plek |
+| `UNIQUE (template_id, name)` | Geen twee categorieën met dezelfde naam |
+| `CHECK (min_answers >= 0)` | Geen negatieve drempel |
+| `template_id → survey_template ON DELETE RESTRICT` | Categorieën verdwijnen niet stilzwijgend |
+
+`survey_question` krijgt daarbij:
+
+```
+category_id     UUID NULL                  → clm.survey_category, ON DELETE RESTRICT
+```
+
+**Nullable, en dat is bewust.** UC1 (de acht Transdev-vragen) heeft géén categorieën; UC2 heeft er
+vijf. Een verplichte categorie zou UC1 dwingen tot een kunstmatige "Algemeen"-categorie die nergens
+getoond wordt. Een vragenlijst is dus óf ingedeeld óf een platte lijst — beide zijn geldig.
+
+**`min_answers` komt uit MVM_V2's `minAnswersPerCategory`** en heeft daar een concrete functie: is
+een categorie met minder dan dit aantal ingevulde vragen beantwoord, dan is de categoriescore
+`null` in plaats van een gemiddelde over te weinig punten. Bij de Transdev-beoordeling staat die op
+3. Zonder die drempel zou één ingevulde vraag uit vier een "score" opleveren die als volwaardig
+oogt.
+
+**Wat dit betekent voor scoreberekening.** MVM_V2 berekent het gemiddelde per categorie en daarna
+het gemiddelde over de categorieën — niet het gemiddelde over alle vragen. Dat is een wezenlijk
+verschil: een categorie met vier vragen weegt daardoor even zwaar als een met acht. Die berekening
+hoort **niet** in de database maar in de servicelaag (in MVM_V2 zit hij in
+`internalSurveyService`), en de uitkomst wordt bewust niet opgeslagen — hij is altijd af te leiden
+uit de antwoorden. Rapportage is uitgesteld (§1a), maar het datamodel belet deze berekening niet.
 
 ### 2a. De acht antwoordtypen
 
@@ -561,9 +616,13 @@ beschrijft: de vragen, hun volgorde, typen en `config`.
   "schema_version": 1,
   "name": "transdev-annual-vendor-it-risk",
   "version": 1,
+  "categories": [
+    { "key": "duidelijkheid", "position": 1, "name": "Duidelijkheid", "min_answers": 3 }
+  ],
   "questions": [
     {
       "question_key": "q1",
+      "category_key": "duidelijkheid",
       "position": 1,
       "title": "ISO 27001 Certification Evidence",
       "body": "…",
@@ -593,6 +652,7 @@ tweemaal gedaan wordt.
 |---|---|
 | `tenant_id` komt **nooit** uit het bestand, altijd uit de sessiecontext | Een importbestand mag geen tenantgrens kunnen oversteken |
 | `question_id` staat **niet** in het export en wordt bij import nieuw gegenereerd | Anders importeer je een verwijzing naar andermans rij |
+| Categorieën worden aangeduid met `category_key`, niet met een UUID | Zelfde reden; de koppeling wordt bij import gelegd. `category_key` leeg of afwezig = vraag zonder categorie |
 | `schema_version` wordt gecontroleerd | Een later formaat moet herkenbaar weigeren in plaats van half inlezen |
 
 De eerste is de belangrijkste en is precies het patroon waar Issue #7 over gaat: een veld uit
@@ -1122,6 +1182,15 @@ Aanvullend uit de twee use cases (§1c):
 | 43 | Bij `survey_kind = 'internal_review'` faalt een respons met een gevulde `vendor_id` |
 | 44 | Een UC2-respons is in te dienen zonder enig `clm.user`-record voor de invuller |
 
+Aanvullend uit de categorieën (§2):
+
+| # | Bewijs |
+|---|---|
+| 45 | Een vraag met een `category_id` van een andere template faalt — op de samengestelde FK, niet op code |
+| 46 | Een vragenlijst zonder categorieën (UC1) is volledig in te dienen — `category_id` mag leeg blijven |
+| 47 | Een categorie met vragen eraan is niet te verwijderen (`ON DELETE RESTRICT`) |
+| 48 | Import legt de categoriekoppeling via `category_key`, en genereert nieuwe UUID's |
+
 Punt 15, 23, 27, 36 en 37 zijn de belangrijkste: die toetsen dat de garantie in de database zit en
 niet alleen in de applicatiecode. Alle vijf moeten getest worden met directe SQL die de
 applicatielaag overslaat — anders test je je eigen validatiecode en niet de garantie.
@@ -1180,7 +1249,7 @@ grootst.
 
 | # | Stap | Levert op |
 |---|---|---|
-| 1 | Migratie: `survey_question`, `survey_answer`, `survey_attachment`, plus `status`, `is_test` en `survey_kind` op `survey_run` en de vier respondentkolommen op `survey_response` (§1c) — met RLS, policies, CHECK-constraints, de partiële unieke index, de samengestelde FK uit §4 en de bevriezingstrigger uit §2 | Het datamodel staat, beide use cases |
+| 1 | Migratie: `survey_category`, `survey_question`, `survey_answer`, `survey_attachment`, plus `status`, `is_test` en `survey_kind` op `survey_run` en de vier respondentkolommen op `survey_response` (§1c) — met RLS, policies, CHECK-constraints, de partiële unieke index, beide samengestelde FK's (§2 en §4) en de bevriezingstrigger uit §2 | Het datamodel staat, beide use cases |
 | 2 | Guard uitbreiden met de statuscontrole (§2b, stap 1b) | Bestaande laag blijft groen — testpunt 30 |
 | 3 | Import/export van het JSON-schema (§2d) | Nodig voor stap 4; levert klonen en versioneren mee |
 | 4 | Seed: de acht Transdev-vragen als template `transdev-annual-vendor-it-risk` v1 (UC1) plus een korte interne beoordelingsvragenlijst (UC2), beide via stap 3 | Beide use cases gevuld |
@@ -1216,20 +1285,10 @@ database. De leverancierskant werkt dan volledig.
 - ~~Meerdere collega's per leverancier~~ → **ja** (§1c). `UNIQUE (run_id, vendor_id)` wordt
   partieel.
 - ~~Ziet de leverancier de interne score~~ → **nee, volledig intern** (§1c)
-
-**BLOKKEREND voor stap 1 van de bouwvolgorde — één vraag:**
-
-- **Heeft de interne beoordeling (UC2) categorieën met een score per categorie?** MVM_V2 heeft ze
-  (`InternalSurveyTemplate.categories[]`, met `minAnswersPerCategory` en een berekende score per
-  categorie), en het portaalscherm toont de vragenlijst daar als stappen per categorie.
-  VendorComply noemde hetzelfde onder "topic sections". Bij de acht Transdev-vragen (UC1) zijn er
-  géén categorieën.
-
-  Dit staat als enige punt vóór de migratie, want het is een tabel erbij (`survey_category`) plus
-  een verwijzing op `survey_question`. **Achteraf toevoegen raakt elke query, elk scherm en de
-  scoreberekening** — dat is de reden dat dit blokkerend is en `date` niet.
-
-  Als het antwoord "één lijst, één totaalscore" is, blijft het ontwerp zoals het nu staat.
+- ~~`frameworkRef` en `date` overnemen uit MVM_V2~~ → **geen van beide** (§1a-bis)
+- ~~Categorieën met score per categorie~~ → **ja** (§2). MVM_V2 is functioneel leidend voor de
+  vragenlijst; de interne beoordeling daar heeft vijf categorieën met 29 vragen. `category_id` is
+  nullable, want UC1 heeft er geen.
 
 **Nog open — voorstellen van mij, niet bevestigd:**
 
@@ -1276,6 +1335,10 @@ database. De leverancierskant werkt dan volledig.
   bestaande tests 39 t/m 43 dekken** — een `NOT NULL` weghalen zonder vervanging is precies hoe
   garanties stilletjes verdwijnen.
 - **`survey_question` krijgt `UNIQUE (question_id, answer_type)`** — nodig voor de samengestelde
-  foreign key uit §4, en niet vanzelfsprekend op een kolom die al primary key is.
+  foreign key uit §4, en niet vanzelfsprekend op een kolom die al primary key is. Hetzelfde geldt
+  voor `survey_category` met `UNIQUE (category_id, template_id)` (§2).
+- **De scoreberekening per categorie hoort in de servicelaag, niet in de database** (§2). MVM_V2
+  middelt per categorie en daarna over de categorieën — niet over alle vragen. Dat verschil is
+  merkbaar zodra categorieën ongelijke aantallen vragen hebben.
 - **Twee beheerschermen, niet één** (§2c). Bij UC1 is de leverancier de deelnemer, bij UC2 het
   onderwerp. Een gedeeld scherm met een schakelaar doet beide half.

--- a/docs/superpowers/specs/2026-07-28-vragenlijst-ontwerp.md
+++ b/docs/superpowers/specs/2026-07-28-vragenlijst-ontwerp.md
@@ -138,6 +138,45 @@ Concept opslaan blijft nodig om een praktische reden die niets met auto-save te 
 vragen met verplichte toelichtingen vul je niet in één keer in, en het token is gehasht en dus niet
 opnieuw te versturen. Zonder opslaan verliest iemand die een tabblad sluit alles, onherstelbaar.
 
+### 1a-bis. Vergelijking met MVM_V2 (2026-07-29)
+
+MVM_V2 heeft al werkende surveyschermen op mock data, en de klant heeft die gezien. Ze zijn op
+2026-07-29 vergeleken met dit ontwerp. **De twee modellen zijn onafhankelijk van elkaar ontworpen
+en komen grotendeels overeen** — dat is een sterker signaal dan wanneer ze op elkaar waren
+afgestemd.
+
+| MVM_V2 (`src/core/models/index.ts`) | Dit ontwerp | Uitkomst |
+|---|---|---|
+| `QuestionType`: `text \| yes_no \| multiple_choice \| date \| upload` | acht typen (§2a) | deelverzameling, sluit aan |
+| `required` | `is_required` | zelfde |
+| `options[]` | `config.options[]` | zelfde |
+| `order` | `position` | zelfde |
+| `requiresEvidence` | `allows_upload` | zelfde, andere naam |
+| `confirmationStyle: boolean` | eigen type `confirmation` | dit ontwerp is expliciever |
+| `date` als type | ontbreekt | **niet bouwen**, zie hieronder |
+| `frameworkRef` ("NIS2 Art. 21.2.b") | ontbreekt | **niet bouwen**, zie hieronder |
+| `categories[]` met score per categorie | platte lijst | zie §1c |
+
+**`frameworkRef` wordt niet gebouwd** (besluit opdrachtgever 2026-07-29). Het koppelt een vraag aan
+een normartikel en dient rapportage over raamwerkdekking. Dat loopt vooruit op meerdere
+compliance-frameworks; **nu bouwen we NIS2**.
+
+Belangrijk onderscheid daarbij, zodat dit besluit later niet verkeerd gelezen wordt: **de tool is
+al framework-agnostisch, alleen de vragen zijn framework-specifiek.** Niets in dit ontwerp neemt
+aan dat er één vragenlijst bestaat — `survey_template` heeft `name` en `version`, en een tweede
+vragenlijst voor een ander framework is straks simpelweg een tweede import (§2d). Wat hier wegvalt
+is uitsluitend de *metadata* die vastlegt bij welk artikel een vraag hoort. Er hoeft dus niets
+gebouwd te worden om die deur open te houden; hij staat al open.
+
+**`date` als negende vraagtype wordt niet gebouwd.** Geen van de acht Transdev-vragen gebruikt het
+en UC2 is een rating. Acht typen volstaan voor beide use cases. Toevoegen is later één waarde in de
+`CHECK`-lijst plus een validatieregel en een kolom die er al is (`answer_text` of een aparte
+`answer_date`) — geen verbouwing.
+
+**Wat wél uit MVM_V2 wordt overgenomen:** de designtaal (`src/shared/design-tokens.ts`), het
+layout, en de schermen als functionele specificatie. Zie het frontendspoor; dat staat los van dit
+ontwerp.
+
 ### 1c. Twee use cases — de scopegrens van de MVP
 
 De MVP ondersteunt precies twee soorten surveys. **Functionaliteit die daarbuiten valt, wordt niet
@@ -1118,6 +1157,8 @@ een voorstel is de toets: *dient dit UC1 of UC2?* Zo niet, dan hoort het in deze
 | Voorwaardelijke logica (logic jumps), secties | Niveau C. Uitgesteld op 2026-07-29 (§1a). Eigen bouwstap ná een werkende B. |
 | AI-beoordeling (Gemini) | Uitgesteld op 2026-07-29 (§1a). Externe dienst plus een openstaande verwerkersvraag. |
 | EFQM KPI-sync | Uitgesteld op 2026-07-29 (§1a) |
+| `frameworkRef` — vraag koppelen aan een normartikel | Uitgesteld op 2026-07-29 (§1a-bis). Loopt vooruit op meerdere frameworks; nu bouwen we NIS2. De tool zelf is al framework-agnostisch. |
+| `date` als negende vraagtype | Uitgesteld op 2026-07-29 (§1a-bis). Geen van beide use cases gebruikt het. |
 | Marketing Mode (publieke anonieme surveys) | Uitgesteld op 2026-07-29 (§1a). Botst met één-link-per-vendor. |
 | Radar/spider charts, rapportage | Uitgesteld op 2026-07-29 (§1a). Volgt op werkende data. |
 | Auto-save tijdens typen | Uitgesteld op 2026-07-29 (§1b). Expliciet opslaan blijft wel. |
@@ -1175,6 +1216,20 @@ database. De leverancierskant werkt dan volledig.
 - ~~Meerdere collega's per leverancier~~ → **ja** (§1c). `UNIQUE (run_id, vendor_id)` wordt
   partieel.
 - ~~Ziet de leverancier de interne score~~ → **nee, volledig intern** (§1c)
+
+**BLOKKEREND voor stap 1 van de bouwvolgorde — één vraag:**
+
+- **Heeft de interne beoordeling (UC2) categorieën met een score per categorie?** MVM_V2 heeft ze
+  (`InternalSurveyTemplate.categories[]`, met `minAnswersPerCategory` en een berekende score per
+  categorie), en het portaalscherm toont de vragenlijst daar als stappen per categorie.
+  VendorComply noemde hetzelfde onder "topic sections". Bij de acht Transdev-vragen (UC1) zijn er
+  géén categorieën.
+
+  Dit staat als enige punt vóór de migratie, want het is een tabel erbij (`survey_category`) plus
+  een verwijzing op `survey_question`. **Achteraf toevoegen raakt elke query, elk scherm en de
+  scoreberekening** — dat is de reden dat dit blokkerend is en `date` niet.
+
+  Als het antwoord "één lijst, één totaalscore" is, blijft het ontwerp zoals het nu staat.
 
 **Nog open — voorstellen van mij, niet bevestigd:**
 

--- a/docs/superpowers/specs/2026-07-28-vragenlijst-ontwerp.md
+++ b/docs/superpowers/specs/2026-07-28-vragenlijst-ontwerp.md
@@ -42,6 +42,23 @@ ingrijpend veranderd — één `answer TEXT`-kolom volstaat niet meer voor acht 
 (de typen), §2b (lifecycle), §2c (deelnemers) en §2d (import/export). Wie de vorige versie kent,
 moet in elk geval §2a en §4 opnieuw lezen.
 
+**Wijziging 3 (2026-07-29) — er zijn twee use cases, niet één.**
+
+Dit document ging tot nu toe uit van één soort respondent: een externe leverancier met een token.
+De opdrachtgever heeft verduidelijkt dat de MVP **twee** soorten surveys moet ondersteunen, en dat
+er niets gebouwd hoeft te worden dat daarbuiten valt:
+
+| | Use case | Wie vult in | Over wie gaat het |
+|---|---|---|---|
+| **UC1** | Vendor compliance (bv. IT) | externe leverancier | zichzelf |
+| **UC2** | Interne beoordeling van een dienstverlener | Transdev-collega | een andere partij |
+
+**Dat raakte het datamodel, niet alleen de tekst.** Bij UC1 vallen "wie vult in" en "over wie gaat
+het" samen; bij UC2 niet. `survey_response.vendor_id` was `NOT NULL` met een foreign key naar
+`vendor` — een interne collega is geen leverancier en paste daar niet in. Zie §1c.
+
+Dit is de scopegrens van de MVP: **UC1 en UC2, niets daarbuiten.**
+
 ---
 
 ## 1. Niveau B — vastgesteld op 2026-07-29
@@ -80,8 +97,9 @@ het een goede keuze is — niet om ergens op aan te sluiten.
 | Import/export als JSON-schema | §2d |
 
 Import/export verdient een aparte opmerking: het lijkt een gemaksfunctie, maar het levert
-"template klonen" en "template delen tussen tenants" er vrijwel gratis bij, en het geeft een
-leesbaar exportformaat voor de vragenlijststructuur. Dat is meer waarde dan de omvang doet vermoeden.
+"template klonen" en "nieuwe versie afsplitsen" er vrijwel gratis bij, en het is tevens de manier
+waarop beide vragenlijsten (UC1 en UC2) de database in komen — geen apart seed-script dat later uit
+de pas loopt met het echte importpad.
 
 **Uitgesteld — bewust niet in dit ontwerp:**
 
@@ -90,7 +108,7 @@ leesbaar exportformaat voor de vragenlijststructuur. Dat is meer waarde dan de o
 | Logic jumps (voorwaardelijke logica) | Niveau C. Verandert "welke vragen zie je" van een lijst in een berekening, en raakt daarmee validatie, voortgang, export en verplichtstelling tegelijk. Eigen bouwstap ná een werkende B. |
 | AI-beoordeling (Gemini) | Externe dienst. Brengt bovendien een verwerkersvraag mee: leverancierscertificaten en compliance-antwoorden naar een externe AI-dienst sturen is een AVG/NIS2-besluit, geen technische keuze. |
 | EFQM KPI-sync | Externe koppeling, niet nodig voor de pilot. |
-| Marketing Mode (publieke anonieme surveys) | Tweede product. Botst met het hele tokenontwerp, dat uitgaat van één link per vendor per ronde. |
+| Marketing Mode (publieke anonieme surveys) | Valt buiten UC1 en UC2 (§1c). Een open link zonder bekende respondent botst bovendien met het tokenontwerp, dat elke respons aan een geadresseerde koppelt. |
 | Radar/spider charts | Rapportage, volgt op werkende data. |
 
 ### 1b. Draft/auto-save en "request revisions" — bewust niet
@@ -119,6 +137,110 @@ net groen is geworden, niet een uitbreiding erop.
 Concept opslaan blijft nodig om een praktische reden die niets met auto-save te maken heeft: acht
 vragen met verplichte toelichtingen vul je niet in één keer in, en het token is gehasht en dus niet
 opnieuw te versturen. Zonder opslaan verliest iemand die een tabblad sluit alles, onherstelbaar.
+
+### 1c. Twee use cases — de scopegrens van de MVP
+
+De MVP ondersteunt precies twee soorten surveys. **Functionaliteit die daarbuiten valt, wordt niet
+gebouwd** — dat is een expliciete instructie van de opdrachtgever en het is de maatstaf waartegen
+elk voorstel in dit document getoetst hoort te worden.
+
+#### UC1 — Vendor compliance (extern)
+
+De bestaande casus. Een externe leverancier beantwoordt vragen over de eigen organisatie. De acht
+Transdev-vragen zijn hiervan de eerste vulling. Toegang via token, want de leverancier heeft geen
+account.
+
+#### UC2 — Interne beoordeling van een dienstverlener
+
+Nieuw. Een Transdev-collega geeft aan hoe een dienstverlener in de praktijk scoort. Kort en
+eenvoudig — in de praktijk een `rating` met eventueel een `open_text` erbij.
+
+**Drie besluiten van de opdrachtgever op 2026-07-29 bepalen hoe dit werkt:**
+
+| Vraag | Besluit | Gevolg |
+|---|---|---|
+| Hoe krijgt een collega toegang? | **Ook via een token-link** | De bestaande tokenlaag blijft ongewijzigd en werkt meteen. De MVP wacht niet op de Entra-guard. |
+| Meerdere collega's per dienstverlener? | **Ja** | `UNIQUE (run_id, vendor_id)` moet eraf — die staat er nu wel. |
+| Ziet de leverancier de interne score? | **Nee, volledig intern** | Vraagt een harde scheiding, afgedwongen in de database. |
+
+Dat de interne route ook via een token loopt, is de belangrijkste van de drie: het betekent dat
+UC2 **geen enkele wijziging in de toegangslaag vraagt**. Dezelfde guard, dezelfde
+`resolve_survey_token()`, dezelfde éénmaligheid. Alleen het datamodel eronder verbreedt.
+
+#### Wat dit in het model verandert
+
+`survey_response` gaat uit van één partij die zowel invult als beoordeeld wordt. Bij UC2 vallen die
+uit elkaar. Drie wijzigingen, alle drie op een tabel die vanochtend gemerged is:
+
+```
+survey_run.survey_kind      TEXT NOT NULL DEFAULT 'vendor_compliance'
+                            → 'vendor_compliance' (UC1) | 'internal_review' (UC2)
+
+survey_response.vendor_id   UUID NULL          → was NOT NULL; leeg bij UC2
+survey_response.subject_vendor_id  UUID NOT NULL  → over wie de survey gaat
+survey_response.respondent_user_id UUID NULL   → welke collega invult (alleen UC2)
+survey_response.respondent_label   TEXT NULL   → naam/rol, als er geen user-record is
+```
+
+| Kolom | UC1 | UC2 |
+|---|---|---|
+| `vendor_id` (wie vult in) | de leverancier | **leeg** |
+| `subject_vendor_id` (over wie) | dezelfde leverancier | de beoordeelde dienstverlener |
+| `respondent_user_id` | leeg | de collega, indien bekend |
+| `respondent_label` | leeg | naam of rol van de collega |
+
+**`subject_vendor_id` is bij beide gevuld.** Dat is bewust: de vraag "welke leverancier betreft
+dit?" heeft bij elke survey een antwoord, en zo is rapportage per leverancier één query in plaats
+van twee met een `UNION`.
+
+Bij UC1 wijzen `vendor_id` en `subject_vendor_id` naar dezelfde rij. Dat is geen redundantie maar
+de expliciete vastlegging dat invuller en onderwerp samenvallen — bij UC2 doen ze dat niet.
+
+**Waarom `respondent_label` naast `respondent_user_id`.** Een collega die een token krijgt, hoeft
+geen `clm.user`-record te hebben; de tokenroute vraagt geen account. Zonder tekstveld zou je voor
+elke invuller eerst een gebruiker moeten aanmaken, en dat is precies het soort werk dat de
+tokenroute wil vermijden. Zodra spoor 1 er is, kan `respondent_user_id` gevuld worden.
+
+#### De constraints die hierbij horen
+
+| Constraint | Dwingt af |
+|---|---|
+| `CHECK (survey_kind IN ('vendor_compliance','internal_review'))` | Alleen de twee use cases |
+| `CHECK (survey_kind <> 'vendor_compliance' OR vendor_id = subject_vendor_id)` | Bij UC1 vallen invuller en onderwerp samen |
+| `CHECK (survey_kind <> 'internal_review' OR vendor_id IS NULL)` | Bij UC2 is de invuller geen leverancier |
+| `UNIQUE (run_id, vendor_id)` **vervalt** | Meerdere collega's per dienstverlener |
+| *vervangen door:* `UNIQUE (run_id, vendor_id) WHERE vendor_id IS NOT NULL` | Bij UC1 nog steeds één respons per leverancier |
+
+Die laatste is een **partiële unieke index**, en hij is nauwkeuriger dan wat er nu staat: bij UC1
+blijft de garantie "één leverancier, één respons" volledig overeind, terwijl UC2 er niet door
+geraakt wordt omdat `vendor_id` daar leeg is. Zonder die partiële vorm zou het weghalen van de
+constraint ook UC1 verzwakken — en dat is precies wat je niet wilt.
+
+#### De scheiding tussen intern en extern
+
+Een leverancier mag de interne beoordelingen over zichzelf nooit zien. **De bestaande architectuur
+regelt dit al**, en het is nuttig om precies te benoemen waarom — anders wordt er beveiliging
+bijgebouwd die er al is.
+
+Een leverancier heeft **geen toegang tot de Transdev-tenant**. Er is geen account, geen sessie en
+geen tenantcontext die hem toebehoort. Wat hij heeft is één token, dat via
+`resolve_survey_token()` precies één `response_id` oplevert — die van hemzelf. Er bestaat geen
+route van "ik ken deze leverancier" naar "toon alle responses over deze leverancier": de lookup
+gaat van tokenhash naar één respons, nooit van vendor naar een verzameling.
+
+Een interne beoordeling is een aparte respons met een eigen token. Dat token krijgt de leverancier
+niet. Daarmee is de scheiding een gevolg van het toegangsmodel, niet van een extra filter dat
+iemand kan vergeten.
+
+**Wat wél nodig is, is één regel discipline bij het bouwen:** leesroutes op de leverancierskant
+filteren op `response_id`, nooit op `subject_vendor_id`. Zodra iemand een route bouwt die "alle
+responses van deze vendor" ophaalt, ontstaat het lek dat er nu niet is. Dat is testpunt 39 — geen
+nieuwe maatregel, maar het vastleggen dat de bestaande garantie ook onder de nieuwe kolommen blijft
+gelden.
+
+**Let op — dit raakt de bestaande auditregels.** Een interne beoordeling is bewijsmateriaal in
+dezelfde zin als een compliance-antwoord: hij hoort in `audit.audit_event`, met dezelfde
+transactiegarantie. De bestaande implementatie doet dat al per respons en vraagt geen wijziging.
 
 ---
 
@@ -326,9 +448,10 @@ Overgenomen uit VendorComply §2.2 fase 2. Alle drie leiden tot hetzelfde eindpu
 | Quick paste | Plaktekst met e-mailadressen, komma of regeleinde gescheiden | Moet vendors aanmaken of matchen |
 | CSV-import | `.csv` met contactgegevens | Idem, plus foutrapportage per regel |
 
-**Het knelpunt zit niet in het inlezen maar in de koppeling.** `survey_response.vendor_id` is
-`NOT NULL` met een foreign key. Een geplakt e-mailadres heeft geen vendor. Er zijn twee opties, en
-dit is een besluit dat vóór het bouwen van §2c genomen moet worden:
+**Het knelpunt verschilt per use case, en dat is wezenlijk.**
+
+**Bij UC1** is de deelnemer de leverancier zelf. `vendor_id` en `subject_vendor_id` wijzen naar
+dezelfde rij, en een geplakt e-mailadres moet dus aan een vendor gekoppeld worden. Twee opties:
 
 1. **Automatisch een vendor aanmaken** bij een onbekend e-mailadres, met het domein als naam.
    Snel, maar vervuilt het vendorbestand met halve records.
@@ -339,9 +462,27 @@ Advies: **optie 2.** Het vendorbestand is bij een compliance-instrument geen bij
 lijst waar de rapportage op leunt. Automatisch aanmaken levert binnen een jaar dubbele vendors op
 (`transdev.nl` en `Transdev Nederland` als twee records), en dat is achteraf duur op te ruimen.
 
-De uniciteitsregel die er al ligt, helpt hierbij: `UNIQUE (run_id, vendor_id)` op `survey_response`
-betekent dat dezelfde vendor niet twee keer in dezelfde ronde kan zitten. Een import die een vendor
-dubbel bevat, moet dus sowieso een nette fout geven in plaats van een databaseconflict.
+**Bij UC2 speelt dat niet.** De deelnemer is een Transdev-collega, geen leverancier; `vendor_id`
+blijft leeg. Wat de beheerder hier kiest, is een andere combinatie:
+
+| Wat de beheerder aangeeft | Landt in |
+|---|---|
+| Over welke dienstverlener deze ronde gaat | `subject_vendor_id` (verplicht, één per respons) |
+| Welke collega's die beoordelen | `respondent_label`, met een e-mailadres voor de tokenlink |
+
+Dat is een wezenlijk andere schermflow: bij UC1 kies je leveranciers en krijgt ieder een eigen
+vragenlijst over zichzelf; bij UC2 kies je één dienstverlener en vervolgens de collega's die hem
+beoordelen. **Twee schermen, geen gedeelde variant met een schakelaar** — dat laatste levert een
+scherm op dat beide dingen half doet.
+
+Quick paste en CSV-import werken bij UC2 op de collega-adressen. Die hoeven aan geen enkel
+vendorrecord gekoppeld te worden, wat het inlezen daar juist simpeler maakt dan bij UC1.
+
+De uniciteitsregel is aangepast aan dit onderscheid (§1c): `UNIQUE (run_id, vendor_id)` wordt
+partieel en geldt alleen waar `vendor_id` gevuld is. Bij UC1 blijft "één leverancier, één respons"
+dus volledig gelden; bij UC2 kunnen meerdere collega's dezelfde dienstverlener beoordelen. Een
+UC1-import die een vendor dubbel bevat, moet nog steeds een nette fout geven in plaats van een
+databaseconflict.
 
 ---
 
@@ -373,10 +514,10 @@ beschrijft: de vragen, hun volgorde, typen en `config`.
 
 Dit levert vier dingen op waarvan er maar één expliciet gevraagd is:
 
-- **Template klonen** — exporteren en weer importeren
+- **Template klonen** — exporteren en weer importeren, bijvoorbeeld om naast de UC1-vragenlijst een
+  UC2-variant op te zetten
 - **Nieuwe versie afsplitsen** van een bevroren template (§2) is dezelfde operatie
-- **Delen tussen tenants** — met `tenant_id` die bij import opnieuw wordt gezet, nooit uit het bestand
-- **De seed van de acht Transdev-vragen** is gewoon zo'n bestand, geen apart migratiescript
+- **De seed van beide vragenlijsten** is gewoon zo'n bestand, geen apart migratiescript
 
 Die laatste is de reden om dit vroeg te bouwen in plaats van laat: het vervangt werk dat anders
 tweemaal gedaan wordt.
@@ -905,6 +1046,17 @@ Aanvullend uit niveau B (§1) en de VendorComply-overname (§1a):
 | 37 | Een `rating`-waarde in `answer_text` faalt op de vormconstraint (§4) |
 | 38 | Een testrun (`is_test = true`) doorloopt exact hetzelfde guardpad als een echte run |
 
+Aanvullend uit de twee use cases (§1c):
+
+| # | Bewijs |
+|---|---|
+| 39 | Een leverancierstoken geeft uitsluitend de eigen respons — een interne beoordeling over dezelfde `subject_vendor_id` is er niet mee bereikbaar |
+| 40 | Twee collega's kunnen dezelfde dienstverlener beoordelen in één ronde (UC2) |
+| 41 | Dezelfde leverancier twee keer in één ronde faalt op de partiële unieke index (UC1) |
+| 42 | Bij `survey_kind = 'vendor_compliance'` faalt een respons waar `vendor_id <> subject_vendor_id` |
+| 43 | Bij `survey_kind = 'internal_review'` faalt een respons met een gevulde `vendor_id` |
+| 44 | Een UC2-respons is in te dienen zonder enig `clm.user`-record voor de invuller |
+
 Punt 15, 23, 27, 36 en 37 zijn de belangrijkste: die toetsen dat de garantie in de database zit en
 niet alleen in de applicatiecode. Alle vijf moeten getest worden met directe SQL die de
 applicatielaag overslaat — anders test je je eigen validatiecode en niet de garantie.
@@ -921,9 +1073,19 @@ er een gebruikt — niet bij de acht Transdev-vragen, want die hebben er geen.
 Punt 31 is de zwaarste in beveiligingstermen: een importbestand is client-invoer, en `tenant_id`
 daaruit overnemen is exact het patroon dat Issue #7 verbiedt.
 
+Punt 39 legt vast dat de scheiding tussen interne en externe beoordelingen ook onder de nieuwe
+kolommen blijft gelden. De garantie volgt uit het toegangsmodel — een leverancier heeft geen
+tenanttoegang, alleen één token voor één respons — maar juist daarom moet er een test op staan: het
+is het soort garantie dat stilzwijgend sneuvelt zodra iemand een route bouwt die op
+`subject_vendor_id` filtert in plaats van op `response_id`.
+
 ---
 
 ## 9. Bewust niet opgelost
+
+**De scopegrens is UC1 en UC2 (§1c).** Alles wat daarbuiten valt, wordt niet gebouwd — dat is een
+expliciete instructie van de opdrachtgever en niet alleen een prioriteitskeuze. Bij twijfel over
+een voorstel is de toets: *dient dit UC1 of UC2?* Zo niet, dan hoort het in deze tabel.
 
 | Onderwerp | Reden |
 |---|---|
@@ -951,10 +1113,10 @@ grootst.
 
 | # | Stap | Levert op |
 |---|---|---|
-| 1 | Migratie: `survey_question`, `survey_answer`, `survey_attachment`, plus `status` en `is_test` op `survey_run` — met RLS, policies, CHECK-constraints, de samengestelde FK uit §4 en de bevriezingstrigger uit §2 | Het datamodel staat |
+| 1 | Migratie: `survey_question`, `survey_answer`, `survey_attachment`, plus `status`, `is_test` en `survey_kind` op `survey_run` en de vier respondentkolommen op `survey_response` (§1c) — met RLS, policies, CHECK-constraints, de partiële unieke index, de samengestelde FK uit §4 en de bevriezingstrigger uit §2 | Het datamodel staat, beide use cases |
 | 2 | Guard uitbreiden met de statuscontrole (§2b, stap 1b) | Bestaande laag blijft groen — testpunt 30 |
 | 3 | Import/export van het JSON-schema (§2d) | Nodig voor stap 4; levert klonen en versioneren mee |
-| 4 | Seed: de acht Transdev-vragen als template `transdev-annual-vendor-it-risk` v1, via stap 3 | De PoC-vulling |
+| 4 | Seed: de acht Transdev-vragen als template `transdev-annual-vendor-it-risk` v1 (UC1) plus een korte interne beoordelingsvragenlijst (UC2), beide via stap 3 | Beide use cases gevuld |
 | 5 | `GET /survey/respond/questions` — vragen ophalen incl. `config` per type | Leverancier ziet de vragenlijst |
 | 6 | Validatie- en indienlogica (§5); `POST /survey/respond` uitbreiden met de antwoordbody | De kern |
 | 7 | `PUT /survey/respond/answers` (concept, expliciet opslaan) | Bruikbaar bij acht vragen |
@@ -982,6 +1144,11 @@ database. De leverancierskant werkt dan volledig.
 - ~~Niveau A, B of C~~ → **B** (§1)
 - ~~Auto-save en "request revisions"~~ → **beide niet** (§1b)
 - ~~Welke VendorComply-features overnemen~~ → zie de twee tabellen in §1a
+- ~~Toegang voor interne invullers (UC2)~~ → **ook via token-link** (§1c). De toegangslaag blijft
+  daarmee ongewijzigd en de MVP wacht niet op de Entra-guard.
+- ~~Meerdere collega's per dienstverlener~~ → **ja** (§1c). `UNIQUE (run_id, vendor_id)` wordt
+  partieel.
+- ~~Ziet de leverancier de interne score~~ → **nee, volledig intern** (§1c)
 
 **Nog open — voorstellen van mij, niet bevestigd:**
 
@@ -989,8 +1156,15 @@ database. De leverancierskant werkt dan volledig.
   interpreteerbaar zijn. Ik zou hem aanhouden, maar hij is niet expliciet bevestigd.
 - **Verplichte toelichting bij `not_confirmed`** (§3). Mijn afleiding uit de bevestigde regels voor
   `not_applicable` en `cannot_upload`.
-- **Onbekend e-mailadres bij import: weigeren of vendor aanmaken** (§2c). Advies: weigeren. Dit moet
-  vóór stap 10 beslist zijn, niet eerder.
+- **Onbekend e-mailadres bij import: weigeren of vendor aanmaken** (§2c). Advies: weigeren. Speelt
+  alleen bij UC1. Dit moet vóór stap 10 beslist zijn, niet eerder.
+- **Of UC1 en UC2 dezelfde vragenlijst-templates delen** (§1c). Het model staat het toe — een
+  template is niet aan een `survey_kind` gebonden. Ik zou dat zo laten: een tenant die een
+  interne vragenlijst per ongeluk aan een leverancier stuurt, maakt een beheerfout, geen
+  systeemfout. Als daar wel een grens hoort, is het één kolom op `survey_template`.
+- **Hoe meerdere interne scores over dezelfde dienstverlener samengevat worden** (§1c). Nu worden
+  ze alleen opgeslagen. Middelen, spreiding tonen of los laten staan is een rapportagevraag, en
+  rapportage is uitgesteld (§1a). Het datamodel belet geen van de varianten.
 - **Toelichting bij de andere zeven typen is per vraag instelbaar en staat standaard op optioneel**
   (§3a). Alternatief zou zijn: nooit een toelichting buiten `confirmation`.
 
@@ -1013,6 +1187,14 @@ database. De leverancierskant werkt dan volledig.
 - **De bestaande `POST /survey/respond`-test** verwacht een lege body en moet aangepast worden.
 - **De bestaande guard krijgt een statuscontrole** (§2b). Dat is een wijziging in code die nu groen
   is; testpunt 30 hoort daarbij geschreven te worden vóór de wijziging.
-- **`survey_run` krijgt twee kolommen** (`status`, `is_test`) die er nu niet zijn.
+- **`survey_run` krijgt drie kolommen** (`status`, `is_test`, `survey_kind`) die er nu niet zijn.
+- **`survey_response` krijgt drie kolommen** (`subject_vendor_id`, `respondent_user_id`,
+  `respondent_label`) en `vendor_id` wordt **nullable**. Dat laatste is een versoepeling op een
+  tabel die vanochtend gemerged is; de bestaande UC1-garantie wordt overgenomen door de partiële
+  unieke index en de twee CHECK-constraints uit §1c. **Bij het bouwen eerst controleren dat de
+  bestaande tests 39 t/m 43 dekken** — een `NOT NULL` weghalen zonder vervanging is precies hoe
+  garanties stilletjes verdwijnen.
 - **`survey_question` krijgt `UNIQUE (question_id, answer_type)`** — nodig voor de samengestelde
   foreign key uit §4, en niet vanzelfsprekend op een kolom die al primary key is.
+- **Twee beheerschermen, niet één** (§2c). UC1 kiest leveranciers; UC2 kiest één dienstverlener en
+  daarna de collega's. Een gedeeld scherm met een schakelaar doet beide half.

--- a/docs/superpowers/specs/2026-07-28-vragenlijst-ontwerp.md
+++ b/docs/superpowers/specs/2026-07-28-vragenlijst-ontwerp.md
@@ -48,14 +48,14 @@ Dit document ging tot nu toe uit van één soort respondent: een externe leveran
 De opdrachtgever heeft verduidelijkt dat de MVP **twee** soorten surveys moet ondersteunen, en dat
 er niets gebouwd hoeft te worden dat daarbuiten valt:
 
-| | Use case | Wie vult in | Over wie gaat het |
+| | Use case | Wie vult in | Over welke leverancier |
 |---|---|---|---|
-| **UC1** | Vendor compliance (bv. IT) | externe leverancier | zichzelf |
-| **UC2** | Interne beoordeling van een dienstverlener | Transdev-collega | een andere partij |
+| **UC1** | Vendor compliance (bv. IT) | de leverancier zelf | zichzelf |
+| **UC2** | Interne beoordeling | een Transdev-collega | dezelfde leverancier |
 
 **Dat raakte het datamodel, niet alleen de tekst.** Bij UC1 vallen "wie vult in" en "over wie gaat
 het" samen; bij UC2 niet. `survey_response.vendor_id` was `NOT NULL` met een foreign key naar
-`vendor` — een interne collega is geen leverancier en paste daar niet in. Zie §1c.
+`vendor`, en bij UC2 is de invuller een collega die daar niet in past. Zie §1c.
 
 Dit is de scopegrens van de MVP: **UC1 en UC2, niets daarbuiten.**
 
@@ -150,17 +150,27 @@ De bestaande casus. Een externe leverancier beantwoordt vragen over de eigen org
 Transdev-vragen zijn hiervan de eerste vulling. Toegang via token, want de leverancier heeft geen
 account.
 
-#### UC2 — Interne beoordeling van een dienstverlener
+#### UC2 — Interne beoordeling
 
-Nieuw. Een Transdev-collega geeft aan hoe een dienstverlener in de praktijk scoort. Kort en
-eenvoudig — in de praktijk een `rating` met eventueel een `open_text` erbij.
+Nieuw. Een Transdev-collega geeft aan hoe een leverancier in de praktijk scoort. Kort en eenvoudig —
+in de praktijk een `rating` met eventueel een `open_text` erbij.
+
+**"Leverancier" en "dienstverlener" zijn hier hetzelfde.** Het gaat om dezelfde partij en dezelfde
+`clm.vendor`-rij; alleen de kant van waaruit ernaar gekeken wordt verschilt. Dit document gebruikt
+daarom consequent **leverancier**.
+
+Dat is geen woordkeuze maar de kern van het model: **dezelfde leverancier kan in beide surveys
+zitten.** Wat hij zelf verklaart (UC1) en hoe hij in de praktijk scoort (UC2) zijn twee beelden van
+één partij, en `subject_vendor_id` is de kolom die ze aan elkaar knoopt. Zonder dat zou je twee
+losse datasets hebben die niet te koppelen zijn — en juist de vergelijking tussen die twee is
+waarschijnlijk wat UC2 waardevol maakt.
 
 **Drie besluiten van de opdrachtgever op 2026-07-29 bepalen hoe dit werkt:**
 
 | Vraag | Besluit | Gevolg |
 |---|---|---|
 | Hoe krijgt een collega toegang? | **Ook via een token-link** | De bestaande tokenlaag blijft ongewijzigd en werkt meteen. De MVP wacht niet op de Entra-guard. |
-| Meerdere collega's per dienstverlener? | **Ja** | `UNIQUE (run_id, vendor_id)` moet eraf — die staat er nu wel. |
+| Meerdere collega's per leverancier? | **Ja** | `UNIQUE (run_id, vendor_id)` moet eraf — die staat er nu wel. |
 | Ziet de leverancier de interne score? | **Nee, volledig intern** | Vraagt een harde scheiding, afgedwongen in de database. |
 
 Dat de interne route ook via een token loopt, is de belangrijkste van de drie: het betekent dat
@@ -184,17 +194,22 @@ survey_response.respondent_label   TEXT NULL   → naam/rol, als er geen user-re
 
 | Kolom | UC1 | UC2 |
 |---|---|---|
-| `vendor_id` (wie vult in) | de leverancier | **leeg** |
-| `subject_vendor_id` (over wie) | dezelfde leverancier | de beoordeelde dienstverlener |
+| `vendor_id` — de leverancier als **deelnemer** | de leverancier | **leeg** |
+| `subject_vendor_id` — de leverancier als **onderwerp** | de leverancier (dezelfde rij) | de beoordeelde leverancier |
 | `respondent_user_id` | leeg | de collega, indien bekend |
 | `respondent_label` | leeg | naam of rol van de collega |
 
-**`subject_vendor_id` is bij beide gevuld.** Dat is bewust: de vraag "welke leverancier betreft
-dit?" heeft bij elke survey een antwoord, en zo is rapportage per leverancier één query in plaats
-van twee met een `UNION`.
+De twee kolommen leggen twee **rollen** vast, niet twee partijen. Bij UC1 vervult de leverancier
+beide rollen tegelijk — hij is deelnemer én onderwerp — en wijzen de kolommen naar dezelfde rij.
+Bij UC2 vervult hij alleen de tweede: hij vult niets in, er wordt over hem ingevuld.
 
-Bij UC1 wijzen `vendor_id` en `subject_vendor_id` naar dezelfde rij. Dat is geen redundantie maar
-de expliciete vastlegging dat invuller en onderwerp samenvallen — bij UC2 doen ze dat niet.
+**`subject_vendor_id` is bij beide gevuld, en dat is het punt.** De vraag "welke leverancier betreft
+dit?" heeft bij elke survey een antwoord. Daardoor is rapportage per leverancier één query in plaats
+van twee met een `UNION`, en — belangrijker — staan de zelfverklaring uit UC1 en de praktijkscore
+uit UC2 over dezelfde partij automatisch naast elkaar.
+
+Dat `vendor_id` bij UC1 dezelfde rij aanwijst is dus geen redundantie: het is de expliciete
+vastlegging dat de leverancier daar zelf aan het woord is.
 
 **Waarom `respondent_label` naast `respondent_user_id`.** Een collega die een token krijgt, hoeft
 geen `clm.user`-record te hebben; de tokenroute vraagt geen account. Zonder tekstveld zou je voor
@@ -208,7 +223,7 @@ tokenroute wil vermijden. Zodra spoor 1 er is, kan `respondent_user_id` gevuld w
 | `CHECK (survey_kind IN ('vendor_compliance','internal_review'))` | Alleen de twee use cases |
 | `CHECK (survey_kind <> 'vendor_compliance' OR vendor_id = subject_vendor_id)` | Bij UC1 vallen invuller en onderwerp samen |
 | `CHECK (survey_kind <> 'internal_review' OR vendor_id IS NULL)` | Bij UC2 is de invuller geen leverancier |
-| `UNIQUE (run_id, vendor_id)` **vervalt** | Meerdere collega's per dienstverlener |
+| `UNIQUE (run_id, vendor_id)` **vervalt** | Meerdere collega's per leverancier |
 | *vervangen door:* `UNIQUE (run_id, vendor_id) WHERE vendor_id IS NOT NULL` | Bij UC1 nog steeds één respons per leverancier |
 
 Die laatste is een **partiële unieke index**, en hij is nauwkeuriger dan wat er nu staat: bij UC1
@@ -462,25 +477,36 @@ Advies: **optie 2.** Het vendorbestand is bij een compliance-instrument geen bij
 lijst waar de rapportage op leunt. Automatisch aanmaken levert binnen een jaar dubbele vendors op
 (`transdev.nl` en `Transdev Nederland` als twee records), en dat is achteraf duur op te ruimen.
 
-**Bij UC2 speelt dat niet.** De deelnemer is een Transdev-collega, geen leverancier; `vendor_id`
-blijft leeg. Wat de beheerder hier kiest, is een andere combinatie:
+**Bij UC2 speelt dat niet.** De deelnemer is een Transdev-collega; die hoeft aan geen enkel
+vendorrecord gekoppeld te worden en `vendor_id` blijft leeg. De leverancier komt hier niet voor als
+deelnemer maar als **onderwerp** — hij vult niets in, er wordt over hem ingevuld.
+
+Wat de beheerder aangeeft:
 
 | Wat de beheerder aangeeft | Landt in |
 |---|---|
-| Over welke dienstverlener deze ronde gaat | `subject_vendor_id` (verplicht, één per respons) |
+| Over welke leverancier deze ronde gaat | `subject_vendor_id` (verplicht) |
 | Welke collega's die beoordelen | `respondent_label`, met een e-mailadres voor de tokenlink |
 
-Dat is een wezenlijk andere schermflow: bij UC1 kies je leveranciers en krijgt ieder een eigen
-vragenlijst over zichzelf; bij UC2 kies je één dienstverlener en vervolgens de collega's die hem
-beoordelen. **Twee schermen, geen gedeelde variant met een schakelaar** — dat laatste levert een
-scherm op dat beide dingen half doet.
+Dat is een wezenlijk andere schermflow, en het verschil zit in wat je selecteert:
 
-Quick paste en CSV-import werken bij UC2 op de collega-adressen. Die hoeven aan geen enkel
-vendorrecord gekoppeld te worden, wat het inlezen daar juist simpeler maakt dan bij UC1.
+| | UC1 | UC2 |
+|---|---|---|
+| Je kiest | een lijst leveranciers | **één** leverancier |
+| Ieder krijgt | een eigen vragenlijst over zichzelf | — |
+| Daarna kies je | — | de collega's die hem beoordelen |
+| Aantal responses | één per leverancier | één per collega |
+
+**Twee schermen, geen gedeelde variant met een schakelaar** — dat laatste levert een scherm op dat
+beide dingen half doet. Bij UC1 is de leverancier de deelnemer, bij UC2 het onderwerp; dat is een
+te wezenlijk verschil om achter een keuzerondje te verbergen.
+
+Quick paste en CSV-import werken bij UC2 op de collega-adressen. Het inlezen is daar juist eenvoudiger
+dan bij UC1, omdat de koppelingsvraag uit de vorige alinea niet speelt.
 
 De uniciteitsregel is aangepast aan dit onderscheid (§1c): `UNIQUE (run_id, vendor_id)` wordt
 partieel en geldt alleen waar `vendor_id` gevuld is. Bij UC1 blijft "één leverancier, één respons"
-dus volledig gelden; bij UC2 kunnen meerdere collega's dezelfde dienstverlener beoordelen. Een
+dus volledig gelden; bij UC2 kunnen meerdere collega's dezelfde leverancier beoordelen. Een
 UC1-import die een vendor dubbel bevat, moet nog steeds een nette fout geven in plaats van een
 databaseconflict.
 
@@ -1051,7 +1077,7 @@ Aanvullend uit de twee use cases (§1c):
 | # | Bewijs |
 |---|---|
 | 39 | Een leverancierstoken geeft uitsluitend de eigen respons — een interne beoordeling over dezelfde `subject_vendor_id` is er niet mee bereikbaar |
-| 40 | Twee collega's kunnen dezelfde dienstverlener beoordelen in één ronde (UC2) |
+| 40 | Twee collega's kunnen dezelfde leverancier beoordelen in één ronde (UC2) |
 | 41 | Dezelfde leverancier twee keer in één ronde faalt op de partiële unieke index (UC1) |
 | 42 | Bij `survey_kind = 'vendor_compliance'` faalt een respons waar `vendor_id <> subject_vendor_id` |
 | 43 | Bij `survey_kind = 'internal_review'` faalt een respons met een gevulde `vendor_id` |
@@ -1146,7 +1172,7 @@ database. De leverancierskant werkt dan volledig.
 - ~~Welke VendorComply-features overnemen~~ → zie de twee tabellen in §1a
 - ~~Toegang voor interne invullers (UC2)~~ → **ook via token-link** (§1c). De toegangslaag blijft
   daarmee ongewijzigd en de MVP wacht niet op de Entra-guard.
-- ~~Meerdere collega's per dienstverlener~~ → **ja** (§1c). `UNIQUE (run_id, vendor_id)` wordt
+- ~~Meerdere collega's per leverancier~~ → **ja** (§1c). `UNIQUE (run_id, vendor_id)` wordt
   partieel.
 - ~~Ziet de leverancier de interne score~~ → **nee, volledig intern** (§1c)
 
@@ -1162,7 +1188,7 @@ database. De leverancierskant werkt dan volledig.
   template is niet aan een `survey_kind` gebonden. Ik zou dat zo laten: een tenant die een
   interne vragenlijst per ongeluk aan een leverancier stuurt, maakt een beheerfout, geen
   systeemfout. Als daar wel een grens hoort, is het één kolom op `survey_template`.
-- **Hoe meerdere interne scores over dezelfde dienstverlener samengevat worden** (§1c). Nu worden
+- **Hoe meerdere interne scores over dezelfde leverancier samengevat worden** (§1c). Nu worden
   ze alleen opgeslagen. Middelen, spreiding tonen of los laten staan is een rapportagevraag, en
   rapportage is uitgesteld (§1a). Het datamodel belet geen van de varianten.
 - **Toelichting bij de andere zeven typen is per vraag instelbaar en staat standaard op optioneel**
@@ -1196,5 +1222,5 @@ database. De leverancierskant werkt dan volledig.
   garanties stilletjes verdwijnen.
 - **`survey_question` krijgt `UNIQUE (question_id, answer_type)`** — nodig voor de samengestelde
   foreign key uit §4, en niet vanzelfsprekend op een kolom die al primary key is.
-- **Twee beheerschermen, niet één** (§2c). UC1 kiest leveranciers; UC2 kiest één dienstverlener en
-  daarna de collega's. Een gedeeld scherm met een schakelaar doet beide half.
+- **Twee beheerschermen, niet één** (§2c). Bij UC1 is de leverancier de deelnemer, bij UC2 het
+  onderwerp. Een gedeeld scherm met een schakelaar doet beide half.

--- a/drizzle/0005_vragenlijst_niveau_b.sql
+++ b/drizzle/0005_vragenlijst_niveau_b.sql
@@ -1,0 +1,459 @@
+CREATE TABLE "clm"."survey_answer" (
+	"answer_id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"tenant_id" uuid NOT NULL,
+	"response_id" uuid NOT NULL,
+	"question_id" uuid NOT NULL,
+	"answer_type" text NOT NULL,
+	"answer_code" text,
+	"answer_codes" text[],
+	"answer_text" text,
+	"answer_number" numeric,
+	"comment" text,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone
+);
+--> statement-breakpoint
+CREATE TABLE "clm"."survey_attachment" (
+	"attachment_id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"tenant_id" uuid NOT NULL,
+	"response_id" uuid NOT NULL,
+	"question_id" uuid NOT NULL,
+	"original_name" text NOT NULL,
+	"storage_key" text NOT NULL,
+	"content_type" text NOT NULL,
+	"byte_size" integer NOT NULL,
+	"sha256" text NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "clm"."survey_category" (
+	"category_id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"tenant_id" uuid NOT NULL,
+	"template_id" uuid NOT NULL,
+	"position" integer NOT NULL,
+	"name" text NOT NULL,
+	"min_answers" smallint DEFAULT 0 NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "clm"."survey_question" (
+	"question_id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"tenant_id" uuid NOT NULL,
+	"template_id" uuid NOT NULL,
+	"category_id" uuid,
+	"position" integer NOT NULL,
+	"question_key" text NOT NULL,
+	"title" text NOT NULL,
+	"body" text NOT NULL,
+	"answer_type" text NOT NULL,
+	"config" jsonb DEFAULT '{}'::jsonb NOT NULL,
+	"is_required" boolean DEFAULT true NOT NULL,
+	"allows_upload" boolean DEFAULT false NOT NULL,
+	"max_files" smallint DEFAULT 0 NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+DROP INDEX "clm"."survey_response_run_vendor_key";--> statement-breakpoint
+ALTER TABLE "clm"."survey_response" ALTER COLUMN "vendor_id" DROP NOT NULL;--> statement-breakpoint
+-- HANDMATIG AANGEPAST t.o.v. de gegenereerde migratie.
+-- drizzle-kit produceerde hier één statement: ADD COLUMN ... uuid NOT NULL.
+-- Dat slaagt alleen op een lege tabel en faalt op elke database met bestaande
+-- responses ("column contains null values") — dus ook op clm-enterprise zodra
+-- daar een survey loopt. Daarom in drie stappen: kolom toevoegen zonder NOT
+-- NULL, vullen, en dan pas de eis opleggen.
+--
+-- De backfill zet subject_vendor_id op vendor_id. Dat klopt per definitie voor
+-- alle bestaande rijen: die dateren van vóór UC2, dus daar is de leverancier
+-- zowel deelnemer als onderwerp.
+ALTER TABLE "clm"."survey_response" ADD COLUMN "subject_vendor_id" uuid;--> statement-breakpoint
+UPDATE clm.survey_response
+   SET subject_vendor_id = vendor_id
+ WHERE subject_vendor_id IS NULL;--> statement-breakpoint
+ALTER TABLE "clm"."survey_response" ALTER COLUMN "subject_vendor_id" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "clm"."survey_response" ADD COLUMN "respondent_user_id" uuid;--> statement-breakpoint
+ALTER TABLE "clm"."survey_response" ADD COLUMN "respondent_label" text;--> statement-breakpoint
+ALTER TABLE "clm"."survey_run" ADD COLUMN "survey_kind" text DEFAULT 'vendor_compliance' NOT NULL;--> statement-breakpoint
+ALTER TABLE "clm"."survey_run" ADD COLUMN "status" text DEFAULT 'draft' NOT NULL;--> statement-breakpoint
+ALTER TABLE "clm"."survey_run" ADD COLUMN "is_test" boolean DEFAULT false NOT NULL;--> statement-breakpoint
+ALTER TABLE "clm"."survey_answer" ADD CONSTRAINT "survey_answer_tenant_id_tenant_tenant_id_fk" FOREIGN KEY ("tenant_id") REFERENCES "clm"."tenant"("tenant_id") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "clm"."survey_answer" ADD CONSTRAINT "survey_answer_response_id_survey_response_response_id_fk" FOREIGN KEY ("response_id") REFERENCES "clm"."survey_response"("response_id") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "clm"."survey_answer" ADD CONSTRAINT "survey_answer_question_id_survey_question_question_id_fk" FOREIGN KEY ("question_id") REFERENCES "clm"."survey_question"("question_id") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "clm"."survey_attachment" ADD CONSTRAINT "survey_attachment_tenant_id_tenant_tenant_id_fk" FOREIGN KEY ("tenant_id") REFERENCES "clm"."tenant"("tenant_id") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "clm"."survey_attachment" ADD CONSTRAINT "survey_attachment_response_id_survey_response_response_id_fk" FOREIGN KEY ("response_id") REFERENCES "clm"."survey_response"("response_id") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "clm"."survey_attachment" ADD CONSTRAINT "survey_attachment_question_id_survey_question_question_id_fk" FOREIGN KEY ("question_id") REFERENCES "clm"."survey_question"("question_id") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "clm"."survey_category" ADD CONSTRAINT "survey_category_tenant_id_tenant_tenant_id_fk" FOREIGN KEY ("tenant_id") REFERENCES "clm"."tenant"("tenant_id") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "clm"."survey_category" ADD CONSTRAINT "survey_category_template_id_survey_template_template_id_fk" FOREIGN KEY ("template_id") REFERENCES "clm"."survey_template"("template_id") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "clm"."survey_question" ADD CONSTRAINT "survey_question_tenant_id_tenant_tenant_id_fk" FOREIGN KEY ("tenant_id") REFERENCES "clm"."tenant"("tenant_id") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "clm"."survey_question" ADD CONSTRAINT "survey_question_template_id_survey_template_template_id_fk" FOREIGN KEY ("template_id") REFERENCES "clm"."survey_template"("template_id") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "survey_answer_response_question_key" ON "clm"."survey_answer" USING btree ("response_id","question_id");--> statement-breakpoint
+CREATE INDEX "survey_answer_tenant_id_idx" ON "clm"."survey_answer" USING btree ("tenant_id");--> statement-breakpoint
+CREATE INDEX "survey_answer_response_id_idx" ON "clm"."survey_answer" USING btree ("response_id");--> statement-breakpoint
+CREATE UNIQUE INDEX "survey_attachment_storage_key_key" ON "clm"."survey_attachment" USING btree ("storage_key");--> statement-breakpoint
+CREATE INDEX "survey_attachment_tenant_id_idx" ON "clm"."survey_attachment" USING btree ("tenant_id");--> statement-breakpoint
+CREATE INDEX "survey_attachment_response_id_idx" ON "clm"."survey_attachment" USING btree ("response_id");--> statement-breakpoint
+CREATE UNIQUE INDEX "survey_category_template_position_key" ON "clm"."survey_category" USING btree ("template_id","position");--> statement-breakpoint
+CREATE UNIQUE INDEX "survey_category_template_name_key" ON "clm"."survey_category" USING btree ("template_id","name");--> statement-breakpoint
+CREATE UNIQUE INDEX "survey_category_id_template_key" ON "clm"."survey_category" USING btree ("category_id","template_id");--> statement-breakpoint
+CREATE INDEX "survey_category_tenant_id_idx" ON "clm"."survey_category" USING btree ("tenant_id");--> statement-breakpoint
+CREATE UNIQUE INDEX "survey_question_template_key_key" ON "clm"."survey_question" USING btree ("template_id","question_key");--> statement-breakpoint
+CREATE UNIQUE INDEX "survey_question_template_position_key" ON "clm"."survey_question" USING btree ("template_id","position");--> statement-breakpoint
+CREATE UNIQUE INDEX "survey_question_id_answer_type_key" ON "clm"."survey_question" USING btree ("question_id","answer_type");--> statement-breakpoint
+CREATE INDEX "survey_question_tenant_id_idx" ON "clm"."survey_question" USING btree ("tenant_id");--> statement-breakpoint
+CREATE INDEX "survey_question_category_id_idx" ON "clm"."survey_question" USING btree ("category_id");--> statement-breakpoint
+ALTER TABLE "clm"."survey_response" ADD CONSTRAINT "survey_response_subject_vendor_id_vendor_vendor_id_fk" FOREIGN KEY ("subject_vendor_id") REFERENCES "clm"."vendor"("vendor_id") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "clm"."survey_response" ADD CONSTRAINT "survey_response_respondent_user_id_user_user_id_fk" FOREIGN KEY ("respondent_user_id") REFERENCES "clm"."user"("user_id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "survey_response_subject_vendor_id_idx" ON "clm"."survey_response" USING btree ("subject_vendor_id");--> statement-breakpoint
+CREATE UNIQUE INDEX "survey_response_run_vendor_key" ON "clm"."survey_response" USING btree ("run_id","vendor_id") WHERE "clm"."survey_response"."vendor_id" IS NOT NULL;--> statement-breakpoint
+
+-- =============================================================================
+-- HANDGESCHREVEN DEEL — alles hieronder komt NIET uit drizzle-kit.
+--
+-- drizzle-kit generate produceert uitsluitend tabellen, indexen en foreign
+-- keys. RLS, policies, CHECK-constraints, samengestelde foreign keys, functies
+-- en triggers zijn handwerk (ADR-010).
+--
+-- Ontwerp: docs/superpowers/specs/2026-07-28-vragenlijst-ontwerp.md
+-- =============================================================================
+
+
+-- ── 1. Samengestelde foreign keys ─────────────────────────────────────────
+-- Twee verwijzingen die een gewone foreign key niet kan bewaken, omdat er
+-- telkens een tweede kolom is die mee moet kloppen.
+
+-- Een vraag mag geen categorie van een ándere template aanwijzen. RLS
+-- beschermt tegen een andere tenant, niet tegen een andere template bínnen
+-- dezelfde tenant. Zonder deze constraint is dat servicelaagwerk waar één
+-- vergeten controle volstaat; met deze constraint weigert de database het.
+ALTER TABLE clm.survey_question
+    ADD CONSTRAINT survey_question_category_template_fk
+    FOREIGN KEY (category_id, template_id)
+    REFERENCES clm.survey_category (category_id, template_id)
+    ON DELETE RESTRICT;--> statement-breakpoint
+
+-- Het answer_type op een antwoord moet gelijk zijn aan dat op de vraag. De
+-- kolom staat bewust gedupliceerd op survey_answer: zonder die kolom zou de
+-- vormconstraint (blok 2) de vraagtabel moeten raadplegen, en dat kan een
+-- CHECK niet.
+ALTER TABLE clm.survey_answer
+    ADD CONSTRAINT survey_answer_question_type_fk
+    FOREIGN KEY (question_id, answer_type)
+    REFERENCES clm.survey_question (question_id, answer_type)
+    ON DELETE RESTRICT;--> statement-breakpoint
+
+
+-- ── 2. CHECK-constraints ──────────────────────────────────────────────────
+
+-- survey_run: de twee use cases en de lifecycle uit ontwerp §1c en §2b.
+ALTER TABLE clm.survey_run
+    ADD CONSTRAINT survey_run_kind_check
+    CHECK (survey_kind IN ('vendor_compliance', 'internal_review'));--> statement-breakpoint
+
+ALTER TABLE clm.survey_run
+    ADD CONSTRAINT survey_run_status_check
+    CHECK (status IN ('draft', 'active', 'finished', 'archived'));--> statement-breakpoint
+
+-- survey_response: welke rolverdeling bij welke use case hoort.
+--
+-- Bij UC1 vallen deelnemer en onderwerp samen; bij UC2 is er geen deelnemende
+-- leverancier. Samen met de partiële unieke index hierboven vervangt dit de
+-- garantie die vóór deze migratie in `vendor_id NOT NULL` zat. Zonder die
+-- vervanging zou het versoepelen van NOT NULL stilzwijgend een garantie
+-- weghalen.
+--
+-- Waarom een trigger en geen CHECK-constraint: survey_kind staat op
+-- survey_run, niet op survey_response. Een CHECK mag geen subquery bevatten en
+-- kan die kolom dus niet raadplegen. De uitwijk zou zijn survey_kind te
+-- dupliceren op survey_response, maar dat levert een derde plek op waar de
+-- waarde kan afwijken — en juist het voorkomen daarvan is het doel.
+CREATE OR REPLACE FUNCTION clm.assert_response_rollen()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path = clm, pg_temp
+AS $fn$
+DECLARE
+    soort TEXT;
+BEGIN
+    SELECT r.survey_kind INTO soort
+      FROM clm.survey_run r
+     WHERE r.run_id = NEW.run_id;
+
+    IF soort = 'vendor_compliance' THEN
+        -- UC1: de leverancier vult in over zichzelf. Deelnemer en onderwerp
+        -- moeten dezelfde rij aanwijzen.
+        IF NEW.vendor_id IS NULL OR NEW.vendor_id <> NEW.subject_vendor_id THEN
+            RAISE EXCEPTION
+                'Bij vendor_compliance moet vendor_id gelijk zijn aan subject_vendor_id'
+                USING ERRCODE = 'raise_exception';
+        END IF;
+    ELSIF soort = 'internal_review' THEN
+        -- UC2: een collega vult in over de leverancier. De invuller is geen
+        -- leverancier, dus vendor_id blijft leeg.
+        IF NEW.vendor_id IS NOT NULL THEN
+            RAISE EXCEPTION
+                'Bij internal_review moet vendor_id leeg zijn; de invuller is geen leverancier'
+                USING ERRCODE = 'raise_exception';
+        END IF;
+    END IF;
+
+    RETURN NEW;
+END;
+$fn$;--> statement-breakpoint
+
+COMMENT ON FUNCTION clm.assert_response_rollen() IS
+    'Bewaakt de rolverdeling per use case: bij vendor_compliance vallen deelnemer en onderwerp samen, bij internal_review is er geen deelnemende leverancier. Zie vragenlijst-ontwerp paragraaf 1c.';--> statement-breakpoint
+
+CREATE TRIGGER survey_response_rollen
+    BEFORE INSERT OR UPDATE ON clm.survey_response
+    FOR EACH ROW EXECUTE FUNCTION clm.assert_response_rollen();--> statement-breakpoint
+
+-- survey_question: acht bekende typen, plus 'instruction' als negende
+-- vraagvorm die zelf geen antwoord oplevert.
+ALTER TABLE clm.survey_question
+    ADD CONSTRAINT survey_question_answer_type_check
+    CHECK (answer_type IN (
+        'instruction', 'confirmation', 'open_text', 'yes_no',
+        'single_choice', 'multi_choice', 'rating', 'number', 'file_upload'
+    ));--> statement-breakpoint
+
+-- Een leesblok kan niet verplicht zijn: er valt niets te beantwoorden. Zonder
+-- deze regel is een vragenlijst met een inleidend tekstblok nooit volledig in
+-- te dienen — de waarschijnlijkste bug bij het bouwen van de validatie.
+ALTER TABLE clm.survey_question
+    ADD CONSTRAINT survey_question_instruction_not_required_check
+    CHECK (answer_type <> 'instruction' OR is_required = false);--> statement-breakpoint
+
+ALTER TABLE clm.survey_question
+    ADD CONSTRAINT survey_question_upload_files_check
+    CHECK (
+        (allows_upload = false AND max_files = 0)
+        OR (allows_upload = true AND max_files BETWEEN 1 AND 5)
+    );--> statement-breakpoint
+
+ALTER TABLE clm.survey_question
+    ADD CONSTRAINT survey_question_position_check
+    CHECK (position >= 1);--> statement-breakpoint
+
+ALTER TABLE clm.survey_category
+    ADD CONSTRAINT survey_category_position_check
+    CHECK (position >= 1);--> statement-breakpoint
+
+ALTER TABLE clm.survey_category
+    ADD CONSTRAINT survey_category_min_answers_check
+    CHECK (min_answers >= 0);--> statement-breakpoint
+
+-- survey_answer: 'instruction' ontbreekt bewust — een leesblok krijgt nooit
+-- een antwoordrij.
+ALTER TABLE clm.survey_answer
+    ADD CONSTRAINT survey_answer_type_check
+    CHECK (answer_type IN (
+        'confirmation', 'open_text', 'yes_no', 'single_choice',
+        'multi_choice', 'rating', 'number', 'file_upload'
+    ));--> statement-breakpoint
+
+-- De vormconstraint: elk type vult precies één waardekolom en laat de rest
+-- leeg. Zonder dit kan een bug een rating als tekst wegschrijven of een
+-- keuzecode in answer_number proppen. Dat merk je pas maanden later bij de
+-- eerste rapportage, wanneer de data niet meer te repareren is omdat niemand
+-- weet wat er oorspronkelijk bedoeld was.
+ALTER TABLE clm.survey_answer
+    ADD CONSTRAINT survey_answer_shape_check
+    CHECK (
+        CASE answer_type
+            WHEN 'confirmation' THEN
+                answer_code IN ('confirmed', 'not_confirmed',
+                                'not_applicable', 'cannot_upload')
+                AND answer_codes IS NULL
+                AND answer_text IS NULL AND answer_number IS NULL
+            WHEN 'yes_no' THEN
+                answer_code IN ('yes', 'no') AND answer_codes IS NULL
+                AND answer_text IS NULL AND answer_number IS NULL
+            WHEN 'single_choice' THEN
+                answer_code IS NOT NULL AND answer_codes IS NULL
+                AND answer_text IS NULL AND answer_number IS NULL
+            WHEN 'multi_choice' THEN
+                answer_codes IS NOT NULL
+                AND array_length(answer_codes, 1) >= 1
+                AND answer_code IS NULL AND answer_text IS NULL
+                AND answer_number IS NULL
+            WHEN 'open_text' THEN
+                answer_text IS NOT NULL AND length(btrim(answer_text)) >= 1
+                AND answer_code IS NULL AND answer_codes IS NULL
+                AND answer_number IS NULL
+            WHEN 'rating' THEN
+                answer_number IS NOT NULL
+                AND answer_number = trunc(answer_number)
+                AND answer_code IS NULL AND answer_codes IS NULL
+                AND answer_text IS NULL
+            WHEN 'number' THEN
+                answer_number IS NOT NULL
+                AND answer_code IS NULL AND answer_codes IS NULL
+                AND answer_text IS NULL
+            WHEN 'file_upload' THEN
+                answer_code IS NULL AND answer_codes IS NULL
+                AND answer_text IS NULL AND answer_number IS NULL
+            ELSE false
+        END
+    );--> statement-breakpoint
+
+-- De toelichtingsplicht bij 'confirmation', op databaseniveau (ontwerp §3).
+-- Alles behalve een bevestiging vereist uitleg.
+--
+-- De ondergrens van 10 tekens houdt "n/a" en "-" tegen: die maken het veld
+-- formeel gevuld en inhoudelijk leeg, en zien er in een overzicht uit als een
+-- antwoord. Dat is erger dan een leeg veld.
+--
+-- Een fout in de validatiecode levert hierdoor een databasefout op in plaats
+-- van een halfleeg compliance-antwoord dat er volledig uitziet.
+ALTER TABLE clm.survey_answer
+    ADD CONSTRAINT survey_answer_comment_required_check
+    CHECK (
+        answer_type <> 'confirmation'
+        OR answer_code = 'confirmed'
+        OR length(btrim(coalesce(comment, ''))) >= 10
+    );--> statement-breakpoint
+
+ALTER TABLE clm.survey_answer
+    ADD CONSTRAINT survey_answer_comment_length_check
+    CHECK (comment IS NULL OR length(comment) <= 2000);--> statement-breakpoint
+
+-- survey_attachment: de grenzen uit OV-7 (maximaal 5 MB, PDF of PNG).
+--
+-- Het maximum aantal bestanden staat bewust NIET in een CHECK: dat komt uit
+-- survey_question.max_files en varieert per vraag. Een CHECK kan noch over
+-- meerdere rijen tellen noch een andere tabel raadplegen. Die telling gebeurt
+-- in de transactie met SELECT ... FOR UPDATE op de responserij (ontwerp §4).
+ALTER TABLE clm.survey_attachment
+    ADD CONSTRAINT survey_attachment_size_check
+    CHECK (byte_size > 0 AND byte_size <= 5242880);--> statement-breakpoint
+
+ALTER TABLE clm.survey_attachment
+    ADD CONSTRAINT survey_attachment_content_type_check
+    CHECK (content_type IN ('application/pdf', 'image/png'));--> statement-breakpoint
+
+
+-- ── 3. Row Level Security ─────────────────────────────────────────────────
+-- Verplicht voor elke tenantgebonden tabel (MCM2-CLAUDE.md §7): zowel USING
+-- als WITH CHECK. Zonder WITH CHECK kan een rij met een vreemde tenant_id
+-- weggeschreven worden die daarna onzichtbaar is — een lek dat pas bij een
+-- audit opvalt.
+--
+-- Bewust géén `deleted_at IS NULL` in USING: dat maakte zacht verwijderen
+-- onmogelijk (Issue #31, migratie 0004).
+
+ALTER TABLE clm.survey_category   ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+ALTER TABLE clm.survey_question   ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+ALTER TABLE clm.survey_answer     ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+ALTER TABLE clm.survey_attachment ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+
+CREATE POLICY survey_category_isolation ON clm.survey_category
+    USING (tenant_id = clm.current_tenant_id())
+    WITH CHECK (tenant_id = clm.current_tenant_id());--> statement-breakpoint
+
+CREATE POLICY survey_question_isolation ON clm.survey_question
+    USING (tenant_id = clm.current_tenant_id())
+    WITH CHECK (tenant_id = clm.current_tenant_id());--> statement-breakpoint
+
+-- survey_answer en survey_attachment: naast tenant-isolatie geldt dat er
+-- alleen geschreven mag worden zolang de response nog openstaat. Dat is de
+-- database-kant van de éénmaligheid (AC12): een bug in de applicatie kan de
+-- éénmaligheid hiermee niet omzeilen.
+--
+-- Let op de asymmetrie. Lezen mag altijd binnen de eigen tenant — een
+-- ingediende response moet leesbaar blijven, anders is het bewijsmateriaal
+-- onbereikbaar. Schrijven mag alleen bij status 'pending'.
+CREATE POLICY survey_answer_isolation ON clm.survey_answer
+    USING (tenant_id = clm.current_tenant_id())
+    WITH CHECK (
+        tenant_id = clm.current_tenant_id()
+        AND EXISTS (
+            SELECT 1
+              FROM clm.survey_response r
+             WHERE r.response_id = survey_answer.response_id
+               AND r.tenant_id   = clm.current_tenant_id()
+               AND r.status      = 'pending'
+        )
+    );--> statement-breakpoint
+
+CREATE POLICY survey_attachment_isolation ON clm.survey_attachment
+    USING (tenant_id = clm.current_tenant_id())
+    WITH CHECK (
+        tenant_id = clm.current_tenant_id()
+        AND EXISTS (
+            SELECT 1
+              FROM clm.survey_response r
+             WHERE r.response_id = survey_attachment.response_id
+               AND r.tenant_id   = clm.current_tenant_id()
+               AND r.status      = 'pending'
+        )
+    );--> statement-breakpoint
+
+
+-- ── 4. Bevriezing van een lopende ronde ───────────────────────────────────
+-- Een tenant wijzigt vraag 4 terwijl twaalf leveranciers midden in het
+-- invullen zitten. Zonder bevriezing krijg je antwoorden op vragen die
+-- inmiddels anders luiden. Bij een instrument dat contractueel bewijsmateriaal
+-- oplevert is dat onbruikbaar: je kunt achteraf niet vaststellen waar iemand
+-- precies mee heeft ingestemd.
+--
+-- Wijzigen mag altijd, maar raakt alleen nieuwe rondes. Zodra er aan een
+-- template een run hangt die niet meer in 'draft' staat, is de template
+-- bevroren; wijzigen kan dan alleen via een kopie naar een nieuwe versie.
+--
+-- Afgedwongen met een trigger en niet met een `if` in de servicelaag: anders
+-- is de garantie zo sterk als de code die hem toevallig niet omzeilt, en hier
+-- hangt bewijskracht aan.
+
+CREATE OR REPLACE FUNCTION clm.assert_template_niet_bevroren()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path = clm, pg_temp
+AS $fn$
+DECLARE
+    doel_template UUID;
+BEGIN
+    doel_template := COALESCE(NEW.template_id, OLD.template_id);
+
+    IF EXISTS (
+        SELECT 1
+          FROM clm.survey_run r
+         WHERE r.template_id = doel_template
+           AND r.status <> 'draft'
+    ) THEN
+        RAISE EXCEPTION
+            'Vragenlijst % is bevroren: er loopt of liep een ronde. Kopieer naar een nieuwe versie.',
+            doel_template
+            USING ERRCODE = 'raise_exception';
+    END IF;
+
+    RETURN COALESCE(NEW, OLD);
+END;
+$fn$;--> statement-breakpoint
+
+COMMENT ON FUNCTION clm.assert_template_niet_bevroren() IS
+    'Weigert wijzigingen aan vragen of categorieen van een template waaraan een niet-draft run hangt. Zie vragenlijst-ontwerp paragraaf 2.';--> statement-breakpoint
+
+CREATE TRIGGER survey_question_bevriezing
+    BEFORE INSERT OR UPDATE OR DELETE ON clm.survey_question
+    FOR EACH ROW EXECUTE FUNCTION clm.assert_template_niet_bevroren();--> statement-breakpoint
+
+CREATE TRIGGER survey_category_bevriezing
+    BEFORE INSERT OR UPDATE OR DELETE ON clm.survey_category
+    FOR EACH ROW EXECUTE FUNCTION clm.assert_template_niet_bevroren();--> statement-breakpoint
+
+
+-- ── 5. Rechten ────────────────────────────────────────────────────────────
+-- ALTER DEFAULT PRIVILEGES uit migratie 0001 dekt tabellen die daarna door
+-- clm_migrator zijn aangemaakt. Expliciet herhalen is idempotent en maakt de
+-- rechten leesbaar bij deze tabellen in plaats van impliciet elders.
+
+GRANT SELECT, INSERT, UPDATE, DELETE
+    ON clm.survey_category, clm.survey_question,
+       clm.survey_answer, clm.survey_attachment
+    TO clm_api, clm_admin;--> statement-breakpoint
+
+GRANT SELECT
+    ON clm.survey_category, clm.survey_question,
+       clm.survey_answer, clm.survey_attachment
+    TO clm_readonly;

--- a/drizzle/0006_ronde_status_in_guard.sql
+++ b/drizzle/0006_ronde_status_in_guard.sql
@@ -1,0 +1,74 @@
+-- =============================================================================
+-- Stap 2 uit de bouwvolgorde: de guard moet de lifecycle van een ronde
+-- meewegen (vragenlijst-ontwerp §2b, §5 stap 1b).
+--
+-- Migratie 0005 gaf survey_run een expliciete status (draft/active/finished/
+-- archived). De guard kende die nog niet: hij weegt alleen revoked_at en
+-- closes_at. Gevolg vóór deze migratie: een ronde in 'draft' — nog niet
+-- gepubliceerd, nog niet bedoeld voor leveranciers — is via een token gewoon
+-- bereikbaar. Datzelfde geldt voor 'finished' en 'archived', zolang closes_at
+-- toevallig leeg is.
+--
+-- Deze migratie voegt de status toe aan resolve_survey_token(). Bewust als
+-- APARTE kolom en niet verwerkt in run_closed:
+--
+--   - 'draft' en 'finished' zijn voor een leverancier iets anders. Bij de
+--     eerste is de ronde nog niet begonnen, bij de tweede voorbij. Eén
+--     gedeelde melding maakt van dat verschil een raadsel.
+--   - run_closed blijft betekenen wat het betekende (ingetrokken of voorbij
+--     closes_at), zodat de bestaande controles ongewijzigd blijven werken.
+--
+-- De functie retourneert nog steeds uitsluitend geldigheidsvelden: geen namen,
+-- geen e-mailadressen, geen antwoorden. Een status is geen inhoudelijk
+-- gegeven — hij zegt of de link werkt, niet wat erachter zit.
+-- =============================================================================
+
+-- DROP vóór CREATE, niet CREATE OR REPLACE. PostgreSQL weigert een replace die
+-- de RETURNS TABLE wijzigt ("cannot change return type of existing function") —
+-- geverifieerd, niet aangenomen. Er komt een kolom bij, dus dit moet.
+--
+-- Het korte gat tussen DROP en CREATE is niet zichtbaar: migraties draaien in
+-- een transactie, dus buiten deze transactie bestaat de oude functie tot het
+-- moment dat de nieuwe er staat.
+DROP FUNCTION IF EXISTS clm.resolve_survey_token(TEXT);--> statement-breakpoint
+
+CREATE FUNCTION clm.resolve_survey_token(p_token_hash TEXT)
+RETURNS TABLE (
+    response_id   UUID,
+    tenant_id     UUID,
+    status        TEXT,
+    expires_at    TIMESTAMPTZ,
+    submitted_at  TIMESTAMPTZ,
+    vendor_active BOOLEAN,
+    run_closed    BOOLEAN,
+    run_status    TEXT
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = clm, pg_temp
+AS $$
+    SELECT r.response_id,
+           r.tenant_id,
+           r.status,
+           r.expires_at,
+           r.submitted_at,
+           (v.vendor_id IS NOT NULL AND v.deleted_at IS NULL) AS vendor_active,
+           (run.revoked_at IS NOT NULL
+            OR (run.closes_at IS NOT NULL AND run.closes_at < now())) AS run_closed,
+           run.status AS run_status
+      FROM clm.survey_response r
+      LEFT JOIN clm.vendor     v   ON v.vendor_id = r.vendor_id
+      LEFT JOIN clm.survey_run run ON run.run_id  = r.run_id
+     WHERE r.token_hash = p_token_hash
+$$;--> statement-breakpoint
+
+COMMENT ON FUNCTION clm.resolve_survey_token(TEXT) IS
+    'Zoekt een survey-response op via de SHA-256-hash van het leverancierstoken. SECURITY DEFINER omdat de tenantcontext pas na deze lookup gezet kan worden. Retourneert uitsluitend geldigheidsvelden, nooit inhoudelijke gegevens.';--> statement-breakpoint
+
+-- Na een DROP zijn de rechten wég: ze hangen aan het functie-object, niet aan
+-- de naam. Zonder deze twee regels kan clm_api de functie niet meer aanroepen
+-- en werkt géén enkele leverancierslink meer. Dit is geen nette herhaling maar
+-- een noodzaak.
+REVOKE ALL ON FUNCTION clm.resolve_survey_token(TEXT) FROM PUBLIC;--> statement-breakpoint
+GRANT EXECUTE ON FUNCTION clm.resolve_survey_token(TEXT) TO clm_api, clm_admin;

--- a/drizzle/meta/0005_snapshot.json
+++ b/drizzle/meta/0005_snapshot.json
@@ -1,0 +1,1967 @@
+{
+  "id": "32934f3b-97d5-4e3d-9353-ff39d567dc55",
+  "prevId": "f22e0b82-bec4-4517-a739-06030035a592",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "audit.audit_event": {
+      "name": "audit_event",
+      "schema": "audit",
+      "columns": {
+        "audit_event_id": {
+          "name": "audit_event_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action_type": {
+          "name": "action_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "old_values": {
+          "name": "old_values",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_values": {
+          "name": "new_values",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "audit_event_tenant_id_idx": {
+          "name": "audit_event_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "ref.business_criticality": {
+      "name": "business_criticality",
+      "schema": "ref",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "ref.compliance_status": {
+      "name": "compliance_status",
+      "schema": "ref",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "clm.survey_answer": {
+      "name": "survey_answer",
+      "schema": "clm",
+      "columns": {
+        "answer_id": {
+          "name": "answer_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "response_id": {
+          "name": "response_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "answer_type": {
+          "name": "answer_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "answer_code": {
+          "name": "answer_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "answer_codes": {
+          "name": "answer_codes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "answer_text": {
+          "name": "answer_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "answer_number": {
+          "name": "answer_number",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "survey_answer_response_question_key": {
+          "name": "survey_answer_response_question_key",
+          "columns": [
+            {
+              "expression": "response_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "question_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "survey_answer_tenant_id_idx": {
+          "name": "survey_answer_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "survey_answer_response_id_idx": {
+          "name": "survey_answer_response_id_idx",
+          "columns": [
+            {
+              "expression": "response_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "survey_answer_tenant_id_tenant_tenant_id_fk": {
+          "name": "survey_answer_tenant_id_tenant_tenant_id_fk",
+          "tableFrom": "survey_answer",
+          "tableTo": "tenant",
+          "schemaTo": "clm",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "tenant_id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "survey_answer_response_id_survey_response_response_id_fk": {
+          "name": "survey_answer_response_id_survey_response_response_id_fk",
+          "tableFrom": "survey_answer",
+          "tableTo": "survey_response",
+          "schemaTo": "clm",
+          "columnsFrom": [
+            "response_id"
+          ],
+          "columnsTo": [
+            "response_id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "survey_answer_question_id_survey_question_question_id_fk": {
+          "name": "survey_answer_question_id_survey_question_question_id_fk",
+          "tableFrom": "survey_answer",
+          "tableTo": "survey_question",
+          "schemaTo": "clm",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "question_id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "clm.survey_attachment": {
+      "name": "survey_attachment",
+      "schema": "clm",
+      "columns": {
+        "attachment_id": {
+          "name": "attachment_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "response_id": {
+          "name": "response_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_name": {
+          "name": "original_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_key": {
+          "name": "storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "byte_size": {
+          "name": "byte_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sha256": {
+          "name": "sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "survey_attachment_storage_key_key": {
+          "name": "survey_attachment_storage_key_key",
+          "columns": [
+            {
+              "expression": "storage_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "survey_attachment_tenant_id_idx": {
+          "name": "survey_attachment_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "survey_attachment_response_id_idx": {
+          "name": "survey_attachment_response_id_idx",
+          "columns": [
+            {
+              "expression": "response_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "survey_attachment_tenant_id_tenant_tenant_id_fk": {
+          "name": "survey_attachment_tenant_id_tenant_tenant_id_fk",
+          "tableFrom": "survey_attachment",
+          "tableTo": "tenant",
+          "schemaTo": "clm",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "tenant_id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "survey_attachment_response_id_survey_response_response_id_fk": {
+          "name": "survey_attachment_response_id_survey_response_response_id_fk",
+          "tableFrom": "survey_attachment",
+          "tableTo": "survey_response",
+          "schemaTo": "clm",
+          "columnsFrom": [
+            "response_id"
+          ],
+          "columnsTo": [
+            "response_id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "survey_attachment_question_id_survey_question_question_id_fk": {
+          "name": "survey_attachment_question_id_survey_question_question_id_fk",
+          "tableFrom": "survey_attachment",
+          "tableTo": "survey_question",
+          "schemaTo": "clm",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "question_id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "clm.survey_category": {
+      "name": "survey_category",
+      "schema": "clm",
+      "columns": {
+        "category_id": {
+          "name": "category_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "min_answers": {
+          "name": "min_answers",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "survey_category_template_position_key": {
+          "name": "survey_category_template_position_key",
+          "columns": [
+            {
+              "expression": "template_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "survey_category_template_name_key": {
+          "name": "survey_category_template_name_key",
+          "columns": [
+            {
+              "expression": "template_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "survey_category_id_template_key": {
+          "name": "survey_category_id_template_key",
+          "columns": [
+            {
+              "expression": "category_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "template_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "survey_category_tenant_id_idx": {
+          "name": "survey_category_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "survey_category_tenant_id_tenant_tenant_id_fk": {
+          "name": "survey_category_tenant_id_tenant_tenant_id_fk",
+          "tableFrom": "survey_category",
+          "tableTo": "tenant",
+          "schemaTo": "clm",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "tenant_id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "survey_category_template_id_survey_template_template_id_fk": {
+          "name": "survey_category_template_id_survey_template_template_id_fk",
+          "tableFrom": "survey_category",
+          "tableTo": "survey_template",
+          "schemaTo": "clm",
+          "columnsFrom": [
+            "template_id"
+          ],
+          "columnsTo": [
+            "template_id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "clm.survey_question": {
+      "name": "survey_question",
+      "schema": "clm",
+      "columns": {
+        "question_id": {
+          "name": "question_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_key": {
+          "name": "question_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "answer_type": {
+          "name": "answer_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "is_required": {
+          "name": "is_required",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "allows_upload": {
+          "name": "allows_upload",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "max_files": {
+          "name": "max_files",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "survey_question_template_key_key": {
+          "name": "survey_question_template_key_key",
+          "columns": [
+            {
+              "expression": "template_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "question_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "survey_question_template_position_key": {
+          "name": "survey_question_template_position_key",
+          "columns": [
+            {
+              "expression": "template_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "survey_question_id_answer_type_key": {
+          "name": "survey_question_id_answer_type_key",
+          "columns": [
+            {
+              "expression": "question_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "answer_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "survey_question_tenant_id_idx": {
+          "name": "survey_question_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "survey_question_category_id_idx": {
+          "name": "survey_question_category_id_idx",
+          "columns": [
+            {
+              "expression": "category_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "survey_question_tenant_id_tenant_tenant_id_fk": {
+          "name": "survey_question_tenant_id_tenant_tenant_id_fk",
+          "tableFrom": "survey_question",
+          "tableTo": "tenant",
+          "schemaTo": "clm",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "tenant_id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "survey_question_template_id_survey_template_template_id_fk": {
+          "name": "survey_question_template_id_survey_template_template_id_fk",
+          "tableFrom": "survey_question",
+          "tableTo": "survey_template",
+          "schemaTo": "clm",
+          "columnsFrom": [
+            "template_id"
+          ],
+          "columnsTo": [
+            "template_id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "clm.survey_response": {
+      "name": "survey_response",
+      "schema": "clm",
+      "columns": {
+        "response_id": {
+          "name": "response_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vendor_id": {
+          "name": "vendor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject_vendor_id": {
+          "name": "subject_vendor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "respondent_user_id": {
+          "name": "respondent_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "respondent_label": {
+          "name": "respondent_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "survey_response_token_hash_key": {
+          "name": "survey_response_token_hash_key",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "survey_response_run_vendor_key": {
+          "name": "survey_response_run_vendor_key",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "vendor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"clm\".\"survey_response\".\"vendor_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "survey_response_tenant_id_idx": {
+          "name": "survey_response_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "survey_response_subject_vendor_id_idx": {
+          "name": "survey_response_subject_vendor_id_idx",
+          "columns": [
+            {
+              "expression": "subject_vendor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "survey_response_tenant_id_tenant_tenant_id_fk": {
+          "name": "survey_response_tenant_id_tenant_tenant_id_fk",
+          "tableFrom": "survey_response",
+          "tableTo": "tenant",
+          "schemaTo": "clm",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "tenant_id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "survey_response_run_id_survey_run_run_id_fk": {
+          "name": "survey_response_run_id_survey_run_run_id_fk",
+          "tableFrom": "survey_response",
+          "tableTo": "survey_run",
+          "schemaTo": "clm",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "run_id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "survey_response_vendor_id_vendor_vendor_id_fk": {
+          "name": "survey_response_vendor_id_vendor_vendor_id_fk",
+          "tableFrom": "survey_response",
+          "tableTo": "vendor",
+          "schemaTo": "clm",
+          "columnsFrom": [
+            "vendor_id"
+          ],
+          "columnsTo": [
+            "vendor_id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "survey_response_subject_vendor_id_vendor_vendor_id_fk": {
+          "name": "survey_response_subject_vendor_id_vendor_vendor_id_fk",
+          "tableFrom": "survey_response",
+          "tableTo": "vendor",
+          "schemaTo": "clm",
+          "columnsFrom": [
+            "subject_vendor_id"
+          ],
+          "columnsTo": [
+            "vendor_id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "survey_response_respondent_user_id_user_user_id_fk": {
+          "name": "survey_response_respondent_user_id_user_user_id_fk",
+          "tableFrom": "survey_response",
+          "tableTo": "user",
+          "schemaTo": "clm",
+          "columnsFrom": [
+            "respondent_user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "clm.survey_run": {
+      "name": "survey_run",
+      "schema": "clm",
+      "columns": {
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "survey_kind": {
+          "name": "survey_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'vendor_compliance'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "is_test": {
+          "name": "is_test",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "closes_at": {
+          "name": "closes_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "survey_run_tenant_id_idx": {
+          "name": "survey_run_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "survey_run_tenant_id_tenant_tenant_id_fk": {
+          "name": "survey_run_tenant_id_tenant_tenant_id_fk",
+          "tableFrom": "survey_run",
+          "tableTo": "tenant",
+          "schemaTo": "clm",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "tenant_id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "survey_run_template_id_survey_template_template_id_fk": {
+          "name": "survey_run_template_id_survey_template_template_id_fk",
+          "tableFrom": "survey_run",
+          "tableTo": "survey_template",
+          "schemaTo": "clm",
+          "columnsFrom": [
+            "template_id"
+          ],
+          "columnsTo": [
+            "template_id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "clm.survey_template": {
+      "name": "survey_template",
+      "schema": "clm",
+      "columns": {
+        "template_id": {
+          "name": "template_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "survey_template_tenant_name_version_key": {
+          "name": "survey_template_tenant_name_version_key",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "survey_template_tenant_id_idx": {
+          "name": "survey_template_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "survey_template_tenant_id_tenant_tenant_id_fk": {
+          "name": "survey_template_tenant_id_tenant_tenant_id_fk",
+          "tableFrom": "survey_template",
+          "tableTo": "tenant",
+          "schemaTo": "clm",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "tenant_id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "clm.tenant": {
+      "name": "tenant",
+      "schema": "clm",
+      "columns": {
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "tenant_name_key": {
+          "name": "tenant_name_key",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "clm.user": {
+      "name": "user",
+      "schema": "clm",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_tenant_id_tenant_tenant_id_fk": {
+          "name": "user_tenant_id_tenant_tenant_id_fk",
+          "tableFrom": "user",
+          "tableTo": "tenant",
+          "schemaTo": "clm",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "tenant_id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "clm.vendor": {
+      "name": "vendor",
+      "schema": "clm",
+      "columns": {
+        "vendor_id": {
+          "name": "vendor_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kvk_number": {
+          "name": "kvk_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vestigingsnummer": {
+          "name": "vestigingsnummer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "statutory_name": {
+          "name": "statutory_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trade_names": {
+          "name": "trade_names",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legal_form": {
+          "name": "legal_form",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "incorporation_date": {
+          "name": "incorporation_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sbi_code": {
+          "name": "sbi_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sbi_description": {
+          "name": "sbi_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category_code": {
+          "name": "category_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "business_criticality_code": {
+          "name": "business_criticality_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "compliance_status_code": {
+          "name": "compliance_status_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country": {
+          "name": "country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'NL'"
+        },
+        "city": {
+          "name": "city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website": {
+          "name": "website",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "annual_spend_eur": {
+          "name": "annual_spend_eur",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "risk_score": {
+          "name": "risk_score",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_review_date": {
+          "name": "last_review_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_review_date": {
+          "name": "next_review_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "vendor_tenant_id_kvk_number_key": {
+          "name": "vendor_tenant_id_kvk_number_key",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kvk_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vendor_tenant_id_idx": {
+          "name": "vendor_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vendor_tenant_id_tenant_tenant_id_fk": {
+          "name": "vendor_tenant_id_tenant_tenant_id_fk",
+          "tableFrom": "vendor",
+          "tableTo": "tenant",
+          "schemaTo": "clm",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "tenant_id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "vendor_category_code_vendor_category_code_fk": {
+          "name": "vendor_category_code_vendor_category_code_fk",
+          "tableFrom": "vendor",
+          "tableTo": "vendor_category",
+          "schemaTo": "ref",
+          "columnsFrom": [
+            "category_code"
+          ],
+          "columnsTo": [
+            "code"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "vendor_business_criticality_code_business_criticality_code_fk": {
+          "name": "vendor_business_criticality_code_business_criticality_code_fk",
+          "tableFrom": "vendor",
+          "tableTo": "business_criticality",
+          "schemaTo": "ref",
+          "columnsFrom": [
+            "business_criticality_code"
+          ],
+          "columnsTo": [
+            "code"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "vendor_compliance_status_code_compliance_status_code_fk": {
+          "name": "vendor_compliance_status_code_compliance_status_code_fk",
+          "tableFrom": "vendor",
+          "tableTo": "compliance_status",
+          "schemaTo": "ref",
+          "columnsFrom": [
+            "compliance_status_code"
+          ],
+          "columnsTo": [
+            "code"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "vendor_owner_user_id_user_user_id_fk": {
+          "name": "vendor_owner_user_id_user_user_id_fk",
+          "tableFrom": "vendor",
+          "tableTo": "user",
+          "schemaTo": "clm",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "ref.vendor_category": {
+      "name": "vendor_category",
+      "schema": "ref",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "clm.vendor_contact": {
+      "name": "vendor_contact",
+      "schema": "clm",
+      "columns": {
+        "contact_id": {
+          "name": "contact_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "vendor_id": {
+          "name": "vendor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "job_title": {
+          "name": "job_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role_description": {
+          "name": "role_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "vendor_contact_tenant_id_idx": {
+          "name": "vendor_contact_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vendor_contact_vendor_id_vendor_vendor_id_fk": {
+          "name": "vendor_contact_vendor_id_vendor_vendor_id_fk",
+          "tableFrom": "vendor_contact",
+          "tableTo": "vendor",
+          "schemaTo": "clm",
+          "columnsFrom": [
+            "vendor_id"
+          ],
+          "columnsTo": [
+            "vendor_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "clm.vendor_tag": {
+      "name": "vendor_tag",
+      "schema": "clm",
+      "columns": {
+        "vendor_id": {
+          "name": "vendor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag": {
+          "name": "tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "vendor_tag_pkey": {
+          "name": "vendor_tag_pkey",
+          "columns": [
+            {
+              "expression": "vendor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tag",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vendor_tag_tenant_id_idx": {
+          "name": "vendor_tag_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vendor_tag_vendor_id_vendor_vendor_id_fk": {
+          "name": "vendor_tag_vendor_id_vendor_vendor_id_fk",
+          "tableFrom": "vendor_tag",
+          "tableTo": "vendor",
+          "schemaTo": "clm",
+          "columnsFrom": [
+            "vendor_id"
+          ],
+          "columnsTo": [
+            "vendor_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {
+    "audit": "audit",
+    "clm": "clm",
+    "ref": "ref"
+  },
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/0006_snapshot.json
+++ b/drizzle/meta/0006_snapshot.json
@@ -1,0 +1,1967 @@
+{
+  "id": "2971c45a-c5aa-412d-b268-a85f1b8a3127",
+  "prevId": "32934f3b-97d5-4e3d-9353-ff39d567dc55",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "audit.audit_event": {
+      "name": "audit_event",
+      "schema": "audit",
+      "columns": {
+        "audit_event_id": {
+          "name": "audit_event_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action_type": {
+          "name": "action_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "old_values": {
+          "name": "old_values",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_values": {
+          "name": "new_values",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "audit_event_tenant_id_idx": {
+          "name": "audit_event_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "ref.business_criticality": {
+      "name": "business_criticality",
+      "schema": "ref",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "ref.compliance_status": {
+      "name": "compliance_status",
+      "schema": "ref",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "clm.survey_answer": {
+      "name": "survey_answer",
+      "schema": "clm",
+      "columns": {
+        "answer_id": {
+          "name": "answer_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "response_id": {
+          "name": "response_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "answer_type": {
+          "name": "answer_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "answer_code": {
+          "name": "answer_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "answer_codes": {
+          "name": "answer_codes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "answer_text": {
+          "name": "answer_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "answer_number": {
+          "name": "answer_number",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "survey_answer_response_question_key": {
+          "name": "survey_answer_response_question_key",
+          "columns": [
+            {
+              "expression": "response_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "question_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "survey_answer_tenant_id_idx": {
+          "name": "survey_answer_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "survey_answer_response_id_idx": {
+          "name": "survey_answer_response_id_idx",
+          "columns": [
+            {
+              "expression": "response_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "survey_answer_tenant_id_tenant_tenant_id_fk": {
+          "name": "survey_answer_tenant_id_tenant_tenant_id_fk",
+          "tableFrom": "survey_answer",
+          "tableTo": "tenant",
+          "schemaTo": "clm",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "tenant_id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "survey_answer_response_id_survey_response_response_id_fk": {
+          "name": "survey_answer_response_id_survey_response_response_id_fk",
+          "tableFrom": "survey_answer",
+          "tableTo": "survey_response",
+          "schemaTo": "clm",
+          "columnsFrom": [
+            "response_id"
+          ],
+          "columnsTo": [
+            "response_id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "survey_answer_question_id_survey_question_question_id_fk": {
+          "name": "survey_answer_question_id_survey_question_question_id_fk",
+          "tableFrom": "survey_answer",
+          "tableTo": "survey_question",
+          "schemaTo": "clm",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "question_id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "clm.survey_attachment": {
+      "name": "survey_attachment",
+      "schema": "clm",
+      "columns": {
+        "attachment_id": {
+          "name": "attachment_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "response_id": {
+          "name": "response_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_name": {
+          "name": "original_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_key": {
+          "name": "storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "byte_size": {
+          "name": "byte_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sha256": {
+          "name": "sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "survey_attachment_storage_key_key": {
+          "name": "survey_attachment_storage_key_key",
+          "columns": [
+            {
+              "expression": "storage_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "survey_attachment_tenant_id_idx": {
+          "name": "survey_attachment_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "survey_attachment_response_id_idx": {
+          "name": "survey_attachment_response_id_idx",
+          "columns": [
+            {
+              "expression": "response_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "survey_attachment_tenant_id_tenant_tenant_id_fk": {
+          "name": "survey_attachment_tenant_id_tenant_tenant_id_fk",
+          "tableFrom": "survey_attachment",
+          "tableTo": "tenant",
+          "schemaTo": "clm",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "tenant_id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "survey_attachment_response_id_survey_response_response_id_fk": {
+          "name": "survey_attachment_response_id_survey_response_response_id_fk",
+          "tableFrom": "survey_attachment",
+          "tableTo": "survey_response",
+          "schemaTo": "clm",
+          "columnsFrom": [
+            "response_id"
+          ],
+          "columnsTo": [
+            "response_id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "survey_attachment_question_id_survey_question_question_id_fk": {
+          "name": "survey_attachment_question_id_survey_question_question_id_fk",
+          "tableFrom": "survey_attachment",
+          "tableTo": "survey_question",
+          "schemaTo": "clm",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "question_id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "clm.survey_category": {
+      "name": "survey_category",
+      "schema": "clm",
+      "columns": {
+        "category_id": {
+          "name": "category_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "min_answers": {
+          "name": "min_answers",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "survey_category_template_position_key": {
+          "name": "survey_category_template_position_key",
+          "columns": [
+            {
+              "expression": "template_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "survey_category_template_name_key": {
+          "name": "survey_category_template_name_key",
+          "columns": [
+            {
+              "expression": "template_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "survey_category_id_template_key": {
+          "name": "survey_category_id_template_key",
+          "columns": [
+            {
+              "expression": "category_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "template_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "survey_category_tenant_id_idx": {
+          "name": "survey_category_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "survey_category_tenant_id_tenant_tenant_id_fk": {
+          "name": "survey_category_tenant_id_tenant_tenant_id_fk",
+          "tableFrom": "survey_category",
+          "tableTo": "tenant",
+          "schemaTo": "clm",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "tenant_id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "survey_category_template_id_survey_template_template_id_fk": {
+          "name": "survey_category_template_id_survey_template_template_id_fk",
+          "tableFrom": "survey_category",
+          "tableTo": "survey_template",
+          "schemaTo": "clm",
+          "columnsFrom": [
+            "template_id"
+          ],
+          "columnsTo": [
+            "template_id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "clm.survey_question": {
+      "name": "survey_question",
+      "schema": "clm",
+      "columns": {
+        "question_id": {
+          "name": "question_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_key": {
+          "name": "question_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "answer_type": {
+          "name": "answer_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "is_required": {
+          "name": "is_required",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "allows_upload": {
+          "name": "allows_upload",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "max_files": {
+          "name": "max_files",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "survey_question_template_key_key": {
+          "name": "survey_question_template_key_key",
+          "columns": [
+            {
+              "expression": "template_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "question_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "survey_question_template_position_key": {
+          "name": "survey_question_template_position_key",
+          "columns": [
+            {
+              "expression": "template_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "survey_question_id_answer_type_key": {
+          "name": "survey_question_id_answer_type_key",
+          "columns": [
+            {
+              "expression": "question_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "answer_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "survey_question_tenant_id_idx": {
+          "name": "survey_question_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "survey_question_category_id_idx": {
+          "name": "survey_question_category_id_idx",
+          "columns": [
+            {
+              "expression": "category_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "survey_question_tenant_id_tenant_tenant_id_fk": {
+          "name": "survey_question_tenant_id_tenant_tenant_id_fk",
+          "tableFrom": "survey_question",
+          "tableTo": "tenant",
+          "schemaTo": "clm",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "tenant_id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "survey_question_template_id_survey_template_template_id_fk": {
+          "name": "survey_question_template_id_survey_template_template_id_fk",
+          "tableFrom": "survey_question",
+          "tableTo": "survey_template",
+          "schemaTo": "clm",
+          "columnsFrom": [
+            "template_id"
+          ],
+          "columnsTo": [
+            "template_id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "clm.survey_response": {
+      "name": "survey_response",
+      "schema": "clm",
+      "columns": {
+        "response_id": {
+          "name": "response_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vendor_id": {
+          "name": "vendor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject_vendor_id": {
+          "name": "subject_vendor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "respondent_user_id": {
+          "name": "respondent_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "respondent_label": {
+          "name": "respondent_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "survey_response_token_hash_key": {
+          "name": "survey_response_token_hash_key",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "survey_response_run_vendor_key": {
+          "name": "survey_response_run_vendor_key",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "vendor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"clm\".\"survey_response\".\"vendor_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "survey_response_tenant_id_idx": {
+          "name": "survey_response_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "survey_response_subject_vendor_id_idx": {
+          "name": "survey_response_subject_vendor_id_idx",
+          "columns": [
+            {
+              "expression": "subject_vendor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "survey_response_tenant_id_tenant_tenant_id_fk": {
+          "name": "survey_response_tenant_id_tenant_tenant_id_fk",
+          "tableFrom": "survey_response",
+          "tableTo": "tenant",
+          "schemaTo": "clm",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "tenant_id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "survey_response_run_id_survey_run_run_id_fk": {
+          "name": "survey_response_run_id_survey_run_run_id_fk",
+          "tableFrom": "survey_response",
+          "tableTo": "survey_run",
+          "schemaTo": "clm",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "run_id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "survey_response_vendor_id_vendor_vendor_id_fk": {
+          "name": "survey_response_vendor_id_vendor_vendor_id_fk",
+          "tableFrom": "survey_response",
+          "tableTo": "vendor",
+          "schemaTo": "clm",
+          "columnsFrom": [
+            "vendor_id"
+          ],
+          "columnsTo": [
+            "vendor_id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "survey_response_subject_vendor_id_vendor_vendor_id_fk": {
+          "name": "survey_response_subject_vendor_id_vendor_vendor_id_fk",
+          "tableFrom": "survey_response",
+          "tableTo": "vendor",
+          "schemaTo": "clm",
+          "columnsFrom": [
+            "subject_vendor_id"
+          ],
+          "columnsTo": [
+            "vendor_id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "survey_response_respondent_user_id_user_user_id_fk": {
+          "name": "survey_response_respondent_user_id_user_user_id_fk",
+          "tableFrom": "survey_response",
+          "tableTo": "user",
+          "schemaTo": "clm",
+          "columnsFrom": [
+            "respondent_user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "clm.survey_run": {
+      "name": "survey_run",
+      "schema": "clm",
+      "columns": {
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "survey_kind": {
+          "name": "survey_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'vendor_compliance'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "is_test": {
+          "name": "is_test",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "closes_at": {
+          "name": "closes_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "survey_run_tenant_id_idx": {
+          "name": "survey_run_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "survey_run_tenant_id_tenant_tenant_id_fk": {
+          "name": "survey_run_tenant_id_tenant_tenant_id_fk",
+          "tableFrom": "survey_run",
+          "tableTo": "tenant",
+          "schemaTo": "clm",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "tenant_id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "survey_run_template_id_survey_template_template_id_fk": {
+          "name": "survey_run_template_id_survey_template_template_id_fk",
+          "tableFrom": "survey_run",
+          "tableTo": "survey_template",
+          "schemaTo": "clm",
+          "columnsFrom": [
+            "template_id"
+          ],
+          "columnsTo": [
+            "template_id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "clm.survey_template": {
+      "name": "survey_template",
+      "schema": "clm",
+      "columns": {
+        "template_id": {
+          "name": "template_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "survey_template_tenant_name_version_key": {
+          "name": "survey_template_tenant_name_version_key",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "survey_template_tenant_id_idx": {
+          "name": "survey_template_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "survey_template_tenant_id_tenant_tenant_id_fk": {
+          "name": "survey_template_tenant_id_tenant_tenant_id_fk",
+          "tableFrom": "survey_template",
+          "tableTo": "tenant",
+          "schemaTo": "clm",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "tenant_id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "clm.tenant": {
+      "name": "tenant",
+      "schema": "clm",
+      "columns": {
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "tenant_name_key": {
+          "name": "tenant_name_key",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "clm.user": {
+      "name": "user",
+      "schema": "clm",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_tenant_id_tenant_tenant_id_fk": {
+          "name": "user_tenant_id_tenant_tenant_id_fk",
+          "tableFrom": "user",
+          "tableTo": "tenant",
+          "schemaTo": "clm",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "tenant_id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "clm.vendor": {
+      "name": "vendor",
+      "schema": "clm",
+      "columns": {
+        "vendor_id": {
+          "name": "vendor_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kvk_number": {
+          "name": "kvk_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vestigingsnummer": {
+          "name": "vestigingsnummer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "statutory_name": {
+          "name": "statutory_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trade_names": {
+          "name": "trade_names",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legal_form": {
+          "name": "legal_form",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "incorporation_date": {
+          "name": "incorporation_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sbi_code": {
+          "name": "sbi_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sbi_description": {
+          "name": "sbi_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category_code": {
+          "name": "category_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "business_criticality_code": {
+          "name": "business_criticality_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "compliance_status_code": {
+          "name": "compliance_status_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country": {
+          "name": "country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'NL'"
+        },
+        "city": {
+          "name": "city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website": {
+          "name": "website",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "annual_spend_eur": {
+          "name": "annual_spend_eur",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "risk_score": {
+          "name": "risk_score",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_review_date": {
+          "name": "last_review_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_review_date": {
+          "name": "next_review_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "vendor_tenant_id_kvk_number_key": {
+          "name": "vendor_tenant_id_kvk_number_key",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kvk_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vendor_tenant_id_idx": {
+          "name": "vendor_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vendor_tenant_id_tenant_tenant_id_fk": {
+          "name": "vendor_tenant_id_tenant_tenant_id_fk",
+          "tableFrom": "vendor",
+          "tableTo": "tenant",
+          "schemaTo": "clm",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "tenant_id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "vendor_category_code_vendor_category_code_fk": {
+          "name": "vendor_category_code_vendor_category_code_fk",
+          "tableFrom": "vendor",
+          "tableTo": "vendor_category",
+          "schemaTo": "ref",
+          "columnsFrom": [
+            "category_code"
+          ],
+          "columnsTo": [
+            "code"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "vendor_business_criticality_code_business_criticality_code_fk": {
+          "name": "vendor_business_criticality_code_business_criticality_code_fk",
+          "tableFrom": "vendor",
+          "tableTo": "business_criticality",
+          "schemaTo": "ref",
+          "columnsFrom": [
+            "business_criticality_code"
+          ],
+          "columnsTo": [
+            "code"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "vendor_compliance_status_code_compliance_status_code_fk": {
+          "name": "vendor_compliance_status_code_compliance_status_code_fk",
+          "tableFrom": "vendor",
+          "tableTo": "compliance_status",
+          "schemaTo": "ref",
+          "columnsFrom": [
+            "compliance_status_code"
+          ],
+          "columnsTo": [
+            "code"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "vendor_owner_user_id_user_user_id_fk": {
+          "name": "vendor_owner_user_id_user_user_id_fk",
+          "tableFrom": "vendor",
+          "tableTo": "user",
+          "schemaTo": "clm",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "ref.vendor_category": {
+      "name": "vendor_category",
+      "schema": "ref",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "clm.vendor_contact": {
+      "name": "vendor_contact",
+      "schema": "clm",
+      "columns": {
+        "contact_id": {
+          "name": "contact_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "vendor_id": {
+          "name": "vendor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "job_title": {
+          "name": "job_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role_description": {
+          "name": "role_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "vendor_contact_tenant_id_idx": {
+          "name": "vendor_contact_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vendor_contact_vendor_id_vendor_vendor_id_fk": {
+          "name": "vendor_contact_vendor_id_vendor_vendor_id_fk",
+          "tableFrom": "vendor_contact",
+          "tableTo": "vendor",
+          "schemaTo": "clm",
+          "columnsFrom": [
+            "vendor_id"
+          ],
+          "columnsTo": [
+            "vendor_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "clm.vendor_tag": {
+      "name": "vendor_tag",
+      "schema": "clm",
+      "columns": {
+        "vendor_id": {
+          "name": "vendor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag": {
+          "name": "tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "vendor_tag_pkey": {
+          "name": "vendor_tag_pkey",
+          "columns": [
+            {
+              "expression": "vendor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tag",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vendor_tag_tenant_id_idx": {
+          "name": "vendor_tag_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vendor_tag_vendor_id_vendor_vendor_id_fk": {
+          "name": "vendor_tag_vendor_id_vendor_vendor_id_fk",
+          "tableFrom": "vendor_tag",
+          "tableTo": "vendor",
+          "schemaTo": "clm",
+          "columnsFrom": [
+            "vendor_id"
+          ],
+          "columnsTo": [
+            "vendor_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {
+    "audit": "audit",
+    "clm": "clm",
+    "ref": "ref"
+  },
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1785247913495,
       "tag": "0004_rls_zonder_deleted_at_filter",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1785321175009,
+      "tag": "0005_vragenlijst_niveau_b",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1785321175009,
       "tag": "0005_vragenlijst_niveau_b",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "7",
+      "when": 1785321175010,
+      "tag": "0006_ronde_status_in_guard",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -198,6 +198,18 @@ export const surveyRun = clm.table(
     templateId: uuid('template_id')
       .notNull()
       .references(() => surveyTemplate.templateId, { onDelete: 'restrict' }),
+    // Welke van de twee use cases deze ronde bedient (ontwerp §1c).
+    // 'vendor_compliance': de leverancier vult zelf in over zichzelf.
+    // 'internal_review':   een collega beoordeelt de leverancier.
+    surveyKind: text('survey_kind').notNull().default('vendor_compliance'),
+    // Lifecycle uit ontwerp §2b: draft → active → finished → archived.
+    // Was voorheen impliciet af te leiden uit closes_at/revoked_at; expliciet
+    // maken voorkomt dat de eerste uitzondering die afleiding breekt.
+    status: text('status').notNull().default('draft'),
+    // Test Mode (ontwerp §2b): een echte run met een echt token, alleen
+    // gemarkeerd. Bewust geen sandbox die de guard omzeilt — dan test je een
+    // nabootsing in plaats van het werkelijke pad.
+    isTest: boolean('is_test').notNull().default(false),
     startedAt: timestamp('started_at', { withTimezone: true })
       .notNull()
       .defaultNow(),
@@ -223,9 +235,29 @@ export const surveyResponse = clm.table(
       // RESTRICT, niet CASCADE zoals vendor_contact/vendor_tag: een ingediende
       // response is bewijsmateriaal en mag nooit stilzwijgend meeverdwijnen.
       .references(() => surveyRun.runId, { onDelete: 'restrict' }),
-    vendorId: uuid('vendor_id')
+    // De leverancier als DEELNEMER: wie vult in. Leeg bij UC2 — daar vult een
+    // Transdev-collega in, en die is geen leverancier. Was NOT NULL vóór
+    // ontwerp §1c; de UC1-garantie is overgenomen door de partiële unieke
+    // index en de twee CHECK-constraints in migratie 0005.
+    vendorId: uuid('vendor_id').references(() => vendor.vendorId, {
+      onDelete: 'restrict',
+    }),
+    // De leverancier als ONDERWERP: over wie gaat het. Bij beide use cases
+    // gevuld. Bij UC1 dezelfde rij als vendor_id — dat is geen redundantie
+    // maar de vastlegging dat de leverancier daar zelf aan het woord is.
+    // Hierdoor staan de zelfverklaring (UC1) en de praktijkscore (UC2) over
+    // dezelfde partij automatisch naast elkaar.
+    subjectVendorId: uuid('subject_vendor_id')
       .notNull()
       .references(() => vendor.vendorId, { onDelete: 'restrict' }),
+    // Alleen UC2. Optioneel: de tokenroute vraagt geen account, dus een
+    // invuller hoeft geen clm.user-record te hebben. Wordt bruikbaar zodra
+    // spoor 1 (Entra-guard) er is.
+    respondentUserId: uuid('respondent_user_id').references(() => user.userId, {
+      onDelete: 'set null',
+    }),
+    // Naam of rol van de invuller wanneer er geen user-record is.
+    respondentLabel: text('respondent_label'),
     // SHA-256 van het ruwe token, nooit het token zelf. Scheidt databasetoegang
     // van surveytoegang: een databasedump geeft geen toegang tot openstaande
     // surveys. Geen bcrypt/argon2 — de invoer is 256 bits entropie, dus een
@@ -240,8 +272,200 @@ export const surveyResponse = clm.table(
   },
   (t) => [
     uniqueIndex('survey_response_token_hash_key').on(t.tokenHash),
-    uniqueIndex('survey_response_run_vendor_key').on(t.runId, t.vendorId),
+    // Partieel: geldt alleen waar vendor_id gevuld is (UC1). Daarmee blijft
+    // "één leverancier, één respons" volledig gelden, terwijl UC2 meerdere
+    // collega's per leverancier toestaat. Een niet-partiële variant zou bij
+    // het toelaten van UC2 ook de UC1-garantie verzwakken.
+    uniqueIndex('survey_response_run_vendor_key')
+      .on(t.runId, t.vendorId)
+      .where(sql`${t.vendorId} IS NOT NULL`),
     index('survey_response_tenant_id_idx').on(t.tenantId),
+    index('survey_response_subject_vendor_id_idx').on(t.subjectVendorId),
+  ],
+);
+
+// ─── clm schema: vragenlijst-cluster ──────────────────────────────────────
+// Zie docs/superpowers/specs/2026-07-28-vragenlijst-ontwerp.md.
+// Niveau B: de tenant kiest per vraag een antwoordtype uit acht.
+
+// Categorieën zijn optioneel per vragenlijst (ontwerp §2). UC1 (de acht
+// Transdev-vragen) heeft er geen; UC2 heeft er vijf met een score per
+// categorie. MVM_V2 is hierin functioneel leidend.
+export const surveyCategory = clm.table(
+  'survey_category',
+  {
+    categoryId: uuid('category_id').primaryKey().defaultRandom(),
+    tenantId: uuid('tenant_id')
+      .notNull()
+      .references(() => tenant.tenantId, { onDelete: 'restrict' }),
+    templateId: uuid('template_id')
+      .notNull()
+      .references(() => surveyTemplate.templateId, { onDelete: 'restrict' }),
+    position: integer('position').notNull(),
+    name: text('name').notNull(),
+    // Onder deze drempel is de categoriescore null in plaats van een
+    // gemiddelde over te weinig punten. Bij Transdev staat die op 3: zonder
+    // deze regel zou één ingevulde vraag uit vier een volwaardig ogende score
+    // opleveren. Overgenomen uit MVM_V2's minAnswersPerCategory.
+    minAnswers: smallint('min_answers').notNull().default(0),
+    createdAt: timestamp('created_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (t) => [
+    uniqueIndex('survey_category_template_position_key').on(
+      t.templateId,
+      t.position,
+    ),
+    uniqueIndex('survey_category_template_name_key').on(t.templateId, t.name),
+    // Doel van deze index is niet snelheid maar de samengestelde foreign key
+    // vanuit survey_question: die dwingt af dat een vraag geen categorie van
+    // een ándere template kan aanwijzen.
+    uniqueIndex('survey_category_id_template_key').on(
+      t.categoryId,
+      t.templateId,
+    ),
+    index('survey_category_tenant_id_idx').on(t.tenantId),
+  ],
+);
+
+export const surveyQuestion = clm.table(
+  'survey_question',
+  {
+    questionId: uuid('question_id').primaryKey().defaultRandom(),
+    tenantId: uuid('tenant_id')
+      .notNull()
+      .references(() => tenant.tenantId, { onDelete: 'restrict' }),
+    templateId: uuid('template_id')
+      .notNull()
+      .references(() => surveyTemplate.templateId, { onDelete: 'restrict' }),
+    // Nullable: een vragenlijst is óf ingedeeld in categorieën óf een platte
+    // lijst. Verplicht stellen zou UC1 dwingen tot een kunstmatige
+    // "Algemeen"-categorie die nergens getoond wordt. De samengestelde FK naar
+    // (category_id, template_id) staat in migratie 0005.
+    categoryId: uuid('category_id'),
+    position: integer('position').notNull(),
+    // Stabiele tekstsleutel naast de UUID. Bij een nieuwe templateversie
+    // krijgt vraag 4 een nieuwe question_id maar behoudt question_key = 'q4',
+    // zodat antwoorden over versies heen vergelijkbaar blijven. Zonder dat is
+    // een jaar-op-jaar-vergelijking niet te maken — precies het punt van een
+    // jaarlijkse compliance-survey.
+    questionKey: text('question_key').notNull(),
+    title: text('title').notNull(),
+    body: text('body').notNull(),
+    // Een van de acht typen uit ontwerp §2a. De toegestane waarden staan als
+    // CHECK-constraint in migratie 0005.
+    answerType: text('answer_type').notNull(),
+    // Typespecifieke instellingen: options[], min/max, schaallabels,
+    // comment-plicht. Bewust JSONB en geen twintig kolommen — een kolom per
+    // instelling geeft een tabel die grotendeels NULL is en een migratie per
+    // nieuw vraagtype. Let op: de database bewaakt de inhoud hiervan niet
+    // (ontwerp §2a), dat is servicelaagwerk.
+    config: jsonb('config').notNull().default({}),
+    isRequired: boolean('is_required').notNull().default(true),
+    allowsUpload: boolean('allows_upload').notNull().default(false),
+    maxFiles: smallint('max_files').notNull().default(0),
+    createdAt: timestamp('created_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (t) => [
+    uniqueIndex('survey_question_template_key_key').on(
+      t.templateId,
+      t.questionKey,
+    ),
+    uniqueIndex('survey_question_template_position_key').on(
+      t.templateId,
+      t.position,
+    ),
+    // Weer geen snelheidsindex: nodig voor de samengestelde FK vanuit
+    // survey_answer, die het antwoordtype aan dat van de vraag koppelt.
+    uniqueIndex('survey_question_id_answer_type_key').on(
+      t.questionId,
+      t.answerType,
+    ),
+    index('survey_question_tenant_id_idx').on(t.tenantId),
+    index('survey_question_category_id_idx').on(t.categoryId),
+  ],
+);
+
+export const surveyAnswer = clm.table(
+  'survey_answer',
+  {
+    answerId: uuid('answer_id').primaryKey().defaultRandom(),
+    tenantId: uuid('tenant_id')
+      .notNull()
+      .references(() => tenant.tenantId, { onDelete: 'restrict' }),
+    responseId: uuid('response_id')
+      .notNull()
+      .references(() => surveyResponse.responseId, { onDelete: 'restrict' }),
+    questionId: uuid('question_id')
+      .notNull()
+      .references(() => surveyQuestion.questionId, { onDelete: 'restrict' }),
+    // Bewust gedupliceerd vanaf de vraag. Zonder deze kolom zou de
+    // vormconstraint hieronder de vraagtabel moeten raadplegen, en dat kan een
+    // CHECK niet. De samengestelde FK in migratie 0005 zorgt dat de waarde
+    // nooit kan afwijken van die op de vraag.
+    answerType: text('answer_type').notNull(),
+    // Aparte kolommen per waardesoort, geen JSONB. Reden is bruikbaarheid
+    // achteraf: een rating in NUMERIC is te sorteren, middelen en aggregeren.
+    // Dezelfde waarde als tekst in JSONB is dat niet — daar moet elke query
+    // casten en laat één niet-numerieke waarde de hele query klappen.
+    answerCode: text('answer_code'),
+    answerCodes: text('answer_codes').array(),
+    answerText: text('answer_text'),
+    answerNumber: numeric('answer_number'),
+    comment: text('comment'),
+    createdAt: timestamp('created_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }),
+  },
+  (t) => [
+    uniqueIndex('survey_answer_response_question_key').on(
+      t.responseId,
+      t.questionId,
+    ),
+    index('survey_answer_tenant_id_idx').on(t.tenantId),
+    index('survey_answer_response_id_idx').on(t.responseId),
+  ],
+);
+
+export const surveyAttachment = clm.table(
+  'survey_attachment',
+  {
+    attachmentId: uuid('attachment_id').primaryKey().defaultRandom(),
+    tenantId: uuid('tenant_id')
+      .notNull()
+      .references(() => tenant.tenantId, { onDelete: 'restrict' }),
+    responseId: uuid('response_id')
+      .notNull()
+      .references(() => surveyResponse.responseId, { onDelete: 'restrict' }),
+    questionId: uuid('question_id')
+      .notNull()
+      .references(() => surveyQuestion.questionId, { onDelete: 'restrict' }),
+    // Zoals de leverancier hem aanleverde. Nooit als pad gebruiken:
+    // '../../etc/passwd.pdf' is een geldige bestandsnaam.
+    originalName: text('original_name').notNull(),
+    // Servergegenereerd: <tenant_id>/<response_id>/<uuid>. Geen enkel teken
+    // uit de invoer.
+    storageKey: text('storage_key').notNull(),
+    // Wat de server heeft vastgesteld uit de eerste bytes, niet wat de client
+    // beweerde (ontwerp §6).
+    contentType: text('content_type').notNull(),
+    byteSize: integer('byte_size').notNull(),
+    // Bij een compliance-bewijsstuk moet later aantoonbaar zijn dat het
+    // bestand niet gewijzigd is sinds indiening. Zelfde redenering als achter
+    // de append-only audit trail.
+    sha256: text('sha256').notNull(),
+    createdAt: timestamp('created_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (t) => [
+    uniqueIndex('survey_attachment_storage_key_key').on(t.storageKey),
+    index('survey_attachment_tenant_id_idx').on(t.tenantId),
+    index('survey_attachment_response_id_idx').on(t.responseId),
   ],
 );
 
@@ -304,6 +528,15 @@ export const vendorRelations = relations(vendor, ({ one, many }) => ({
   }),
   contacts: many(vendorContact),
   tags: many(vendorTag),
+  // Twee verwijzingen naar dezelfde tabel: de leverancier is bij UC1 de
+  // deelnemer en bij UC2 het onderwerp. Drizzle vereist expliciete
+  // relationName's om die uit elkaar te houden.
+  responsesAsParticipant: many(surveyResponse, {
+    relationName: 'responseParticipant',
+  }),
+  responsesAsSubject: many(surveyResponse, {
+    relationName: 'responseSubject',
+  }),
 }));
 
 export const vendorContactRelations = relations(vendorContact, ({ one }) => ({
@@ -328,6 +561,75 @@ export const surveyTemplateRelations = relations(
       references: [tenant.tenantId],
     }),
     runs: many(surveyRun),
+    categories: many(surveyCategory),
+    questions: many(surveyQuestion),
+  }),
+);
+
+export const surveyCategoryRelations = relations(
+  surveyCategory,
+  ({ one, many }) => ({
+    tenant: one(tenant, {
+      fields: [surveyCategory.tenantId],
+      references: [tenant.tenantId],
+    }),
+    template: one(surveyTemplate, {
+      fields: [surveyCategory.templateId],
+      references: [surveyTemplate.templateId],
+    }),
+    questions: many(surveyQuestion),
+  }),
+);
+
+export const surveyQuestionRelations = relations(
+  surveyQuestion,
+  ({ one, many }) => ({
+    tenant: one(tenant, {
+      fields: [surveyQuestion.tenantId],
+      references: [tenant.tenantId],
+    }),
+    template: one(surveyTemplate, {
+      fields: [surveyQuestion.templateId],
+      references: [surveyTemplate.templateId],
+    }),
+    category: one(surveyCategory, {
+      fields: [surveyQuestion.categoryId],
+      references: [surveyCategory.categoryId],
+    }),
+    answers: many(surveyAnswer),
+  }),
+);
+
+export const surveyAnswerRelations = relations(surveyAnswer, ({ one }) => ({
+  tenant: one(tenant, {
+    fields: [surveyAnswer.tenantId],
+    references: [tenant.tenantId],
+  }),
+  response: one(surveyResponse, {
+    fields: [surveyAnswer.responseId],
+    references: [surveyResponse.responseId],
+  }),
+  question: one(surveyQuestion, {
+    fields: [surveyAnswer.questionId],
+    references: [surveyQuestion.questionId],
+  }),
+}));
+
+export const surveyAttachmentRelations = relations(
+  surveyAttachment,
+  ({ one }) => ({
+    tenant: one(tenant, {
+      fields: [surveyAttachment.tenantId],
+      references: [tenant.tenantId],
+    }),
+    response: one(surveyResponse, {
+      fields: [surveyAttachment.responseId],
+      references: [surveyResponse.responseId],
+    }),
+    question: one(surveyQuestion, {
+      fields: [surveyAttachment.questionId],
+      references: [surveyQuestion.questionId],
+    }),
   }),
 );
 
@@ -343,20 +645,37 @@ export const surveyRunRelations = relations(surveyRun, ({ one, many }) => ({
   responses: many(surveyResponse),
 }));
 
-export const surveyResponseRelations = relations(surveyResponse, ({ one }) => ({
-  tenant: one(tenant, {
-    fields: [surveyResponse.tenantId],
-    references: [tenant.tenantId],
+export const surveyResponseRelations = relations(
+  surveyResponse,
+  ({ one, many }) => ({
+    tenant: one(tenant, {
+      fields: [surveyResponse.tenantId],
+      references: [tenant.tenantId],
+    }),
+    run: one(surveyRun, {
+      fields: [surveyResponse.runId],
+      references: [surveyRun.runId],
+    }),
+    // De leverancier als deelnemer (UC1); leeg bij UC2.
+    vendor: one(vendor, {
+      fields: [surveyResponse.vendorId],
+      references: [vendor.vendorId],
+      relationName: 'responseParticipant',
+    }),
+    // De leverancier als onderwerp; bij beide use cases gevuld.
+    subjectVendor: one(vendor, {
+      fields: [surveyResponse.subjectVendorId],
+      references: [vendor.vendorId],
+      relationName: 'responseSubject',
+    }),
+    respondent: one(user, {
+      fields: [surveyResponse.respondentUserId],
+      references: [user.userId],
+    }),
+    answers: many(surveyAnswer),
+    attachments: many(surveyAttachment),
   }),
-  run: one(surveyRun, {
-    fields: [surveyResponse.runId],
-    references: [surveyRun.runId],
-  }),
-  vendor: one(vendor, {
-    fields: [surveyResponse.vendorId],
-    references: [vendor.vendorId],
-  }),
-}));
+);
 
 // ─── Tenant-context ────────────────────────────────────────────────────────
 // Iedere tenantgebonden query draait binnen een transactie die begint met

--- a/src/survey/survey-token.guard.ts
+++ b/src/survey/survey-token.guard.ts
@@ -55,6 +55,11 @@ function melding(reden: WeigerReden, datum?: Date): string {
         : 'Deze link is verlopen. Neem contact op met de opdrachtgever voor een nieuwe link.';
     case 'ronde-gesloten':
       return 'Deze vragenlijstronde is gesloten.';
+    case 'ronde-niet-open':
+      // De ronde staat nog in 'draft': wel aangemaakt, nog niet opengesteld.
+      // Anders geformuleerd dan 'gesloten', want hier valt nog wél iets te
+      // verwachten — dit is een tijdelijke toestand, geen eindpunt.
+      return 'Deze vragenlijst is nog niet opengesteld. Neem contact op met de opdrachtgever.';
     case 'vendor-inactief':
       return 'Deze link is niet langer beschikbaar. Neem contact op met de opdrachtgever.';
     default:

--- a/src/survey/survey-token.service.ts
+++ b/src/survey/survey-token.service.ts
@@ -12,6 +12,7 @@ export type WeigerReden =
   | 'al-ingediend'
   | 'verlopen'
   | 'ronde-gesloten'
+  | 'ronde-niet-open'
   | 'vendor-inactief';
 
 export interface TokenGeldig {
@@ -44,6 +45,15 @@ interface LookupRij extends Record<string, unknown> {
   submitted_at: Date | string | null;
   vendor_active: boolean;
   run_closed: boolean;
+  /**
+   * Lifecycle van de ronde (migratie 0006). Alleen 'active' geeft toegang.
+   *
+   * Staat los van run_closed, dat blijft betekenen "ingetrokken of voorbij
+   * closes_at". Voor een leverancier is 'draft' (nog niet begonnen) iets
+   * anders dan 'finished' (voorbij), en dat verschil hoort in de melding
+   * terug te komen.
+   */
+  run_status: string | null;
 }
 
 function alsDatum(waarde: Date | string | null): Date | null {
@@ -134,6 +144,28 @@ export class SurveyTokenService {
       return { geldig: false, reden: 'ronde-gesloten' };
     }
 
+    // Stap 1b uit ontwerp §5: de lifecycle van de ronde (§2b). Alleen 'active'
+    // geeft toegang.
+    //
+    // Vóór migratie 0006 bestond deze controle niet en was een ronde in
+    // 'draft' — nog niet gepubliceerd — via een token gewoon bereikbaar. De
+    // twee bestaande controles dekken dat niet af: revoked_at en closes_at
+    // zeggen niets over een ronde die nog niet begonnen is.
+    //
+    // Onderscheid tussen 'draft' en de rest is bewust: een ronde die nog moet
+    // beginnen vraagt om geduld, een afgesloten ronde is voorbij. Dezelfde
+    // melding voor beide maakt van dat verschil een raadsel.
+    //
+    // run_status is NULL wanneer de ronde niet gevonden wordt (LEFT JOIN).
+    // Dat behandelen we als gesloten: geen ronde betekent geen toegang.
+    if (rij.run_status !== 'active') {
+      return {
+        geldig: false,
+        reden:
+          rij.run_status === 'draft' ? 'ronde-niet-open' : 'ronde-gesloten',
+      };
+    }
+
     if (!rij.vendor_active) {
       return { geldig: false, reden: 'vendor-inactief' };
     }
@@ -163,12 +195,21 @@ export class SurveyTokenService {
   async dienIn(tenantId: string, responseId: string): Promise<boolean> {
     return this.db.withTenant(tenantId, async (tx) => {
       const resultaat = await tx.execute<{ response_id: string }>(
-        sql`UPDATE clm.survey_response
+        // De ronde-status staat óók in dit statement, niet alleen in de guard.
+        // De guard beschermt het HTTP-pad; deze voorwaarde beschermt de
+        // methode zelf, zodat een toekomstige aanroeper die de guard niet
+        // passeert geen indiening kan forceren op een ronde die dicht staat.
+        sql`UPDATE clm.survey_response AS r
                SET status = 'submitted', submitted_at = now()
-             WHERE response_id = ${responseId}
-               AND status = 'pending'
-               AND expires_at > now()
-         RETURNING response_id`,
+             WHERE r.response_id = ${responseId}
+               AND r.status = 'pending'
+               AND r.expires_at > now()
+               AND EXISTS (
+                     SELECT 1 FROM clm.survey_run run
+                      WHERE run.run_id = r.run_id
+                        AND run.status = 'active'
+                   )
+         RETURNING r.response_id`,
       );
 
       const gelukt = resultaat.rows.length === 1;

--- a/test/survey-routes.e2e-spec.ts
+++ b/test/survey-routes.e2e-spec.ts
@@ -57,14 +57,22 @@ describe('Leverancierroutes (e2e)', () => {
         sql`INSERT INTO clm.survey_template (tenant_id, name) VALUES (${TENANT}, ${`t-${opties.naam}`})
             RETURNING template_id`,
       );
+      // status 'active': sinds migratie 0005 heeft survey_run een expliciete
+      // lifecycle met 'draft' als default (ontwerp §2b). Een draft-ronde is
+      // voor een leverancier niet bereikbaar.
       const run = await tx.execute<{ run_id: string }>(
-        sql`INSERT INTO clm.survey_run (tenant_id, template_id)
-            VALUES (${TENANT}, ${template.rows[0].template_id}) RETURNING run_id`,
+        sql`INSERT INTO clm.survey_run (tenant_id, template_id, status)
+            VALUES (${TENANT}, ${template.rows[0].template_id}, 'active') RETURNING run_id`,
       );
+      // subject_vendor_id is sinds migratie 0005 verplicht. Dit is een
+      // UC1-respons (vendor_compliance), dus deelnemer en onderwerp zijn
+      // dezelfde leverancier — de trigger assert_response_rollen eist dat.
       await tx.execute(
         sql`INSERT INTO clm.survey_response
-              (tenant_id, run_id, vendor_id, token_hash, status, expires_at, submitted_at)
+              (tenant_id, run_id, vendor_id, subject_vendor_id, token_hash,
+               status, expires_at, submitted_at)
             VALUES (${TENANT}, ${run.rows[0].run_id}, ${vendor.rows[0].vendor_id},
+                    ${vendor.rows[0].vendor_id},
                     ${hashToken(token)}, ${opties.status ?? 'pending'}, ${verval},
                     ${opties.status === 'submitted' ? new Date() : null})`,
       );

--- a/test/survey-routes.e2e-spec.ts
+++ b/test/survey-routes.e2e-spec.ts
@@ -37,6 +37,8 @@ describe('Leverancierroutes (e2e)', () => {
     naam: string;
     verlooptOver?: number;
     status?: string;
+    /** Lifecycle van de ronde (migratie 0005/0006). Default 'active'. */
+    rondeStatus?: 'draft' | 'active' | 'finished' | 'archived';
   }): Promise<string> {
     const token = genereerToken();
     const verval =
@@ -57,12 +59,13 @@ describe('Leverancierroutes (e2e)', () => {
         sql`INSERT INTO clm.survey_template (tenant_id, name) VALUES (${TENANT}, ${`t-${opties.naam}`})
             RETURNING template_id`,
       );
-      // status 'active': sinds migratie 0005 heeft survey_run een expliciete
-      // lifecycle met 'draft' als default (ontwerp §2b). Een draft-ronde is
-      // voor een leverancier niet bereikbaar.
+      // Sinds migratie 0005 heeft survey_run een expliciete lifecycle met
+      // 'draft' als default (ontwerp §2b). Standaard 'active': dat is de
+      // toestand waarin een leverancier de link daadwerkelijk gebruikt.
       const run = await tx.execute<{ run_id: string }>(
         sql`INSERT INTO clm.survey_run (tenant_id, template_id, status)
-            VALUES (${TENANT}, ${template.rows[0].template_id}, 'active') RETURNING run_id`,
+            VALUES (${TENANT}, ${template.rows[0].template_id},
+                    ${opties.rondeStatus ?? 'active'}) RETURNING run_id`,
       );
       // subject_vendor_id is sinds migratie 0005 verplicht. Dit is een
       // UC1-respons (vendor_compliance), dus deelnemer en onderwerp zijn
@@ -154,6 +157,31 @@ describe('Leverancierroutes (e2e)', () => {
       .expect(410);
 
     expect(body(res).message).toContain('verlopen');
+  });
+
+  // Testpunt 30 op HTTP-niveau: de service weigert de draft-ronde al (zie
+  // survey-token-isolatie), hier gaat het erom dat de guard er ook echt een
+  // 410 van maakt met een melding die een leverancier verder helpt.
+  it('weigert een link naar een nog niet opengestelde ronde met 410', async () => {
+    const token = await maakLink({ naam: 'draftronde', rondeStatus: 'draft' });
+
+    const res = await request(server)
+      .get(`/survey/respond?t=${token}`)
+      .expect(410);
+
+    expect(body(res).message).toContain('nog niet opengesteld');
+  });
+
+  it('weigert indienen op een nog niet opengestelde ronde', async () => {
+    const token = await maakLink({
+      naam: 'draftindienen',
+      rondeStatus: 'draft',
+    });
+
+    // De guard hangt op controllerniveau, dus POST hoort dezelfde weigering
+    // te geven als GET. Zonder deze test zou een guard die alleen op GET
+    // controleert onopgemerkt blijven.
+    await request(server).post(`/survey/respond?t=${token}`).expect(410);
   });
 
   // ── Indienen ──────────────────────────────────────────────────────────────

--- a/test/survey-token-isolatie.e2e-spec.ts
+++ b/test/survey-token-isolatie.e2e-spec.ts
@@ -33,6 +33,8 @@ describe('Leverancierstoken — isolatie en levenscyclus (e2e)', () => {
       status?: string;
       rondeGesloten?: boolean;
       rondeIngetrokken?: boolean;
+      /** Lifecycle van de ronde (migratie 0005/0006). Default 'active'. */
+      rondeStatus?: 'draft' | 'active' | 'finished' | 'archived';
     },
   ): Promise<{ token: string; responseId: string; vendorId: string }> {
     const token = genereerToken();
@@ -58,11 +60,13 @@ describe('Leverancierstoken — isolatie en levenscyclus (e2e)', () => {
             RETURNING template_id`,
       );
 
-      // status 'active': survey_run heeft sinds migratie 0005 een expliciete
-      // lifecycle met 'draft' als default (ontwerp §2b).
+      // survey_run heeft sinds migratie 0005 een expliciete lifecycle met
+      // 'draft' als default (ontwerp §2b). De helper zet standaard 'active',
+      // want dat is de toestand waarin een leverancier de link gebruikt.
       const run = await tx.execute<{ run_id: string }>(
         sql`INSERT INTO clm.survey_run (tenant_id, template_id, status, closes_at, revoked_at)
-            VALUES (${tenantId}, ${template.rows[0].template_id}, 'active',
+            VALUES (${tenantId}, ${template.rows[0].template_id},
+                    ${opties.rondeStatus ?? 'active'},
                     ${opties.rondeGesloten ? new Date(Date.now() - 1000) : null},
                     ${opties.rondeIngetrokken ? new Date() : null})
             RETURNING run_id`,
@@ -310,6 +314,80 @@ describe('Leverancierstoken — isolatie en levenscyclus (e2e)', () => {
     const uitkomst = await tokens.controleer(token);
     expect(uitkomst.geldig).toBe(false);
     if (!uitkomst.geldig) expect(uitkomst.reden).toBe('ronde-gesloten');
+  });
+
+  // ── Lifecycle van de ronde (testpunt 30, ontwerp §2b) ─────────────────────
+  // Vóór migratie 0006 kende de guard alleen revoked_at en closes_at. Een
+  // ronde in 'draft' — aangemaakt maar nog niet opengesteld — was daarmee
+  // gewoon bereikbaar. Deze vier tests dekken elke lifecycle-toestand af,
+  // inclusief de enige die wél toegang geeft.
+
+  it('weigert een token als de ronde nog in draft staat, ook binnen de vervaltermijn', async () => {
+    const { token } = await maakResponse(TENANT_A, {
+      naam: 'nogdraft',
+      rondeStatus: 'draft',
+    });
+
+    const uitkomst = await tokens.controleer(token);
+    expect(uitkomst.geldig).toBe(false);
+    // Bewust een eigen reden: 'nog niet opengesteld' is voor een leverancier
+    // iets anders dan 'gesloten'. De eerste is tijdelijk, de tweede definitief.
+    if (!uitkomst.geldig) expect(uitkomst.reden).toBe('ronde-niet-open');
+  });
+
+  it('weigert een token als de ronde is afgerond', async () => {
+    const { token } = await maakResponse(TENANT_A, {
+      naam: 'afgerond',
+      rondeStatus: 'finished',
+    });
+
+    const uitkomst = await tokens.controleer(token);
+    expect(uitkomst.geldig).toBe(false);
+    if (!uitkomst.geldig) expect(uitkomst.reden).toBe('ronde-gesloten');
+  });
+
+  it('weigert een token als de ronde gearchiveerd is', async () => {
+    const { token } = await maakResponse(TENANT_A, {
+      naam: 'archief',
+      rondeStatus: 'archived',
+    });
+
+    const uitkomst = await tokens.controleer(token);
+    expect(uitkomst.geldig).toBe(false);
+    if (!uitkomst.geldig) expect(uitkomst.reden).toBe('ronde-gesloten');
+  });
+
+  it('laat een token toe zodra de ronde actief is', async () => {
+    const { token } = await maakResponse(TENANT_A, {
+      naam: 'actief',
+      rondeStatus: 'active',
+    });
+
+    // De tegenproef bij de drie tests hierboven: zonder deze zou een guard die
+    // álles weigert ook groen zijn.
+    const uitkomst = await tokens.controleer(token);
+    expect(uitkomst.geldig).toBe(true);
+  });
+
+  it('weigert indienen op een niet-actieve ronde, ook buiten de guard om', async () => {
+    const { responseId } = await maakResponse(TENANT_A, {
+      naam: 'draftdirect',
+      rondeStatus: 'draft',
+    });
+
+    // dienIn() rechtstreeks aanroepen slaat de guard over. De voorwaarde zit
+    // daarom óók in het UPDATE-statement zelf: een toekomstige aanroeper die
+    // de guard niet passeert mag geen indiening kunnen forceren.
+    const gelukt = await tokens.dienIn(TENANT_A, responseId);
+    expect(gelukt).toBe(false);
+
+    // En de response moet onaangeroerd zijn gebleven.
+    const na = await db.withTenant(TENANT_A, (tx) =>
+      tx.execute<{ status: string }>(
+        sql`SELECT status FROM clm.survey_response WHERE response_id = ${responseId}`,
+      ),
+    );
+    expect(na.rows[0].status).toBe('pending');
   });
 
   // ── Opslag ────────────────────────────────────────────────────────────────

--- a/test/survey-token-isolatie.e2e-spec.ts
+++ b/test/survey-token-isolatie.e2e-spec.ts
@@ -58,18 +58,23 @@ describe('Leverancierstoken — isolatie en levenscyclus (e2e)', () => {
             RETURNING template_id`,
       );
 
+      // status 'active': survey_run heeft sinds migratie 0005 een expliciete
+      // lifecycle met 'draft' als default (ontwerp §2b).
       const run = await tx.execute<{ run_id: string }>(
-        sql`INSERT INTO clm.survey_run (tenant_id, template_id, closes_at, revoked_at)
-            VALUES (${tenantId}, ${template.rows[0].template_id},
+        sql`INSERT INTO clm.survey_run (tenant_id, template_id, status, closes_at, revoked_at)
+            VALUES (${tenantId}, ${template.rows[0].template_id}, 'active',
                     ${opties.rondeGesloten ? new Date(Date.now() - 1000) : null},
                     ${opties.rondeIngetrokken ? new Date() : null})
             RETURNING run_id`,
       );
 
+      // UC1-respons: deelnemer en onderwerp zijn dezelfde leverancier.
       const response = await tx.execute<{ response_id: string }>(
         sql`INSERT INTO clm.survey_response
-              (tenant_id, run_id, vendor_id, token_hash, status, expires_at, submitted_at)
-            VALUES (${tenantId}, ${run.rows[0].run_id}, ${vendorId}, ${hashToken(token)},
+              (tenant_id, run_id, vendor_id, subject_vendor_id, token_hash,
+               status, expires_at, submitted_at)
+            VALUES (${tenantId}, ${run.rows[0].run_id}, ${vendorId}, ${vendorId},
+                    ${hashToken(token)},
                     ${opties.status ?? 'pending'}, ${verval},
                     ${opties.status === 'submitted' ? new Date() : null})
             RETURNING response_id`,


### PR DESCRIPTION
Zeven commits. Begonnen als documentatie, inmiddels ook de eerste migratie. Drie samenhangende delen:

1. **Het vragenlijst-ontwerp** — van "onvolledig, niet bouwen" naar bouwbaar
2. **De migratie** — stap 1 uit de bouwvolgorde, geverifieerd tegen een echte database
3. **ADR-012** — hoe de frontend wordt uitgerold

---

## 1. Ontwerp: niveau B, twee use cases, categorieën

### Niveau B in plaats van A

De openstaande vraag was hoeveel vrijheid de tenant krijgt. Het eerdere advies was A (één antwoordtype), omdat er nog geen tweede vraagvorm was om tegen te ontwerpen.

Die onderbouwing verviel toen `VendorComply Help en Manual.md` beschikbaar kwam — de handleiding van een bestaand, werkend product met acht in de praktijk bewezen vraagtypen.

**Overgenomen:** de acht vraagtypen, lifecycle Draft → Active → Finished/Archived, Test Mode, drie manieren om deelnemers toe te voegen, deadline met overdue-markering, import/export als JSON-schema.

**Uitgesteld:** logic jumps (niveau C), AI-beoordeling via Gemini, EFQM-sync, Marketing Mode, rapportagegrafieken, `frameworkRef` (loopt vooruit op meerdere frameworks — nu bouwen we NIS2), `date` als negende vraagtype.

**Bewust niet gebouwd:** auto-save en "request revisions". Beide zouden vragen dat indienen terugdraaibaar wordt — precies de garantie die de tokenlaag uit PR #32 levert. **Die laag blijft ongewijzigd.**

### Twee use cases, niets daarbuiten

| | Use case | Wie vult in | Over welke leverancier |
|---|---|---|---|
| **UC1** | Vendor compliance | de leverancier zelf | zichzelf |
| **UC2** | Interne beoordeling | een Transdev-collega | dezelfde leverancier |

"Leverancier" en "dienstverlener" zijn hetzelfde: dezelfde `clm.vendor`-rij, bekeken vanuit een andere kant. Bij UC1 is de leverancier de **deelnemer**, bij UC2 het **onderwerp**.

Omdat `subject_vendor_id` bij beide gevuld is, staan de zelfverklaring en de praktijkscore over dezelfde partij automatisch naast elkaar.

Drie besluiten: interne invullers krijgen **ook een token-link** (de toegangslaag blijft dus ongewijzigd), **meerdere collega's** mogen dezelfde leverancier beoordelen, en de interne score is **niet zichtbaar** voor de leverancier — dat volgt al uit de architectuur, want een leverancier heeft geen tenanttoegang.

### Categorieën

MVM_V2 is functioneel leidend voor de vragenlijst. De interne beoordeling daar heeft vijf categorieën met 29 vragen. `category_id` is **nullable**: UC1 heeft er geen, UC2 vijf.

---

## 2. Migratie `0005_vragenlijst_niveau_b.sql`

459 regels: ongeveer een derde gegenereerd, de rest handwerk. Zoals ADR-010 voorspelt levert drizzle-kit geen RLS, CHECK-constraints, samengestelde foreign keys, functies of triggers.

| Tabel | Wijziging |
|---|---|
| `survey_category` | nieuw |
| `survey_question` | nieuw |
| `survey_answer` | nieuw — aparte kolommen per waardesoort, geen JSONB |
| `survey_attachment` | nieuw |
| `survey_run` | `survey_kind`, `status`, `is_test` erbij |
| `survey_response` | `subject_vendor_id`, `respondent_user_id`, `respondent_label` erbij; **`vendor_id` nullable** |

### Twee dingen die aandacht verdienen bij review

**Een gegenereerd statement is handmatig gecorrigeerd.** drizzle-kit maakte `ADD COLUMN subject_vendor_id uuid NOT NULL` — dat slaagt op een lege tabel en **faalt zodra er responses bestaan**, dus ook op `clm-enterprise`. Vervangen door: kolom toevoegen, backfillen vanuit `vendor_id`, dan pas `NOT NULL`. De backfill klopt per definitie — bestaande rijen dateren van vóór UC2.

**Eén garantie kon niet als CHECK.** De rolverdeling per use case leest `survey_kind` van `survey_run`, en een CHECK mag geen subquery bevatten. Gekozen voor een trigger in plaats van `survey_kind` dupliceren op `survey_response` — dupliceren zou een derde plek opleveren waar de waarde kan afwijken, en juist dat voorkomen is het doel.

**Het versoepelen van `vendor_id` naar nullable haalt geen garantie weg:** de UC1-regel "één leverancier, één respons" is overgenomen door een partiële unieke index (`WHERE vendor_id IS NOT NULL`) plus de rollentrigger.

### Verificatie — uitgevoerd, niet beredeneerd

Volledige keten 0000 t/m 0005 tegen een verse Postgres 17.6-container via `clm_migrator`. Daarna **elke garantie geprobeerd te breken**. Alle acht geweigerd door de database:

| Poging | Geweigerd door |
|---|---|
| Categorie van een andere template | `survey_question_category_template_fk` |
| Verplicht leesblok (`instruction`) | `survey_question_instruction_not_required_check` |
| `answer_type` wijkt af van de vraag | `survey_answer_question_type_fk` |
| Rating-waarde in `answer_text` | `survey_answer_shape_check` |
| Toelichting van drie spaties | `survey_answer_comment_required_check` |
| Dezelfde leverancier twee keer in UC1 | `survey_response_run_vendor_key` |
| Wijzigen van een bevroren template | trigger `survey_question_bevriezing` |
| Bestand boven 5 MB | `survey_attachment_size_check` |

En het omgekeerde: **twee collega's die dezelfde leverancier beoordelen in een UC2-ronde slaagt wel.** Dat bewijst dat de partiële index UC1 beschermt zonder UC2 te blokkeren.

**46 van 46 e2e-tests groen**, inclusief de schema-conformiteitspoort die de vier nieuwe tabellen op RLS-dekking controleert. Alle zeven survey-tabellen hebben RLS met zowel `USING` als `WITH CHECK`.

### Aangepast aan de nieuwe situatie

Twee testhelpers: `survey_response` krijgt nu `subject_vendor_id` mee, en `survey_run` wordt expliciet op `active` gezet omdat de lifecycle op `draft` begint.

---

## 3. ADR-012 — frontend-uitrol

**Next.js in een eigen repository, uitgerold als containerimage — de enige uitrolweg.** Tot golive lokaal via `docker compose`, kosten nul. Bij golive is AWS de beoogde doelplek met **App Runner** als voorkeur (indicatie $25–40/mnd, *niet op de bron geverifieerd*).

Doorslaggevend criterium van de eigenaar: **robuust en eenvoudig deployen** — één manier van uitrollen die overal hetzelfde werkt.

**Vercel is overwogen en afgewezen**, evenals de tussenvorm "Vercel nu, Docker later". Beide introduceren een tweede uitrolweg die bij de overstap naar AWS weer afgeleerd zou moeten worden.

**Wat dat kost, expliciet vastgelegd:** iets laten zien aan de klant wordt een handeling in plaats van een link, en de acceptatieomgeving (#12) kan niet meer worden overgeslagen.

Uit MVM_V2 komen de design tokens (kopiëren, niet via een gedeeld pakket), het leverancierportaal op token, en de mock/live-schakelaar. **Eén ding gaat er expliciet uit:** MVM_V2 stuurt de tenant mee in het webadres (`?tenant=demo`) — het patroon dat MCM2-CLAUDE.md §6 verbiedt en waarom `feat/fase0-skeleton-vendors` is weggegooid.

---

## Wat hierna komt

**De guard weet nog niets van de statuskolom.** Een ronde in `draft` is nu gewoon bereikbaar voor een leverancier. Dat is stap 2 uit de bouwvolgorde en het eerstvolgende dat gebouwd moet worden.

## Te reviewen

Zes voorstellen die nog niet bevestigd zijn, geen ervan blokkerend:

- Een gestarte ronde **bevriest** de vragenlijst (§2) — nu wel al gebouwd als trigger
- Toelichting ook verplicht bij "I do not confirm" (§3)
- Toelichting bij de overige zeven typen per vraag instelbaar, standaard optioneel (§3a)
- Onbekend e-mailadres bij import: weigeren in plaats van een vendor aanmaken (§2c, alleen UC1)
- UC1 en UC2 mogen dezelfde templates delen (§1c)
- Meerdere interne scores worden alleen opgeslagen, niet samengevat (rapportage is uitgesteld)

Ook benoemd: drie validatieregels leunen op de servicelaag omdat een CHECK de vraagrij niet kan raadplegen (§3a).

Refs #9, #7
