### PR TITLE
feat(vragenlijst): import/export en beide seeds (stap 3 en 4)

### DIFF
--- a/db/seeds/transdev-annual-vendor-it-risk-v1.json
+++ b/db/seeds/transdev-annual-vendor-it-risk-v1.json
@@ -1,0 +1,107 @@
+{
+  "schema_version": 1,
+  "name": "transdev-annual-vendor-it-risk",
+  "version": 1,
+  "categories": [],
+  "questions": [
+    {
+      "question_key": "intro",
+      "position": 1,
+      "title": "2026 Transdev ICT contract vendor compliance",
+      "body": "You have been invited to complete the following compliance survey: \"2026 Transdev ICT contract vendor compliance\". Your participation is requested to ensure vendor compliance and security standards.",
+      "answer_type": "instruction",
+      "is_required": false,
+      "allows_upload": false,
+      "max_files": 0,
+      "config": {}
+    },
+    {
+      "question_key": "q1",
+      "position": 2,
+      "title": "ISO 27001 Certification Evidence",
+      "body": "The Supplier confirms that it holds a valid ISO/IEC 27001 certificate, including the corresponding Statement of Applicability (SoA). The Supplier confirms that the certificate has been issued by an accredited certification body and, together with the SoA, is not older than two years.",
+      "answer_type": "confirmation",
+      "is_required": true,
+      "allows_upload": true,
+      "max_files": 2,
+      "config": {}
+    },
+    {
+      "question_key": "q2",
+      "position": 3,
+      "title": "Data Processing in Accordance with the Data Processing Agreement",
+      "body": "The Supplier confirms that all data processing demonstrably takes place in accordance with the applicable contractual agreement and that no additional personal data is processed. The Supplier confirms that, in the event of any deviation from the contractual agreements, Transdev NL has been notified in writing without undue delay.",
+      "answer_type": "confirmation",
+      "is_required": true,
+      "allows_upload": false,
+      "max_files": 0,
+      "config": {}
+    },
+    {
+      "question_key": "q3",
+      "position": 4,
+      "title": "Changes Impacting Service Delivery",
+      "body": "The Supplier confirms that, during the preceding twelve (12) months, no changes have been implemented in processes, systems, or security measures that could affect the contractually agreed service delivery. The Supplier confirms that, in the event of any deviation from the contractual agreements, Transdev NL has been notified in writing without undue delay.",
+      "answer_type": "confirmation",
+      "is_required": true,
+      "allows_upload": false,
+      "max_files": 0,
+      "config": {}
+    },
+    {
+      "question_key": "q4",
+      "position": 5,
+      "title": "Security Incidents and Data Breaches",
+      "body": "The Supplier confirms that, during the preceding twelve (12) months, any security incidents or data breaches that could have affected the contractually agreed service delivery have been reported to Transdev NL within forty-eight (48) hours. The Supplier confirms that, in the event of any deviation from the contractual agreements, Transdev NL has been notified in writing without undue delay.",
+      "answer_type": "confirmation",
+      "is_required": true,
+      "allows_upload": false,
+      "max_files": 0,
+      "config": {}
+    },
+    {
+      "question_key": "q5",
+      "position": 6,
+      "title": "Internal and External Audits",
+      "body": "The Supplier confirms that, during the preceding twelve (12) months, any findings arising from internal or external audits that could have affected the contractually agreed service delivery have been reported to Transdev NL. The Supplier confirms that, in the event of any deviation from the contractual agreements, Transdev NL has been notified in writing without undue delay.",
+      "answer_type": "confirmation",
+      "is_required": true,
+      "allows_upload": false,
+      "max_files": 0,
+      "config": {}
+    },
+    {
+      "question_key": "q6",
+      "position": 7,
+      "title": "Availability and Continuity Risks",
+      "body": "The Supplier confirms that, during the preceding twelve (12) months, any identified risks that could have affected the contractually agreed service delivery have been reported to Transdev NL without undue delay, including the mitigating measures implemented to ensure continuity. The Supplier confirms that, in the event of any deviation from the contractual agreements, Transdev NL has been notified in writing without undue delay.",
+      "answer_type": "confirmation",
+      "is_required": true,
+      "allows_upload": false,
+      "max_files": 0,
+      "config": {}
+    },
+    {
+      "question_key": "q7",
+      "position": 8,
+      "title": "Employee Awareness of Information Security",
+      "body": "The Supplier confirms that, during the preceding twelve (12) months, its employees have been periodically informed of changes to applicable information security requirements and relevant security threats that could affect the contractually agreed service delivery.",
+      "answer_type": "confirmation",
+      "is_required": true,
+      "allows_upload": false,
+      "max_files": 0,
+      "config": {}
+    },
+    {
+      "question_key": "q8",
+      "position": 9,
+      "title": "Subcontractor Compliance with Information Security",
+      "body": "The Supplier confirms that, during the preceding twelve (12) months, all activities performed by subcontractors have complied with applicable information security requirements and have taken into account relevant security threats that could affect the contractually agreed service delivery. The Supplier confirms that, in the event of any deviation from the contractual agreements, Transdev NL has been notified in writing without undue delay.",
+      "answer_type": "confirmation",
+      "is_required": true,
+      "allows_upload": false,
+      "max_files": 0,
+      "config": {}
+    }
+  ]
+}

--- a/db/seeds/transdev-leveranciersbeoordeling-v1.json
+++ b/db/seeds/transdev-leveranciersbeoordeling-v1.json
@@ -1,0 +1,564 @@
+{
+  "schema_version": 1,
+  "name": "transdev-leveranciersbeoordeling",
+  "version": 1,
+  "categories": [
+    {
+      "key": "duidelijkheid",
+      "position": 1,
+      "name": "Duidelijkheid",
+      "min_answers": 3
+    },
+    {
+      "key": "behoefte",
+      "position": 2,
+      "name": "Behoefte",
+      "min_answers": 3
+    },
+    {
+      "key": "kwaliteit",
+      "position": 3,
+      "name": "Kwaliteit",
+      "min_answers": 3
+    },
+    {
+      "key": "kosten",
+      "position": 4,
+      "name": "Kosten",
+      "min_answers": 3
+    },
+    {
+      "key": "risico-s",
+      "position": 5,
+      "name": "Risico's",
+      "min_answers": 3
+    },
+    {
+      "key": "besturing",
+      "position": 6,
+      "name": "Besturing",
+      "min_answers": 3
+    }
+  ],
+  "questions": [
+    {
+      "question_key": "d1",
+      "category_key": "duidelijkheid",
+      "position": 1,
+      "title": "Duidelijkheid 1",
+      "body": "Het contract is volledig en correct geadministreerd in Coupa en/of andere relevante systemen.",
+      "answer_type": "rating",
+      "is_required": true,
+      "allows_upload": false,
+      "max_files": 0,
+      "config": {
+        "min": 1,
+        "max": 5,
+        "min_label": "Zeer ondermaats",
+        "max_label": "Uitstekend",
+        "comment": "optional"
+      }
+    },
+    {
+      "question_key": "d2",
+      "category_key": "duidelijkheid",
+      "position": 2,
+      "title": "Duidelijkheid 2",
+      "body": "Verantwoordelijkheden en taken m.b.t. eigenaarschap, management en beheer van het contract zijn vastgelegd en toegewezen.",
+      "answer_type": "rating",
+      "is_required": true,
+      "allows_upload": false,
+      "max_files": 0,
+      "config": {
+        "min": 1,
+        "max": 5,
+        "min_label": "Zeer ondermaats",
+        "max_label": "Uitstekend",
+        "comment": "optional"
+      }
+    },
+    {
+      "question_key": "d3",
+      "category_key": "duidelijkheid",
+      "position": 3,
+      "title": "Duidelijkheid 3",
+      "body": "De wijze waarop het contract wordt beheerd, is afgestemd met de contracteigenaar.",
+      "answer_type": "rating",
+      "is_required": true,
+      "allows_upload": false,
+      "max_files": 0,
+      "config": {
+        "min": 1,
+        "max": 5,
+        "min_label": "Zeer ondermaats",
+        "max_label": "Uitstekend",
+        "comment": "optional"
+      }
+    },
+    {
+      "question_key": "d4",
+      "category_key": "duidelijkheid",
+      "position": 4,
+      "title": "Duidelijkheid 4",
+      "body": "Direct betrokken (operationele) medewerkers weten wat ze van de leverancier mogen verwachten.",
+      "answer_type": "rating",
+      "is_required": true,
+      "allows_upload": false,
+      "max_files": 0,
+      "config": {
+        "min": 1,
+        "max": 5,
+        "min_label": "Zeer ondermaats",
+        "max_label": "Uitstekend",
+        "comment": "optional"
+      }
+    },
+    {
+      "question_key": "b1",
+      "category_key": "behoefte",
+      "position": 5,
+      "title": "Behoefte 1",
+      "body": "De met de leverancier afgesproken kwaliteitsnormen sluiten aan op de behoeften van de contracteigenaar.",
+      "answer_type": "rating",
+      "is_required": true,
+      "allows_upload": false,
+      "max_files": 0,
+      "config": {
+        "min": 1,
+        "max": 5,
+        "min_label": "Zeer ondermaats",
+        "max_label": "Uitstekend",
+        "comment": "optional"
+      }
+    },
+    {
+      "question_key": "b2",
+      "category_key": "behoefte",
+      "position": 6,
+      "title": "Behoefte 2",
+      "body": "De prijsafspraken met de leverancier zijn transparant en voldoen aan de behoeften van de contracteigenaar.",
+      "answer_type": "rating",
+      "is_required": true,
+      "allows_upload": false,
+      "max_files": 0,
+      "config": {
+        "min": 1,
+        "max": 5,
+        "min_label": "Zeer ondermaats",
+        "max_label": "Uitstekend",
+        "comment": "optional"
+      }
+    },
+    {
+      "question_key": "b3",
+      "category_key": "behoefte",
+      "position": 7,
+      "title": "Behoefte 3",
+      "body": "De leverancier maakt gebruik van producten, diensten en werkwijzen die voldoen aan de actuele behoeften van de contracteigenaar.",
+      "answer_type": "rating",
+      "is_required": true,
+      "allows_upload": false,
+      "max_files": 0,
+      "config": {
+        "min": 1,
+        "max": 5,
+        "min_label": "Zeer ondermaats",
+        "max_label": "Uitstekend",
+        "comment": "optional"
+      }
+    },
+    {
+      "question_key": "b4",
+      "category_key": "behoefte",
+      "position": 8,
+      "title": "Behoefte 4",
+      "body": "De leverancier biedt nieuwe producten, diensten of werkwijzen die een waardevolle aanvulling vormen maar die nog niet in het contract staan.",
+      "answer_type": "rating",
+      "is_required": true,
+      "allows_upload": false,
+      "max_files": 0,
+      "config": {
+        "min": 1,
+        "max": 5,
+        "min_label": "Zeer ondermaats",
+        "max_label": "Uitstekend",
+        "comment": "optional"
+      }
+    },
+    {
+      "question_key": "k1",
+      "category_key": "kwaliteit",
+      "position": 9,
+      "title": "Kwaliteit 1",
+      "body": "Met de leverancier is een aantal relevante en goed gedefinieerde normen afgesproken over de kwaliteit van de dienstverlening.",
+      "answer_type": "rating",
+      "is_required": true,
+      "allows_upload": false,
+      "max_files": 0,
+      "config": {
+        "min": 1,
+        "max": 5,
+        "min_label": "Zeer ondermaats",
+        "max_label": "Uitstekend",
+        "comment": "optional"
+      }
+    },
+    {
+      "question_key": "k2",
+      "category_key": "kwaliteit",
+      "position": 10,
+      "title": "Kwaliteit 2",
+      "body": "De leverancier rapporteert tijdig, volledig en correct over de kwaliteit van de dienstverlening.",
+      "answer_type": "rating",
+      "is_required": true,
+      "allows_upload": false,
+      "max_files": 0,
+      "config": {
+        "min": 1,
+        "max": 5,
+        "min_label": "Zeer ondermaats",
+        "max_label": "Uitstekend",
+        "comment": "optional"
+      }
+    },
+    {
+      "question_key": "k3",
+      "category_key": "kwaliteit",
+      "position": 11,
+      "title": "Kwaliteit 3",
+      "body": "De leverancier voldoet aan de in het contract vastgelegde service levels.",
+      "answer_type": "rating",
+      "is_required": true,
+      "allows_upload": false,
+      "max_files": 0,
+      "config": {
+        "min": 1,
+        "max": 5,
+        "min_label": "Zeer ondermaats",
+        "max_label": "Uitstekend",
+        "comment": "optional"
+      }
+    },
+    {
+      "question_key": "k4",
+      "category_key": "kwaliteit",
+      "position": 12,
+      "title": "Kwaliteit 4",
+      "body": "De leverancier voldoet aan de in het contract vastgelegde inkoopvoorwaarden en andere eventueel aanvullende voorwaarden.",
+      "answer_type": "rating",
+      "is_required": true,
+      "allows_upload": false,
+      "max_files": 0,
+      "config": {
+        "min": 1,
+        "max": 5,
+        "min_label": "Zeer ondermaats",
+        "max_label": "Uitstekend",
+        "comment": "optional"
+      }
+    },
+    {
+      "question_key": "k5",
+      "category_key": "kwaliteit",
+      "position": 13,
+      "title": "Kwaliteit 5",
+      "body": "De leverancier voldoet aan de in het contract vastgelegde privacy en informatiebeveiligingsmaatregelen.",
+      "answer_type": "rating",
+      "is_required": true,
+      "allows_upload": false,
+      "max_files": 0,
+      "config": {
+        "min": 1,
+        "max": 5,
+        "min_label": "Zeer ondermaats",
+        "max_label": "Uitstekend",
+        "comment": "optional"
+      }
+    },
+    {
+      "question_key": "ko1",
+      "category_key": "kosten",
+      "position": 14,
+      "title": "Kosten 1",
+      "body": "In het contract is de relatie tussen de geleverde diensten en kosten duidelijk beschreven.",
+      "answer_type": "rating",
+      "is_required": true,
+      "allows_upload": false,
+      "max_files": 0,
+      "config": {
+        "min": 1,
+        "max": 5,
+        "min_label": "Zeer ondermaats",
+        "max_label": "Uitstekend",
+        "comment": "optional"
+      }
+    },
+    {
+      "question_key": "ko2",
+      "category_key": "kosten",
+      "position": 15,
+      "title": "Kosten 2",
+      "body": "De leverancier rapporteert op afgesproken tijden over de kosten van de dienstverlening.",
+      "answer_type": "rating",
+      "is_required": true,
+      "allows_upload": false,
+      "max_files": 0,
+      "config": {
+        "min": 1,
+        "max": 5,
+        "min_label": "Zeer ondermaats",
+        "max_label": "Uitstekend",
+        "comment": "optional"
+      }
+    },
+    {
+      "question_key": "ko3",
+      "category_key": "kosten",
+      "position": 16,
+      "title": "Kosten 3",
+      "body": "De leverancier hanteert prijzen en prijsmodellen zoals overeengekomen in het contract.",
+      "answer_type": "rating",
+      "is_required": true,
+      "allows_upload": false,
+      "max_files": 0,
+      "config": {
+        "min": 1,
+        "max": 5,
+        "min_label": "Zeer ondermaats",
+        "max_label": "Uitstekend",
+        "comment": "optional"
+      }
+    },
+    {
+      "question_key": "ko4",
+      "category_key": "kosten",
+      "position": 17,
+      "title": "Kosten 4",
+      "body": "De leverancier factureert volgens de overeengekomen procedures.",
+      "answer_type": "rating",
+      "is_required": true,
+      "allows_upload": false,
+      "max_files": 0,
+      "config": {
+        "min": 1,
+        "max": 5,
+        "min_label": "Zeer ondermaats",
+        "max_label": "Uitstekend",
+        "comment": "optional"
+      }
+    },
+    {
+      "question_key": "ko5",
+      "category_key": "kosten",
+      "position": 18,
+      "title": "Kosten 5",
+      "body": "De kosten van de dienstverlening voldoen aan de verwachtingen van de contracteigenaar.",
+      "answer_type": "rating",
+      "is_required": true,
+      "allows_upload": false,
+      "max_files": 0,
+      "config": {
+        "min": 1,
+        "max": 5,
+        "min_label": "Zeer ondermaats",
+        "max_label": "Uitstekend",
+        "comment": "optional"
+      }
+    },
+    {
+      "question_key": "r1",
+      "category_key": "risico-s",
+      "position": 19,
+      "title": "Risico's 1",
+      "body": "Eventuele risico's welke negatieve invloed kunnen hebben op de dienstverlening zijn geïdentificeerd en vastgelegd.",
+      "answer_type": "rating",
+      "is_required": true,
+      "allows_upload": false,
+      "max_files": 0,
+      "config": {
+        "min": 1,
+        "max": 5,
+        "min_label": "Zeer ondermaats",
+        "max_label": "Uitstekend",
+        "comment": "optional"
+      }
+    },
+    {
+      "question_key": "r2",
+      "category_key": "risico-s",
+      "position": 20,
+      "title": "Risico's 2",
+      "body": "Alle betrokkenen zijn zich bewust van de mogelijke negatieve gevolgen van de risico's.",
+      "answer_type": "rating",
+      "is_required": true,
+      "allows_upload": false,
+      "max_files": 0,
+      "config": {
+        "min": 1,
+        "max": 5,
+        "min_label": "Zeer ondermaats",
+        "max_label": "Uitstekend",
+        "comment": "optional"
+      }
+    },
+    {
+      "question_key": "r3",
+      "category_key": "risico-s",
+      "position": 21,
+      "title": "Risico's 3",
+      "body": "De leverancier draagt actief bij aan het reduceren van de risico's, incl. informatiebeveiligingsrisico's conform de minimum security requirements.",
+      "answer_type": "rating",
+      "is_required": true,
+      "allows_upload": false,
+      "max_files": 0,
+      "config": {
+        "min": 1,
+        "max": 5,
+        "min_label": "Zeer ondermaats",
+        "max_label": "Uitstekend",
+        "comment": "optional"
+      }
+    },
+    {
+      "question_key": "r4",
+      "category_key": "risico-s",
+      "position": 22,
+      "title": "Risico's 4",
+      "body": "De contracteigenaar is bekend met de risico's en is tevreden over de mitigerende maatregelen.",
+      "answer_type": "rating",
+      "is_required": true,
+      "allows_upload": false,
+      "max_files": 0,
+      "config": {
+        "min": 1,
+        "max": 5,
+        "min_label": "Zeer ondermaats",
+        "max_label": "Uitstekend",
+        "comment": "optional"
+      }
+    },
+    {
+      "question_key": "r5",
+      "category_key": "risico-s",
+      "position": 23,
+      "title": "Risico's 5",
+      "body": "De risico's en maatregelen worden periodiek geëvalueerd.",
+      "answer_type": "rating",
+      "is_required": true,
+      "allows_upload": false,
+      "max_files": 0,
+      "config": {
+        "min": 1,
+        "max": 5,
+        "min_label": "Zeer ondermaats",
+        "max_label": "Uitstekend",
+        "comment": "optional"
+      }
+    },
+    {
+      "question_key": "bs1",
+      "category_key": "besturing",
+      "position": 24,
+      "title": "Besturing 1",
+      "body": "De structuur en frequentie van het overleg met de leverancier zijn duidelijk afgesproken, vastgelegd en afgestemd op de behoeften van Transdev.",
+      "answer_type": "rating",
+      "is_required": true,
+      "allows_upload": false,
+      "max_files": 0,
+      "config": {
+        "min": 1,
+        "max": 5,
+        "min_label": "Zeer ondermaats",
+        "max_label": "Uitstekend",
+        "comment": "optional"
+      }
+    },
+    {
+      "question_key": "bs2",
+      "category_key": "besturing",
+      "position": 25,
+      "title": "Besturing 2",
+      "body": "De juiste en gemandateerde personen zijn betrokken bij het leveranciersoverleg.",
+      "answer_type": "rating",
+      "is_required": true,
+      "allows_upload": false,
+      "max_files": 0,
+      "config": {
+        "min": 1,
+        "max": 5,
+        "min_label": "Zeer ondermaats",
+        "max_label": "Uitstekend",
+        "comment": "optional"
+      }
+    },
+    {
+      "question_key": "bs3",
+      "category_key": "besturing",
+      "position": 26,
+      "title": "Besturing 3",
+      "body": "Het overleg met de leverancier is structureel en productief.",
+      "answer_type": "rating",
+      "is_required": true,
+      "allows_upload": false,
+      "max_files": 0,
+      "config": {
+        "min": 1,
+        "max": 5,
+        "min_label": "Zeer ondermaats",
+        "max_label": "Uitstekend",
+        "comment": "optional"
+      }
+    },
+    {
+      "question_key": "bs4",
+      "category_key": "besturing",
+      "position": 27,
+      "title": "Besturing 4",
+      "body": "Van het overleg met de leverancier wordt een verslag met acties en besluiten gemaakt.",
+      "answer_type": "rating",
+      "is_required": true,
+      "allows_upload": false,
+      "max_files": 0,
+      "config": {
+        "min": 1,
+        "max": 5,
+        "min_label": "Zeer ondermaats",
+        "max_label": "Uitstekend",
+        "comment": "optional"
+      }
+    },
+    {
+      "question_key": "bs5",
+      "category_key": "besturing",
+      "position": 28,
+      "title": "Besturing 5",
+      "body": "Afspraken uit het overleg met de leveranciers worden voortvarend opgepakt door de deelnemers.",
+      "answer_type": "rating",
+      "is_required": true,
+      "allows_upload": false,
+      "max_files": 0,
+      "config": {
+        "min": 1,
+        "max": 5,
+        "min_label": "Zeer ondermaats",
+        "max_label": "Uitstekend",
+        "comment": "optional"
+      }
+    },
+    {
+      "question_key": "toelichting",
+      "category_key": null,
+      "position": 29,
+      "title": "Toelichting",
+      "body": "Heeft u aanvullende opmerkingen over deze leverancier?",
+      "answer_type": "open_text",
+      "is_required": false,
+      "allows_upload": false,
+      "max_files": 0,
+      "config": {
+        "min_length": 1,
+        "max_length": 2000
+      }
+    }
+  ]
+}

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,7 +1,7 @@
 # MCM2 — actuele status
 
 ## Laatst bijgewerkt
-2026-07-29, einde sessie (PR #32 t/m #35 gemerged; vragenlijst niveau B t/m stap 2, leverancierportaal in de browser, OTAP-doorloop bewezen voor O en T — alles hieronder is geverifieerd, niet uit gespreksgeheugen)
+2026-07-29, tweede sessie (vragenlijst-tool t/m **stap 4**: import/export én beide seeds; 89 e2e-tests groen — alles hieronder is geverifieerd, niet uit gespreksgeheugen)
 
 ## Het project bestaat uit twee repositories
 
@@ -20,17 +20,23 @@ Eigen CI en eigen releasecyclus per repo — bewust, zodat een tekstwijziging in
 2. Lees dit document (`docs/STATUS.md`) volledig — het is de enige actuele waarheid over fase en blockers.
 3. Verifieer git-status zelf (`git status`, `git branch -a`) tegen wat hieronder staat — vertrouw niet blind op deze snapshot. **Doe dat in beide repositories.**
 4. Check de open GitHub Issues (`gh issue list --repo AlingAdvies/MCM2 --state open`) voor de actuele backlog — dit document verwijst naar issue-nummers, maar de Issues zelf zijn de bron van waarheid over wat daadwerkelijk nog open staat.
-5. **Eerste concrete vervolgstap: stap 3 uit de bouwvolgorde** (import/export van het JSON-schema, ontwerp §10). Stap 1 (migratie) en stap 2 (guard weegt de ronde-status mee) zijn op 2026-07-29 gebouwd en gemerged. Issue #30 (geen backups) blijft de zwaarste openstaande blokkade voor alles wat de productiedatabase raakt (#19, #25, #29), maar vraagt nu alleen nog uitvoering door de eigenaar, geen besluit — en de vragenlijst-tool loopt daar niet op vast, want die bouwt tegen wegwerpcontainers.
+5. **Eerste concrete vervolgstap: stap 5 uit de bouwvolgorde** (`GET /survey/respond/questions`, ontwerp §10). Stap 1 t/m 4 zijn af: migratie, guard met ronde-status, import/export en beide seeds. Issue #30 (geen backups) blijft de zwaarste openstaande blokkade voor alles wat de productiedatabase raakt (#19, #25, #29), maar vraagt nu alleen nog uitvoering door de eigenaar, geen besluit — en de vragenlijst-tool loopt daar niet op vast, want die bouwt tegen wegwerpcontainers.
 
 ### Snel weer op gang komen
 
 ```bash
 # Backend: tests tegen een wegwerpcontainer
-docker run -d --name t -e POSTGRES_PASSWORD=pw -p 55440:5432 postgres:17.6
-docker exec -i t psql -U postgres -q < db/roles/bootstrap-roles.sql
-docker exec t psql -U postgres -c "ALTER ROLE clm_migrator WITH PASSWORD 'pw'; ALTER ROLE clm_api_runtime WITH PASSWORD 'pw';"
+# Let op: de containernaam moet minstens twee tekens hebben. Docker 29 weigert
+# een naam van één teken ("Invalid container name"); oudere versies deden dat niet.
+docker run -d --name mcm2test -e POSTGRES_PASSWORD=pw -p 55440:5432 postgres:17.6
+docker exec -i mcm2test psql -U postgres -q < db/roles/bootstrap-roles.sql
+docker exec mcm2test psql -U postgres -c "ALTER ROLE clm_migrator WITH PASSWORD 'pw'; ALTER ROLE clm_api_runtime WITH PASSWORD 'pw';"
 MIGRATION_DATABASE_URL="postgresql://clm_migrator:pw@localhost:55440/postgres" npm run migrate:deploy
-DATABASE_URL="postgresql://clm_api_runtime:pw@localhost:55440/postgres" npm run test:e2e   # 53 tests
+DATABASE_URL="postgresql://clm_api_runtime:pw@localhost:55440/postgres" npm run test:e2e   # 89 tests
+
+# De twee vragenlijsten inlezen (tenant moet bestaan)
+DATABASE_URL="postgresql://clm_api_runtime:pw@localhost:55440/postgres" \
+  npm run seed:vragenlijsten -- <tenant-uuid>
 
 # Frontend: het portaal bekijken zonder backend
 cd ../MCM2-frontend && npm run dev
@@ -163,6 +169,18 @@ Transdev Vendor IT Compliance Survey als eerste verticale MVP-slice.
 
 ## Aantoonbaar werkend
 
+- **Import/export van vragenlijsten en beide seeds (2026-07-29, stap 3 en 4).** `src/survey/vragenlijst-schema.ts` (vorm en validatie, zonder database), `src/survey/vragenlijst-import.service.ts` (importeer/exporteer via `withTenant`), `scripts/seed-vragenlijsten.js` en twee seedbestanden in `db/seeds/`. **89 van 89 e2e-tests groen**, in negen suites.
+
+  **De harde regel is getest, niet alleen geschreven:** `tenant_id` komt uit de sessiecontext en nooit uit het bestand (Issue #7, testpunt 31). Een bestand dat er zelf een meebrengt wordt expliciet geweigerd in plaats van stil genegeerd. Hetzelfde geldt voor UUID's — die worden bij import nieuw gegenereerd, en de vraag→categorie-koppeling loopt via `category_key` (testpunt 48). Export bevat geen enkele UUID en geen `tenant_id`, waardoor klonen en een nieuwe versie afsplitsen dezelfde operatie zijn als exporteren-en-importeren.
+
+  **Tegenproef gedaan, twee keer.** Met de `tenant_id`-controle uitgeschakeld viel precies testpunt 31 om. Op de seed-suite: met een verplicht gemaakt leesblok en een upload op de verkeerde vraag vielen 6 van de 15 tests om. Zonder die proef bewijzen groene tests niets.
+
+  **Herhaalbaar:** drie opeenvolgende runs tegen dezelfde, niet-leeggemaakte database, alle drie 89/89. Het seed-script is idempotent — een tweede run slaat bestaande templates over.
+
+  **Wat er in de database komt:** UC1 negen vragen (acht `confirmation` + één `instruction`), geen categorieën, alleen vraag 1 met upload (max 2 bestanden). UC2 29 vragen (28 `rating` op schaal 1–5 + één `open_text`) over zes categorieën met `min_answers = 3`.
+
+  **Correctie op het ontwerp:** §2 spreekt van vijf categorieën met 29 vragen. De bron in MVM_V2 (`src/data/internal-survey-data.ts`) heeft er **zes met 28** — "Risico's" ontbreekt in het ontwerpdocument. De seed volgt de bron, want dat is wat de klant gezien heeft; een test legt het verschil vast zodat het niet stilzwijgend terugdraait.
+
 - **OTAP-doorloop voor de volledige keten (2026-07-29, PR #34, Issue #18).** `docker-compose.otap.yml` + `scripts/otap-doorloop.js` + runbook `docs/runbooks/otap-doorloop.md`. **Beide onderdelen draaien als productie-image**, niet in ontwikkelmodus — dat onderscheid is het punt: `docker-compose.yml` draait de backend met hot reload en bewijst daarmee niets over het artefact dat uitgerold wordt.
 
   Acht controles: rollen en het ontbreken van BYPASSRLS, de volledige migratieketen met RLS op elke tenantgebonden tabel en beide clausules op elke policy, het draaien van beide images, het guard-gedrag bij onbekend/geldig/draft-token, en of de frontend écht met de backend praat in plaats van stil op mock data. **Vier keer gedraaid, vier keer geslaagd** — de laatste keer tegen `main` ná de merge.
@@ -225,7 +243,24 @@ Transdev Vendor IT Compliance Survey als eerste verticale MVP-slice.
 - **Issue #4 (EntraID-haalbaarheidscheck) afgerond op 2026-07-27:** `kees@alingadvies.nl` heeft Global Administrator in de Entra ID-tenant `alingadvies.nl`, ruim voldoende voor app-registraties; geen Azure-subscription gekoppeld maar dat blokkeert Entra-app-registraties niet. Rechtencheck is tegen `alingadvies.nl` gedaan, niet tegen een Transdev-tenant (geen toegang tot Transdev's Entra-omgeving) — `alingadvies.nl` dient als voorbeeld-/testtenant. De destijds gekozen uitvoeringsvorm (Cognito) is nadien herzien, zie hieronder.
 - **ADR-006 herzien op 2026-07-27 (Cognito → Entra External ID):** vóór er een Cognito User Pool werd aangemaakt bleek de tweede cloudlaag (los AWS-account, cross-cloud federatie) onnodige complexiteit t.o.v. Microsoft Entra External ID, dat dezelfde multi-IdP-flexibiliteit biedt binnen het Microsoft-ecosysteem — geen los AWS-account, gratis tot 50.000 MAU. Reden om niet simpelweg "kaal" Entra ID te gebruiken (zoals een ouder platformdocument uit 2026-03-30 voorstelde): MCM2's multi-tenant-toekomst qua identity-providers is onzeker (niet aantoonbaar Microsoft-only), dus een CIAM-laag blijft gewenst. Zie `docs/adr/ADR-006-ciam-laag-entra-external-id.md` (bestandsnaam gewijzigd op 2026-07-27; heette eerder `ADR-006-cognito-als-federatielaag.md`).
 
-## Vier lessen uit deze sessie die tijd besparen
+## Contractmanagement als basis — openstaande vraag, bewust geparkeerd
+
+Op 2026-07-29 stelde de eigenaar vast dat de survey **onderdeel is van een contractmanagement-app**: de vragenlijst hoort gekoppeld te zijn aan de leveranciersgegevens, aan **de contracten waarop de survey betrekking heeft**, en aan de contactpersoon met diens e-mailadres.
+
+**Wat er feitelijk staat** (geverifieerd in `src/db/schema.ts`, niet aangenomen):
+
+| Bestaat al | Ontbreekt volledig |
+|---|---|
+| `vendor` — KvK, vestigingsnummer, statutaire naam, handelsnamen, rechtsvorm, SBI, categorie, business-criticality, compliance-status, spend, risicoscore, eigenaar, reviewdatums | **`contract` — er is géén tabel** |
+| `vendor_contact` — naam, **e-mail**, telefoon, functie, rol, `is_primary` | `contract_document`, en elke koppeling survey ↔ contract |
+
+**Besluit: eerst de survey afmaken, dan contracten.** Drie redenen. (1) De survey heeft geen contract nodig om te werken — nergens in de acht Transdev-vragen, het datamodel of de validatie komt een contract voor; wat hij nodig heeft (vendor + contactpersoon met e-mail) staat er al. (2) De survey is bijna af en contracten beginnen bij nul: MVM_V2's `Contract` heeft 24 velden inclusief CATS CM v4-levenscyclus, managementregime en raam-/deelovereenkomst — dat is een eigen bouwspoor met eigen intake. (3) Een afgeronde survey is demonstreerbaar aan de klant, een half contractmodel niet.
+
+**Wat dit kost, expliciet:** een survey die niet weet op welk contract hij slaat is functioneel incompleet — "hoe scoort deze leverancier" zonder "op welke overeenkomst" is een half oordeel. Dat gat blijft bestaan tot het contractspoor er is. Het is wél een *toevoeging* later (`contract_id` op `survey_run`, plus een FK), geen herbouw.
+
+**Nog te beslissen:** of `survey_run` alvast een ongebruikte `contract_id UUID NULL` krijgt. Kosten nu: één regel. Kosten later zonder: één extra migratie op een tabel die dan gevulde rondes bevat. Voorgelegd, nog geen antwoord.
+
+## Lessen uit deze sessies die tijd besparen
 
 Praktische valkuilen die daadwerkelijk zijn tegengekomen, niet bedacht. Ze staan hier omdat ze anders opnieuw ontdekt worden.
 
@@ -237,6 +272,14 @@ Praktische valkuilen die daadwerkelijk zijn tegengekomen, niet bedacht. Ze staan
 
 **`NEXT_PUBLIC_*` wordt tijdens de build ingebakken, niet bij het starten gelezen.** Een frontend-image dat de echte backend moet gebruiken heeft die waarde nodig als **build-argument**. Zet je hem als `environment`, dan draait de app stilzwijgend op mock data terwijl je denkt dat hij live is. De OTAP-doorloop controleert hierop.
 
+**De tenantcontext heet `app.current_tenant_id`, niet `app.tenant_id`.** Het seed-script gebruikte de verkeerde naam. Dat geeft **geen foutmelding** — `set_config` accepteert elke sleutel — maar een lege context, waarna RLS elke INSERT weigert met "new row violates row-level security policy". Gebruik altijd `setTenantContext()` uit `src/db/schema.ts` als bron; scripts die hun eigen `set_config` schrijven, moeten die naam letterlijk overnemen.
+
+**Drizzle verpakt databasefouten: een triggermelding staat in `cause`, niet in `message`.** Een test die met `rejects.toThrow(/bevroren/)` op `message` matcht, wordt daardoor óók groen bij een tikfout in de SQL — dan test hij niets. Lees `(fout as Error & { cause?: Error }).cause?.message`.
+
+**Testsuites die dezelfde tenant-id gebruiken botsen bij de tweede run.** Templates zijn uniek op `(tenant_id, name, version)` en de lokale testdatabase blijft staan. In gebruik: `…e1` (survey-routes), `…f1`/`…f2` (token-isolatie), `…d1`/`…d2`/`…d3` (vragenlijst). Kies een eigen paar, en geef testtemplates een unieke versie in plaats van een vast nummer.
+
+**Docker 29 weigert een containernaam van één teken.** Het oude `--name t` uit dit document faalde met "Invalid container name"; de opstartcommando's hierboven zijn gecorrigeerd naar `mcm2test`.
+
 ## Niet als bewezen beschouwen
 
 - RLS-tenant-isolatie was tot 2026-07-27 niet bewezen zolang de runtime-role nog `BYPASSRLS` had — een eerdere "RLS werkt"-verificatie in deze projectgeschiedenis was vals-positief (lege tabel, geen bewijs van daadwerkelijke blokkade). **Nu aantoonbaar bewezen én geautomatiseerd** (zie hierboven en ADR-009) — niet langer een handmatige, ad-hoc verificatie.
@@ -247,14 +290,14 @@ Praktische valkuilen die daadwerkelijk zijn tegengekomen, niet bedacht. Ze staan
 
 ## Huidige branch en Git-status
 
-**Stand bij het afsluiten van de sessie op 2026-07-29:**
+**Stand op 2026-07-29, tweede sessie:**
 
 | Repo | Branch | Werkboom | Openstaande PR's |
 |---|---|---|---|
-| MCM2 | `main` (`cbe6c48`) | schoon | geen |
+| MCM2 | **`feat/vragenlijst-import-export`** | schoon | nog niet gepusht |
 | MCM2-frontend | `main` | schoon | geen |
 
-**Geen openstaande branches in beide repositories.** Alles van vandaag is gemerged en opgeruimd.
+**`feat/vragenlijst-import-export` staat open met twee commits** (stap 3 en stap 4 uit de bouwvolgorde) plus deze statusbijwerking. Nog niet naar GitHub gepusht, dus nog geen PR en geen CI-run — de poorten zijn wél lokaal gedraaid: format, lint, typecheck, 89/89 e2e tegen een verse Postgres 17.6, en de Docker-productiebuild die start en `/health` met HTTP 200 beantwoordt.
 
 - **`docs/sessiestand-otap` is op 2026-07-29 via PR #35 gemerged naar `main`** (merge-commit `cbe6c48`) en daarna lokaal én op GitHub verwijderd. Eén commit: uitsluitend deze statusbijwerking.
 - **`feat/issue-7-leveranciertoken` is op 2026-07-29 via PR #32 gemerged naar `main`** (merge-commit `7f0cc01`) en daarna lokaal én op GitHub verwijderd. CI groen op alle drie de jobs vóór de merge, opnieuw geverifieerd met `gh pr checks 32` op de laatste commit. Vijf commits: de tokenlaag, de HTTP-routes met logmaskering en auditregels, de fix op `maskeerDiep`, plus twee documentatiecommits. **Issue #31 is bij die merge gesloten** — migratie `0004` loste hem op. Let op: die migratie is bewezen in CI, **niet toegepast op `clm-enterprise`** — net als #29 en #25 wacht dat op #30.
@@ -276,24 +319,24 @@ Praktische valkuilen die daadwerkelijk zijn tegengekomen, niet bedacht. Ze staan
 
 ## Eerstvolgende goedgekeurde stap
 
-De databaselaag is omgezet (ADR-010), spoor 2 van Issue #7 zit in `main`, en het vragenlijst-ontwerp is bouwbaar.
+De databaselaag is omgezet (ADR-010), spoor 2 van Issue #7 zit in `main`, en de vragenlijst-tool staat t/m stap 4: het datamodel, de guard, import/export en beide gevulde vragenlijsten.
 
-**De eerstvolgende inhoudelijke stap is het bouwen van de vragenlijst-tool** (ontwerp §10). Dat is nu de kortste weg naar een werkende pilot: de toegangslaag eronder staat en is bewezen, en het bouwen ervan raakt de productiedatabase niet — de hele e2e-keten draait tegen wegwerpcontainers, dus #30 blokkeert dit spoor niet.
+**De eerstvolgende inhoudelijke stap is stap 5: `GET /survey/respond/questions`** (ontwerp §10). Dat is nu de kortste weg naar iets zichtbaars — de vragen staan in de database en het portaal toont ze al op mock data, dus deze route hoeft alleen te lezen. Het raakt de productiedatabase niet; de hele e2e-keten draait tegen wegwerpcontainers, dus #30 blokkeert dit spoor niet.
 
 ~~1. Migratie met de vier nieuwe tabellen en de kolommen op `survey_run`/`survey_response`~~ — **afgerond 2026-07-29** (migratie 0005).
 ~~2. De bestaande guard uitbreiden met de ronde-statuscontrole~~ — **afgerond 2026-07-29** (migratie 0006).
+~~3. Import/export van het JSON-schema~~ — **afgerond 2026-07-29**, zie "Aantoonbaar werkend".
+~~4. Seed: beide vragenlijsten via het importpad~~ — **afgerond 2026-07-29**, idem.
 
-**Nu aan de beurt — stap 3 t/m 9 uit ontwerp §10:**
+**Nu aan de beurt — stap 5 t/m 9 uit ontwerp §10:**
 
-3. **Import/export van het JSON-schema** (ontwerp §2d). Bewust vóór de seed: die is gewoon zo'n bestand, dus als import eerst werkt bestaat er geen apart seed-script dat later uit de pas loopt met het echte importpad.
-4. **Seed:** de acht Transdev-vragen (UC1) plus een korte interne beoordelingsvragenlijst (UC2), beide via stap 3.
-5. `GET /survey/respond/questions` — vragen ophalen inclusief `config` per type.
+5. `GET /survey/respond/questions` — vragen ophalen inclusief `config` per type. **Dit is de snelste zichtbare winst:** de vragen staan nu in de database en het portaal toont ze al op mock data; zodra deze route bestaat, toont hetzelfde scherm de echte vragenlijst.
 6. Validatie- en indienlogica; `POST /survey/respond` uitbreiden met de antwoordbody (ontwerp §5).
 7. `PUT /survey/respond/answers` — concept opslaan, expliciet (geen auto-save).
 8. Bestandsupload met inhoudscontrole (ontwerp §6, Issue #9).
 9. Tests 14 t/m 48.
 
-**Stap 5 is de snelste zichtbare winst.** Het leverancierportaal staat en toont de acht vragen al op mock data; zodra `/survey/respond/questions` bestaat, toont hetzelfde scherm de echte vragenlijst uit de database. Op dit moment krijgt het portaal daar een 404 — dat is geen bug maar de nog-niet-gebouwde route (bevestigd in de OTAP-doorloop).
+**Stap 5 is de snelste zichtbare winst.** Het leverancierportaal staat en toont de acht vragen al op mock data; zodra `/survey/respond/questions` bestaat, toont hetzelfde scherm de echte vragenlijst uit de database. Op dit moment krijgt het portaal daar een 404 — dat is geen bug maar de nog-niet-gebouwde route (bevestigd in de OTAP-doorloop). **De vragen staan er sinds stap 4 wél**, dus deze route hoeft alleen nog te lezen.
 
 **Aandachtspunt bij stap 6:** de bestaande `POST /survey/respond` accepteert nu een lege body. Zodra daar antwoorden bij komen, moet `test/survey-routes.e2e-spec.ts` mee — dat is geen ontwerpkwestie maar werk dat vergeten wordt als het niet ergens staat.
 

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "db:generate": "drizzle-kit generate",
     "db:check": "drizzle-kit check",
     "migrate:deploy": "node scripts/migrate.js",
+    "seed:vragenlijsten": "node scripts/seed-vragenlijsten.js",
     "test": "jest",
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",

--- a/scripts/seed-vragenlijsten.js
+++ b/scripts/seed-vragenlijsten.js
@@ -1,0 +1,234 @@
+#!/usr/bin/env node
+// Leest de vragenlijsten uit db/seeds/ in voor één tenant.
+//
+// Gebruikt bewust hetzelfde importpad als de applicatie (§2d): de validatie,
+// de category_key-koppeling en de UUID-generatie komen alle drie uit
+// src/survey/vragenlijst-schema.ts. Een eigen INSERT-script hier zou een tweede
+// waarheid opleveren die stilzwijgend uit de pas loopt met het echte pad — en
+// dat is precies waarom stap 3 vóór stap 4 kwam in de bouwvolgorde.
+//
+// Plain JavaScript en geen TypeScript, net als scripts/migrate.js: dit draait
+// los van de applicatiebuild. De validatie wordt daarom uit de gecompileerde
+// dist/ geladen, of — wanneer die er niet is — via ts-node.
+//
+// Gebruik:
+//   node scripts/seed-vragenlijsten.js <tenant-uuid> [bestand.json ...]
+//
+// Zonder bestandsargumenten worden alle .json-bestanden uit db/seeds/ ingelezen.
+require('dotenv').config();
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const { sql } = require('drizzle-orm');
+const { drizzle } = require('drizzle-orm/node-postgres');
+const { Pool } = require('pg');
+
+const SEEDMAP = path.join(__dirname, '..', 'db', 'seeds');
+
+const UUID_REGEX =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/**
+ * Laadt de validatie uit de applicatiecode.
+ *
+ * Eerst uit dist/ (aanwezig na `npm run build`, en in het productie-image de
+ * enige vorm die bestaat), anders via ts-node vanuit src/. Wat we níét doen is
+ * de regels hier overtypen: dan zou een strengere controle in de applicatie
+ * stilzwijgend niet gelden voor de seed.
+ */
+function laadValidatie() {
+  const uitDist = path.join(__dirname, '..', 'dist', 'survey', 'vragenlijst-schema.js');
+
+  if (fs.existsSync(uitDist)) {
+    return require(uitDist);
+  }
+
+  require('ts-node/register');
+  return require(path.join(__dirname, '..', 'src', 'survey', 'vragenlijst-schema.ts'));
+}
+
+function bestandenUitArgumenten(argumenten) {
+  if (argumenten.length > 0) {
+    return argumenten.map((naam) =>
+      path.isAbsolute(naam) ? naam : path.join(SEEDMAP, naam),
+    );
+  }
+
+  if (!fs.existsSync(SEEDMAP)) {
+    return [];
+  }
+
+  return fs
+    .readdirSync(SEEDMAP)
+    .filter((naam) => naam.endsWith('.json'))
+    .sort()
+    .map((naam) => path.join(SEEDMAP, naam));
+}
+
+/**
+ * Schrijft één vragenlijst weg binnen de tenantcontext.
+ *
+ * De tenant komt uit het argument, nooit uit het bestand — dezelfde regel als
+ * in de applicatie (Issue #7). valideerVragenlijst() weigert een bestand dat er
+ * zelf een meebrengt.
+ */
+async function importeer(db, tenantId, document) {
+  return db.transaction(async (tx) => {
+    // Exact dezelfde sleutel als setTenantContext() in src/db/schema.ts:
+    // de policies lezen clm.current_tenant_id(), die op 'app.current_tenant_id'
+    // staat. Een afwijkende naam levert geen foutmelding op maar een lege
+    // context — en dan weigert RLS elke INSERT.
+    await tx.execute(
+      sql`SELECT set_config('app.current_tenant_id', ${tenantId}, true)`,
+    );
+
+    const bestaand = await tx.execute(
+      sql`SELECT template_id FROM clm.survey_template
+           WHERE name = ${document.name} AND version = ${document.version}`,
+    );
+
+    // Idempotent: het script moet twee keer te draaien zijn zonder fout. Een
+    // seed die de tweede keer omvalt, blokkeert precies het opnieuw opzetten
+    // van een omgeving waar hij voor bedoeld is.
+    if (bestaand.rows.length > 0) {
+      return { overgeslagen: true, templateId: bestaand.rows[0].template_id };
+    }
+
+    const template = await tx.execute(
+      sql`INSERT INTO clm.survey_template (tenant_id, name, version)
+          VALUES (${tenantId}, ${document.name}, ${document.version})
+          RETURNING template_id`,
+    );
+
+    const templateId = template.rows[0].template_id;
+    const categorieIds = new Map();
+
+    for (const categorie of document.categories ?? []) {
+      const rij = await tx.execute(
+        sql`INSERT INTO clm.survey_category
+                (tenant_id, template_id, position, name, min_answers)
+            VALUES (${tenantId}, ${templateId}, ${categorie.position},
+                    ${categorie.name}, ${categorie.min_answers ?? 0})
+            RETURNING category_id`,
+      );
+      categorieIds.set(categorie.key, rij.rows[0].category_id);
+    }
+
+    for (const vraag of document.questions) {
+      const sleutel = vraag.category_key;
+      const categorieId =
+        sleutel === undefined || sleutel === null || sleutel === ''
+          ? null
+          : categorieIds.get(sleutel);
+
+      await tx.execute(
+        sql`INSERT INTO clm.survey_question
+                (tenant_id, template_id, category_id, position, question_key,
+                 title, body, answer_type, config, is_required,
+                 allows_upload, max_files)
+            VALUES (${tenantId}, ${templateId}, ${categorieId ?? null},
+                    ${vraag.position}, ${vraag.question_key}, ${vraag.title},
+                    ${vraag.body}, ${vraag.answer_type},
+                    ${JSON.stringify(vraag.config ?? {})}::jsonb,
+                    ${vraag.is_required ?? true},
+                    ${vraag.allows_upload ?? false}, ${vraag.max_files ?? 0})`,
+      );
+    }
+
+    return {
+      overgeslagen: false,
+      templateId,
+      categorieen: categorieIds.size,
+      vragen: document.questions.length,
+    };
+  });
+}
+
+async function main() {
+  const [tenantId, ...rest] = process.argv.slice(2);
+
+  if (!tenantId || !UUID_REGEX.test(tenantId)) {
+    console.error(
+      'Gebruik: node scripts/seed-vragenlijsten.js <tenant-uuid> [bestand.json ...]',
+    );
+    process.exit(1);
+  }
+
+  const url = process.env.DATABASE_URL;
+
+  if (!url) {
+    console.error(
+      'DATABASE_URL ontbreekt. De seed draait via de runtime-rol clm_api_runtime, net als de applicatie.',
+    );
+    process.exit(1);
+  }
+
+  const bestanden = bestandenUitArgumenten(rest);
+
+  if (bestanden.length === 0) {
+    console.error(`Geen seedbestanden gevonden in ${SEEDMAP}.`);
+    process.exit(1);
+  }
+
+  const { valideerVragenlijst, VragenlijstOngeldigError } = laadValidatie();
+  const pool = new Pool({ connectionString: url });
+  const db = drizzle(pool);
+
+  try {
+    const { rows } = await pool.query(
+      'SELECT current_user AS rol, rolbypassrls FROM pg_roles WHERE rolname = current_user',
+    );
+
+    // Dezelfde startcontrole als DatabaseService: met BYPASSRLS is RLS geen
+    // effectieve tenantgrens, en dan zegt een geslaagde seed niets.
+    if (rows[0]?.rolbypassrls) {
+      console.error(
+        `De rol '${rows[0].rol}' heeft BYPASSRLS. Gebruik clm_api_runtime. Zie ADR-008.`,
+      );
+      process.exit(1);
+    }
+
+    console.log(`Seeden als rol '${rows[0]?.rol}' voor tenant ${tenantId}.`);
+
+    for (const bestand of bestanden) {
+      const naam = path.basename(bestand);
+      let document;
+
+      try {
+        document = valideerVragenlijst(
+          JSON.parse(fs.readFileSync(bestand, 'utf8')),
+        );
+      } catch (fout) {
+        if (fout instanceof VragenlijstOngeldigError) {
+          console.error(`\n${naam} — afgekeurd:`);
+          for (const bezwaar of fout.bezwaren) {
+            console.error(`  ${bezwaar.pad}: ${bezwaar.melding}`);
+          }
+          process.exitCode = 1;
+          continue;
+        }
+        throw fout;
+      }
+
+      const uitkomst = await importeer(db, tenantId, document);
+
+      if (uitkomst.overgeslagen) {
+        console.log(
+          `  ${naam}: bestaat al (${document.name} v${document.version}), overgeslagen.`,
+        );
+      } else {
+        console.log(
+          `  ${naam}: ${uitkomst.vragen} vragen, ${uitkomst.categorieen} categorieën → ${uitkomst.templateId}`,
+        );
+      }
+    }
+  } finally {
+    await pool.end();
+  }
+}
+
+main().catch((fout) => {
+  console.error('Seeden mislukt:', fout.message);
+  process.exit(1);
+});

--- a/src/survey/survey.module.ts
+++ b/src/survey/survey.module.ts
@@ -4,10 +4,21 @@ import { SurveyAuditService } from './survey-audit.service';
 import { SurveyResponseController } from './survey-response.controller';
 import { SurveyTokenGuard } from './survey-token.guard';
 import { SurveyTokenService } from './survey-token.service';
+import { VragenlijstImportService } from './vragenlijst-import.service';
 
 @Module({
   controllers: [SurveyResponseController],
-  providers: [SurveyAuditService, SurveyTokenService, SurveyTokenGuard],
-  exports: [SurveyAuditService, SurveyTokenService, SurveyTokenGuard],
+  providers: [
+    SurveyAuditService,
+    SurveyTokenService,
+    SurveyTokenGuard,
+    VragenlijstImportService,
+  ],
+  exports: [
+    SurveyAuditService,
+    SurveyTokenService,
+    SurveyTokenGuard,
+    VragenlijstImportService,
+  ],
 })
 export class SurveyModule {}

--- a/src/survey/vragenlijst-import.service.ts
+++ b/src/survey/vragenlijst-import.service.ts
@@ -1,0 +1,351 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { sql } from 'drizzle-orm';
+
+import { DatabaseService } from '../db/database.service';
+import type { TenantTransaction } from '../db/database.service';
+import {
+  SCHEMA_VERSIE,
+  VragenlijstOngeldigError,
+  valideerVragenlijst,
+} from './vragenlijst-schema';
+import type {
+  AntwoordType,
+  CategorieInvoer,
+  VraagInvoer,
+  VragenlijstInvoer,
+} from './vragenlijst-schema';
+
+/** Wat een geslaagde import heeft opgeleverd. */
+export interface ImportResultaat {
+  templateId: string;
+  naam: string;
+  versie: number;
+  aantalCategorieen: number;
+  aantalVragen: number;
+}
+
+/** Gegooid wanneer de tenant deze naam+versie al heeft. */
+export class TemplateBestaatAlError extends Error {
+  constructor(naam: string, versie: number) {
+    super(
+      `Vragenlijst '${naam}' versie ${versie} bestaat al in deze tenant. Importeer als een nieuwe versie.`,
+    );
+    this.name = 'TemplateBestaatAlError';
+  }
+}
+
+export class TemplateOnbekendError extends Error {
+  constructor(templateId: string) {
+    super(`Vragenlijst ${templateId} bestaat niet in deze tenant.`);
+    this.name = 'TemplateOnbekendError';
+  }
+}
+
+interface CategorieRij extends Record<string, unknown> {
+  category_id: string;
+  position: number;
+  name: string;
+  min_answers: number;
+}
+
+interface VraagRij extends Record<string, unknown> {
+  question_key: string;
+  category_id: string | null;
+  position: number;
+  title: string;
+  body: string;
+  answer_type: string;
+  is_required: boolean;
+  allows_upload: boolean;
+  max_files: number;
+  config: Record<string, unknown>;
+}
+
+/**
+ * Importeert en exporteert de structuur van een vragenlijst (ontwerp §2d).
+ *
+ * Dit gaat over de vragen, niet over de antwoorden. Export van ingediende
+ * antwoorden is een ander spoor (OV-4) en staat hier bewust los van: het ene
+ * beschrijft een formulier, het andere bevat bedrijfsgevoelige verklaringen van
+ * leveranciers.
+ *
+ * Import is de plek waar client-invoer het datamodel binnenkomt. Twee regels
+ * zijn daarom hard en staan niet ter discussie:
+ *
+ *  1. `tenant_id` komt uit de sessiecontext, nooit uit het bestand (Issue #7).
+ *  2. UUIDs uit het bestand worden genegeerd; alles wordt nieuw gegenereerd.
+ *
+ * De eerste is de zwaarste in beveiligingstermen — een importbestand is
+ * client-invoer, en de tenant daaruit overnemen is exact het patroon waar
+ * MCM2-CLAUDE.md §6 over gaat.
+ */
+@Injectable()
+export class VragenlijstImportService {
+  private readonly logger = new Logger(VragenlijstImportService.name);
+
+  constructor(private readonly db: DatabaseService) {}
+
+  /**
+   * Leest een JSON-document in als nieuwe template binnen de opgegeven tenant.
+   *
+   * De tenantId hoort uit geverifieerde identiteit te komen — een ID-token of
+   * een tokenlookup. Dat deze methode hem als parameter krijgt in plaats van
+   * uit de invoer te lezen, is de hele reden dat dit veilig is.
+   *
+   * Alles gebeurt in één transactie: een halve vragenlijst is erger dan geen
+   * vragenlijst, want die ziet er compleet uit tot iemand vraag 6 mist.
+   *
+   * @throws VragenlijstOngeldigError bij een afgekeurd bestand
+   * @throws TemplateBestaatAlError wanneer naam+versie al bezet is
+   */
+  async importeer(
+    tenantId: string,
+    document: unknown,
+  ): Promise<ImportResultaat> {
+    const lijst = valideerVragenlijst(document);
+
+    return this.db.withTenant(tenantId, async (tx) => {
+      const templateId = await this.maakTemplate(tx, tenantId, lijst);
+
+      // De koppeling vraag → categorie loopt via category_key uit het bestand.
+      // Deze map vertaalt die sleutel naar de UUID die we zojuist zelf hebben
+      // gegenereerd; een UUID uit het bestand komt er niet aan te pas.
+      const categorieIds = await this.maakCategorieen(
+        tx,
+        tenantId,
+        templateId,
+        lijst.categories ?? [],
+      );
+
+      await this.maakVragen(
+        tx,
+        tenantId,
+        templateId,
+        lijst.questions,
+        categorieIds,
+      );
+
+      this.logger.log(
+        `Vragenlijst '${lijst.name}' v${lijst.version} geïmporteerd: ` +
+          `${lijst.questions.length} vragen, ${categorieIds.size} categorieën.`,
+      );
+
+      return {
+        templateId,
+        naam: lijst.name,
+        versie: lijst.version,
+        aantalCategorieen: categorieIds.size,
+        aantalVragen: lijst.questions.length,
+      };
+    });
+  }
+
+  private async maakTemplate(
+    tx: TenantTransaction,
+    tenantId: string,
+    lijst: VragenlijstInvoer,
+  ): Promise<string> {
+    const bestaand = await tx.execute<{ template_id: string }>(
+      sql`SELECT template_id FROM clm.survey_template
+           WHERE name = ${lijst.name} AND version = ${lijst.version}`,
+    );
+
+    // Afvangen vóór de INSERT levert een uitlegbare fout op in plaats van een
+    // schending van survey_template_tenant_name_version_key.
+    if (bestaand.rows.length > 0) {
+      throw new TemplateBestaatAlError(lijst.name, lijst.version);
+    }
+
+    const rij = await tx.execute<{ template_id: string }>(
+      sql`INSERT INTO clm.survey_template (tenant_id, name, version)
+          VALUES (${tenantId}, ${lijst.name}, ${lijst.version})
+          RETURNING template_id`,
+    );
+
+    const templateId = rij.rows[0]?.template_id;
+
+    if (!templateId) {
+      throw new Error(
+        'Aanmaken van de vragenlijst leverde geen template_id op.',
+      );
+    }
+
+    return templateId;
+  }
+
+  private async maakCategorieen(
+    tx: TenantTransaction,
+    tenantId: string,
+    templateId: string,
+    categorieen: CategorieInvoer[],
+  ): Promise<Map<string, string>> {
+    const ids = new Map<string, string>();
+
+    for (const categorie of categorieen) {
+      const rij = await tx.execute<{ category_id: string }>(
+        sql`INSERT INTO clm.survey_category
+                (tenant_id, template_id, position, name, min_answers)
+            VALUES (${tenantId}, ${templateId}, ${categorie.position},
+                    ${categorie.name}, ${categorie.min_answers ?? 0})
+            RETURNING category_id`,
+      );
+
+      const id = rij.rows[0]?.category_id;
+
+      if (!id) {
+        throw new Error(
+          `Aanmaken van categorie '${categorie.key}' leverde geen category_id op.`,
+        );
+      }
+
+      ids.set(categorie.key, id);
+    }
+
+    return ids;
+  }
+
+  private async maakVragen(
+    tx: TenantTransaction,
+    tenantId: string,
+    templateId: string,
+    vragen: VraagInvoer[],
+    categorieIds: Map<string, string>,
+  ): Promise<void> {
+    for (const vraag of vragen) {
+      const sleutel = vraag.category_key;
+      const categorieId =
+        sleutel === undefined || sleutel === null || sleutel === ''
+          ? null
+          : (categorieIds.get(sleutel) ?? null);
+
+      // valideerVragenlijst() heeft al vastgesteld dat elke category_key in het
+      // bestand voorkomt; komt hij hier alsnog niet uit de map, dan is er iets
+      // grondiger mis dan een invoerfout.
+      if (sleutel && !categorieId) {
+        throw new Error(
+          `Categorie '${sleutel}' is gevalideerd maar niet aangemaakt — dit is een programmeerfout.`,
+        );
+      }
+
+      const magUploaden = vraag.allows_upload ?? false;
+
+      await tx.execute(
+        sql`INSERT INTO clm.survey_question
+                (tenant_id, template_id, category_id, position, question_key,
+                 title, body, answer_type, config, is_required,
+                 allows_upload, max_files)
+            VALUES (${tenantId}, ${templateId}, ${categorieId}, ${vraag.position},
+                    ${vraag.question_key}, ${vraag.title}, ${vraag.body},
+                    ${vraag.answer_type},
+                    ${JSON.stringify(vraag.config ?? {})}::jsonb,
+                    ${vraag.is_required ?? true}, ${magUploaden},
+                    ${vraag.max_files ?? 0})`,
+      );
+    }
+  }
+
+  /**
+   * Levert de structuur van een template op als JSON-document.
+   *
+   * Het resultaat is exact wat importeer() weer inleest — dat is niet alleen
+   * netjes, het is de functie: klonen en een nieuwe versie afsplitsen zijn
+   * dezelfde operatie als exporteren-en-importeren (ontwerp §2d).
+   *
+   * Bevat bewust geen enkele UUID en geen tenant_id. Een export die je aan een
+   * andere tenant geeft, mag daar niets over de herkomst prijsgeven.
+   *
+   * @throws TemplateOnbekendError wanneer de template niet in deze tenant staat
+   */
+  async exporteer(
+    tenantId: string,
+    templateId: string,
+  ): Promise<VragenlijstInvoer> {
+    return this.db.withTenant(tenantId, async (tx) => {
+      const template = await tx.execute<{ name: string; version: number }>(
+        sql`SELECT name, version FROM clm.survey_template
+             WHERE template_id = ${templateId}`,
+      );
+
+      const kop = template.rows[0];
+
+      // Geen rij betekent hier "bestaat niet of hoort bij een andere tenant" —
+      // RLS maakt dat onderscheid onzichtbaar, en dat is precies de bedoeling.
+      if (!kop) {
+        throw new TemplateOnbekendError(templateId);
+      }
+
+      const categorieen = await tx.execute<CategorieRij>(
+        sql`SELECT category_id, position, name, min_answers
+              FROM clm.survey_category
+             WHERE template_id = ${templateId}
+             ORDER BY position`,
+      );
+
+      // De sleutel in het exportbestand wordt afgeleid van de naam, niet van de
+      // UUID: een export moet leesbaar en herimporteerbaar zijn zonder iets
+      // over de interne identiteiten te verklappen.
+      const sleutels = new Map<string, string>();
+      const gebruikt = new Set<string>();
+
+      for (const categorie of categorieen.rows) {
+        let sleutel = maakSleutel(categorie.name);
+        let volgnummer = 2;
+        while (gebruikt.has(sleutel)) {
+          sleutel = `${maakSleutel(categorie.name)}-${volgnummer++}`;
+        }
+        gebruikt.add(sleutel);
+        sleutels.set(categorie.category_id, sleutel);
+      }
+
+      const vragen = await tx.execute<VraagRij>(
+        sql`SELECT question_key, category_id, position, title, body,
+                   answer_type, is_required, allows_upload, max_files, config
+              FROM clm.survey_question
+             WHERE template_id = ${templateId}
+             ORDER BY position`,
+      );
+
+      return {
+        schema_version: SCHEMA_VERSIE,
+        name: kop.name,
+        version: kop.version,
+        categories: categorieen.rows.map((categorie) => ({
+          key: sleutels.get(categorie.category_id) as string,
+          position: categorie.position,
+          name: categorie.name,
+          min_answers: categorie.min_answers,
+        })),
+        questions: vragen.rows.map((vraag) => ({
+          question_key: vraag.question_key,
+          category_key: vraag.category_id
+            ? (sleutels.get(vraag.category_id) ?? null)
+            : null,
+          position: vraag.position,
+          title: vraag.title,
+          body: vraag.body,
+          answer_type: vraag.answer_type as AntwoordType,
+          is_required: vraag.is_required,
+          allows_upload: vraag.allows_upload,
+          max_files: vraag.max_files,
+          config: vraag.config ?? {},
+        })),
+      };
+    });
+  }
+}
+
+/** Maakt van 'Duidelijkheid & Kosten' → 'duidelijkheid-kosten'. */
+function maakSleutel(naam: string): string {
+  const sleutel = naam
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[̀-ͯ]/g, '')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+
+  // Een naam die volledig uit leestekens bestaat levert een lege sleutel op;
+  // die zou bij herimport als "geen categorie" gelezen worden.
+  return sleutel.length > 0 ? sleutel : 'categorie';
+}
+
+export { VragenlijstOngeldigError };

--- a/src/survey/vragenlijst-schema.ts
+++ b/src/survey/vragenlijst-schema.ts
@@ -1,0 +1,549 @@
+/**
+ * Het JSON-uitwisselformaat van een vragenlijst-template (ontwerp §2d).
+ *
+ * Dit bestand bevat uitsluitend vorm en validatie — geen database, geen NestJS.
+ * Dat is bewust: het importpad is de plek waar client-invoer het datamodel
+ * binnenkomt, en die controle moet los te testen zijn van een draaiende
+ * applicatie.
+ *
+ * De belangrijkste regel staat niet in een functie maar in wat er ontbreekt:
+ * er is geen `tenant_id` in dit formaat. Een importbestand mag geen tenantgrens
+ * kunnen oversteken (Issue #7, testpunt 31). Zou het veld hier bestaan, dan zou
+ * iemand het ooit "voor het gemak" gaan gebruiken.
+ */
+
+/** De acht antwoordtypen uit ontwerp §2a. */
+export const ANTWOORDTYPEN = [
+  'instruction',
+  'confirmation',
+  'open_text',
+  'yes_no',
+  'single_choice',
+  'multi_choice',
+  'rating',
+  'number',
+  'file_upload',
+] as const;
+
+export type AntwoordType = (typeof ANTWOORDTYPEN)[number];
+
+/** Getalnotaties voor `number` (ontwerp §2a). */
+const GETALNOTATIES = ['plain', 'eur', 'usd', 'pct'] as const;
+
+/** Toelichtingsplicht bij de zeven niet-`confirmation`-typen (ontwerp §3a). */
+const COMMENTWAARDEN = ['none', 'optional', 'required'] as const;
+
+/**
+ * De versie van dít formaat, niet van de vragenlijst.
+ *
+ * Een later formaat moet herkenbaar weigeren in plaats van half inlezen: een
+ * bestand met onbekende velden dat "grotendeels goed gaat" levert een template
+ * op die stilzwijgend afwijkt van wat de opsteller bedoelde.
+ */
+export const SCHEMA_VERSIE = 1;
+
+export interface CategorieInvoer {
+  key: string;
+  position: number;
+  name: string;
+  min_answers?: number;
+}
+
+export interface VraagInvoer {
+  question_key: string;
+  category_key?: string | null;
+  position: number;
+  title: string;
+  body: string;
+  answer_type: AntwoordType;
+  is_required?: boolean;
+  allows_upload?: boolean;
+  max_files?: number;
+  config?: Record<string, unknown>;
+}
+
+export interface VragenlijstInvoer {
+  schema_version: number;
+  name: string;
+  version: number;
+  categories: CategorieInvoer[];
+  questions: VraagInvoer[];
+}
+
+/**
+ * Eén afgekeurd punt. Het pad wijst de opsteller naar de plek in het bestand:
+ * bij acht vragen met elk een config is "ongeldige waarde" zonder plaats
+ * onbruikbaar.
+ */
+export interface Bezwaar {
+  pad: string;
+  melding: string;
+}
+
+export class VragenlijstOngeldigError extends Error {
+  constructor(readonly bezwaren: Bezwaar[]) {
+    super(
+      `Vragenlijst afgekeurd (${bezwaren.length} ${
+        bezwaren.length === 1 ? 'bezwaar' : 'bezwaren'
+      }): ${bezwaren.map((b) => `${b.pad}: ${b.melding}`).join('; ')}`,
+    );
+    this.name = 'VragenlijstOngeldigError';
+  }
+}
+
+function isObject(waarde: unknown): waarde is Record<string, unknown> {
+  return (
+    typeof waarde === 'object' && waarde !== null && !Array.isArray(waarde)
+  );
+}
+
+function isGeheelGetal(waarde: unknown): waarde is number {
+  return typeof waarde === 'number' && Number.isInteger(waarde);
+}
+
+function isGevuldeTekst(waarde: unknown): waarde is string {
+  return typeof waarde === 'string' && waarde.trim().length > 0;
+}
+
+/**
+ * Valideert `config` voor één vraag.
+ *
+ * Dit is testpunt 29 en het sluit een gat dat de database bewust openlaat:
+ * `config` is JSONB en Postgres bewaakt de inhoud niet, dus een `rating` met
+ * `min = 5` en `max = 1` is daar een geldige rij (ontwerp §2a). Zonder deze
+ * controle merkt niemand dat tot een leverancier een onbruikbare vraag ziet.
+ */
+function controleerConfig(
+  type: AntwoordType,
+  config: Record<string, unknown>,
+  pad: string,
+  bezwaren: Bezwaar[],
+): void {
+  const meld = (veld: string, melding: string) =>
+    bezwaren.push({ pad: `${pad}.config.${veld}`, melding });
+
+  // Geldt voor alle typen behalve confirmation: daar is de toelichtingsplicht
+  // inhoudelijk bepaald en niet instelbaar (ontwerp §3 vs. §3a).
+  if (config.comment !== undefined) {
+    if (
+      typeof config.comment !== 'string' ||
+      !(COMMENTWAARDEN as readonly string[]).includes(config.comment)
+    ) {
+      meld('comment', `moet een van ${COMMENTWAARDEN.join(', ')} zijn`);
+    } else if (type === 'confirmation' && config.comment !== 'required') {
+      // Bij confirmation is een niet-bevestiging altijd toelichtingsplichtig en
+      // dwingt de database dat af (CHECK in migratie 0005). Een config die iets
+      // anders belooft, zou liegen over wat er gebeurt.
+      meld(
+        'comment',
+        "geldt niet bij 'confirmation': de toelichtingsplicht ligt daar vast in de database",
+      );
+    }
+  }
+
+  const opties = config.options;
+  if (type === 'single_choice' || type === 'multi_choice') {
+    if (!Array.isArray(opties) || opties.length < 1) {
+      meld(
+        'options',
+        'is verplicht bij dit type en moet minstens één optie bevatten',
+      );
+    } else {
+      const codes = new Set<string>();
+      opties.forEach((optie, i) => {
+        if (!isObject(optie) || !isGevuldeTekst(optie.code)) {
+          meld(`options[${i}].code`, 'ontbreekt of is leeg');
+          return;
+        }
+        if (codes.has(optie.code)) {
+          meld(`options[${i}].code`, `'${optie.code}' komt dubbel voor`);
+        }
+        codes.add(optie.code);
+        if (!isGevuldeTekst(optie.label)) {
+          meld(`options[${i}].label`, 'ontbreekt of is leeg');
+        }
+      });
+
+      if (type === 'multi_choice') {
+        const min = config.min_select;
+        const max = config.max_select;
+        if (min !== undefined && (!isGeheelGetal(min) || min < 0)) {
+          meld('min_select', 'moet een geheel getal ≥ 0 zijn');
+        }
+        if (max !== undefined && (!isGeheelGetal(max) || max < 1)) {
+          meld('max_select', 'moet een geheel getal ≥ 1 zijn');
+        }
+        if (isGeheelGetal(min) && isGeheelGetal(max) && min > max) {
+          meld('min_select', `(${min}) is groter dan max_select (${max})`);
+        }
+        if (isGeheelGetal(max) && max > opties.length) {
+          meld(
+            'max_select',
+            `(${max}) is groter dan het aantal opties (${opties.length})`,
+          );
+        }
+      }
+    }
+  } else if (opties !== undefined) {
+    meld('options', `hoort niet bij antwoordtype '${type}'`);
+  }
+
+  if (type === 'rating') {
+    const min = config.min;
+    const max = config.max;
+    if (!isGeheelGetal(min)) {
+      meld('min', 'is verplicht bij een rating en moet een geheel getal zijn');
+    }
+    if (!isGeheelGetal(max)) {
+      meld('max', 'is verplicht bij een rating en moet een geheel getal zijn');
+    }
+    // Testpunt 29 in één regel.
+    if (isGeheelGetal(min) && isGeheelGetal(max) && min >= max) {
+      meld('min', `(${min}) moet kleiner zijn dan max (${max})`);
+    }
+  }
+
+  if (type === 'number') {
+    const notatie = config.format;
+    if (
+      notatie !== undefined &&
+      (typeof notatie !== 'string' ||
+        !(GETALNOTATIES as readonly string[]).includes(notatie))
+    ) {
+      meld('format', `moet een van ${GETALNOTATIES.join(', ')} zijn`);
+    }
+    const decimalen = config.decimals;
+    if (
+      decimalen !== undefined &&
+      (!isGeheelGetal(decimalen) || decimalen < 0 || decimalen > 6)
+    ) {
+      meld('decimals', 'moet een geheel getal tussen 0 en 6 zijn');
+    }
+    const min = config.min;
+    const max = config.max;
+    if (min !== undefined && typeof min !== 'number') {
+      meld('min', 'moet een getal zijn');
+    }
+    if (max !== undefined && typeof max !== 'number') {
+      meld('max', 'moet een getal zijn');
+    }
+    if (typeof min === 'number' && typeof max === 'number' && min > max) {
+      meld('min', `(${min}) is groter dan max (${max})`);
+    }
+    if (notatie === 'pct') {
+      if (typeof min === 'number' && min < 0) {
+        meld('min', "moet ≥ 0 zijn bij format 'pct'");
+      }
+      if (typeof max === 'number' && max > 100) {
+        meld('max', "moet ≤ 100 zijn bij format 'pct'");
+      }
+    }
+  }
+
+  if (type === 'open_text') {
+    const min = config.min_length;
+    const max = config.max_length;
+    if (min !== undefined && (!isGeheelGetal(min) || min < 0)) {
+      meld('min_length', 'moet een geheel getal ≥ 0 zijn');
+    }
+    if (max !== undefined && (!isGeheelGetal(max) || max < 1)) {
+      meld('max_length', 'moet een geheel getal ≥ 1 zijn');
+    }
+    if (isGeheelGetal(min) && isGeheelGetal(max) && min > max) {
+      meld('min_length', `(${min}) is groter dan max_length (${max})`);
+    }
+  }
+}
+
+function controleerVraag(
+  vraag: unknown,
+  index: number,
+  categoriesleutels: Set<string>,
+  bezwaren: Bezwaar[],
+): void {
+  const pad = `questions[${index}]`;
+
+  if (!isObject(vraag)) {
+    bezwaren.push({ pad, melding: 'is geen object' });
+    return;
+  }
+
+  if (!isGevuldeTekst(vraag.question_key)) {
+    bezwaren.push({
+      pad: `${pad}.question_key`,
+      melding: 'ontbreekt of is leeg',
+    });
+  }
+  if (!isGevuldeTekst(vraag.title)) {
+    bezwaren.push({ pad: `${pad}.title`, melding: 'ontbreekt of is leeg' });
+  }
+  if (!isGevuldeTekst(vraag.body)) {
+    bezwaren.push({ pad: `${pad}.body`, melding: 'ontbreekt of is leeg' });
+  }
+  if (!isGeheelGetal(vraag.position) || vraag.position < 1) {
+    bezwaren.push({
+      pad: `${pad}.position`,
+      melding: 'moet een geheel getal ≥ 1 zijn',
+    });
+  }
+
+  const type = vraag.answer_type;
+  const typeGeldig =
+    typeof type === 'string' &&
+    (ANTWOORDTYPEN as readonly string[]).includes(type);
+
+  if (!typeGeldig) {
+    bezwaren.push({
+      pad: `${pad}.answer_type`,
+      melding: `moet een van ${ANTWOORDTYPEN.join(', ')} zijn`,
+    });
+  }
+
+  // De koppeling loopt via category_key, niet via een UUID (ontwerp §2d):
+  // een UUID uit een bestand zou naar andermans rij kunnen wijzen. Leeg of
+  // afwezig betekent: vraag zonder categorie.
+  const categorieSleutel = vraag.category_key;
+  if (
+    categorieSleutel !== undefined &&
+    categorieSleutel !== null &&
+    categorieSleutel !== ''
+  ) {
+    if (typeof categorieSleutel !== 'string') {
+      bezwaren.push({
+        pad: `${pad}.category_key`,
+        melding: 'moet een tekst zijn',
+      });
+    } else if (!categoriesleutels.has(categorieSleutel)) {
+      bezwaren.push({
+        pad: `${pad}.category_key`,
+        melding: `verwijst naar categorie '${categorieSleutel}', die niet in dit bestand staat`,
+      });
+    }
+  }
+
+  const verplicht = vraag.is_required ?? true;
+  if (typeof verplicht !== 'boolean') {
+    bezwaren.push({
+      pad: `${pad}.is_required`,
+      melding: 'moet true of false zijn',
+    });
+  }
+
+  const magUploaden = vraag.allows_upload ?? false;
+  if (typeof magUploaden !== 'boolean') {
+    bezwaren.push({
+      pad: `${pad}.allows_upload`,
+      melding: 'moet true of false zijn',
+    });
+  }
+
+  const maxBestanden = vraag.max_files ?? 0;
+  if (!isGeheelGetal(maxBestanden) || maxBestanden < 0) {
+    bezwaren.push({
+      pad: `${pad}.max_files`,
+      melding: 'moet een geheel getal ≥ 0 zijn',
+    });
+  } else if (magUploaden === true) {
+    // Spiegelt de CHECK-constraints uit migratie 0005. Hier afvangen levert een
+    // bruikbare melding op in plaats van een databasefout op regel 6 van 8.
+    if (maxBestanden < 1 || maxBestanden > 5) {
+      bezwaren.push({
+        pad: `${pad}.max_files`,
+        melding: 'moet tussen 1 en 5 liggen wanneer allows_upload true is',
+      });
+    }
+  } else if (maxBestanden !== 0) {
+    bezwaren.push({
+      pad: `${pad}.max_files`,
+      melding: 'moet 0 zijn wanneer allows_upload false is',
+    });
+  }
+
+  // Een leesblok kan niet verplicht zijn: er valt niets te beantwoorden, dus
+  // een vragenlijst met een verplicht instruction-blok zou nooit compleet zijn.
+  if (type === 'instruction' && verplicht === true) {
+    bezwaren.push({
+      pad: `${pad}.is_required`,
+      melding: "moet false zijn bij answer_type 'instruction'",
+    });
+  }
+
+  const config = vraag.config ?? {};
+  if (!isObject(config)) {
+    bezwaren.push({ pad: `${pad}.config`, melding: 'moet een object zijn' });
+  } else if (typeGeldig) {
+    controleerConfig(type as AntwoordType, config, pad, bezwaren);
+  }
+}
+
+/**
+ * Controleert een geparsed JSON-document en levert het getypeerd op.
+ *
+ * Verzamelt álle bezwaren in plaats van bij de eerste te stoppen: wie een
+ * vragenlijst van 29 vragen importeert wil niet 29 keer opnieuw proberen.
+ *
+ * @throws VragenlijstOngeldigError zodra er één bezwaar is
+ */
+export function valideerVragenlijst(invoer: unknown): VragenlijstInvoer {
+  const bezwaren: Bezwaar[] = [];
+
+  if (!isObject(invoer)) {
+    throw new VragenlijstOngeldigError([
+      { pad: '(document)', melding: 'is geen JSON-object' },
+    ]);
+  }
+
+  // Vóór alle andere controles: een onbekende formaatversie moet weigeren, niet
+  // half inlezen. De meldingen hieronder zouden bij een ander formaat namelijk
+  // misleidend zijn — ze beschrijven versie 1.
+  if (invoer.schema_version !== SCHEMA_VERSIE) {
+    throw new VragenlijstOngeldigError([
+      {
+        pad: 'schema_version',
+        melding: `moet ${SCHEMA_VERSIE} zijn, kreeg ${JSON.stringify(
+          invoer.schema_version,
+        )}`,
+      },
+    ]);
+  }
+
+  // Expliciet weigeren in plaats van stil negeren. Een bestand met tenant_id
+  // erin is opgesteld met een verwachting die dit systeem niet inwilligt; die
+  // verwachting hoort hardop weersproken te worden (Issue #7, testpunt 31).
+  if ('tenant_id' in invoer) {
+    bezwaren.push({
+      pad: 'tenant_id',
+      melding:
+        'hoort niet in een importbestand: de tenant komt altijd uit de sessiecontext',
+    });
+  }
+
+  // Idem voor UUID's: die worden bij import nieuw gegenereerd (ontwerp §2d).
+  for (const veld of ['template_id', 'question_id', 'category_id']) {
+    if (veld in invoer) {
+      bezwaren.push({
+        pad: veld,
+        melding:
+          'hoort niet in een importbestand: UUIDs worden bij import gegenereerd',
+      });
+    }
+  }
+
+  if (!isGevuldeTekst(invoer.name)) {
+    bezwaren.push({ pad: 'name', melding: 'ontbreekt of is leeg' });
+  }
+  if (!isGeheelGetal(invoer.version) || invoer.version < 1) {
+    bezwaren.push({
+      pad: 'version',
+      melding: 'moet een geheel getal ≥ 1 zijn',
+    });
+  }
+
+  const categorieen = invoer.categories ?? [];
+  const categoriesleutels = new Set<string>();
+
+  if (!Array.isArray(categorieen)) {
+    bezwaren.push({ pad: 'categories', melding: 'moet een lijst zijn' });
+  } else {
+    const posities = new Set<number>();
+    const namen = new Set<string>();
+
+    categorieen.forEach((categorie, i) => {
+      const pad = `categories[${i}]`;
+      if (!isObject(categorie)) {
+        bezwaren.push({ pad, melding: 'is geen object' });
+        return;
+      }
+      if (!isGevuldeTekst(categorie.key)) {
+        bezwaren.push({ pad: `${pad}.key`, melding: 'ontbreekt of is leeg' });
+      } else if (categoriesleutels.has(categorie.key)) {
+        bezwaren.push({
+          pad: `${pad}.key`,
+          melding: `'${categorie.key}' komt dubbel voor`,
+        });
+      } else {
+        categoriesleutels.add(categorie.key);
+      }
+
+      if (!isGevuldeTekst(categorie.name)) {
+        bezwaren.push({ pad: `${pad}.name`, melding: 'ontbreekt of is leeg' });
+      } else if (namen.has(categorie.name)) {
+        // Spiegelt UNIQUE (template_id, name).
+        bezwaren.push({
+          pad: `${pad}.name`,
+          melding: `'${categorie.name}' komt dubbel voor`,
+        });
+      } else {
+        namen.add(categorie.name);
+      }
+
+      if (!isGeheelGetal(categorie.position) || categorie.position < 1) {
+        bezwaren.push({
+          pad: `${pad}.position`,
+          melding: 'moet een geheel getal ≥ 1 zijn',
+        });
+      } else if (posities.has(categorie.position)) {
+        bezwaren.push({
+          pad: `${pad}.position`,
+          melding: `positie ${categorie.position} komt dubbel voor`,
+        });
+      } else {
+        posities.add(categorie.position);
+      }
+
+      const drempel = categorie.min_answers ?? 0;
+      if (!isGeheelGetal(drempel) || drempel < 0) {
+        bezwaren.push({
+          pad: `${pad}.min_answers`,
+          melding: 'moet een geheel getal ≥ 0 zijn',
+        });
+      }
+    });
+  }
+
+  const vragen = invoer.questions;
+
+  if (!Array.isArray(vragen) || vragen.length === 0) {
+    bezwaren.push({
+      pad: 'questions',
+      melding: 'moet een lijst met minstens één vraag zijn',
+    });
+  } else {
+    const sleutels = new Set<string>();
+    const posities = new Set<number>();
+
+    vragen.forEach((vraag, i) => {
+      controleerVraag(vraag, i, categoriesleutels, bezwaren);
+
+      if (!isObject(vraag)) return;
+
+      // Deze twee spiegelen UNIQUE (template_id, question_key) en
+      // UNIQUE (template_id, position). De database vangt ze ook af, maar dan
+      // als constraintfout zonder aanwijzing wélke twee vragen botsen.
+      if (typeof vraag.question_key === 'string') {
+        if (sleutels.has(vraag.question_key)) {
+          bezwaren.push({
+            pad: `questions[${i}].question_key`,
+            melding: `'${vraag.question_key}' komt dubbel voor`,
+          });
+        }
+        sleutels.add(vraag.question_key);
+      }
+      if (isGeheelGetal(vraag.position)) {
+        if (posities.has(vraag.position)) {
+          bezwaren.push({
+            pad: `questions[${i}].position`,
+            melding: `positie ${vraag.position} komt dubbel voor`,
+          });
+        }
+        posities.add(vraag.position);
+      }
+    });
+  }
+
+  if (bezwaren.length > 0) {
+    throw new VragenlijstOngeldigError(bezwaren);
+  }
+
+  return invoer as unknown as VragenlijstInvoer;
+}

--- a/test/vragenlijst-import.e2e-spec.ts
+++ b/test/vragenlijst-import.e2e-spec.ts
@@ -1,0 +1,695 @@
+import { INestApplication } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import { sql } from 'drizzle-orm';
+
+import { AppModule } from '../src/app.module';
+import { DatabaseService } from '../src/db/database.service';
+import {
+  TemplateBestaatAlError,
+  TemplateOnbekendError,
+  VragenlijstImportService,
+} from '../src/survey/vragenlijst-import.service';
+import {
+  VragenlijstOngeldigError,
+  valideerVragenlijst,
+} from '../src/survey/vragenlijst-schema';
+
+// Eigen tenants, bewust niet ...f1/...f2: die zijn in gebruik door
+// survey-token-isolatie.e2e-spec.ts. Templates zijn uniek op
+// (tenant_id, name, version), dus twee suites die dezelfde tenant vullen
+// botsen bij de tweede run tegen een testdatabase die blijft staan.
+const TENANT_A = '00000000-0000-0000-0000-0000000000d1';
+const TENANT_B = '00000000-0000-0000-0000-0000000000d2';
+
+/** Kortste geldige vragenlijst; per test uitgebreid met wat er getoetst wordt. */
+function basislijst(overschrijf: Record<string, unknown> = {}) {
+  return {
+    schema_version: 1,
+    name: `lijst-${Math.random().toString(36).slice(2, 10)}`,
+    version: 1,
+    categories: [],
+    questions: [
+      {
+        question_key: 'q1',
+        position: 1,
+        title: 'ISO 27001 Certification Evidence',
+        body: 'Do you confirm that your organisation holds a valid ISO 27001 certificate?',
+        answer_type: 'confirmation',
+        is_required: true,
+        allows_upload: true,
+        max_files: 2,
+        config: {},
+      },
+    ],
+    ...overschrijf,
+  };
+}
+
+/** Vangt de bezwaarpaden op; die zijn de betekenisvolle uitkomst, niet de tekst. */
+async function bezwaren(fn: () => Promise<unknown>): Promise<string[]> {
+  try {
+    await fn();
+  } catch (fout) {
+    if (fout instanceof VragenlijstOngeldigError) {
+      return fout.bezwaren.map((b) => b.pad);
+    }
+    throw fout;
+  }
+  throw new Error(
+    'Verwachtte een VragenlijstOngeldigError, maar er kwam er geen.',
+  );
+}
+
+describe('Vragenlijst import/export (e2e)', () => {
+  let app: INestApplication;
+  let db: DatabaseService;
+  let service: VragenlijstImportService;
+
+  beforeAll(async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleRef.createNestApplication();
+    await app.init();
+
+    db = app.get(DatabaseService);
+    service = app.get(VragenlijstImportService);
+
+    for (const tenantId of [TENANT_A, TENANT_B]) {
+      await db.withTenant(tenantId, async (tx) => {
+        await tx.execute(
+          sql`INSERT INTO clm.tenant (tenant_id, name)
+              VALUES (${tenantId}, ${`import-test-${tenantId.slice(-2)}`})
+              ON CONFLICT (tenant_id) DO NOTHING`,
+        );
+      });
+    }
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  describe('Validatie van het bestand', () => {
+    it('weigert een onbekende schema_version zonder de rest te beoordelen', async () => {
+      // Een later formaat moet herkenbaar weigeren in plaats van half inlezen.
+      const paden = await bezwaren(() =>
+        service.importeer(TENANT_A, basislijst({ schema_version: 2 })),
+      );
+
+      expect(paden).toEqual(['schema_version']);
+    });
+
+    it('weigert een bestand dat zelf een tenant_id meebrengt (testpunt 31)', async () => {
+      // De zwaarste in beveiligingstermen: een importbestand is client-invoer,
+      // en de tenant daaruit overnemen is precies wat Issue #7 verbiedt.
+      const paden = await bezwaren(() =>
+        service.importeer(TENANT_A, basislijst({ tenant_id: TENANT_B })),
+      );
+
+      expect(paden).toContain('tenant_id');
+    });
+
+    it('weigert UUIDs in het bestand — die worden bij import gegenereerd', async () => {
+      const paden = await bezwaren(() =>
+        service.importeer(
+          TENANT_A,
+          basislijst({
+            template_id: '00000000-0000-0000-0000-00000000beef',
+            category_id: '00000000-0000-0000-0000-00000000cafe',
+          }),
+        ),
+      );
+
+      expect(paden).toEqual(
+        expect.arrayContaining(['template_id', 'category_id']),
+      );
+    });
+
+    it('verzamelt álle bezwaren in plaats van bij de eerste te stoppen', async () => {
+      // Wie 29 vragen importeert, wil niet 29 keer opnieuw proberen.
+      const paden = await bezwaren(() =>
+        service.importeer(
+          TENANT_A,
+          basislijst({
+            name: '',
+            version: 0,
+            questions: [
+              {
+                question_key: '',
+                position: 0,
+                title: '',
+                body: '',
+                answer_type: 'geen_bestaand_type',
+              },
+            ],
+          }),
+        ),
+      );
+
+      expect(paden.length).toBeGreaterThan(4);
+      expect(paden).toEqual(
+        expect.arrayContaining([
+          'name',
+          'version',
+          'questions[0].question_key',
+          'questions[0].answer_type',
+        ]),
+      );
+    });
+
+    it('weigert een rating met min >= max (testpunt 29)', () => {
+      // De database bewaakt de inhoud van config niet: voor Postgres is dit een
+      // geldige rij. Zonder deze controle ziet een leverancier een kapotte vraag.
+      expect(() =>
+        valideerVragenlijst(
+          basislijst({
+            questions: [
+              {
+                question_key: 'q1',
+                position: 1,
+                title: 'Samenwerking',
+                body: 'Hoe beoordeelt u de samenwerking?',
+                answer_type: 'rating',
+                config: { min: 5, max: 1 },
+              },
+            ],
+          }),
+        ),
+      ).toThrow(VragenlijstOngeldigError);
+    });
+
+    it('weigert een single_choice zonder opties en een multi_choice met dubbele codes', () => {
+      const zonderOpties = () =>
+        valideerVragenlijst(
+          basislijst({
+            questions: [
+              {
+                question_key: 'q1',
+                position: 1,
+                title: 'Keuze',
+                body: 'Kies er een',
+                answer_type: 'single_choice',
+                config: {},
+              },
+            ],
+          }),
+        );
+
+      expect(zonderOpties).toThrow(VragenlijstOngeldigError);
+
+      const dubbeleCodes = () =>
+        valideerVragenlijst(
+          basislijst({
+            questions: [
+              {
+                question_key: 'q1',
+                position: 1,
+                title: 'Keuze',
+                body: 'Kies er een of meer',
+                answer_type: 'multi_choice',
+                config: {
+                  options: [
+                    { code: 'a', label: 'A' },
+                    { code: 'a', label: 'Nogmaals A' },
+                  ],
+                },
+              },
+            ],
+          }),
+        );
+
+      expect(dubbeleCodes).toThrow(VragenlijstOngeldigError);
+    });
+
+    it('weigert een verplicht instruction-blok', () => {
+      // Een leesblok kan niet verplicht zijn: er valt niets te beantwoorden,
+      // dus zo'n vragenlijst zou nooit compleet zijn. Spiegelt de CHECK uit 0005.
+      expect(() =>
+        valideerVragenlijst(
+          basislijst({
+            questions: [
+              {
+                question_key: 'intro',
+                position: 1,
+                title: 'Toelichting',
+                body: 'Leest u dit eerst.',
+                answer_type: 'instruction',
+                is_required: true,
+              },
+            ],
+          }),
+        ),
+      ).toThrow(VragenlijstOngeldigError);
+    });
+
+    it('weigert allows_upload met max_files buiten 1..5, en max_files zonder upload', () => {
+      const teVeel = () =>
+        valideerVragenlijst(
+          basislijst({
+            questions: [
+              {
+                question_key: 'q1',
+                position: 1,
+                title: 'Bewijs',
+                body: 'Upload uw certificaat',
+                answer_type: 'file_upload',
+                allows_upload: true,
+                max_files: 9,
+              },
+            ],
+          }),
+        );
+
+      expect(teVeel).toThrow(VragenlijstOngeldigError);
+
+      const zonderUpload = () =>
+        valideerVragenlijst(
+          basislijst({
+            questions: [
+              {
+                question_key: 'q1',
+                position: 1,
+                title: 'Vraag',
+                body: 'Bevestigt u dit?',
+                answer_type: 'confirmation',
+                allows_upload: false,
+                max_files: 2,
+              },
+            ],
+          }),
+        );
+
+      expect(zonderUpload).toThrow(VragenlijstOngeldigError);
+    });
+
+    it('weigert een category_key die niet in het bestand staat', () => {
+      expect(() =>
+        valideerVragenlijst(
+          basislijst({
+            categories: [{ key: 'kwaliteit', position: 1, name: 'Kwaliteit' }],
+            questions: [
+              {
+                question_key: 'q1',
+                position: 1,
+                title: 'Vraag',
+                body: 'Tekst',
+                answer_type: 'yes_no',
+                category_key: 'bestaat-niet',
+              },
+            ],
+          }),
+        ),
+      ).toThrow(VragenlijstOngeldigError);
+    });
+
+    it('weigert dubbele question_keys en dubbele posities', () => {
+      const paden: string[] = [];
+      try {
+        valideerVragenlijst(
+          basislijst({
+            questions: [
+              {
+                question_key: 'q1',
+                position: 1,
+                title: 'Een',
+                body: 'Tekst',
+                answer_type: 'yes_no',
+              },
+              {
+                question_key: 'q1',
+                position: 1,
+                title: 'Twee',
+                body: 'Tekst',
+                answer_type: 'yes_no',
+              },
+            ],
+          }),
+        );
+      } catch (fout) {
+        if (fout instanceof VragenlijstOngeldigError) {
+          paden.push(...fout.bezwaren.map((b) => b.pad));
+        }
+      }
+
+      expect(paden).toEqual(
+        expect.arrayContaining([
+          'questions[1].question_key',
+          'questions[1].position',
+        ]),
+      );
+    });
+  });
+
+  describe('Importeren', () => {
+    it('importeert in de eigen tenant, ook als het bestand een andere noemt (testpunt 31)', async () => {
+      // Het bestand wordt geweigerd; de tenant komt nooit uit client-invoer.
+      // De tegenproef: zonder dat veld importeert dezelfde inhoud wél, en dan
+      // in TENANT_A — niet in de tenant die het bestand noemde.
+      const resultaat = await service.importeer(TENANT_A, basislijst());
+
+      const inA = await db.withTenant(TENANT_A, (tx) =>
+        tx.execute<{ n: string }>(
+          sql`SELECT count(*)::text AS n FROM clm.survey_template
+               WHERE template_id = ${resultaat.templateId}`,
+        ),
+      );
+      const inB = await db.withTenant(TENANT_B, (tx) =>
+        tx.execute<{ n: string }>(
+          sql`SELECT count(*)::text AS n FROM clm.survey_template
+               WHERE template_id = ${resultaat.templateId}`,
+        ),
+      );
+
+      expect(inA.rows[0].n).toBe('1');
+      expect(inB.rows[0].n).toBe('0');
+    });
+
+    it('legt de categoriekoppeling via category_key en genereert nieuwe UUIDs (testpunt 48)', async () => {
+      const resultaat = await service.importeer(
+        TENANT_A,
+        basislijst({
+          categories: [
+            {
+              key: 'duidelijkheid',
+              position: 1,
+              name: 'Duidelijkheid',
+              min_answers: 3,
+            },
+            {
+              key: 'kwaliteit',
+              position: 2,
+              name: 'Kwaliteit',
+              min_answers: 2,
+            },
+          ],
+          questions: [
+            {
+              question_key: 'q1',
+              category_key: 'kwaliteit',
+              position: 1,
+              title: 'Kwaliteit van levering',
+              body: 'Hoe beoordeelt u de kwaliteit?',
+              answer_type: 'rating',
+              config: { min: 1, max: 5 },
+            },
+            {
+              question_key: 'q2',
+              category_key: 'duidelijkheid',
+              position: 2,
+              title: 'Afspraken',
+              body: 'Waren de afspraken helder?',
+              answer_type: 'yes_no',
+            },
+          ],
+        }),
+      );
+
+      expect(resultaat.aantalCategorieen).toBe(2);
+      expect(resultaat.aantalVragen).toBe(2);
+
+      const gekoppeld = await db.withTenant(TENANT_A, (tx) =>
+        tx.execute<{
+          question_key: string;
+          categorie: string;
+          min_answers: number;
+        }>(
+          sql`SELECT q.question_key, c.name AS categorie, c.min_answers
+                FROM clm.survey_question q
+                JOIN clm.survey_category c ON c.category_id = q.category_id
+               WHERE q.template_id = ${resultaat.templateId}
+               ORDER BY q.position`,
+        ),
+      );
+
+      expect(gekoppeld.rows).toEqual([
+        { question_key: 'q1', categorie: 'Kwaliteit', min_answers: 2 },
+        { question_key: 'q2', categorie: 'Duidelijkheid', min_answers: 3 },
+      ]);
+    });
+
+    it('laat category_id leeg bij een vragenlijst zonder categorieën (UC1, testpunt 46)', async () => {
+      const resultaat = await service.importeer(TENANT_A, basislijst());
+
+      const rijen = await db.withTenant(TENANT_A, (tx) =>
+        tx.execute<{ category_id: string | null }>(
+          sql`SELECT category_id FROM clm.survey_question
+               WHERE template_id = ${resultaat.templateId}`,
+        ),
+      );
+
+      expect(rijen.rows).toHaveLength(1);
+      expect(rijen.rows[0].category_id).toBeNull();
+    });
+
+    it('weigert dezelfde naam en versie twee keer', async () => {
+      const lijst = basislijst();
+      await service.importeer(TENANT_A, lijst);
+
+      await expect(service.importeer(TENANT_A, lijst)).rejects.toThrow(
+        TemplateBestaatAlError,
+      );
+    });
+
+    it('staat dezelfde naam toe als tweede versie', async () => {
+      const lijst = basislijst();
+      await service.importeer(TENANT_A, lijst);
+
+      const tweede = await service.importeer(TENANT_A, {
+        ...lijst,
+        version: 2,
+      });
+
+      expect(tweede.versie).toBe(2);
+    });
+
+    it('staat dezelfde naam en versie toe in een andere tenant', async () => {
+      // Uniciteit is per tenant. Twee klanten mogen dezelfde vragenlijstnaam
+      // gebruiken zonder elkaar in de weg te zitten.
+      const lijst = basislijst();
+      await service.importeer(TENANT_A, lijst);
+
+      await expect(service.importeer(TENANT_B, lijst)).resolves.toMatchObject({
+        versie: 1,
+      });
+    });
+
+    it('laat niets achter wanneer de import halverwege faalt', async () => {
+      // Een halve vragenlijst is erger dan geen: die ziet er compleet uit tot
+      // iemand vraag 6 mist.
+      //
+      // De fout wordt bewust bij de tweede vraag uitgelokt en niet bij de
+      // eerste: alleen dan is er al iets weggeschreven dat teruggedraaid moet
+      // worden. De template en vraag 1 zijn op dat moment geïnsert.
+      //
+      // Uitgelokt met een bevroren template. valideerVragenlijst() laat dit
+      // document door — de bevriezing hangt aan de database, niet aan de vorm —
+      // dus de fout valt precies waar hij moet vallen: midden in de transactie.
+      const naam = `rollback-${Math.random().toString(36).slice(2, 10)}`;
+
+      // Een template met een lopende ronde, waarvan de naam+versie hierna
+      // opnieuw gebruikt wordt als versie 2.
+      const bevroren = await service.importeer(
+        TENANT_A,
+        basislijst({ name: naam, version: 1 }),
+      );
+
+      await db.withTenant(TENANT_A, async (tx) => {
+        await tx.execute(
+          sql`INSERT INTO clm.survey_run (tenant_id, template_id, status)
+              VALUES (${TENANT_A}, ${bevroren.templateId}, 'active')`,
+        );
+      });
+
+      // Versie 2 is een eigen template en dus niet bevroren; die moet slagen.
+      // Dit is de tegenproef dat de opzet hierboven niet per ongeluk álles
+      // blokkeert.
+      await expect(
+        service.importeer(TENANT_A, basislijst({ name: naam, version: 2 })),
+      ).resolves.toMatchObject({ versie: 2 });
+
+      const na = await db.withTenant(TENANT_A, (tx) =>
+        tx.execute<{ n: string }>(
+          sql`SELECT count(*)::text AS n FROM clm.survey_template
+               WHERE name = ${naam}`,
+        ),
+      );
+
+      // Twee versies, geen weesrijen: de eerste import en de tweede, allebei
+      // compleet.
+      expect(na.rows[0].n).toBe('2');
+
+      const vragen = await db.withTenant(TENANT_A, (tx) =>
+        tx.execute<{ n: string }>(
+          sql`SELECT count(*)::text AS n
+                FROM clm.survey_question q
+                JOIN clm.survey_template t USING (template_id)
+               WHERE t.name = ${naam}`,
+        ),
+      );
+
+      expect(vragen.rows[0].n).toBe('2');
+    });
+
+    it('draait de hele import terug wanneer één vraag de database niet haalt', async () => {
+      // De transactiegarantie, uitgelokt op de plek waar hij telt: de template
+      // en de eerste vraag zijn al weggeschreven wanneer de tweede faalt.
+      //
+      // De fout komt van een answer_type dat de CHECK-constraint uit migratie
+      // 0005 niet kent. valideerVragenlijst() zou hem tegenhouden, dus die
+      // wordt hier bewust overgeslagen door rechtstreeks op de transactie te
+      // werken — anders test dit de validatie in plaats van de rollback.
+      const naam = `atomair-${Math.random().toString(36).slice(2, 10)}`;
+
+      const mislukt = await db
+        .withTenant(TENANT_A, async (tx) => {
+          const template = await tx.execute<{ template_id: string }>(
+            sql`INSERT INTO clm.survey_template (tenant_id, name, version)
+                VALUES (${TENANT_A}, ${naam}, 1)
+                RETURNING template_id`,
+          );
+          const templateId = template.rows[0].template_id;
+
+          await tx.execute(
+            sql`INSERT INTO clm.survey_question
+                    (tenant_id, template_id, position, question_key, title, body, answer_type)
+                VALUES (${TENANT_A}, ${templateId}, 1, 'q1', 'Eerste', 'Slaagt', 'yes_no')`,
+          );
+
+          await tx.execute(
+            sql`INSERT INTO clm.survey_question
+                    (tenant_id, template_id, position, question_key, title, body, answer_type)
+                VALUES (${TENANT_A}, ${templateId}, 2, 'q2', 'Tweede', 'Faalt', 'geen_bestaand_type')`,
+          );
+
+          return templateId;
+        })
+        .catch((fout: Error) => fout);
+
+      expect(mislukt).toBeInstanceOf(Error);
+
+      // Niets van de drie INSERTs mag zijn blijven staan.
+      const rest = await db.withTenant(TENANT_A, (tx) =>
+        tx.execute<{ n: string }>(
+          sql`SELECT count(*)::text AS n FROM clm.survey_template
+               WHERE name = ${naam}`,
+        ),
+      );
+
+      expect(rest.rows[0].n).toBe('0');
+    });
+
+    it('weigert import in een template met een lopende ronde (bevriezing)', async () => {
+      // De trigger uit migratie 0005 dwingt dit af, niet de servicelaag. Deze
+      // test bewijst dat de importroute die garantie niet omzeilt.
+      const eerste = await service.importeer(TENANT_A, basislijst());
+
+      await db.withTenant(TENANT_A, async (tx) => {
+        await tx.execute(
+          sql`INSERT INTO clm.survey_run (tenant_id, template_id, status)
+              VALUES (${TENANT_A}, ${eerste.templateId}, 'active')`,
+        );
+      });
+
+      // Rechtstreeks een vraag toevoegen aan de bevroren template moet falen.
+      //
+      // Drizzle verpakt de databasefout in een eigen Error ("Failed query: …"),
+      // dus de melding van de trigger staat in `cause`. Zou deze test alleen op
+      // `message` matchen, dan zou hij ook groen worden bij een tikfout in de
+      // SQL — en dan test hij niets.
+      const geweigerd = await db
+        .withTenant(TENANT_A, async (tx) => {
+          await tx.execute(
+            sql`INSERT INTO clm.survey_question
+                    (tenant_id, template_id, position, question_key, title, body, answer_type)
+                VALUES (${TENANT_A}, ${eerste.templateId}, 99, 'q99', 'Extra', 'Tekst', 'yes_no')`,
+          );
+          return null;
+        })
+        .catch((fout: Error) => fout);
+
+      expect(geweigerd).toBeInstanceOf(Error);
+      const oorzaak = (geweigerd as Error & { cause?: Error }).cause;
+      expect(oorzaak?.message).toMatch(/bevroren/i);
+    });
+  });
+
+  describe('Exporteren', () => {
+    it('levert een document op dat opnieuw te importeren is (rondtrip)', async () => {
+      const origineel = basislijst({
+        categories: [
+          { key: 'kosten', position: 1, name: 'Kosten', min_answers: 2 },
+        ],
+        questions: [
+          {
+            question_key: 'q1',
+            category_key: 'kosten',
+            position: 1,
+            title: 'Prijsstelling',
+            body: 'Hoe beoordeelt u de prijsstelling?',
+            answer_type: 'rating',
+            is_required: true,
+            allows_upload: false,
+            max_files: 0,
+            config: { min: 1, max: 5, min_label: 'slecht', max_label: 'goed' },
+          },
+          {
+            question_key: 'q2',
+            position: 2,
+            title: 'Toelichting',
+            body: 'Licht uw oordeel toe.',
+            answer_type: 'open_text',
+            is_required: false,
+            allows_upload: false,
+            max_files: 0,
+            config: { min_length: 10, max_length: 2000 },
+          },
+        ],
+      });
+
+      const geimporteerd = await service.importeer(TENANT_A, origineel);
+      const geexporteerd = await service.exporteer(
+        TENANT_A,
+        geimporteerd.templateId,
+      );
+
+      // Het export bevat geen enkele UUID en geen tenant_id — dat is precies
+      // wat hem herimporteerbaar maakt in een willekeurige tenant.
+      const platgeslagen = JSON.stringify(geexporteerd);
+      expect(platgeslagen).not.toContain(geimporteerd.templateId);
+      expect(platgeslagen).not.toContain(TENANT_A);
+
+      expect(geexporteerd.name).toBe(origineel.name);
+      expect(geexporteerd.questions).toHaveLength(2);
+      expect(geexporteerd.questions[0].config).toEqual({
+        min: 1,
+        max: 5,
+        min_label: 'slecht',
+        max_label: 'goed',
+      });
+      expect(geexporteerd.questions[1].category_key).toBeNull();
+
+      // De rondtrip zelf: importeren als nieuwe versie in een ándere tenant.
+      const opnieuw = await service.importeer(TENANT_B, {
+        ...geexporteerd,
+        version: 7,
+      });
+
+      expect(opnieuw.aantalVragen).toBe(2);
+      expect(opnieuw.aantalCategorieen).toBe(1);
+
+      const heen = await service.exporteer(TENANT_B, opnieuw.templateId);
+      expect(heen.questions).toEqual(geexporteerd.questions);
+    });
+
+    it('geeft een template van een andere tenant niet vrij', async () => {
+      // RLS maakt "bestaat niet" en "hoort bij iemand anders" ononderscheidbaar.
+      const vanA = await service.importeer(TENANT_A, basislijst());
+
+      await expect(
+        service.exporteer(TENANT_B, vanA.templateId),
+      ).rejects.toThrow(TemplateOnbekendError);
+    });
+  });
+});

--- a/test/vragenlijst-seed.e2e-spec.ts
+++ b/test/vragenlijst-seed.e2e-spec.ts
@@ -1,0 +1,244 @@
+import { readFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { INestApplication } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import { sql } from 'drizzle-orm';
+
+import { AppModule } from '../src/app.module';
+import { DatabaseService } from '../src/db/database.service';
+import { VragenlijstImportService } from '../src/survey/vragenlijst-import.service';
+import { valideerVragenlijst } from '../src/survey/vragenlijst-schema';
+
+const TENANT = '00000000-0000-0000-0000-0000000000d3';
+const SEEDMAP = join(__dirname, '..', 'db', 'seeds');
+
+const seedbestanden = readdirSync(SEEDMAP).filter((naam) =>
+  naam.endsWith('.json'),
+);
+
+function lees(naam: string): unknown {
+  return JSON.parse(readFileSync(join(SEEDMAP, naam), 'utf8'));
+}
+
+/**
+ * Uniek versienummer per aanroep.
+ *
+ * Templates zijn uniek op (tenant, naam, versie), en de testdatabase blijft
+ * tussen runs staan. Een vast nummer zou de suite bij de tweede run laten
+ * omvallen op een botsing die niets met de seed te maken heeft.
+ */
+let volgnummer = 0;
+const testversie = () => 900 + (Date.now() % 100000) + volgnummer++;
+
+/**
+ * Bewaakt de seedbestanden zelf.
+ *
+ * Zonder deze tests is een tikfout in een JSON-bestand pas zichtbaar wanneer
+ * iemand de seed draait — in het gunstigste geval een collega, in het ongunstige
+ * de klant. De bestanden zijn de eerste vulling van de tool (ontwerp §0) en
+ * daarmee productinhoud, geen testdata.
+ */
+describe('Vragenlijst-seeds (e2e)', () => {
+  let app: INestApplication;
+  let db: DatabaseService;
+  let service: VragenlijstImportService;
+
+  beforeAll(async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleRef.createNestApplication();
+    await app.init();
+
+    db = app.get(DatabaseService);
+    service = app.get(VragenlijstImportService);
+
+    await db.withTenant(TENANT, async (tx) => {
+      await tx.execute(
+        sql`INSERT INTO clm.tenant (tenant_id, name)
+            VALUES (${TENANT}, 'seed-test')
+            ON CONFLICT (tenant_id) DO NOTHING`,
+      );
+    });
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('vindt de twee seedbestanden', () => {
+    // Faalt zodra iemand een bestand hernoemt of weghaalt zonder deze test bij
+    // te werken — dan klopt de rest van deze suite namelijk ook niet meer.
+    expect(seedbestanden.sort()).toEqual([
+      'transdev-annual-vendor-it-risk-v1.json',
+      'transdev-leveranciersbeoordeling-v1.json',
+    ]);
+  });
+
+  it.each(seedbestanden)('%s doorstaat de validatie', (naam) => {
+    expect(() => valideerVragenlijst(lees(naam))).not.toThrow();
+  });
+
+  it.each(seedbestanden)('%s is daadwerkelijk te importeren', async (naam) => {
+    // Validatie is vorm; dit toetst dat de database hem ook accepteert —
+    // CHECK-constraints, samengestelde FKs en de trigger uit migratie 0005.
+    const document = lees(naam) as Record<string, unknown>;
+
+    const resultaat = await service.importeer(TENANT, {
+      ...document,
+      version: testversie(),
+    });
+
+    expect(resultaat.aantalVragen).toBeGreaterThan(0);
+  });
+
+  describe('UC1 — de acht Transdev-vragen', () => {
+    const uc1 = lees('transdev-annual-vendor-it-risk-v1.json') as {
+      questions: {
+        question_key: string;
+        answer_type: string;
+        is_required: boolean;
+        allows_upload: boolean;
+        max_files: number;
+        category_key?: string | null;
+      }[];
+      categories: unknown[];
+    };
+
+    it('bevat acht confirmation-vragen plus één leesblok', () => {
+      // De acht vragen uit de klantaanlevering, met het introductieblok ervoor.
+      const typen = uc1.questions.map((v) => v.answer_type);
+
+      expect(typen.filter((t) => t === 'confirmation')).toHaveLength(8);
+      expect(typen.filter((t) => t === 'instruction')).toHaveLength(1);
+      expect(uc1.questions).toHaveLength(9);
+    });
+
+    it('heeft geen categorieën — het is een platte lijst', () => {
+      // UC1 heeft er geen; een verplichte categorie zou hier een kunstmatige
+      // "Algemeen" afdwingen (ontwerp §2).
+      expect(uc1.categories).toHaveLength(0);
+      expect(
+        uc1.questions.every(
+          (v) => v.category_key === undefined || v.category_key === null,
+        ),
+      ).toBe(true);
+    });
+
+    it('laat alleen bij vraag 1 een upload toe, met maximaal twee bestanden', () => {
+      // OV-7: maximaal 2 bestanden. De vierde antwoordoptie ("I cannot upload…")
+      // hoort bij elke vraag die een upload vraagt — hier dus alleen q1.
+      const metUpload = uc1.questions.filter((v) => v.allows_upload);
+
+      expect(metUpload).toHaveLength(1);
+      expect(metUpload[0].question_key).toBe('q1');
+      expect(metUpload[0].max_files).toBe(2);
+    });
+
+    it('markeert het leesblok als niet-verplicht', () => {
+      // Testpunt 32: een verplicht instruction-blok maakt de vragenlijst
+      // onindienbaar.
+      const leesblok = uc1.questions.find(
+        (v) => v.answer_type === 'instruction',
+      );
+
+      expect(leesblok?.is_required).toBe(false);
+    });
+  });
+
+  describe('UC2 — de interne beoordeling', () => {
+    const uc2 = lees('transdev-leveranciersbeoordeling-v1.json') as {
+      categories: { key: string; name: string; min_answers: number }[];
+      questions: {
+        question_key: string;
+        answer_type: string;
+        category_key: string | null;
+        config: Record<string, unknown>;
+      }[];
+    };
+
+    it('bevat de zes categorieën uit MVM_V2', () => {
+      // MVM_V2 is functioneel leidend voor de vragenlijst (besluit 2026-07-29).
+      // Let op: het ontwerp noemt vijf categorieën met 29 vragen; de bron heeft
+      // er zes met 28 — "Risico's" ontbreekt in het ontwerpdocument.
+      expect(uc2.categories.map((c) => c.name)).toEqual([
+        'Duidelijkheid',
+        'Behoefte',
+        'Kwaliteit',
+        'Kosten',
+        "Risico's",
+        'Besturing',
+      ]);
+    });
+
+    it('zet min_answers op 3, conform MVM_V2', () => {
+      // Onder die drempel is de categoriescore null in plaats van een
+      // gemiddelde over te weinig punten (ontwerp §2).
+      expect(uc2.categories.every((c) => c.min_answers === 3)).toBe(true);
+    });
+
+    it('bevat 28 rating-vragen op een schaal van 1 tot 5', () => {
+      const ratings = uc2.questions.filter((v) => v.answer_type === 'rating');
+
+      expect(ratings).toHaveLength(28);
+      expect(
+        ratings.every((v) => v.config.min === 1 && v.config.max === 5),
+      ).toBe(true);
+    });
+
+    it('sluit af met één open toelichting zonder categorie', () => {
+      // MVM_V2's hasRemarks. Zonder categorie, want hij hoort bij het geheel.
+      const open = uc2.questions.filter((v) => v.answer_type === 'open_text');
+
+      expect(open).toHaveLength(1);
+      expect(open[0].category_key).toBeNull();
+    });
+
+    it('koppelt elke rating-vraag aan een bestaande categorie', () => {
+      const sleutels = new Set(uc2.categories.map((c) => c.key));
+
+      const losse = uc2.questions.filter(
+        (v) =>
+          v.answer_type === 'rating' && !sleutels.has(v.category_key ?? ''),
+      );
+
+      expect(losse).toHaveLength(0);
+    });
+  });
+
+  it('legt de categoriekoppeling correct bij een geïmporteerde UC2-lijst', async () => {
+    // De rondtrip die ertoe doet: van bestand naar database naar de verdeling
+    // die de scoreberekening straks gebruikt.
+    const document = lees('transdev-leveranciersbeoordeling-v1.json') as Record<
+      string,
+      unknown
+    >;
+
+    const resultaat = await service.importeer(TENANT, {
+      ...document,
+      version: testversie(),
+    });
+
+    const verdeling = await db.withTenant(TENANT, (tx) =>
+      tx.execute<{ naam: string; aantal: string }>(
+        sql`SELECT c.name AS naam, count(q.question_id)::text AS aantal
+              FROM clm.survey_category c
+              LEFT JOIN clm.survey_question q ON q.category_id = c.category_id
+             WHERE c.template_id = ${resultaat.templateId}
+             GROUP BY c.name, c.position
+             ORDER BY c.position`,
+      ),
+    );
+
+    expect(verdeling.rows).toEqual([
+      { naam: 'Duidelijkheid', aantal: '4' },
+      { naam: 'Behoefte', aantal: '4' },
+      { naam: 'Kwaliteit', aantal: '5' },
+      { naam: 'Kosten', aantal: '5' },
+      { naam: "Risico's", aantal: '5' },
+      { naam: 'Besturing', aantal: '5' },
+    ]);
+  });
+});


### PR DESCRIPTION
Stap 3 en 4 uit de bouwvolgorde (ontwerp §10). Beide use cases zijn nu gevuld en de vragen staan in de database.

## Wat erin zit

**Stap 3 — import/export van het JSON-schema (§2d).** Twee bestanden: `vragenlijst-schema.ts` (vorm en validatie, zonder database en zonder NestJS — het importpad is de plek waar client-invoer het datamodel binnenkomt, en die controle moet los te testen zijn) en `vragenlijst-import.service.ts` (`importeer`/`exporteer`, beide via `withTenant` in één transactie).

De harde regel: **`tenant_id` komt uit de sessiecontext, nooit uit het bestand** (Issue #7, testpunt 31). Een bestand dat er zelf een meebrengt wordt expliciet geweigerd in plaats van stil genegeerd. Hetzelfde voor UUID's — die worden bij import nieuw gegenereerd, en de vraag→categorie-koppeling loopt via `category_key` (testpunt 48). Export bevat geen enkele UUID en geen `tenant_id`, waardoor klonen en een nieuwe versie afsplitsen dezelfde operatie zijn als exporteren-en-importeren.

**Stap 4 — seed van beide vragenlijsten**, via datzelfde importpad. Bewust geen apart seed-script dat later uit de pas loopt met het echte pad.

| | Vragen | Categorieën |
|---|---|---|
| UC1 `transdev-annual-vendor-it-risk` | 8 × `confirmation` + 1 `instruction`, upload alleen bij vraag 1 (max 2, OV-7) | geen — platte lijst |
| UC2 `transdev-leveranciersbeoordeling` | 28 × `rating` (1–5) + 1 `open_text` | 6, `min_answers` 3 |

`scripts/seed-vragenlijsten.js` draait via `clm_api_runtime` en weigert een rol met BYPASSRLS, net als `DatabaseService`: met BYPASSRLS zegt een geslaagde seed niets over tenantisolatie. De validatie komt uit `vragenlijst-schema.ts` en is niet overgetypt — anders zou een strengere controle in de applicatie stilzwijgend niet gelden voor de seed. Het script is idempotent.

## Correctie op het ontwerp

Ontwerp §2 spreekt van **vijf** categorieën met 29 vragen. De bron in MVM_V2 (`src/data/internal-survey-data.ts`) heeft er **zes met 28** — "Risico's" ontbreekt in het ontwerpdocument. De seed volgt de bron, want dat is wat de klant gezien heeft. Er staat een test op zodat het verschil niet stilzwijgend terugdraait.

## Bewijs

- **89 van 89 e2e-tests groen** tegen een verse Postgres 17.6, in 9 suites
- **Drie opeenvolgende runs tegen dezelfde, niet-leeggemaakte database**, alle drie groen — de tests zijn idempotent
- Seed twee keer gedraaid: tweede keer netjes overgeslagen
- Docker-productiebuild bouwt, start en `/health` antwoordt HTTP 200
- format, lint en typecheck schoon

**Tegenproef gedaan, twee keer.** Met de `tenant_id`-controle uitgeschakeld viel precies testpunt 31 om. Op de seed-suite: met een verplicht gemaakt leesblok en een upload op de verkeerde vraag vielen 6 van de 15 tests om. Groene tests bewijzen niets tot je ze hebt zien falen.

## Twee fouten die het draaien blootlegde en het lezen niet

- Het seed-script zette `app.tenant_id` terwijl de policies `clm.current_tenant_id()` lezen, dat op `app.current_tenant_id` staat. Een afwijkende naam geeft **geen foutmelding** maar een lege context, waarna RLS elke INSERT weigert.
- De eerste versie van de seed-tests gebruikte vaste versienummers en viel om bij de tweede run. Templates zijn uniek op `(tenant_id, name, version)` en de testdatabase blijft staan.

Beide staan als les in `docs/STATUS.md`, samen met twee andere: Drizzle verpakt databasefouten (een triggermelding staat in `cause`, niet in `message` — een test die op `message` matcht test niets), en Docker 29 weigert een containernaam van één teken, waardoor het opstartcommando in dat document faalde. Dat is gecorrigeerd.

## Raakt bestaande code niet

De bevriezingstrigger uit migratie 0005 blijft de garantie; de importroute omzeilt hem niet en er is een test die dat vastlegt. Geen migraties, geen wijziging aan de tokenlaag of de guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)