### PR TITLE
feat(vragenlijst): contract_id op survey_run + drie ontwerpbesluiten bevestigd

### DIFF
--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,7 +1,7 @@
 # MCM2 — actuele status
 
 ## Laatst bijgewerkt
-2026-07-29, tweede sessie (vragenlijst-tool t/m **stap 4**: import/export én beide seeds; 89 e2e-tests groen — alles hieronder is geverifieerd, niet uit gespreksgeheugen)
+2026-07-29, tweede sessie (vragenlijst-tool t/m **stap 4**: import/export én beide seeds; `contract_id` op `survey_run`; alle blokkerende ontwerpvragen beantwoord; 92 e2e-tests groen — alles hieronder is geverifieerd, niet uit gespreksgeheugen)
 
 ## Het project bestaat uit twee repositories
 
@@ -32,7 +32,7 @@ docker run -d --name mcm2test -e POSTGRES_PASSWORD=pw -p 55440:5432 postgres:17.
 docker exec -i mcm2test psql -U postgres -q < db/roles/bootstrap-roles.sql
 docker exec mcm2test psql -U postgres -c "ALTER ROLE clm_migrator WITH PASSWORD 'pw'; ALTER ROLE clm_api_runtime WITH PASSWORD 'pw';"
 MIGRATION_DATABASE_URL="postgresql://clm_migrator:pw@localhost:55440/postgres" npm run migrate:deploy
-DATABASE_URL="postgresql://clm_api_runtime:pw@localhost:55440/postgres" npm run test:e2e   # 89 tests
+DATABASE_URL="postgresql://clm_api_runtime:pw@localhost:55440/postgres" npm run test:e2e   # 92 tests
 
 # De twee vragenlijsten inlezen (tenant moet bestaan)
 DATABASE_URL="postgresql://clm_api_runtime:pw@localhost:55440/postgres" \
@@ -85,7 +85,13 @@ Uit de vergelijking (ontwerp §1a-bis) kwam dat beide modellen onafhankelijk gro
 - **`frameworkRef` niet** — koppelt een vraag aan een normartikel en loopt vooruit op meerdere compliance-frameworks. Nu bouwen we NIS2. De tool is al framework-agnostisch; een tweede framework is straks een tweede import.
 - **`date` als negende vraagtype niet** — geen van beide use cases gebruikt het.
 
-**Nog open in het ontwerp (voorstellen, niet bevestigd, geen van alle blokkerend):** dat een gestarte ronde de vragenlijst bevriest (§2), dat een toelichting ook verplicht is bij "I do not confirm" (§3), en wat er gebeurt bij een geïmporteerd e-mailadres zonder bekende vendor (§2c — advies: weigeren, niet automatisch aanmaken).
+**De drie laatste openstaande ontwerpvoorstellen zijn op 2026-07-29 bevestigd door de eigenaar,** alle drie conform advies:
+
+- **Een gestarte ronde bevriest de vragenlijst** (§2). Wijzigen mag altijd maar raakt alleen nieuwe rondes; een vragenlijst met een niet-`draft` ronde is uitsluitend te kopiëren naar een nieuwe versie. Zonder die regel krijg je antwoorden op vragen die inmiddels anders luiden. Al gebouwd als trigger in migratie 0005.
+- **Een toelichting is óók verplicht bij "I do not confirm"** (§3). De regel luidt daarmee: *alles behalve een bevestiging vereist uitleg*, minimaal 10 tekens. Al gebouwd als CHECK-constraint in migratie 0005.
+- **Een geïmporteerd e-mailadres zonder bekende vendor wordt geweigerd en teruggemeld** (§2c), met een expliciete "aanmaken"-stap. Automatisch aanmaken zou binnen een jaar dubbele records opleveren. **Nog niet gebouwd** — landt bij stap 10 (deelnemersbeheer).
+
+Daarmee zijn alle blokkerende ontwerpvragen beantwoord. Wat nog openstaat in §11 raakt geen enkele bouwstap: of UC1 en UC2 dezelfde templates delen, hoe meerdere interne scores samengevat worden, en of een toelichting buiten `confirmation` überhaupt moet kunnen.
 
 **Drie dingen raken bestaande, groene code** en verdienen aandacht bij het bouwen: `survey_run` krijgt drie kolommen (`status`, `is_test`, `survey_kind`), `survey_response` krijgt er drie (`subject_vendor_id`, `respondent_user_id`, `respondent_label`) waarbij `vendor_id` **nullable** wordt, en de bestaande guard moet de ronde-status meewegen naast `closes_at`/`revoked_at`. Die nullable-wijziging is een versoepeling op een tabel die vanochtend gemerged is — de UC1-garantie wordt overgenomen door een partiële unieke index plus twee CHECK-constraints, en testpunten 41 t/m 43 horen te bewijzen dat er niets weglekt.
 
@@ -258,7 +264,11 @@ Op 2026-07-29 stelde de eigenaar vast dat de survey **onderdeel is van een contr
 
 **Wat dit kost, expliciet:** een survey die niet weet op welk contract hij slaat is functioneel incompleet — "hoe scoort deze leverancier" zonder "op welke overeenkomst" is een half oordeel. Dat gat blijft bestaan tot het contractspoor er is. Het is wél een *toevoeging* later (`contract_id` op `survey_run`, plus een FK), geen herbouw.
 
-**Nog te beslissen:** of `survey_run` alvast een ongebruikte `contract_id UUID NULL` krijgt. Kosten nu: één regel. Kosten later zonder: één extra migratie op een tabel die dan gevulde rondes bevat. Voorgelegd, nog geen antwoord.
+**Besluit eigenaar 2026-07-29: `survey_run` krijgt nu een `contract_id`** — migratie 0007, nullable en bewust nog zonder foreign key, want `clm.contract` bestaat niet. Als lege kolom hoefde de ALTER niets te backfillen; straks bevat de tabel gevulde rondes en maakt de bevriezingstrigger uit 0005 wijzigen rond lopende rondes bewust lastig. Nullable blijft het ook na invoering van de contracttabel: een leverancier kan beoordeeld worden vóór er een overeenkomst is.
+
+Drie tests in `test/schema-conformiteit.e2e-spec.ts` bewaken de kolom. De middelste is zo geschreven dat hij automatisch omslaat: zolang `clm.contract` niet bestaat eist hij géén foreign key, zodra die tabel er wél is eist hij er één. **Dat is de plek die eraan herinnert wanneer de FK gelegd moet worden.**
+
+**Aandachtspunt voor het contractspoor:** zodra `clm.contract` bestaat, moet die tabel een eigen RLS-policy krijgen vóórdat de foreign key gelegd wordt. Een verwijzing naar een tabel zonder RLS is een lek.
 
 ## Lessen uit deze sessies die tijd besparen
 
@@ -294,10 +304,12 @@ Praktische valkuilen die daadwerkelijk zijn tegengekomen, niet bedacht. Ze staan
 
 | Repo | Branch | Werkboom | Openstaande PR's |
 |---|---|---|---|
-| MCM2 | **`feat/vragenlijst-import-export`** | schoon | nog niet gepusht |
+| MCM2 | **`feat/contract-op-survey-run`** | schoon | nog niet gepusht |
 | MCM2-frontend | `main` | schoon | geen |
 
-**`feat/vragenlijst-import-export` staat open met twee commits** (stap 3 en stap 4 uit de bouwvolgorde) plus deze statusbijwerking. Nog niet naar GitHub gepusht, dus nog geen PR en geen CI-run — de poorten zijn wél lokaal gedraaid: format, lint, typecheck, 89/89 e2e tegen een verse Postgres 17.6, en de Docker-productiebuild die start en `/health` met HTTP 200 beantwoordt.
+**PR #37 (stap 3 en 4) is gemerged naar `main`** (merge-commit `ef62cd6`), CI groen op alle drie de jobs, branch lokaal én op GitHub verwijderd. Na de merge opnieuw geverifieerd tégen `main`: volledige migratieketen op een verse Postgres 17.6, daarna 89/89 e2e groen.
+
+**`feat/contract-op-survey-run` staat open met één commit:** migratie 0007 (`contract_id` op `survey_run`) plus deze statusbijwerking en de drie bevestigde ontwerpbesluiten. Nog niet gepusht. Lokale poorten wél gedraaid: format, lint, typecheck en 92/92 e2e tegen een verse Postgres 17.6.
 
 - **`docs/sessiestand-otap` is op 2026-07-29 via PR #35 gemerged naar `main`** (merge-commit `cbe6c48`) en daarna lokaal én op GitHub verwijderd. Eén commit: uitsluitend deze statusbijwerking.
 - **`feat/issue-7-leveranciertoken` is op 2026-07-29 via PR #32 gemerged naar `main`** (merge-commit `7f0cc01`) en daarna lokaal én op GitHub verwijderd. CI groen op alle drie de jobs vóór de merge, opnieuw geverifieerd met `gh pr checks 32` op de laatste commit. Vijf commits: de tokenlaag, de HTTP-routes met logmaskering en auditregels, de fix op `maskeerDiep`, plus twee documentatiecommits. **Issue #31 is bij die merge gesloten** — migratie `0004` loste hem op. Let op: die migratie is bewezen in CI, **niet toegepast op `clm-enterprise`** — net als #29 en #25 wacht dat op #30.

--- a/docs/superpowers/specs/2026-07-28-vragenlijst-ontwerp.md
+++ b/docs/superpowers/specs/2026-07-28-vragenlijst-ontwerp.md
@@ -445,9 +445,10 @@ Dit is de regel die de tool inhoudelijk lastig maakt, en die vastgelegd moet wor
 
 Een tenant wijzigt vraag 4 terwijl twaalf leveranciers midden in het invullen zitten. Wat dan?
 
-**Voorstel: wijzigen mag altijd, maar raakt alleen nieuwe rondes.** Op het moment dat een
-`survey_run` start, ligt de templateversie vast. De run verwijst al naar `template_id`, en een
-template met een lopende run is niet meer te wijzigen — alleen te kopiëren naar een nieuwe versie.
+**Besluit opdrachtgever 2026-07-29: wijzigen mag altijd, maar raakt alleen nieuwe rondes.** Op het
+moment dat een `survey_run` start, ligt de templateversie vast. De run verwijst al naar
+`template_id`, en een template met een lopende run is niet meer te wijzigen — alleen te kopiëren
+naar een nieuwe versie.
 
 Zonder die bevriezing krijg je antwoorden op vragen die inmiddels anders luiden. Bij een
 compliance-instrument dat contractueel bewijsmateriaal oplevert, is dat onbruikbaar: je kunt
@@ -567,9 +568,11 @@ dezelfde rij, en een geplakt e-mailadres moet dus aan een vendor gekoppeld worde
 2. **Weigeren en terugmelden** welke adressen geen bekende vendor hebben, met een expliciete
    "aanmaken"-stap. Meer handelingen, schoner bestand.
 
-Advies: **optie 2.** Het vendorbestand is bij een compliance-instrument geen bijzaak — het is de
-lijst waar de rapportage op leunt. Automatisch aanmaken levert binnen een jaar dubbele vendors op
-(`transdev.nl` en `Transdev Nederland` als twee records), en dat is achteraf duur op te ruimen.
+**Besluit opdrachtgever 2026-07-29: optie 2 — weigeren en terugmelden.** Het vendorbestand is bij
+een compliance-instrument geen bijzaak; het is de lijst waar de rapportage op leunt. Automatisch
+aanmaken levert binnen een jaar dubbele vendors op (`transdev.nl` en `Transdev Nederland` als twee
+records), en dat is achteraf duur op te ruimen. Landt bij stap 10 (deelnemersbeheer); nog niet
+gebouwd.
 
 **Bij UC2 speelt dat niet.** De deelnemer is een Transdev-collega; die hoeft aan geen enkel
 vendorrecord gekoppeld te worden en `vendor_id` blijft leeg. De leverancier komt hier niet voor als
@@ -708,9 +711,9 @@ niet binnen 48 uur gemeld zijn". Zonder verplichte toelichting krijgt de opdrach
 vinkje zonder context en moet er alsnog achteraan gebeld worden — precies het handwerk dat dit
 systeem moet wegnemen.
 
-> **Aanname, niet bevestigd.** De opdrachtgever bevestigde de verplichte toelichting bij
-> `not_applicable` en `cannot_upload`. Voor `not_confirmed` is dit mijn afleiding. Het is één regel
-> in de validatietabel; als het anders moet, kost het geen herontwerp.
+> **Bevestigd op 2026-07-29.** De opdrachtgever bevestigde eerder de verplichte toelichting bij
+> `not_applicable` en `cannot_upload`; `not_confirmed` was mijn afleiding daaruit en is nu expliciet
+> bekrachtigd. De regel geldt daarmee voor alle drie de niet-bevestigingen.
 
 ### Grenzen aan de toelichting
 
@@ -1290,14 +1293,27 @@ database. De leverancierskant werkt dan volledig.
   vragenlijst; de interne beoordeling daar heeft vijf categorieën met 29 vragen. `category_id` is
   nullable, want UC1 heeft er geen.
 
+**Beslist op 2026-07-29 (tweede sessie) — de drie laatste openstaande voorstellen:**
+
+- ~~Bevriezing van een lopende ronde~~ → **ja, aangehouden** (§2). Wijzigen mag altijd maar raakt
+  alleen nieuwe rondes; een vragenlijst met een niet-`draft` ronde is uitsluitend te kopiëren naar
+  een nieuwe versie. Doorslaggevend: zonder bevriezing krijg je antwoorden op vragen die inmiddels
+  anders luiden, en dan is achteraf niet vast te stellen waar iemand mee heeft ingestemd. Al
+  gebouwd als trigger in migratie 0005.
+- ~~Verplichte toelichting bij `not_confirmed`~~ → **ja, verplicht** (§3). De regel luidt daarmee:
+  *alles behalve een bevestiging vereist uitleg*, minimaal 10 tekens. Doorslaggevend: het is
+  inhoudelijk het zwaarste antwoord dat een leverancier kan geven — bij Transdev-vraag 4 betekent
+  het "er zijn incidenten niet binnen 48 uur gemeld". Zonder toelichting levert dat een rood vinkje
+  zonder context op, en moet er alsnog achteraan gebeld worden. Al gebouwd als CHECK-constraint in
+  migratie 0005.
+- ~~Onbekend e-mailadres bij import: weigeren of vendor aanmaken~~ → **weigeren en terugmelden**
+  (§2c), met een expliciete "aanmaken"-stap. Doorslaggevend: het vendorbestand is de lijst waar de
+  rapportage op leunt; automatisch aanmaken levert binnen een jaar dubbele records op
+  (`transdev.nl` naast `Transdev Nederland`). Speelt alleen bij UC1. **Nog niet gebouwd** — dit
+  landt bij stap 10 (deelnemersbeheer).
+
 **Nog open — voorstellen van mij, niet bevestigd:**
 
-- **Bevriezing van een lopende ronde** (§2). Het is de regel die bepaalt of antwoorden achteraf nog
-  interpreteerbaar zijn. Ik zou hem aanhouden, maar hij is niet expliciet bevestigd.
-- **Verplichte toelichting bij `not_confirmed`** (§3). Mijn afleiding uit de bevestigde regels voor
-  `not_applicable` en `cannot_upload`.
-- **Onbekend e-mailadres bij import: weigeren of vendor aanmaken** (§2c). Advies: weigeren. Speelt
-  alleen bij UC1. Dit moet vóór stap 10 beslist zijn, niet eerder.
 - **Of UC1 en UC2 dezelfde vragenlijst-templates delen** (§1c). Het model staat het toe — een
   template is niet aan een `survey_kind` gebonden. Ik zou dat zo laten: een tenant die een
   interne vragenlijst per ongeluk aan een leverancier stuurt, maakt een beheerfout, geen

--- a/drizzle/0007_contract_op_survey_run.sql
+++ b/drizzle/0007_contract_op_survey_run.sql
@@ -1,0 +1,37 @@
+-- =============================================================================
+-- survey_run krijgt contract_id: op welk contract een ronde betrekking heeft.
+--
+-- De survey is onderdeel van een contractmanagement-applicatie. Een
+-- leveranciersbeoordeling zonder de vraag "op welke overeenkomst?" is een half
+-- oordeel — dat is de reden dat deze kolom er hoort te komen.
+--
+-- BEWUST NOG ZONDER FOREIGN KEY. Er bestaat nog geen clm.contract-tabel: MCM2
+-- heeft vendor en vendor_contact wel, contracten niet. Dat is een eigen
+-- bouwspoor met een eigen datamodel (MVM_V2's Contract heeft 24 velden,
+-- inclusief CATS CM v4-levenscyclus). Zodra die tabel er is, is dit één
+-- ALTER TABLE ... ADD CONSTRAINT erbij.
+--
+-- WAAROM NU EN NIET STRAKS. Als lege kolom is dit een ALTER die niets hoeft te
+-- backfillen. Straks bevat survey_run gevulde rondes, en de bevriezingstrigger
+-- uit migratie 0005 maakt wijzigen rond lopende rondes bewust lastig. Eén regel
+-- nu bespaart dan een migratie met een backfillstap.
+--
+-- NULLABLE, EN DAT BLIJFT ZO. Een ronde hoeft niet aan een contract te hangen:
+-- een leverancier kan beoordeeld worden voordat er een overeenkomst is, en de
+-- acht Transdev-vragen gaan over de organisatie als geheel, niet over een
+-- specifiek contract. Verplicht stellen zou UC1 breken.
+--
+-- Geen RLS-wijziging nodig: survey_run heeft al een policy op tenant_id, en
+-- een kolom erbij valt daar automatisch onder. Zodra clm.contract bestaat,
+-- moet díé tabel een eigen policy krijgen — een FK naar een tabel zonder RLS
+-- zou een lek zijn.
+-- =============================================================================
+
+ALTER TABLE "clm"."survey_run" ADD COLUMN "contract_id" uuid;--> statement-breakpoint
+
+-- Rapportage vraagt straks "alle rondes over contract X". Zonder index is dat
+-- een volledige scan over een tabel die per tenant per jaar aangroeit.
+CREATE INDEX "survey_run_contract_id_idx" ON "clm"."survey_run" USING btree ("contract_id");--> statement-breakpoint
+
+COMMENT ON COLUMN "clm"."survey_run"."contract_id" IS
+    'Op welk contract deze ronde betrekking heeft. Nog zonder foreign key: clm.contract bestaat nog niet. Blijft nullable, ook na invoering van die tabel.';

--- a/drizzle/meta/0007_snapshot.json
+++ b/drizzle/meta/0007_snapshot.json
@@ -1,0 +1,1988 @@
+{
+  "id": "a3230585-596b-4820-9c44-97970e600791",
+  "prevId": "2971c45a-c5aa-412d-b268-a85f1b8a3127",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "audit.audit_event": {
+      "name": "audit_event",
+      "schema": "audit",
+      "columns": {
+        "audit_event_id": {
+          "name": "audit_event_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action_type": {
+          "name": "action_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "old_values": {
+          "name": "old_values",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_values": {
+          "name": "new_values",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "audit_event_tenant_id_idx": {
+          "name": "audit_event_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "ref.business_criticality": {
+      "name": "business_criticality",
+      "schema": "ref",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "ref.compliance_status": {
+      "name": "compliance_status",
+      "schema": "ref",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "clm.survey_answer": {
+      "name": "survey_answer",
+      "schema": "clm",
+      "columns": {
+        "answer_id": {
+          "name": "answer_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "response_id": {
+          "name": "response_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "answer_type": {
+          "name": "answer_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "answer_code": {
+          "name": "answer_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "answer_codes": {
+          "name": "answer_codes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "answer_text": {
+          "name": "answer_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "answer_number": {
+          "name": "answer_number",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "survey_answer_response_question_key": {
+          "name": "survey_answer_response_question_key",
+          "columns": [
+            {
+              "expression": "response_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "question_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "survey_answer_tenant_id_idx": {
+          "name": "survey_answer_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "survey_answer_response_id_idx": {
+          "name": "survey_answer_response_id_idx",
+          "columns": [
+            {
+              "expression": "response_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "survey_answer_tenant_id_tenant_tenant_id_fk": {
+          "name": "survey_answer_tenant_id_tenant_tenant_id_fk",
+          "tableFrom": "survey_answer",
+          "tableTo": "tenant",
+          "schemaTo": "clm",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "tenant_id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "survey_answer_response_id_survey_response_response_id_fk": {
+          "name": "survey_answer_response_id_survey_response_response_id_fk",
+          "tableFrom": "survey_answer",
+          "tableTo": "survey_response",
+          "schemaTo": "clm",
+          "columnsFrom": [
+            "response_id"
+          ],
+          "columnsTo": [
+            "response_id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "survey_answer_question_id_survey_question_question_id_fk": {
+          "name": "survey_answer_question_id_survey_question_question_id_fk",
+          "tableFrom": "survey_answer",
+          "tableTo": "survey_question",
+          "schemaTo": "clm",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "question_id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "clm.survey_attachment": {
+      "name": "survey_attachment",
+      "schema": "clm",
+      "columns": {
+        "attachment_id": {
+          "name": "attachment_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "response_id": {
+          "name": "response_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_name": {
+          "name": "original_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_key": {
+          "name": "storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "byte_size": {
+          "name": "byte_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sha256": {
+          "name": "sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "survey_attachment_storage_key_key": {
+          "name": "survey_attachment_storage_key_key",
+          "columns": [
+            {
+              "expression": "storage_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "survey_attachment_tenant_id_idx": {
+          "name": "survey_attachment_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "survey_attachment_response_id_idx": {
+          "name": "survey_attachment_response_id_idx",
+          "columns": [
+            {
+              "expression": "response_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "survey_attachment_tenant_id_tenant_tenant_id_fk": {
+          "name": "survey_attachment_tenant_id_tenant_tenant_id_fk",
+          "tableFrom": "survey_attachment",
+          "tableTo": "tenant",
+          "schemaTo": "clm",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "tenant_id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "survey_attachment_response_id_survey_response_response_id_fk": {
+          "name": "survey_attachment_response_id_survey_response_response_id_fk",
+          "tableFrom": "survey_attachment",
+          "tableTo": "survey_response",
+          "schemaTo": "clm",
+          "columnsFrom": [
+            "response_id"
+          ],
+          "columnsTo": [
+            "response_id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "survey_attachment_question_id_survey_question_question_id_fk": {
+          "name": "survey_attachment_question_id_survey_question_question_id_fk",
+          "tableFrom": "survey_attachment",
+          "tableTo": "survey_question",
+          "schemaTo": "clm",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "question_id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "clm.survey_category": {
+      "name": "survey_category",
+      "schema": "clm",
+      "columns": {
+        "category_id": {
+          "name": "category_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "min_answers": {
+          "name": "min_answers",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "survey_category_template_position_key": {
+          "name": "survey_category_template_position_key",
+          "columns": [
+            {
+              "expression": "template_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "survey_category_template_name_key": {
+          "name": "survey_category_template_name_key",
+          "columns": [
+            {
+              "expression": "template_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "survey_category_id_template_key": {
+          "name": "survey_category_id_template_key",
+          "columns": [
+            {
+              "expression": "category_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "template_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "survey_category_tenant_id_idx": {
+          "name": "survey_category_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "survey_category_tenant_id_tenant_tenant_id_fk": {
+          "name": "survey_category_tenant_id_tenant_tenant_id_fk",
+          "tableFrom": "survey_category",
+          "tableTo": "tenant",
+          "schemaTo": "clm",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "tenant_id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "survey_category_template_id_survey_template_template_id_fk": {
+          "name": "survey_category_template_id_survey_template_template_id_fk",
+          "tableFrom": "survey_category",
+          "tableTo": "survey_template",
+          "schemaTo": "clm",
+          "columnsFrom": [
+            "template_id"
+          ],
+          "columnsTo": [
+            "template_id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "clm.survey_question": {
+      "name": "survey_question",
+      "schema": "clm",
+      "columns": {
+        "question_id": {
+          "name": "question_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_key": {
+          "name": "question_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "answer_type": {
+          "name": "answer_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "is_required": {
+          "name": "is_required",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "allows_upload": {
+          "name": "allows_upload",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "max_files": {
+          "name": "max_files",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "survey_question_template_key_key": {
+          "name": "survey_question_template_key_key",
+          "columns": [
+            {
+              "expression": "template_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "question_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "survey_question_template_position_key": {
+          "name": "survey_question_template_position_key",
+          "columns": [
+            {
+              "expression": "template_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "survey_question_id_answer_type_key": {
+          "name": "survey_question_id_answer_type_key",
+          "columns": [
+            {
+              "expression": "question_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "answer_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "survey_question_tenant_id_idx": {
+          "name": "survey_question_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "survey_question_category_id_idx": {
+          "name": "survey_question_category_id_idx",
+          "columns": [
+            {
+              "expression": "category_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "survey_question_tenant_id_tenant_tenant_id_fk": {
+          "name": "survey_question_tenant_id_tenant_tenant_id_fk",
+          "tableFrom": "survey_question",
+          "tableTo": "tenant",
+          "schemaTo": "clm",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "tenant_id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "survey_question_template_id_survey_template_template_id_fk": {
+          "name": "survey_question_template_id_survey_template_template_id_fk",
+          "tableFrom": "survey_question",
+          "tableTo": "survey_template",
+          "schemaTo": "clm",
+          "columnsFrom": [
+            "template_id"
+          ],
+          "columnsTo": [
+            "template_id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "clm.survey_response": {
+      "name": "survey_response",
+      "schema": "clm",
+      "columns": {
+        "response_id": {
+          "name": "response_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vendor_id": {
+          "name": "vendor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject_vendor_id": {
+          "name": "subject_vendor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "respondent_user_id": {
+          "name": "respondent_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "respondent_label": {
+          "name": "respondent_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "survey_response_token_hash_key": {
+          "name": "survey_response_token_hash_key",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "survey_response_run_vendor_key": {
+          "name": "survey_response_run_vendor_key",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "vendor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"clm\".\"survey_response\".\"vendor_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "survey_response_tenant_id_idx": {
+          "name": "survey_response_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "survey_response_subject_vendor_id_idx": {
+          "name": "survey_response_subject_vendor_id_idx",
+          "columns": [
+            {
+              "expression": "subject_vendor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "survey_response_tenant_id_tenant_tenant_id_fk": {
+          "name": "survey_response_tenant_id_tenant_tenant_id_fk",
+          "tableFrom": "survey_response",
+          "tableTo": "tenant",
+          "schemaTo": "clm",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "tenant_id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "survey_response_run_id_survey_run_run_id_fk": {
+          "name": "survey_response_run_id_survey_run_run_id_fk",
+          "tableFrom": "survey_response",
+          "tableTo": "survey_run",
+          "schemaTo": "clm",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "run_id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "survey_response_vendor_id_vendor_vendor_id_fk": {
+          "name": "survey_response_vendor_id_vendor_vendor_id_fk",
+          "tableFrom": "survey_response",
+          "tableTo": "vendor",
+          "schemaTo": "clm",
+          "columnsFrom": [
+            "vendor_id"
+          ],
+          "columnsTo": [
+            "vendor_id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "survey_response_subject_vendor_id_vendor_vendor_id_fk": {
+          "name": "survey_response_subject_vendor_id_vendor_vendor_id_fk",
+          "tableFrom": "survey_response",
+          "tableTo": "vendor",
+          "schemaTo": "clm",
+          "columnsFrom": [
+            "subject_vendor_id"
+          ],
+          "columnsTo": [
+            "vendor_id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "survey_response_respondent_user_id_user_user_id_fk": {
+          "name": "survey_response_respondent_user_id_user_user_id_fk",
+          "tableFrom": "survey_response",
+          "tableTo": "user",
+          "schemaTo": "clm",
+          "columnsFrom": [
+            "respondent_user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "clm.survey_run": {
+      "name": "survey_run",
+      "schema": "clm",
+      "columns": {
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "survey_kind": {
+          "name": "survey_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'vendor_compliance'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "is_test": {
+          "name": "is_test",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "closes_at": {
+          "name": "closes_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contract_id": {
+          "name": "contract_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "survey_run_tenant_id_idx": {
+          "name": "survey_run_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "survey_run_contract_id_idx": {
+          "name": "survey_run_contract_id_idx",
+          "columns": [
+            {
+              "expression": "contract_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "survey_run_tenant_id_tenant_tenant_id_fk": {
+          "name": "survey_run_tenant_id_tenant_tenant_id_fk",
+          "tableFrom": "survey_run",
+          "tableTo": "tenant",
+          "schemaTo": "clm",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "tenant_id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "survey_run_template_id_survey_template_template_id_fk": {
+          "name": "survey_run_template_id_survey_template_template_id_fk",
+          "tableFrom": "survey_run",
+          "tableTo": "survey_template",
+          "schemaTo": "clm",
+          "columnsFrom": [
+            "template_id"
+          ],
+          "columnsTo": [
+            "template_id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "clm.survey_template": {
+      "name": "survey_template",
+      "schema": "clm",
+      "columns": {
+        "template_id": {
+          "name": "template_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "survey_template_tenant_name_version_key": {
+          "name": "survey_template_tenant_name_version_key",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "survey_template_tenant_id_idx": {
+          "name": "survey_template_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "survey_template_tenant_id_tenant_tenant_id_fk": {
+          "name": "survey_template_tenant_id_tenant_tenant_id_fk",
+          "tableFrom": "survey_template",
+          "tableTo": "tenant",
+          "schemaTo": "clm",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "tenant_id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "clm.tenant": {
+      "name": "tenant",
+      "schema": "clm",
+      "columns": {
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "tenant_name_key": {
+          "name": "tenant_name_key",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "clm.user": {
+      "name": "user",
+      "schema": "clm",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_tenant_id_tenant_tenant_id_fk": {
+          "name": "user_tenant_id_tenant_tenant_id_fk",
+          "tableFrom": "user",
+          "tableTo": "tenant",
+          "schemaTo": "clm",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "tenant_id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "clm.vendor": {
+      "name": "vendor",
+      "schema": "clm",
+      "columns": {
+        "vendor_id": {
+          "name": "vendor_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kvk_number": {
+          "name": "kvk_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vestigingsnummer": {
+          "name": "vestigingsnummer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "statutory_name": {
+          "name": "statutory_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trade_names": {
+          "name": "trade_names",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legal_form": {
+          "name": "legal_form",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "incorporation_date": {
+          "name": "incorporation_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sbi_code": {
+          "name": "sbi_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sbi_description": {
+          "name": "sbi_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category_code": {
+          "name": "category_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "business_criticality_code": {
+          "name": "business_criticality_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "compliance_status_code": {
+          "name": "compliance_status_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country": {
+          "name": "country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'NL'"
+        },
+        "city": {
+          "name": "city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website": {
+          "name": "website",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "annual_spend_eur": {
+          "name": "annual_spend_eur",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "risk_score": {
+          "name": "risk_score",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_review_date": {
+          "name": "last_review_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_review_date": {
+          "name": "next_review_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "vendor_tenant_id_kvk_number_key": {
+          "name": "vendor_tenant_id_kvk_number_key",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kvk_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vendor_tenant_id_idx": {
+          "name": "vendor_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vendor_tenant_id_tenant_tenant_id_fk": {
+          "name": "vendor_tenant_id_tenant_tenant_id_fk",
+          "tableFrom": "vendor",
+          "tableTo": "tenant",
+          "schemaTo": "clm",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "tenant_id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "vendor_category_code_vendor_category_code_fk": {
+          "name": "vendor_category_code_vendor_category_code_fk",
+          "tableFrom": "vendor",
+          "tableTo": "vendor_category",
+          "schemaTo": "ref",
+          "columnsFrom": [
+            "category_code"
+          ],
+          "columnsTo": [
+            "code"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "vendor_business_criticality_code_business_criticality_code_fk": {
+          "name": "vendor_business_criticality_code_business_criticality_code_fk",
+          "tableFrom": "vendor",
+          "tableTo": "business_criticality",
+          "schemaTo": "ref",
+          "columnsFrom": [
+            "business_criticality_code"
+          ],
+          "columnsTo": [
+            "code"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "vendor_compliance_status_code_compliance_status_code_fk": {
+          "name": "vendor_compliance_status_code_compliance_status_code_fk",
+          "tableFrom": "vendor",
+          "tableTo": "compliance_status",
+          "schemaTo": "ref",
+          "columnsFrom": [
+            "compliance_status_code"
+          ],
+          "columnsTo": [
+            "code"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "vendor_owner_user_id_user_user_id_fk": {
+          "name": "vendor_owner_user_id_user_user_id_fk",
+          "tableFrom": "vendor",
+          "tableTo": "user",
+          "schemaTo": "clm",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "ref.vendor_category": {
+      "name": "vendor_category",
+      "schema": "ref",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "clm.vendor_contact": {
+      "name": "vendor_contact",
+      "schema": "clm",
+      "columns": {
+        "contact_id": {
+          "name": "contact_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "vendor_id": {
+          "name": "vendor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "job_title": {
+          "name": "job_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role_description": {
+          "name": "role_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "vendor_contact_tenant_id_idx": {
+          "name": "vendor_contact_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vendor_contact_vendor_id_vendor_vendor_id_fk": {
+          "name": "vendor_contact_vendor_id_vendor_vendor_id_fk",
+          "tableFrom": "vendor_contact",
+          "tableTo": "vendor",
+          "schemaTo": "clm",
+          "columnsFrom": [
+            "vendor_id"
+          ],
+          "columnsTo": [
+            "vendor_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "clm.vendor_tag": {
+      "name": "vendor_tag",
+      "schema": "clm",
+      "columns": {
+        "vendor_id": {
+          "name": "vendor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag": {
+          "name": "tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "vendor_tag_pkey": {
+          "name": "vendor_tag_pkey",
+          "columns": [
+            {
+              "expression": "vendor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tag",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vendor_tag_tenant_id_idx": {
+          "name": "vendor_tag_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vendor_tag_vendor_id_vendor_vendor_id_fk": {
+          "name": "vendor_tag_vendor_id_vendor_vendor_id_fk",
+          "tableFrom": "vendor_tag",
+          "tableTo": "vendor",
+          "schemaTo": "clm",
+          "columnsFrom": [
+            "vendor_id"
+          ],
+          "columnsTo": [
+            "vendor_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {
+    "audit": "audit",
+    "clm": "clm",
+    "ref": "ref"
+  },
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -50,6 +50,13 @@
       "when": 1785321175010,
       "tag": "0006_ronde_status_in_guard",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "7",
+      "when": 1785336038093,
+      "tag": "0007_contract_op_survey_run",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -219,8 +219,27 @@ export const surveyRun = clm.table(
     // ontwerp §5a.
     closesAt: timestamp('closes_at', { withTimezone: true }),
     revokedAt: timestamp('revoked_at', { withTimezone: true }),
+    // Op welk contract deze ronde betrekking heeft.
+    //
+    // Nog niet in gebruik en bewust zonder foreign key: er bestaat nog geen
+    // clm.contract-tabel. MCM2 heeft vendor en vendor_contact wél, contracten
+    // niet — dat is een eigen bouwspoor (zie docs/STATUS.md).
+    //
+    // Nu toegevoegd op verzoek van de eigenaar, omdat de kolom later toevoegen
+    // een migratie kost op een tabel die dan gevulde, mogelijk bevroren rondes
+    // bevat. Als lege kolom is dat een ALTER die niets hoeft te backfillen;
+    // straks is het alleen nog de FK erbij leggen.
+    //
+    // Nullable blijft het ook daarna: een ronde hoeft niet aan een contract te
+    // hangen. Een leverancier kan beoordeeld worden vóór er een overeenkomst
+    // is, en de acht Transdev-vragen gaan over de organisatie, niet over één
+    // contract.
+    contractId: uuid('contract_id'),
   },
-  (t) => [index('survey_run_tenant_id_idx').on(t.tenantId)],
+  (t) => [
+    index('survey_run_tenant_id_idx').on(t.tenantId),
+    index('survey_run_contract_id_idx').on(t.contractId),
+  ],
 );
 
 export const surveyResponse = clm.table(

--- a/test/schema-conformiteit.e2e-spec.ts
+++ b/test/schema-conformiteit.e2e-spec.ts
@@ -189,4 +189,71 @@ describe('Schema-conformiteit (e2e)', () => {
 
     expect(rows[0].rolbypassrls).toBe(false);
   });
+
+  describe('survey_run.contract_id (migratie 0007)', () => {
+    it('bestaat als nullable uuid', async () => {
+      // Nullable is een ontwerpkeuze, geen tussenstand: een ronde hoeft niet
+      // aan een contract te hangen. Een leverancier kan beoordeeld worden vóór
+      // er een overeenkomst is, en de acht Transdev-vragen gaan over de
+      // organisatie als geheel. Verplicht stellen zou UC1 breken.
+      const { rows } = await client.query<{
+        data_type: string;
+        is_nullable: string;
+      }>(
+        `SELECT data_type, is_nullable
+           FROM information_schema.columns
+          WHERE table_schema = 'clm'
+            AND table_name = 'survey_run'
+            AND column_name = 'contract_id'`,
+      );
+
+      expect(rows).toHaveLength(1);
+      expect(rows[0].data_type).toBe('uuid');
+      expect(rows[0].is_nullable).toBe('YES');
+    });
+
+    it('heeft nog géén foreign key — clm.contract bestaat niet', async () => {
+      // Legt de huidige situatie expliciet vast. Deze test hoort te FALEN op
+      // het moment dat clm.contract wordt ingevoerd: dan moet hier een FK
+      // liggen, en dan is dit de plek die eraan herinnert. Een ontbrekende FK
+      // die niemand opmerkt is precies hoe een verwijzing naar een
+      // niet-bestaande rij binnensluipt.
+      const { rows: tabel } = await client.query(
+        `SELECT 1 FROM information_schema.tables
+          WHERE table_schema = 'clm' AND table_name = 'contract'`,
+      );
+
+      const { rows: fks } = await client.query(
+        `SELECT 1
+           FROM information_schema.table_constraints tc
+           JOIN information_schema.key_column_usage kcu
+             ON kcu.constraint_name = tc.constraint_name
+          WHERE tc.table_schema = 'clm'
+            AND tc.table_name = 'survey_run'
+            AND tc.constraint_type = 'FOREIGN KEY'
+            AND kcu.column_name = 'contract_id'`,
+      );
+
+      if (tabel.length > 0) {
+        // clm.contract is er inmiddels: dan hóórt de FK er ook te zijn.
+        expect(fks.length).toBe(1);
+      } else {
+        expect(fks.length).toBe(0);
+      }
+    });
+
+    it('is doorzoekbaar via een index', async () => {
+      // Rapportage vraagt straks "alle rondes over contract X". Zonder index
+      // is dat een volledige scan over een tabel die per tenant per jaar
+      // aangroeit.
+      const { rows } = await client.query(
+        `SELECT 1 FROM pg_indexes
+          WHERE schemaname = 'clm'
+            AND tablename = 'survey_run'
+            AND indexname = 'survey_run_contract_id_idx'`,
+      );
+
+      expect(rows).toHaveLength(1);
+    });
+  });
 });


### PR DESCRIPTION
Twee dingen: de kolom die de survey aan een contract koppelt, en de bevestiging van de laatste drie openstaande ontwerpvoorstellen.

## `contract_id` op `survey_run` (migratie 0007)

De survey is onderdeel van een contractmanagement-applicatie. Een leveranciersbeoordeling zonder de vraag "op welke overeenkomst?" is een half oordeel; deze kolom legt dat verband.

**Bewust nog zonder foreign key** — `clm.contract` bestaat niet. MCM2 heeft `vendor` en `vendor_contact` (inclusief e-mailadres) wél, contracten niet; dat is een eigen bouwspoor met een eigen datamodel. Zodra die tabel er is, is dit één `ADD CONSTRAINT` erbij.

**Waarom nu en niet straks:** als lege kolom hoeft deze `ALTER` niets te backfillen. Straks bevat `survey_run` gevulde rondes en maakt de bevriezingstrigger uit migratie 0005 wijzigen rond lopende rondes bewust lastig.

**Nullable, en dat blijft zo** — ook na invoering van de contracttabel. Een leverancier kan beoordeeld worden vóór er een overeenkomst is, en de acht Transdev-vragen gaan over de organisatie als geheel. Verplicht stellen zou UC1 breken.

Geen RLS-wijziging nodig: `survey_run` heeft al een policy op `tenant_id` en een kolom erbij valt daar automatisch onder. **Aandachtspunt voor later:** zodra `clm.contract` bestaat, moet díé tabel een eigen policy krijgen vóórdat de FK gelegd wordt — een verwijzing naar een tabel zonder RLS is een lek.

### Drie tests, waarvan één die zichzelf omdraait

De middelste test in `schema-conformiteit.e2e-spec.ts` is zo geschreven dat hij automatisch omslaat: zolang `clm.contract` niet bestaat eist hij géén foreign key, zodra die tabel er wél is eist hij er één. Daarmee is het de plek die eraan herinnert wanneer het zover is, in plaats van een comment die niemand terugleest.

## Drie ontwerpbesluiten bevestigd

Alle drie conform advies, waarmee elke blokkerende ontwerpvraag beantwoord is:

| Punt | Besluit | Status |
|---|---|---|
| Bevriest een gestarte ronde de vragenlijst? (§2) | **Ja** — wijzigen raakt alleen nieuwe rondes | zat al als trigger in 0005 |
| Toelichting verplicht bij "I do not confirm"? (§3) | **Ja** — alles behalve een bevestiging vereist uitleg | zat al als CHECK in 0005 |
| Onbekend e-mailadres bij import (§2c) | **Weigeren en terugmelden** | nog niet gebouwd, landt bij stap 10 |

De eerste twee waren al gebouwd op basis van het advies; deze PR legt vast dat het nu een besluit is en geen aanname. In het ontwerp zijn de passages van "voorstel" naar "besluit opdrachtgever" gezet, inclusief het aannameblok bij §3.

Wat in §11 overblijft raakt geen bouwstap: of UC1 en UC2 templates delen, hoe meerdere interne scores samengevat worden, en of een toelichting buiten `confirmation` moet kunnen.

## Bewijs

- Volledige migratieketen **0000 t/m 0007** op een verse Postgres 17.6
- Kolom, index en kolomcommentaar geverifieerd in `information_schema` — niet aangenomen
- **92 van 92 e2e-tests groen**
- format, lint en typecheck schoon
- **Tegenproef:** met de kolom verwijderd vielen 2 van de 3 nieuwe tests om. De derde bleef terecht groen — zonder `clm.contract` hóórt er geen FK te zijn.

## Eén ding om te weten voor de volgende migratie

`drizzle-kit` genereerde ditmaal wél veilige SQL (nullable kolom, geen backfill). Het bestand heette `0007_famous_bloodaxe`; hernoemd naar `0007_contract_op_survey_run` **inclusief de tag in `drizzle/meta/_journal.json`** — zonder die tweede wijziging vindt de migrator het bestand niet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)