### PR TITLE
chore(#18): OTAP-doorloop voor frontend en backend

### DIFF
--- a/docker-compose.otap.yml
+++ b/docker-compose.otap.yml
@@ -1,0 +1,63 @@
+# OTAP-doorloop: de volledige keten in productievorm (Issue #18).
+#
+# Verschil met docker-compose.yml: dáár draait de backend in ontwikkelmodus met
+# hot reload, hier draaien beide onderdelen als PRODUCTIE-image — precies het
+# artefact dat straks naar AWS gaat (ADR-012). Dat is het verschil tussen "het
+# werkt op mijn machine" en "het uitrolbare artefact werkt".
+#
+# Wat dit bewijst:
+#   - de database komt vanaf niets tot een volledig migratieschema
+#   - het backend-image start en bedient de leverancierroutes
+#   - het frontend-image start en praat met die backend
+#   - de keten browser → frontend → backend → database werkt end-to-end
+#
+# Gebruik:
+#   docker compose -f docker-compose.otap.yml up --build -d
+#   scripts/otap-doorloop.js
+#   docker compose -f docker-compose.otap.yml down -v
+#
+# De frontend verwacht MCM2-frontend als zustermap naast deze repository. Dat
+# is de enige aanname die dit bestand doet over de omgeving.
+
+services:
+  db:
+    image: postgres:17.6
+    environment:
+      POSTGRES_PASSWORD: otap_pw
+      POSTGRES_DB: postgres
+    ports:
+      - "55500:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 2s
+      timeout: 3s
+      retries: 30
+
+  api:
+    build:
+      context: .
+      # Geen target: de laatste stage is de productie-image. Bewust niet de
+      # development-stage — die bewijst niets over wat er uitgerold wordt.
+    environment:
+      # De runtime-rol, nooit postgres en nooit clm_migrator (ADR-009).
+      DATABASE_URL: postgresql://clm_api_runtime:otap_pw@db:5432/postgres
+      PORT: "5001"
+    ports:
+      - "5001:5001"
+    depends_on:
+      db:
+        condition: service_healthy
+
+  frontend:
+    build:
+      context: ../MCM2-frontend
+      args:
+        # NEXT_PUBLIC_* wordt tijdens de BUILD in de bundel gebakken, niet bij
+        # het starten gelezen. Daarom een build-arg en geen environment-regel;
+        # dat laatste zou stilzwijgend niets doen en de frontend op mock data
+        # laten draaien terwijl je denkt dat hij live is.
+        NEXT_PUBLIC_API_URL: http://localhost:5001
+    ports:
+      - "3000:3000"
+    depends_on:
+      - api

--- a/docs/runbooks/otap-doorloop.md
+++ b/docs/runbooks/otap-doorloop.md
@@ -1,0 +1,156 @@
+# Runbook — OTAP-doorloop voor frontend en backend
+
+**Type:** D (routineoperatie)
+**Eigenaar:** projecteigenaar
+**Laatste update:** 2026-07-29
+**Vereiste toegang:** Docker Desktop, beide repositories lokaal
+**Raakt:** Issue #18 (volledige OTAP-doorloop minimaal één keer bewezen)
+
+---
+
+## Waarom dit bestaat
+
+Issue #18 vraagt om één bewezen doorloop van de volledige keten. Het risico dat
+daarachter zit: onbekende gaten die pas tijdens een echte crisis opvallen.
+
+Deze doorloop dekt **Ontwikkel → Test** volledig en bewijst dat het uitrolbare
+artefact werkt. Wat het níét dekt: Acceptatie en Productie — die omgevingen
+bestaan nog niet (Issue #12).
+
+**Het onderscheid dat dit waardevol maakt:** `docker-compose.yml` draait de
+backend in ontwikkelmodus met hot reload. Deze doorloop draait **beide
+onderdelen als productie-image**, precies het artefact dat straks naar AWS gaat
+(ADR-012). Dat is het verschil tussen "het werkt op mijn machine" en "wat we
+uitrollen werkt".
+
+---
+
+## Voorwaarden
+
+- Docker Desktop draait
+- `MCM2-frontend` staat als zustermap naast `MCM2`
+- Poorten 3000, 5001 en 55500 zijn vrij
+
+> **Poort 3000 is de gebruikelijke struikelblok.** Een `npm run dev` die nog
+> draait houdt hem bezet en de stack weigert te starten met "ports are not
+> available". Sluit die eerst af.
+
+---
+
+## Stap 1 — Images bouwen
+
+```bash
+docker compose -f docker-compose.otap.yml build
+```
+
+**Verwacht resultaat:** `Image mcm2-api Built` en `Image mcm2-frontend Built`.
+
+**Bij afwijking:** een build die faalt is zelf de bevinding. Beide Dockerfiles
+worden ook in CI gebouwd, dus een lokale fout wijst meestal op een verschil in
+de werkkopie.
+
+---
+
+## Stap 2 — Stack starten
+
+```bash
+docker compose -f docker-compose.otap.yml up -d
+```
+
+**Verwacht resultaat:** drie containers gestart, `db` als eerste en gezond.
+
+---
+
+## Stap 3 — Database vanaf niets opbouwen
+
+Dit hoort bij de doorloop: het bewijst dat een lege database via de
+migratieketen tot een werkend schema komt.
+
+```bash
+docker compose -f docker-compose.otap.yml exec -T db \
+  psql -U postgres -q -v ON_ERROR_STOP=1 < db/roles/bootstrap-roles.sql
+
+docker compose -f docker-compose.otap.yml exec -T db psql -U postgres -q -c \
+  "ALTER ROLE clm_migrator WITH PASSWORD 'otap_pw'; \
+   ALTER ROLE clm_api_runtime WITH PASSWORD 'otap_pw';"
+
+MIGRATION_DATABASE_URL="postgresql://clm_migrator:otap_pw@localhost:55500/postgres" \
+  npm run migrate:deploy
+```
+
+**Verwacht resultaat:** `Migraties voltooid.`
+
+**Let op:** de API is gestart vóórdat de rollen bestonden en kan daardoor niet
+verbinden. Herstart hem:
+
+```bash
+docker compose -f docker-compose.otap.yml restart api
+```
+
+---
+
+## Stap 4 — De doorloop draaien
+
+```bash
+node scripts/otap-doorloop.js
+```
+
+**Verwacht resultaat:** `OTAP-doorloop GESLAAGD — de volledige keten werkt.`
+
+Acht stappen, elk met eigen controles:
+
+| # | Wat |
+|---|---|
+| 1 | Database bereikbaar, zes `clm_*`-rollen, `clm_api_runtime` zonder BYPASSRLS |
+| 2 | Migratieketen volledig, RLS op elke tenantgebonden tabel, elke policy met `USING` én `WITH CHECK` |
+| 3 | Backend-image draait, `/health` antwoordt 200 |
+| 4 | Onbekend token → 404 |
+| 5 | Geldig token → 200, en de respons lekt geen tenant-ID |
+| 6 | Draft-ronde → 410, met een melding die "nog niet open" onderscheidt van "gesloten" |
+| 7 | Frontend-image draait en serveert het portaal |
+| 8 | Frontend praat met de echte backend, niet met mock data |
+
+Het script is idempotent: het ruimt zijn eigen testdata op vóór elke run.
+
+---
+
+## Stap 5 — Opruimen
+
+```bash
+docker compose -f docker-compose.otap.yml down -v
+```
+
+`-v` gooit ook het databasevolume weg. Dat is de bedoeling: de volgende
+doorloop hoort weer vanaf niets te beginnen, anders bewijst stap 3 niets.
+
+---
+
+## Wat de eerste doorloop opleverde (2026-07-29)
+
+Twee echte bevindingen, wat het nut van deze doorloop meteen aantoont:
+
+**1. Een routepad lekte naar de leverancier.** Het portaal toonde letterlijk
+`Cannot GET /survey/respond/questions` omdat die route nog niet gebouwd is. De
+frontend vertrouwde elke 404-melding van de backend, wat klopt voor de guard
+maar niet voor een 404 van het framework zelf. Gerepareerd: een framework-404
+wordt nu herkend en vervangen door dezelfde melding als bij een onbekend token.
+
+**2. Het doorloopscript was zelf niet idempotent.** `ON CONFLICT DO NOTHING`
+sloeg bij een tweede run de insert over, waardoor de rij van de vórige run met
+een oude tokenhash bleef staan en de doorloop faalde met een misleidende
+"geldig token gaf 404". Gerepareerd door de testdata eerst te verwijderen.
+
+Beide zijn precies het soort gat dat Issue #18 bedoelt: geen van beide was
+zichtbaar in unit- of e2e-tests.
+
+---
+
+## Bekende beperkingen
+
+- **Acceptatie en Productie ontbreken** — die omgevingen bestaan nog niet
+  (Issue #12). Deze doorloop dekt O en T.
+- **`/survey/respond/questions` bestaat nog niet**, dus het portaal kan de
+  vragenlijst nog niet echt tonen tegen de live backend. Dat is stap 5 uit de
+  bouwvolgorde; de mockmodus toont het scherm wél volledig.
+- **De doorloop draait handmatig.** Automatiseren in CI vraagt beide
+  repositories in één workflow; nu de moeite niet waard.

--- a/scripts/otap-doorloop.js
+++ b/scripts/otap-doorloop.js
@@ -1,0 +1,277 @@
+#!/usr/bin/env node
+/**
+ * OTAP-doorloop: bewijst dat de volledige keten werkt (Issue #18).
+ *
+ * Draait tegen de stack uit docker-compose.otap.yml — beide onderdelen als
+ * PRODUCTIE-image, niet in ontwikkelmodus. Dat onderscheid is het hele punt:
+ * een dev-server die werkt bewijst niets over het artefact dat uitgerold wordt.
+ *
+ * Wat er gecontroleerd wordt, in volgorde van afhankelijkheid:
+ *
+ *   1. Database bereikbaar en rollen aanwezig
+ *   2. Migratieketen volledig toegepast, RLS op alle tenantgebonden tabellen
+ *   3. Backend-image draait en bedient /health
+ *   4. Backend weigert een onbekend token met 404
+ *   5. Backend accepteert een geldig token en geeft de juiste status
+ *   6. Backend weigert een ronde die niet 'active' is (migratie 0006)
+ *   7. Frontend-image draait en serveert het portaal
+ *   8. De frontend praat met de echte backend, niet met mock data
+ *
+ * Elke stap faalt hard. Een groene doorloop betekent dat de keten
+ * browser → frontend → backend → database aantoonbaar werkt.
+ */
+
+'use strict';
+
+const { execFileSync } = require('node:child_process');
+const crypto = require('node:crypto');
+
+// Binnen de db-container: poort 5432, niet de 55500 die naar de host is
+// gemapt. Die mapping bestaat alleen buiten de container.
+const DB = 'postgresql://postgres:otap_pw@localhost:5432/postgres';
+const API = 'http://localhost:5001';
+const FRONTEND = 'http://localhost:3000';
+
+let stap = 0;
+const fouten = [];
+
+function meld(tekst) {
+  process.stdout.write(`${tekst}\n`);
+}
+
+function ok(tekst) {
+  meld(`  ✓ ${tekst}`);
+}
+
+function fout(tekst) {
+  meld(`  ✗ ${tekst}`);
+  fouten.push(tekst);
+}
+
+function kop(tekst) {
+  stap += 1;
+  meld(`\n${stap}. ${tekst}`);
+}
+
+/** Voert psql uit in de db-container. Geeft de kale uitvoer terug. */
+function sql(query) {
+  return execFileSync(
+    'docker',
+    ['compose', '-f', 'docker-compose.otap.yml', 'exec', '-T', 'db',
+     'psql', DB, '-tAc', query],
+    { encoding: 'utf8' },
+  ).trim();
+}
+
+async function http(url, opties = {}) {
+  const res = await fetch(url, { ...opties, redirect: 'manual' });
+  const tekst = await res.text();
+  return { status: res.status, tekst };
+}
+
+async function main() {
+  meld('OTAP-doorloop — volledige keten in productievorm\n');
+  meld('Stack: docker-compose.otap.yml (db + api + frontend)');
+
+  // ── 1. Database ─────────────────────────────────────────────────────────
+  kop('Database bereikbaar en rollen aanwezig');
+
+  const rollen = sql(
+    "SELECT count(*) FROM pg_roles WHERE rolname LIKE 'clm\\_%'",
+  );
+  if (Number(rollen) >= 6) {
+    ok(`${rollen} clm-rollen aanwezig`);
+  } else {
+    fout(`Verwachtte minstens 6 clm-rollen, vond er ${rollen}`);
+  }
+
+  const bypass = sql(
+    "SELECT rolbypassrls FROM pg_roles WHERE rolname = 'clm_api_runtime'",
+  );
+  if (bypass === 'f') {
+    ok('clm_api_runtime heeft geen BYPASSRLS');
+  } else {
+    fout('clm_api_runtime kan RLS omzeilen — tenant-isolatie is waardeloos');
+  }
+
+  // ── 2. Migraties ────────────────────────────────────────────────────────
+  kop('Migratieketen volledig toegepast');
+
+  const migraties = sql('SELECT count(*) FROM drizzle.__drizzle_migrations');
+  if (Number(migraties) >= 7) {
+    ok(`${migraties} migraties toegepast`);
+  } else {
+    fout(`Verwachtte minstens 7 migraties, vond er ${migraties}`);
+  }
+
+  const zonderRls = sql(`
+    SELECT count(*) FROM pg_tables t
+     WHERE t.schemaname = 'clm'
+       AND EXISTS (SELECT 1 FROM information_schema.columns c
+                    WHERE c.table_schema = 'clm' AND c.table_name = t.tablename
+                      AND c.column_name = 'tenant_id')
+       AND NOT t.rowsecurity`);
+  if (zonderRls === '0') {
+    ok('elke tenantgebonden tabel heeft RLS');
+  } else {
+    fout(`${zonderRls} tenantgebonden tabel(len) zonder RLS`);
+  }
+
+  const zonderCheck = sql(`
+    SELECT count(*) FROM pg_policies
+     WHERE schemaname = 'clm' AND (qual IS NULL OR with_check IS NULL)`);
+  if (zonderCheck === '0') {
+    ok('elke policy heeft zowel USING als WITH CHECK');
+  } else {
+    fout(`${zonderCheck} policy/policies mist USING of WITH CHECK`);
+  }
+
+  // ── 3. Backend draait ───────────────────────────────────────────────────
+  kop('Backend-image draait');
+
+  const health = await http(`${API}/health`);
+  if (health.status === 200) {
+    ok('/health antwoordt 200');
+  } else {
+    fout(`/health gaf ${health.status}`);
+  }
+
+  // ── 4-6. Backend-gedrag ─────────────────────────────────────────────────
+  kop('Backend weigert een onbekend token');
+
+  const onbekend = await http(`${API}/survey/respond?t=${'x'.repeat(43)}`);
+  if (onbekend.status === 404) {
+    ok('onbekend token → 404');
+  } else {
+    fout(`onbekend token gaf ${onbekend.status}, verwacht 404`);
+  }
+
+  // Testdata aanmaken via de database: de beheerroutes bestaan nog niet.
+  //
+  // Eerst de responses van een vorige doorloop weggooien. Zonder dit slaat
+  // ON CONFLICT DO NOTHING de insert stilzwijgend over — de rij bestaat dan
+  // nog met de tokenhash van de vórige run, en de doorloop faalt met een
+  // misleidende "geldig token gaf 404". Zelf tegengekomen bij de tweede run.
+  sql(`DELETE FROM clm.survey_response
+        WHERE tenant_id = '11111111-1111-1111-1111-111111111111'`);
+
+  const token = crypto.randomBytes(32).toString('base64url');
+  const hash = crypto.createHash('sha256').update(token).digest('hex');
+  const tokenDraft = crypto.randomBytes(32).toString('base64url');
+  const hashDraft = crypto.createHash('sha256').update(tokenDraft).digest('hex');
+
+  sql(`
+    INSERT INTO clm.tenant (tenant_id, name)
+    VALUES ('11111111-1111-1111-1111-111111111111', 'OTAP')
+    ON CONFLICT DO NOTHING;
+
+    INSERT INTO clm.vendor (vendor_id, tenant_id, name)
+    VALUES ('22222222-2222-2222-2222-222222222222',
+            '11111111-1111-1111-1111-111111111111', 'OTAP Leverancier')
+    ON CONFLICT DO NOTHING;
+
+    INSERT INTO clm.survey_template (template_id, tenant_id, name)
+    VALUES ('33333333-3333-3333-3333-333333333333',
+            '11111111-1111-1111-1111-111111111111', 'OTAP lijst')
+    ON CONFLICT DO NOTHING;
+
+    INSERT INTO clm.survey_run (run_id, tenant_id, template_id, status)
+    VALUES ('44444444-4444-4444-4444-444444444444',
+            '11111111-1111-1111-1111-111111111111',
+            '33333333-3333-3333-3333-333333333333', 'active')
+    ON CONFLICT DO NOTHING;
+
+    INSERT INTO clm.survey_run (run_id, tenant_id, template_id, status)
+    VALUES ('55555555-5555-5555-5555-555555555555',
+            '11111111-1111-1111-1111-111111111111',
+            '33333333-3333-3333-3333-333333333333', 'draft')
+    ON CONFLICT DO NOTHING;
+
+    INSERT INTO clm.survey_response
+      (tenant_id, run_id, vendor_id, subject_vendor_id, token_hash, expires_at)
+    VALUES ('11111111-1111-1111-1111-111111111111',
+            '44444444-4444-4444-4444-444444444444',
+            '22222222-2222-2222-2222-222222222222',
+            '22222222-2222-2222-2222-222222222222',
+            '${hash}', now() + interval '30 days')
+    ON CONFLICT DO NOTHING;
+
+    INSERT INTO clm.survey_response
+      (tenant_id, run_id, vendor_id, subject_vendor_id, token_hash, expires_at)
+    VALUES ('11111111-1111-1111-1111-111111111111',
+            '55555555-5555-5555-5555-555555555555',
+            '22222222-2222-2222-2222-222222222222',
+            '22222222-2222-2222-2222-222222222222',
+            '${hashDraft}', now() + interval '30 days')
+    ON CONFLICT DO NOTHING;
+  `);
+
+  kop('Backend accepteert een geldig token');
+
+  const geldig = await http(`${API}/survey/respond?t=${token}`);
+  if (geldig.status === 200) {
+    ok('geldig token → 200');
+    if (!geldig.tekst.includes('11111111')) {
+      ok('respons lekt geen tenant-ID');
+    } else {
+      fout('respons bevat een tenant-ID');
+    }
+  } else {
+    fout(`geldig token gaf ${geldig.status}, verwacht 200`);
+  }
+
+  kop('Backend weigert een ronde in draft (migratie 0006)');
+
+  const draft = await http(`${API}/survey/respond?t=${tokenDraft}`);
+  if (draft.status === 410) {
+    ok('draft-ronde → 410');
+    if (draft.tekst.includes('nog niet opengesteld')) {
+      ok('melding onderscheidt "nog niet open" van "gesloten"');
+    } else {
+      fout('melding maakt het onderscheid niet zichtbaar');
+    }
+  } else {
+    fout(`draft-ronde gaf ${draft.status}, verwacht 410`);
+  }
+
+  // ── 7-8. Frontend ───────────────────────────────────────────────────────
+  kop('Frontend-image draait en serveert het portaal');
+
+  const home = await http(FRONTEND);
+  if (home.status === 200) {
+    ok('startpagina antwoordt 200');
+  } else {
+    fout(`startpagina gaf ${home.status}`);
+  }
+
+  if (home.tekst.includes('Live backend')) {
+    ok('frontend draait op de echte backend, niet op mock data');
+  } else {
+    fout('frontend draait op mock data — NEXT_PUBLIC_API_URL niet ingebakken');
+  }
+
+  const portaal = await http(`${FRONTEND}/portal/survey/${token}`);
+  if (portaal.status === 200) {
+    ok('portaalroute antwoordt 200');
+  } else {
+    fout(`portaalroute gaf ${portaal.status}`);
+  }
+
+  // ── Uitkomst ────────────────────────────────────────────────────────────
+  meld('\n' + '='.repeat(62));
+  if (fouten.length === 0) {
+    meld('OTAP-doorloop GESLAAGD — de volledige keten werkt.');
+    meld('='.repeat(62));
+    process.exit(0);
+  }
+
+  meld(`OTAP-doorloop GEFAALD — ${fouten.length} probleem/problemen:`);
+  for (const f of fouten) meld(`  - ${f}`);
+  meld('='.repeat(62));
+  process.exit(1);
+}
+
+main().catch((err) => {
+  meld(`\nOnverwachte fout: ${err.message}`);
+  process.exit(1);
+});


### PR DESCRIPTION
Issue #18 vraagt om **één bewezen doorloop van de volledige keten**. Dit is die doorloop.

Geen applicatiecode gewijzigd: een compose-stack, een verificatiescript en een runbook.

## Wat het bewijst

Beide onderdelen draaien als **productie-image**, niet in ontwikkelmodus. Dat onderscheid is het hele punt: `docker-compose.yml` draait de backend met hot reload, en dat bewijst niets over het artefact dat straks naar AWS gaat (ADR-012).

| # | Controle |
|---|---|
| 1 | Zes `clm_*`-rollen, `clm_api_runtime` zonder BYPASSRLS |
| 2 | Migratieketen volledig; RLS op elke tenantgebonden tabel; elke policy met `USING` én `WITH CHECK` |
| 3 | Backend-image draait, `/health` → 200 |
| 4 | Onbekend token → 404 |
| 5 | Geldig token → 200, respons lekt geen tenant-ID |
| 6 | Draft-ronde → 410, met onderscheid tussen "nog niet open" en "gesloten" |
| 7 | Frontend-image draait en serveert het portaal |
| 8 | Frontend praat met de echte backend, niet met mock data |

Stap 8 verdient toelichting: `NEXT_PUBLIC_*`-variabelen worden **tijdens de build** ingebakken, niet bij het starten gelezen. Een frontend die stilletjes op mock data draait terwijl je denkt dat hij live is, is een makkelijke vergissing — deze controle sluit die uit.

## Twee bevindingen uit de eerste doorloop

Dit is wat Issue #18 bedoelt met "onbekende gaten". Geen van beide was zichtbaar in unit- of e2e-tests.

**Een routepad lekte naar de leverancier.** Het portaal toonde letterlijk `Cannot GET /survey/respond/questions`, omdat die route nog niet gebouwd is (stap 5 uit de bouwvolgorde). De frontend vertrouwde elke 404-melding van de backend — dat klopt voor de guard, maar niet voor een 404 van het framework zelf. Gerepareerd in `MCM2-frontend`.

**Het script was zelf niet idempotent.** `ON CONFLICT DO NOTHING` sloeg bij een tweede run de insert over, waardoor de rij van de vórige run met een oude tokenhash bleef staan. Dat gaf een misleidende "geldig token gaf 404" — een falende test die niets zei over de code. Gerepareerd door de testdata eerst te verwijderen.

## Verificatie

**Drie keer achter elkaar gedraaid, drie keer geslaagd.** De eerste run legde de twee bevindingen hierboven bloot; de laatste twee bevestigen dat het script herhaalbaar is.

Ook handmatig in de browser doorlopen tegen de draaiende stack, vóór en ná de 404-fix.

## Wat dit niet dekt

**Acceptatie en Productie**, want die omgevingen bestaan nog niet (Issue #12). Deze doorloop dekt Ontwikkel en Test volledig.

`/survey/respond/questions` bestaat nog niet, dus het portaal kan de vragenlijst nog niet tonen tegen de live backend. In mockmodus werkt het scherm wél volledig — dat is precies waar de mock/live-schakelaar voor is.

De doorloop draait handmatig. Automatiseren in CI vraagt beide repositories in één workflow; dat is nu de moeite niet waard.

## Bijbehorend

Runbook: `docs/runbooks/otap-doorloop.md` — vijf stappen, inclusief de bekende struikelblokken (poort 3000 bezet door een dev-server, en de API die herstart moet worden omdat hij vóór de rollen opstartte).

Refs #18, #12
