### PR TITLE
feat(vragenlijst): GET /survey/respond/questions (stap 5) + guardfix voor UC2

### DIFF
--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,7 +1,7 @@
 # MCM2 — actuele status
 
 ## Laatst bijgewerkt
-2026-07-29, tweede sessie (vragenlijst-tool t/m **stap 4**: import/export én beide seeds; `contract_id` op `survey_run`; alle blokkerende ontwerpvragen beantwoord; 92 e2e-tests groen — alles hieronder is geverifieerd, niet uit gespreksgeheugen)
+2026-07-29, tweede sessie (vragenlijst-tool t/m **stap 5**: import/export, beide seeds én `GET /survey/respond/questions`; `contract_id` op `survey_run`; **guardbug gevonden waardoor UC2 in het geheel niet werkte**; 112 e2e-tests groen — alles hieronder is geverifieerd, niet uit gespreksgeheugen)
 
 ## Het project bestaat uit twee repositories
 
@@ -32,7 +32,7 @@ docker run -d --name mcm2test -e POSTGRES_PASSWORD=pw -p 55440:5432 postgres:17.
 docker exec -i mcm2test psql -U postgres -q < db/roles/bootstrap-roles.sql
 docker exec mcm2test psql -U postgres -c "ALTER ROLE clm_migrator WITH PASSWORD 'pw'; ALTER ROLE clm_api_runtime WITH PASSWORD 'pw';"
 MIGRATION_DATABASE_URL="postgresql://clm_migrator:pw@localhost:55440/postgres" npm run migrate:deploy
-DATABASE_URL="postgresql://clm_api_runtime:pw@localhost:55440/postgres" npm run test:e2e   # 92 tests
+DATABASE_URL="postgresql://clm_api_runtime:pw@localhost:55440/postgres" npm run test:e2e   # 112 tests
 
 # De twee vragenlijsten inlezen (tenant moet bestaan)
 DATABASE_URL="postgresql://clm_api_runtime:pw@localhost:55440/postgres" \
@@ -175,6 +175,22 @@ Transdev Vendor IT Compliance Survey als eerste verticale MVP-slice.
 
 ## Aantoonbaar werkend
 
+- **`GET /survey/respond/questions` (2026-07-29, stap 5).** `src/survey/vragenlijst-lezen.service.ts` plus de route op de bestaande `SurveyResponseController`, dus automatisch achter dezelfde guard. **112 van 112 e2e-tests groen** in tien suites, tegen een verse Postgres 17.6 met de volledige keten 0000 t/m 0008.
+
+  De vorm sluit aan op het model dat het portaal al gebruikt (`MCM2-frontend/src/core/models/survey.ts`): categorieën en losse vragen gescheiden. De `config`-jsonb wordt in de **backend** naar camelCase vertaald — een frontend die dat zelf doet gaat afwijken zodra er een veld bijkomt. Alleen bekende sleutels gaan mee: `config` is een vrij veld dat de database niet bewaakt, en alles doorgeven zou betekenen dat wat daar ooit in belandt automatisch bij de leverancier terechtkomt.
+
+  **Deze route legde een bug bloot waardoor UC2 in het geheel niet werkte** — zie het blok hieronder.
+
+- **Guardbug: elke interne beoordeling gaf 410 (2026-07-29, migratie 0008).** `resolve_survey_token()` bepaalde `vendor_active` via een join op `survey_response.vendor_id`. Bij UC2 is die kolom bewust `NULL` — de invuller is een Transdev-collega, geen leverancier — waardoor de join niets opleverde, `vendor_active` op `false` kwam en de guard **élke** interne beoordeling afwees met "vendor-inactief".
+
+  **Aangetoond tegen de database, niet beredeneerd:** alle drie de UC2-responses in de testset gaven `vendor_active = false`.
+
+  Migratie 0006 is geschreven vóórdat UC2 bestond; 0005 maakte `vendor_id` nullable zonder deze functie mee te nemen. **Geen enkele test merkte het,** omdat geen enkele test een UC2-link over HTTP ophaalde — stap 5 is de eerste die dat doet.
+
+  De fix joint op `subject_vendor_id`, die bij beide use cases gevuld en `NOT NULL` is. Voor UC1 verandert er niets, en dat is geen aanname: een CHECK uit 0005 dwingt daar `vendor_id = subject_vendor_id` af. Twee tests leggen beide kanten vast — een UC2-link wérkt, en hij werkt niet meer zodra de beoordeelde leverancier zacht verwijderd is.
+
+  **`CREATE OR REPLACE` mocht hier wél**, anders dan bij 0006: de `RETURNS TABLE` blijft ongewijzigd, dus de rechten blijven staan.
+
 - **Import/export van vragenlijsten en beide seeds (2026-07-29, stap 3 en 4).** `src/survey/vragenlijst-schema.ts` (vorm en validatie, zonder database), `src/survey/vragenlijst-import.service.ts` (importeer/exporteer via `withTenant`), `scripts/seed-vragenlijsten.js` en twee seedbestanden in `db/seeds/`. **89 van 89 e2e-tests groen**, in negen suites.
 
   **De harde regel is getest, niet alleen geschreven:** `tenant_id` komt uit de sessiecontext en nooit uit het bestand (Issue #7, testpunt 31). Een bestand dat er zelf een meebrengt wordt expliciet geweigerd in plaats van stil genegeerd. Hetzelfde geldt voor UUID's — die worden bij import nieuw gegenereerd, en de vraag→categorie-koppeling loopt via `category_key` (testpunt 48). Export bevat geen enkele UUID en geen `tenant_id`, waardoor klonen en een nieuwe versie afsplitsen dezelfde operatie zijn als exporteren-en-importeren.
@@ -290,6 +306,10 @@ Praktische valkuilen die daadwerkelijk zijn tegengekomen, niet bedacht. Ze staan
 
 **Docker 29 weigert een containernaam van één teken.** Het oude `--name t` uit dit document faalde met "Invalid container name"; de opstartcommando's hierboven zijn gecorrigeerd naar `mcm2test`.
 
+**Een tegenproef kan zélf onvoldoende zijn — controleer of de testopzet het lek kán zien.** Bij stap 5 is het lek uit ontwerp §1c daadwerkelijk ingebouwd (filteren op `subject_vendor_id` in plaats van `response_id`) en **bleef alles groen**. Oorzaak: elke leverancier in de test had een eigen vendor, dus de verkeerde filter selecteerde toevallig dezelfde rij. Pas met **twee responses over dezelfde leverancier** — het echte UC1/UC2-scenario — viel testpunt 39 om. Een tegenproef die niet faalt betekent dus niet automatisch dat de code goed is; het kan ook zijn dat de opzet het probleem niet kan aantonen.
+
+**Een nullable kolom maken raakt méér dan de tabel.** Migratie 0005 maakte `survey_response.vendor_id` nullable voor UC2, maar `resolve_survey_token()` joinde daar nog op — waardoor elke interne beoordeling 410 gaf. Bij het versoepelen van een kolom hoort een zoektocht naar elke plek die hem gebruikt: functies, views, policies. `grep -rn "vendor_id" drizzle/` had dit gevonden.
+
 ## Niet als bewezen beschouwen
 
 - RLS-tenant-isolatie was tot 2026-07-27 niet bewezen zolang de runtime-role nog `BYPASSRLS` had — een eerdere "RLS werkt"-verificatie in deze projectgeschiedenis was vals-positief (lege tabel, geen bewijs van daadwerkelijke blokkade). **Nu aantoonbaar bewezen én geautomatiseerd** (zie hierboven en ADR-009) — niet langer een handmatige, ad-hoc verificatie.
@@ -304,12 +324,12 @@ Praktische valkuilen die daadwerkelijk zijn tegengekomen, niet bedacht. Ze staan
 
 | Repo | Branch | Werkboom | Openstaande PR's |
 |---|---|---|---|
-| MCM2 | **`feat/contract-op-survey-run`** | schoon | nog niet gepusht |
+| MCM2 | **`feat/vragenlijst-ophalen`** | schoon | nog niet gepusht |
 | MCM2-frontend | `main` | schoon | geen |
 
-**PR #37 (stap 3 en 4) is gemerged naar `main`** (merge-commit `ef62cd6`), CI groen op alle drie de jobs, branch lokaal én op GitHub verwijderd. Na de merge opnieuw geverifieerd tégen `main`: volledige migratieketen op een verse Postgres 17.6, daarna 89/89 e2e groen.
+**Twee PR's gemerged naar `main`:** #37 (stap 3 en 4, merge-commit `ef62cd6`) en #38 (migratie 0007 plus de drie bevestigde ontwerpbesluiten, merge-commit `4b09026`). Beide met CI groen op alle drie de jobs, beide branches lokaal én op GitHub verwijderd. Na elke merge opnieuw geverifieerd tégen `main` zelf.
 
-**`feat/contract-op-survey-run` staat open met één commit:** migratie 0007 (`contract_id` op `survey_run`) plus deze statusbijwerking en de drie bevestigde ontwerpbesluiten. Nog niet gepusht. Lokale poorten wél gedraaid: format, lint, typecheck en 92/92 e2e tegen een verse Postgres 17.6.
+**`feat/vragenlijst-ophalen` staat open met één commit:** stap 5 (`GET /survey/respond/questions`) plus migratie 0008 die de UC2-guardbug repareert, en deze statusbijwerking. Nog niet gepusht. Lokale poorten wél gedraaid: format, lint, typecheck, 112/112 e2e tegen een verse Postgres 17.6, en de Docker-productiebuild die start, de route mapt en `/health` met 200 beantwoordt.
 
 - **`docs/sessiestand-otap` is op 2026-07-29 via PR #35 gemerged naar `main`** (merge-commit `cbe6c48`) en daarna lokaal én op GitHub verwijderd. Eén commit: uitsluitend deze statusbijwerking.
 - **`feat/issue-7-leveranciertoken` is op 2026-07-29 via PR #32 gemerged naar `main`** (merge-commit `7f0cc01`) en daarna lokaal én op GitHub verwijderd. CI groen op alle drie de jobs vóór de merge, opnieuw geverifieerd met `gh pr checks 32` op de laatste commit. Vijf commits: de tokenlaag, de HTTP-routes met logmaskering en auditregels, de fix op `maskeerDiep`, plus twee documentatiecommits. **Issue #31 is bij die merge gesloten** — migratie `0004` loste hem op. Let op: die migratie is bewezen in CI, **niet toegepast op `clm-enterprise`** — net als #29 en #25 wacht dat op #30.
@@ -333,22 +353,24 @@ Praktische valkuilen die daadwerkelijk zijn tegengekomen, niet bedacht. Ze staan
 
 De databaselaag is omgezet (ADR-010), spoor 2 van Issue #7 zit in `main`, en de vragenlijst-tool staat t/m stap 4: het datamodel, de guard, import/export en beide gevulde vragenlijsten.
 
-**De eerstvolgende inhoudelijke stap is stap 5: `GET /survey/respond/questions`** (ontwerp §10). Dat is nu de kortste weg naar iets zichtbaars — de vragen staan in de database en het portaal toont ze al op mock data, dus deze route hoeft alleen te lezen. Het raakt de productiedatabase niet; de hele e2e-keten draait tegen wegwerpcontainers, dus #30 blokkeert dit spoor niet.
+**De eerstvolgende inhoudelijke stap is stap 6: validatie- en indienlogica** (ontwerp §5, §10). `POST /survey/respond` accepteert nu een lege body; daar komen de antwoorden bij, met de tienstappenvalidatie uit §5. Dat raakt de productiedatabase niet; de hele e2e-keten draait tegen wegwerpcontainers, dus #30 blokkeert dit spoor niet.
+
+**Daarnaast, en dat kost geen code:** het portaal tegen de echte backend zetten via een OTAP-doorloop. De vragen staan in de database en de route bestaat, dus dit is de eerste keer dat de klant de echte vragenlijst in de browser kan zien in plaats van mock data.
 
 ~~1. Migratie met de vier nieuwe tabellen en de kolommen op `survey_run`/`survey_response`~~ — **afgerond 2026-07-29** (migratie 0005).
 ~~2. De bestaande guard uitbreiden met de ronde-statuscontrole~~ — **afgerond 2026-07-29** (migratie 0006).
 ~~3. Import/export van het JSON-schema~~ — **afgerond 2026-07-29**, zie "Aantoonbaar werkend".
 ~~4. Seed: beide vragenlijsten via het importpad~~ — **afgerond 2026-07-29**, idem.
 
-**Nu aan de beurt — stap 5 t/m 9 uit ontwerp §10:**
+~~5. `GET /survey/respond/questions`~~ — **afgerond 2026-07-29**, zie "Aantoonbaar werkend". Legde en passant de UC2-guardbug bloot.
 
-5. `GET /survey/respond/questions` — vragen ophalen inclusief `config` per type. **Dit is de snelste zichtbare winst:** de vragen staan nu in de database en het portaal toont ze al op mock data; zodra deze route bestaat, toont hetzelfde scherm de echte vragenlijst.
+**Nu aan de beurt — stap 6 t/m 9 uit ontwerp §10:**
 6. Validatie- en indienlogica; `POST /survey/respond` uitbreiden met de antwoordbody (ontwerp §5).
 7. `PUT /survey/respond/answers` — concept opslaan, expliciet (geen auto-save).
 8. Bestandsupload met inhoudscontrole (ontwerp §6, Issue #9).
 9. Tests 14 t/m 48.
 
-**Stap 5 is de snelste zichtbare winst.** Het leverancierportaal staat en toont de acht vragen al op mock data; zodra `/survey/respond/questions` bestaat, toont hetzelfde scherm de echte vragenlijst uit de database. Op dit moment krijgt het portaal daar een 404 — dat is geen bug maar de nog-niet-gebouwde route (bevestigd in de OTAP-doorloop). **De vragen staan er sinds stap 4 wél**, dus deze route hoeft alleen nog te lezen.
+**De 404 die de OTAP-doorloop signaleerde is weg:** `/survey/respond/questions` bestaat en levert de vragenlijst uit de database. **Nog niet in de browser bekeken** — het portaal draait nog op mock data tot iemand het met `NEXT_PUBLIC_API_URL` tegen de backend zet. Dat is de eerstvolgende zichtbare stap en kost geen code, alleen een OTAP-doorloop.
 
 **Aandachtspunt bij stap 6:** de bestaande `POST /survey/respond` accepteert nu een lege body. Zodra daar antwoorden bij komen, moet `test/survey-routes.e2e-spec.ts` mee — dat is geen ontwerpkwestie maar werk dat vergeten wordt als het niet ergens staat.
 

--- a/drizzle/0008_guard_kent_uc2.sql
+++ b/drizzle/0008_guard_kent_uc2.sql
@@ -1,0 +1,87 @@
+-- =============================================================================
+-- BUGFIX: de guard weigerde élke interne beoordeling (UC2) met 410 Gone.
+--
+-- Gevonden op 2026-07-29 bij het bouwen van GET /survey/respond/questions —
+-- de eerste keer dat een UC2-link daadwerkelijk over HTTP werd opgehaald.
+--
+-- WAT ER MIS WAS. resolve_survey_token() bepaalt vendor_active met:
+--
+--     LEFT JOIN clm.vendor v ON v.vendor_id = r.vendor_id
+--     (v.vendor_id IS NOT NULL AND v.deleted_at IS NULL) AS vendor_active
+--
+-- Bij UC2 is survey_response.vendor_id bewust NULL: de invuller is een
+-- Transdev-collega, geen leverancier (ontwerp §1c). De LEFT JOIN levert dan
+-- niets, vendor_active wordt false, en de guard geeft 410 met de reden
+-- 'vendor-inactief'. Elke interne beoordeling was daarmee onbereikbaar.
+--
+-- Migratie 0006 is geschreven vóórdat UC2 bestond; 0005 maakte vendor_id
+-- nullable zonder deze functie mee te nemen. Geen enkele test merkte het,
+-- omdat geen enkele test een UC2-link over HTTP ophaalde. Aangetoond tegen de
+-- database, niet beredeneerd: alle drie de UC2-responses in de testset gaven
+-- guard_zegt_actief = false.
+--
+-- DE FIX. Kijk naar subject_vendor_id in plaats van vendor_id. Die kolom is bij
+-- BEIDE use cases gevuld en is NOT NULL — het is per definitie de leverancier
+-- waar de survey over gaat. De controle "bestaat deze leverancier nog en is hij
+-- niet zacht verwijderd" hoort daar dan ook op te slaan:
+--
+--   UC1  vendor_id = subject_vendor_id  → zelfde uitkomst als voorheen
+--   UC2  vendor_id IS NULL              → nu de beoordeelde leverancier
+--
+-- Voor UC1 verandert er dus niets. Dat is geen aanname: een CHECK-constraint
+-- uit migratie 0005 dwingt af dat bij survey_kind = 'vendor_compliance' geldt
+-- dat vendor_id = subject_vendor_id.
+--
+-- WAAROM DIT DE JUISTE CONTROLE IS. De bedoeling van vendor_active is: heeft
+-- deze vragenlijst nog een onderwerp? Een beoordeling over een leverancier die
+-- uit het bestand verwijderd is, hoort niet meer ingevuld te worden — of de
+-- invuller nu de leverancier zelf is of een collega. subject_vendor_id drukt
+-- precies dat uit; vendor_id drukte uit "wie vult in", en dat is een andere
+-- vraag.
+--
+-- CREATE OR REPLACE mag hier wél, anders dan bij 0006: de RETURNS TABLE blijft
+-- ongewijzigd. Daarmee blijven ook de rechten staan (die hangen aan het
+-- functie-object) en is de GRANT-herhaling uit 0006 hier niet nodig. De
+-- REVOKE/GRANT staan er toch, zodat deze migratie ook op een database met een
+-- afwijkende rechtenstand het juiste eindresultaat geeft.
+-- =============================================================================
+
+CREATE OR REPLACE FUNCTION clm.resolve_survey_token(p_token_hash TEXT)
+RETURNS TABLE (
+    response_id   UUID,
+    tenant_id     UUID,
+    status        TEXT,
+    expires_at    TIMESTAMPTZ,
+    submitted_at  TIMESTAMPTZ,
+    vendor_active BOOLEAN,
+    run_closed    BOOLEAN,
+    run_status    TEXT
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = clm, pg_temp
+AS $$
+    SELECT r.response_id,
+           r.tenant_id,
+           r.status,
+           r.expires_at,
+           r.submitted_at,
+           -- subject_vendor_id, niet vendor_id: de leverancier waar de survey
+           -- OVER gaat, niet degene die invult. Bij UC2 is dat het verschil
+           -- tussen werken en 410.
+           (v.vendor_id IS NOT NULL AND v.deleted_at IS NULL) AS vendor_active,
+           (run.revoked_at IS NOT NULL
+            OR (run.closes_at IS NOT NULL AND run.closes_at < now())) AS run_closed,
+           run.status AS run_status
+      FROM clm.survey_response r
+      LEFT JOIN clm.vendor     v   ON v.vendor_id = r.subject_vendor_id
+      LEFT JOIN clm.survey_run run ON run.run_id  = r.run_id
+     WHERE r.token_hash = p_token_hash
+$$;--> statement-breakpoint
+
+COMMENT ON FUNCTION clm.resolve_survey_token(TEXT) IS
+    'Zoekt een survey-response op via de SHA-256-hash van het leverancierstoken. SECURITY DEFINER omdat de tenantcontext pas na deze lookup gezet kan worden. Retourneert uitsluitend geldigheidsvelden, nooit inhoudelijke gegevens. vendor_active slaat op subject_vendor_id (de beoordeelde leverancier), zodat UC2 werkt waar de invuller geen leverancier is.';--> statement-breakpoint
+
+REVOKE ALL ON FUNCTION clm.resolve_survey_token(TEXT) FROM PUBLIC;--> statement-breakpoint
+GRANT EXECUTE ON FUNCTION clm.resolve_survey_token(TEXT) TO clm_api, clm_admin;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -57,6 +57,13 @@
       "when": 1785336038093,
       "tag": "0007_contract_op_survey_run",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "7",
+      "when": 1785336038094,
+      "tag": "0008_guard_kent_uc2",
+      "breakpoints": true
     }
   ]
 }

--- a/src/survey/survey-response.controller.ts
+++ b/src/survey/survey-response.controller.ts
@@ -2,6 +2,7 @@ import {
   Controller,
   Get,
   HttpCode,
+  NotFoundException,
   Post,
   Req,
   UseGuards,
@@ -10,6 +11,7 @@ import {
 
 import { SurveyTokenGuard, type RequestMetToken } from './survey-token.guard';
 import { SurveyTokenService } from './survey-token.service';
+import { VragenlijstLeesService } from './vragenlijst-lezen.service';
 
 /**
  * De enige endpoints die een externe leverancier bereikt.
@@ -25,7 +27,10 @@ import { SurveyTokenService } from './survey-token.service';
 @Controller('survey/respond')
 @UseGuards(SurveyTokenGuard)
 export class SurveyResponseController {
-  constructor(private readonly tokens: SurveyTokenService) {}
+  constructor(
+    private readonly tokens: SurveyTokenService,
+    private readonly vragenlijst: VragenlijstLeesService,
+  ) {}
 
   /**
    * Toont of de link geldig is en tot wanneer.
@@ -34,8 +39,9 @@ export class SurveyResponseController {
    * van wie hij de e-mail kreeg, en wie een geldig token bemachtigt hoort daar
    * niet extra informatie uit te halen.
    *
-   * De vragenlijst zelf zit hier nog niet in — die structuur hangt aan OV-6 en
-   * OV-8, die nog openstaan bij de klant.
+   * De vragenlijst zelf zit hier bewust niet in: dit is de goedkope controle
+   * "werkt deze link nog", die het portaal doet vóórdat het de vragen ophaalt.
+   * Zie GET /survey/respond/questions.
    */
   @Get()
   status(@Req() request: RequestMetToken) {
@@ -46,6 +52,45 @@ export class SurveyResponseController {
       status: 'open' as const,
       verlooptOp: context.expiresAt.toISOString(),
     };
+  }
+
+  /**
+   * Levert de vragenlijst die bij deze link hoort.
+   *
+   * De `response_id` komt uit de guard, nooit uit de URL of de body — er
+   * bestáát geen veld waarin een leverancier een andere respons kan benoemen.
+   * Dat is testpunt 39: een interne beoordeling over dezelfde leverancier is
+   * langs deze route niet bereikbaar, want de lookup gaat van token naar één
+   * respons en nooit van vendor naar een verzameling.
+   *
+   * De vorm sluit aan op het model dat het leverancierportaal al gebruikt
+   * (`MCM2-frontend/src/core/models/survey.ts`): categorieën en losse vragen
+   * gescheiden, want een vragenlijst is óf ingedeeld (UC2) óf een platte lijst
+   * (UC1).
+   *
+   * Retourneert bewust geen tenant, vendor of response-ID — dezelfde
+   * terughoudendheid als bij de statusroute hierboven.
+   */
+  @Get('questions')
+  async vragen(@Req() request: RequestMetToken) {
+    const context = request.surveyToken!;
+
+    const lijst = await this.vragenlijst.haalVragenlijst(
+      context.tenantId,
+      context.responseId,
+    );
+
+    // Een geldig token waarvan de ronde nog geen vragen heeft. Zeldzaam, maar
+    // niet onmogelijk: een ronde kan gestart worden op een template die nog
+    // leeg is. Een lege lijst teruggeven zou het portaal een formulier zonder
+    // vragen laten tonen, wat er kapot uitziet zonder te zeggen waarom.
+    if (!lijst) {
+      throw new NotFoundException(
+        'Er staat op dit moment geen vragenlijst klaar voor deze link.',
+      );
+    }
+
+    return lijst;
   }
 
   /**

--- a/src/survey/survey.module.ts
+++ b/src/survey/survey.module.ts
@@ -5,6 +5,7 @@ import { SurveyResponseController } from './survey-response.controller';
 import { SurveyTokenGuard } from './survey-token.guard';
 import { SurveyTokenService } from './survey-token.service';
 import { VragenlijstImportService } from './vragenlijst-import.service';
+import { VragenlijstLeesService } from './vragenlijst-lezen.service';
 
 @Module({
   controllers: [SurveyResponseController],
@@ -13,12 +14,14 @@ import { VragenlijstImportService } from './vragenlijst-import.service';
     SurveyTokenService,
     SurveyTokenGuard,
     VragenlijstImportService,
+    VragenlijstLeesService,
   ],
   exports: [
     SurveyAuditService,
     SurveyTokenService,
     SurveyTokenGuard,
     VragenlijstImportService,
+    VragenlijstLeesService,
   ],
 })
 export class SurveyModule {}

--- a/src/survey/vragenlijst-lezen.service.ts
+++ b/src/survey/vragenlijst-lezen.service.ts
@@ -1,0 +1,258 @@
+import { Injectable } from '@nestjs/common';
+import { sql } from 'drizzle-orm';
+
+import { DatabaseService } from '../db/database.service';
+import type { AntwoordType } from './vragenlijst-schema';
+
+/**
+ * Typespecifieke instellingen zoals de leverancierskant ze ziet.
+ *
+ * camelCase, terwijl `config` in de database snake_case is. Die vertaling
+ * gebeurt hier bewust en niet in de frontend: het is de backend die bepaalt
+ * wat het contract is, en een frontend die zelf sleutels omzet gaat afwijken
+ * zodra er een veld bijkomt.
+ */
+export interface VraagConfig {
+  options?: { code: string; label: string }[];
+  min?: number;
+  max?: number;
+  minLabel?: string;
+  maxLabel?: string;
+  minSelect?: number;
+  maxSelect?: number;
+  minLength?: number;
+  maxLength?: number;
+  format?: string;
+  decimals?: number;
+  comment?: string;
+}
+
+export interface Vraag {
+  questionKey: string;
+  title: string;
+  body: string;
+  answerType: AntwoordType;
+  isRequired: boolean;
+  allowsUpload: boolean;
+  maxFiles: number;
+  config: VraagConfig;
+}
+
+export interface Categorie {
+  key: string;
+  name: string;
+  minAnswers: number;
+  questions: Vraag[];
+}
+
+export interface Vragenlijst {
+  name: string;
+  /** Leeg bij een platte lijst (UC1); gevuld bij een ingedeelde lijst (UC2). */
+  categories: Categorie[];
+  /** Vragen zonder categorie. Bij UC1 staat hier alles in. */
+  questions: Vraag[];
+  closesAt: string | null;
+}
+
+interface VraagRij extends Record<string, unknown> {
+  question_key: string;
+  title: string;
+  body: string;
+  answer_type: string;
+  is_required: boolean;
+  allows_upload: boolean;
+  max_files: number;
+  config: Record<string, unknown> | null;
+  category_id: string | null;
+  category_name: string | null;
+  category_position: number | null;
+  category_min_answers: number | null;
+  template_name: string;
+  closes_at: Date | string | null;
+}
+
+/** Maakt van 'Duidelijkheid & Kosten' → 'duidelijkheid-kosten'. */
+function maakSleutel(naam: string): string {
+  const sleutel = naam
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[̀-ͯ]/g, '')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+
+  return sleutel.length > 0 ? sleutel : 'categorie';
+}
+
+/**
+ * Vertaalt de `config`-jsonb naar het contract van de leverancierskant.
+ *
+ * Alleen bekende sleutels gaan mee. Dat is geen netheid maar een grens: `config`
+ * is een vrij JSONB-veld dat de database niet inhoudelijk bewaakt (ontwerp §2a),
+ * en alles klakkeloos doorgeven zou betekenen dat wat daar ooit in belandt
+ * automatisch bij de leverancier terechtkomt.
+ */
+function vertaalConfig(config: Record<string, unknown> | null): VraagConfig {
+  if (!config) return {};
+
+  const uit: VraagConfig = {};
+
+  if (Array.isArray(config.options)) {
+    uit.options = config.options
+      .filter(
+        (optie): optie is { code: string; label: string } =>
+          typeof optie === 'object' &&
+          optie !== null &&
+          typeof (optie as { code?: unknown }).code === 'string' &&
+          typeof (optie as { label?: unknown }).label === 'string',
+      )
+      .map((optie) => ({ code: optie.code, label: optie.label }));
+  }
+
+  const getal = (waarde: unknown): number | undefined =>
+    typeof waarde === 'number' ? waarde : undefined;
+  const tekst = (waarde: unknown): string | undefined =>
+    typeof waarde === 'string' ? waarde : undefined;
+
+  uit.min = getal(config.min);
+  uit.max = getal(config.max);
+  uit.minLabel = tekst(config.min_label);
+  uit.maxLabel = tekst(config.max_label);
+  uit.minSelect = getal(config.min_select);
+  uit.maxSelect = getal(config.max_select);
+  uit.minLength = getal(config.min_length);
+  uit.maxLength = getal(config.max_length);
+  uit.format = tekst(config.format);
+  uit.decimals = getal(config.decimals);
+  uit.comment = tekst(config.comment);
+
+  // Ongedefinieerde sleutels weglaten in plaats van als null meesturen: het
+  // verschil tussen "niet ingesteld" en "op null gezet" hoort niet te bestaan
+  // in een contract dat een formulier beschrijft.
+  for (const sleutel of Object.keys(uit) as (keyof VraagConfig)[]) {
+    if (uit[sleutel] === undefined) delete uit[sleutel];
+  }
+
+  return uit;
+}
+
+/**
+ * Leest de vragenlijst die bij een response hoort.
+ *
+ * Kernregel, en de reden dat deze service zo klein is: er wordt uitsluitend
+ * gezocht vanaf de `response_id` die de guard heeft vastgesteld — nooit vanaf
+ * een vendor, een template of een run die de client benoemt. Dat is testpunt
+ * 39: een leverancier bereikt langs deze route alleen zijn eigen respons, en
+ * een interne beoordeling over dezelfde `subject_vendor_id` is er niet mee te
+ * vinden.
+ *
+ * De query filtert daarom op `response_id` en niet op `subject_vendor_id`.
+ * Zodra iemand dat omdraait, ontstaat het lek dat er nu niet is.
+ *
+ * Dat is geen theorie: het lek is tijdens het bouwen daadwerkelijk ingebouwd om
+ * te toetsen of de tests het merken. Ze deden dat pas nadat de test twee
+ * responses over DEZELFDE leverancier gebruikte — met twee verschillende
+ * leveranciers bleef alles groen. Wie deze query aanpast, moet dus ook
+ * controleren dat de test in `vragenlijst-ophalen.e2e-spec.ts` nog steeds één
+ * gedeelde `vendorId` gebruikt.
+ */
+@Injectable()
+export class VragenlijstLeesService {
+  constructor(private readonly db: DatabaseService) {}
+
+  async haalVragenlijst(
+    tenantId: string,
+    responseId: string,
+  ): Promise<Vragenlijst | null> {
+    return this.db.withTenant(tenantId, async (tx) => {
+      const resultaat = await tx.execute<VraagRij>(
+        // De keten response → run → template → vragen. Elke stap zit binnen de
+        // tenantcontext, dus RLS beschermt tegen een andere tenant; de
+        // response_id-voorwaarde beschermt tegen een andere respons binnen
+        // dezelfde tenant.
+        sql`SELECT q.question_key,
+                   q.title,
+                   q.body,
+                   q.answer_type,
+                   q.is_required,
+                   q.allows_upload,
+                   q.max_files,
+                   q.config,
+                   c.category_id,
+                   c.name        AS category_name,
+                   c.position    AS category_position,
+                   c.min_answers AS category_min_answers,
+                   t.name        AS template_name,
+                   run.closes_at
+              FROM clm.survey_response r
+              JOIN clm.survey_run      run ON run.run_id      = r.run_id
+              JOIN clm.survey_template t   ON t.template_id   = run.template_id
+              JOIN clm.survey_question q   ON q.template_id   = t.template_id
+              LEFT JOIN clm.survey_category c ON c.category_id = q.category_id
+             WHERE r.response_id = ${responseId}
+             ORDER BY c.position NULLS FIRST, q.position`,
+      );
+
+      const rijen = resultaat.rows;
+
+      // Geen rijen betekent: de respons bestaat niet in deze tenant, of de
+      // template heeft nog geen vragen. Voor de aanroeper is dat hetzelfde —
+      // er valt niets te tonen.
+      if (rijen.length === 0) {
+        return null;
+      }
+
+      const categorieen = new Map<string, Categorie>();
+      const losseVragen: Vraag[] = [];
+
+      for (const rij of rijen) {
+        const vraag: Vraag = {
+          questionKey: rij.question_key,
+          title: rij.title,
+          body: rij.body,
+          answerType: rij.answer_type as AntwoordType,
+          isRequired: rij.is_required,
+          allowsUpload: rij.allows_upload,
+          maxFiles: rij.max_files,
+          config: vertaalConfig(rij.config),
+        };
+
+        if (rij.category_id === null || rij.category_name === null) {
+          losseVragen.push(vraag);
+          continue;
+        }
+
+        let categorie = categorieen.get(rij.category_id);
+
+        if (!categorie) {
+          categorie = {
+            key: maakSleutel(rij.category_name),
+            name: rij.category_name,
+            minAnswers: rij.category_min_answers ?? 0,
+            questions: [],
+          };
+          categorieen.set(rij.category_id, categorie);
+        }
+
+        categorie.questions.push(vraag);
+      }
+
+      const eerste = rijen[0];
+      const sluit = eerste.closes_at;
+
+      return {
+        name: eerste.template_name,
+        categories: [...categorieen.values()],
+        questions: losseVragen,
+        // Tijdstippen komen bij ruwe SQL als string terug wanneer ze uit een
+        // JOIN komen; vandaar de dubbele behandeling. Zelfde patroon als
+        // alsDatum() in survey-token.service.ts.
+        closesAt:
+          sluit === null
+            ? null
+            : sluit instanceof Date
+              ? sluit.toISOString()
+              : new Date(sluit).toISOString(),
+      };
+    });
+  }
+}

--- a/test/vragenlijst-ophalen.e2e-spec.ts
+++ b/test/vragenlijst-ophalen.e2e-spec.ts
@@ -1,0 +1,550 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { INestApplication } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import { sql } from 'drizzle-orm';
+import request from 'supertest';
+import type { App } from 'supertest/types';
+
+import { AppModule } from '../src/app.module';
+import { DatabaseService } from '../src/db/database.service';
+import {
+  berekenVervalmoment,
+  genereerToken,
+  hashToken,
+} from '../src/survey/survey-token';
+import { VragenlijstImportService } from '../src/survey/vragenlijst-import.service';
+
+const TENANT_A = '00000000-0000-0000-0000-0000000000c1';
+const TENANT_B = '00000000-0000-0000-0000-0000000000c2';
+const SEEDMAP = join(__dirname, '..', 'db', 'seeds');
+
+interface VraagVorm {
+  questionKey: string;
+  title: string;
+  body: string;
+  answerType: string;
+  isRequired: boolean;
+  allowsUpload: boolean;
+  maxFiles: number;
+  config: Record<string, unknown>;
+}
+
+interface VragenlijstVorm {
+  name: string;
+  categories: {
+    key: string;
+    name: string;
+    minAnswers: number;
+    questions: VraagVorm[];
+  }[];
+  questions: VraagVorm[];
+  closesAt: string | null;
+}
+
+let volgnummer = 0;
+const uniekeVersie = () => 700 + (Date.now() % 100000) + volgnummer++;
+
+/**
+ * Toetst GET /survey/respond/questions van buitenaf — precies zoals het
+ * leverancierportaal hem bereikt: via HTTP, met alleen een token.
+ */
+describe('Vragenlijst ophalen (e2e)', () => {
+  let app: INestApplication<App>;
+  let db: DatabaseService;
+  let importService: VragenlijstImportService;
+  let server: App;
+
+  /**
+   * Zet een volledige keten neer: template → run → response → token.
+   *
+   * `vendorId` meegeven koppelt de respons aan een bestaande leverancier in
+   * plaats van een nieuwe aan te maken. Dat is nodig om het UC1/UC2-scenario na
+   * te bootsen: twee responses over dezelfde leverancier, met verschillende
+   * vragenlijsten.
+   */
+  async function maakLink(opties: {
+    tenantId: string;
+    templateId: string;
+    naam: string;
+    rondeStatus?: string;
+    sluitOver?: number;
+    vendorId?: string;
+    /** UC2: de invuller is een collega, dus vendor_id blijft leeg. */
+    interneBeoordeling?: boolean;
+  }): Promise<{ token: string; vendorId: string }> {
+    const token = genereerToken();
+
+    const vendorId = await db.withTenant(opties.tenantId, async (tx) => {
+      if (opties.vendorId) return opties.vendorId;
+
+      const vendor = await tx.execute<{ vendor_id: string }>(
+        sql`INSERT INTO clm.vendor (tenant_id, name)
+            VALUES (${opties.tenantId}, ${`v-${opties.naam}`})
+            RETURNING vendor_id`,
+      );
+      return vendor.rows[0].vendor_id;
+    });
+
+    await db.withTenant(opties.tenantId, async (tx) => {
+      const run = await tx.execute<{ run_id: string }>(
+        sql`INSERT INTO clm.survey_run
+                (tenant_id, template_id, status, survey_kind, closes_at)
+            VALUES (${opties.tenantId}, ${opties.templateId},
+                    ${opties.rondeStatus ?? 'active'},
+                    ${
+                      opties.interneBeoordeling
+                        ? 'internal_review'
+                        : 'vendor_compliance'
+                    },
+                    ${
+                      opties.sluitOver === undefined
+                        ? null
+                        : new Date(Date.now() + opties.sluitOver).toISOString()
+                    })
+            RETURNING run_id`,
+      );
+
+      await tx.execute(
+        sql`INSERT INTO clm.survey_response
+                (tenant_id, run_id, vendor_id, subject_vendor_id,
+                 respondent_label, token_hash, expires_at)
+            VALUES (${opties.tenantId}, ${run.rows[0].run_id},
+                    ${opties.interneBeoordeling ? null : vendorId},
+                    ${vendorId},
+                    ${opties.interneBeoordeling ? 'collega' : null},
+                    ${hashToken(token)},
+                    ${berekenVervalmoment().toISOString()})`,
+      );
+    });
+
+    return { token, vendorId };
+  }
+
+  async function importeerSeed(
+    tenantId: string,
+    bestand: string,
+  ): Promise<string> {
+    const document = JSON.parse(
+      readFileSync(join(SEEDMAP, bestand), 'utf8'),
+    ) as Record<string, unknown>;
+
+    const resultaat = await importService.importeer(tenantId, {
+      ...document,
+      version: uniekeVersie(),
+    });
+
+    return resultaat.templateId;
+  }
+
+  beforeAll(async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleRef.createNestApplication();
+    await app.init();
+
+    db = app.get(DatabaseService);
+    importService = app.get(VragenlijstImportService);
+    server = app.getHttpServer();
+
+    for (const tenantId of [TENANT_A, TENANT_B]) {
+      await db.withTenant(tenantId, async (tx) => {
+        await tx.execute(
+          sql`INSERT INTO clm.tenant (tenant_id, name)
+              VALUES (${tenantId}, ${`ophalen-${tenantId.slice(-2)}`})
+              ON CONFLICT (tenant_id) DO NOTHING`,
+        );
+      });
+    }
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  describe('UC1 — de acht Transdev-vragen', () => {
+    let token: string;
+    let lijst: VragenlijstVorm;
+
+    beforeAll(async () => {
+      const templateId = await importeerSeed(
+        TENANT_A,
+        'transdev-annual-vendor-it-risk-v1.json',
+      );
+      ({ token } = await maakLink({
+        tenantId: TENANT_A,
+        templateId,
+        naam: 'uc1',
+        sluitOver: 30 * 24 * 60 * 60 * 1000,
+      }));
+
+      const res = await request(server)
+        .get('/survey/respond/questions')
+        .query({ t: token })
+        .expect(200);
+
+      lijst = res.body as VragenlijstVorm;
+    });
+
+    it('levert negen vragen als platte lijst, zonder categorieën', () => {
+      // UC1 heeft geen categorieën; alles hoort in `questions` te staan.
+      expect(lijst.categories).toHaveLength(0);
+      expect(lijst.questions).toHaveLength(9);
+    });
+
+    it('houdt de volgorde aan uit het bestand', () => {
+      expect(lijst.questions.map((v) => v.questionKey)).toEqual([
+        'intro',
+        'q1',
+        'q2',
+        'q3',
+        'q4',
+        'q5',
+        'q6',
+        'q7',
+        'q8',
+      ]);
+    });
+
+    it('geeft het leesblok als instruction, niet verplicht', () => {
+      // Testpunt 32: het portaal moet dit blok kunnen overslaan bij het
+      // bepalen of alles beantwoord is.
+      const intro = lijst.questions[0];
+
+      expect(intro.answerType).toBe('instruction');
+      expect(intro.isRequired).toBe(false);
+    });
+
+    it('geeft de uploadvraag met allowsUpload en maxFiles', () => {
+      const q1 = lijst.questions.find((v) => v.questionKey === 'q1');
+
+      expect(q1?.answerType).toBe('confirmation');
+      expect(q1?.allowsUpload).toBe(true);
+      expect(q1?.maxFiles).toBe(2);
+    });
+
+    it('geeft de deadline van de ronde mee', () => {
+      expect(lijst.closesAt).not.toBeNull();
+      expect(new Date(lijst.closesAt as string).getTime()).toBeGreaterThan(
+        Date.now(),
+      );
+    });
+
+    it('lekt geen tenant, vendor of response-ID', () => {
+      // Dezelfde terughoudendheid als de statusroute: wie een geldig token
+      // bemachtigt, hoort daar geen extra gegevens uit te kunnen halen.
+      //
+      // Getoetst op de VELDNAMEN en op de UUIDs, niet op losse woorden in de
+      // JSON. De vraagteksten bevatten namelijk zelf "vendor compliance" — een
+      // regex over de hele body zou daarop afgaan en daarmee iets anders
+      // toetsen dan bedoeld.
+      const velden = new Set<string>();
+      const verzamel = (waarde: unknown): void => {
+        if (Array.isArray(waarde)) {
+          waarde.forEach(verzamel);
+        } else if (typeof waarde === 'object' && waarde !== null) {
+          for (const [sleutel, inhoud] of Object.entries(waarde)) {
+            velden.add(sleutel);
+            verzamel(inhoud);
+          }
+        }
+      };
+      verzamel(lijst);
+
+      const verdacht = [...velden].filter((veld) =>
+        /tenant|vendor|response|token|template_?id/i.test(veld),
+      );
+
+      expect(verdacht).toEqual([]);
+      expect(JSON.stringify(lijst)).not.toContain(TENANT_A);
+    });
+  });
+
+  describe('UC2 — de interne beoordeling', () => {
+    let lijst: VragenlijstVorm;
+
+    beforeAll(async () => {
+      const templateId = await importeerSeed(
+        TENANT_A,
+        'transdev-leveranciersbeoordeling-v1.json',
+      );
+      const { token } = await maakLink({
+        tenantId: TENANT_A,
+        templateId,
+        naam: 'uc2',
+        interneBeoordeling: true,
+      });
+
+      const res = await request(server)
+        .get('/survey/respond/questions')
+        .query({ t: token })
+        .expect(200);
+
+      lijst = res.body as VragenlijstVorm;
+    });
+
+    it('groepeert de vragen in zes categorieën, op volgorde', () => {
+      expect(lijst.categories.map((c) => c.name)).toEqual([
+        'Duidelijkheid',
+        'Behoefte',
+        'Kwaliteit',
+        'Kosten',
+        "Risico's",
+        'Besturing',
+      ]);
+    });
+
+    it('verdeelt de 28 ratingvragen over de categorieën', () => {
+      expect(lijst.categories.map((c) => c.questions.length)).toEqual([
+        4, 4, 5, 5, 5, 5,
+      ]);
+    });
+
+    it('zet de vraag zonder categorie apart', () => {
+      // De afsluitende open toelichting hoort bij het geheel, niet bij één
+      // categorie. Het portaal toont hem daarom los.
+      expect(lijst.questions).toHaveLength(1);
+      expect(lijst.questions[0].answerType).toBe('open_text');
+    });
+
+    it('geeft minAnswers per categorie mee', () => {
+      // Onder die drempel is de categoriescore null in plaats van een
+      // gemiddelde over te weinig punten (ontwerp §2).
+      expect(lijst.categories.every((c) => c.minAnswers === 3)).toBe(true);
+    });
+
+    it('vertaalt config naar camelCase', () => {
+      // De database heeft min_label/max_label; het portaal verwacht
+      // minLabel/maxLabel. Die vertaling hoort in de backend, anders gaan
+      // frontend en backend uit elkaar lopen zodra er een veld bijkomt.
+      const eerste = lijst.categories[0].questions[0];
+
+      expect(eerste.answerType).toBe('rating');
+      expect(eerste.config).toMatchObject({
+        min: 1,
+        max: 5,
+        minLabel: 'Zeer ondermaats',
+        maxLabel: 'Uitstekend',
+      });
+      expect(eerste.config).not.toHaveProperty('min_label');
+    });
+
+    it('geeft closesAt als null wanneer de ronde geen deadline heeft', () => {
+      expect(lijst.closesAt).toBeNull();
+    });
+  });
+
+  describe('Toegang', () => {
+    it('weigert een verzoek zonder token met 404', async () => {
+      await request(server).get('/survey/respond/questions').expect(404);
+    });
+
+    it('weigert een onbekend token met 404', async () => {
+      await request(server)
+        .get('/survey/respond/questions')
+        .query({ t: genereerToken() })
+        .expect(404);
+    });
+
+    it('weigert een ronde die nog in draft staat met 410', async () => {
+      // De guard weegt de lifecycle mee (migratie 0006). Deze route erft dat
+      // gedrag doordat de guard op controllerniveau staat.
+      const templateId = await importeerSeed(
+        TENANT_A,
+        'transdev-annual-vendor-it-risk-v1.json',
+      );
+      const { token } = await maakLink({
+        tenantId: TENANT_A,
+        templateId,
+        naam: 'draft',
+        rondeStatus: 'draft',
+      });
+
+      await request(server)
+        .get('/survey/respond/questions')
+        .query({ t: token })
+        .expect(410);
+    });
+
+    it('geeft een leverancier uitsluitend zijn eigen respons (testpunt 39)', async () => {
+      // De kern van de scheiding tussen UC1 en UC2. Twee responses in
+      // dezelfde tenant, op verschillende vragenlijsten. Het token van de een
+      // mag nooit de vragen van de ander opleveren.
+      //
+      // Deze test bewaakt de garantie die sneuvelt zodra iemand een route
+      // bouwt die op subject_vendor_id filtert in plaats van op response_id.
+      const uc1Template = await importeerSeed(
+        TENANT_A,
+        'transdev-annual-vendor-it-risk-v1.json',
+      );
+      const uc2Template = await importeerSeed(
+        TENANT_A,
+        'transdev-leveranciersbeoordeling-v1.json',
+      );
+
+      // Cruciaal: ÉÉN leverancier, twee responses. De UC2-beoordeling gaat
+      // over dezelfde partij (`subject_vendor_id`), maar wordt ingevuld door
+      // een collega. Zouden dit twee verschillende leveranciers zijn, dan zou
+      // deze test ook slagen met een route die op subject_vendor_id filtert —
+      // en dan bewijst hij niets. Geverifieerd door dat lek in te bouwen: met
+      // twee vendors bleef alles groen, met één vendor valt hij om.
+      const { token: tokenExtern, vendorId } = await maakLink({
+        tenantId: TENANT_A,
+        templateId: uc1Template,
+        naam: 'gedeelde-vendor',
+      });
+      const { token: tokenIntern } = await maakLink({
+        tenantId: TENANT_A,
+        templateId: uc2Template,
+        naam: 'intern',
+        vendorId,
+        interneBeoordeling: true,
+      });
+
+      const extern = await request(server)
+        .get('/survey/respond/questions')
+        .query({ t: tokenExtern })
+        .expect(200);
+      const intern = await request(server)
+        .get('/survey/respond/questions')
+        .query({ t: tokenIntern })
+        .expect(200);
+
+      const externeLijst = extern.body as VragenlijstVorm;
+      const interneLijst = intern.body as VragenlijstVorm;
+
+      // De externe leverancier ziet de compliance-vragen, niet de interne
+      // beoordeling — en andersom.
+      expect(externeLijst.categories).toHaveLength(0);
+      expect(externeLijst.questions).toHaveLength(9);
+      expect(interneLijst.categories).toHaveLength(6);
+
+      // Geen enkele vraagsleutel van de interne beoordeling komt voor in wat
+      // de leverancier krijgt.
+      const interneSleutels = interneLijst.categories
+        .flatMap((c) => c.questions)
+        .map((v) => v.questionKey);
+      const externeSleutels = externeLijst.questions.map((v) => v.questionKey);
+
+      expect(
+        externeSleutels.filter((s) => interneSleutels.includes(s)),
+      ).toEqual([]);
+    });
+
+    it('geeft een UC2-link toegang, ook al is de invuller geen leverancier', async () => {
+      // Regressietest voor de bug die migratie 0008 repareert.
+      //
+      // resolve_survey_token() bepaalde vendor_active via een join op
+      // survey_response.vendor_id. Bij UC2 is die kolom bewust NULL — de
+      // invuller is een collega — waardoor de join niets opleverde,
+      // vendor_active false werd en de guard élke interne beoordeling met 410
+      // afwees. De fix joint op subject_vendor_id, die bij beide use cases
+      // gevuld is.
+      //
+      // Deze test hoort te falen zodra iemand die join terugdraait.
+      const templateId = await importeerSeed(
+        TENANT_A,
+        'transdev-leveranciersbeoordeling-v1.json',
+      );
+      const { token } = await maakLink({
+        tenantId: TENANT_A,
+        templateId,
+        naam: 'uc2-toegang',
+        interneBeoordeling: true,
+      });
+
+      await request(server)
+        .get('/survey/respond/questions')
+        .query({ t: token })
+        .expect(200);
+    });
+
+    it('weigert een UC2-link zodra de beoordeelde leverancier is verwijderd', async () => {
+      // De keerzijde van bovenstaande fix: vendor_active moet nog steeds
+      // wérken. Een beoordeling over een leverancier die uit het bestand is
+      // gehaald, hoort niet meer ingevuld te worden — ook niet door een
+      // collega. Zonder deze test zou "join op subject_vendor_id" ook kunnen
+      // betekenen "controleer helemaal niets meer".
+      const templateId = await importeerSeed(
+        TENANT_A,
+        'transdev-leveranciersbeoordeling-v1.json',
+      );
+      const { token, vendorId } = await maakLink({
+        tenantId: TENANT_A,
+        templateId,
+        naam: 'uc2-verwijderd',
+        interneBeoordeling: true,
+      });
+
+      await db.withTenant(TENANT_A, async (tx) => {
+        await tx.execute(
+          sql`UPDATE clm.vendor SET deleted_at = now()
+               WHERE vendor_id = ${vendorId}`,
+        );
+      });
+
+      await request(server)
+        .get('/survey/respond/questions')
+        .query({ t: token })
+        .expect(410);
+    });
+
+    it('geeft een token van tenant A nooit de vragen van tenant B', async () => {
+      const templateB = await importeerSeed(
+        TENANT_B,
+        'transdev-annual-vendor-it-risk-v1.json',
+      );
+      const { token: tokenB } = await maakLink({
+        tenantId: TENANT_B,
+        templateId: templateB,
+        naam: 'tenant-b',
+      });
+
+      // Het token van B werkt in B, en levert daar B's eigen vragenlijst.
+      const res = await request(server)
+        .get('/survey/respond/questions')
+        .query({ t: tokenB })
+        .expect(200);
+
+      const lijst = res.body as VragenlijstVorm;
+      expect(lijst.questions).toHaveLength(9);
+      expect(JSON.stringify(lijst)).not.toContain(TENANT_A);
+    });
+  });
+
+  describe('Een ronde zonder vragen', () => {
+    it('geeft 404 met een leesbare melding in plaats van een leeg formulier', async () => {
+      // Een lege template is zeldzaam maar mogelijk: een ronde kan gestart
+      // worden voordat er vragen in staan. Een lege lijst teruggeven zou het
+      // portaal een formulier zonder vragen laten tonen — kapot ogend zonder
+      // uit te leggen waarom.
+      const leeg = await db.withTenant(TENANT_A, async (tx) => {
+        const rij = await tx.execute<{ template_id: string }>(
+          sql`INSERT INTO clm.survey_template (tenant_id, name, version)
+              VALUES (${TENANT_A}, ${`leeg-${uniekeVersie()}`}, 1)
+              RETURNING template_id`,
+        );
+        return rij.rows[0].template_id;
+      });
+
+      const { token } = await maakLink({
+        tenantId: TENANT_A,
+        templateId: leeg,
+        naam: 'leeg',
+      });
+
+      const res = await request(server)
+        .get('/survey/respond/questions')
+        .query({ t: token })
+        .expect(404);
+
+      const body = res.body as { message?: string };
+      expect(body.message).toMatch(/geen vragenlijst/i);
+      // Geen framework-404: die begint met "Cannot GET" en lekt het routepad.
+      expect(body.message).not.toMatch(/^Cannot /);
+    });
+  });
+});


### PR DESCRIPTION
Stap 5 uit de bouwvolgorde. De vragen staan sinds stap 4 in de database; deze route ontsluit ze voor het leverancierportaal, dat ze tot nu toe alleen op mock data toonde. **De 404 die de OTAP-doorloop signaleerde is daarmee weg.**

Onderweg kwam een bug boven die niemand had opgemerkt — zie hieronder.

## De route

De vorm sluit aan op het model dat de frontend al gebruikt (`MCM2-frontend/src/core/models/survey.ts`): categorieën en losse vragen gescheiden, want een vragenlijst is óf ingedeeld (UC2) óf een platte lijst (UC1).

De `config`-jsonb wordt in de **backend** naar camelCase vertaald (`min_label` → `minLabel`). Dat hoort daar en niet in de frontend: het is de backend die het contract bepaalt, en een frontend die zelf sleutels omzet gaat afwijken zodra er een veld bijkomt.

**Alleen bekende configsleutels gaan mee.** Dat is geen netheid maar een grens: `config` is een vrij JSONB-veld dat de database niet inhoudelijk bewaakt (ontwerp §2a), en alles doorgeven zou betekenen dat wat daar ooit in belandt automatisch bij de leverancier terechtkomt.

De route hangt aan de bestaande controller en zit daarmee automatisch achter dezelfde guard — dat was al zo ontworpen, en deze PR bevestigt het.

## De bug: UC2 werkte in het geheel niet

`resolve_survey_token()` bepaalde `vendor_active` via:

```sql
LEFT JOIN clm.vendor v ON v.vendor_id = r.vendor_id
(v.vendor_id IS NOT NULL AND v.deleted_at IS NULL) AS vendor_active
```

Bij UC2 is `survey_response.vendor_id` bewust `NULL` — de invuller is een Transdev-collega, geen leverancier (ontwerp §1c). De LEFT JOIN levert dan niets, `vendor_active` wordt `false`, en de guard weigert met **410 Gone / "vendor-inactief"**. Elke interne beoordeling was onbereikbaar.

**Aangetoond tegen de database, niet beredeneerd:** alle drie de UC2-responses in de testset gaven `vendor_active = false`.

Migratie 0006 is geschreven vóórdat UC2 bestond; 0005 maakte `vendor_id` nullable zonder deze functie mee te nemen. **Geen enkele test merkte het**, omdat geen enkele test een UC2-link over HTTP ophaalde — deze route is de eerste die dat doet.

**Migratie 0008 joint op `subject_vendor_id`**, die bij beide use cases gevuld en `NOT NULL` is. Voor UC1 verandert er niets, en dat is geen aanname: een CHECK uit 0005 dwingt daar `vendor_id = subject_vendor_id` af.

Twee tests leggen beide kanten vast — een UC2-link wérkt, en hij werkt niet meer zodra de beoordeelde leverancier zacht verwijderd is. Die tweede is er bewust bij: zonder hem zou "join op `subject_vendor_id`" ook kunnen betekenen "controleer helemaal niets meer".

`CREATE OR REPLACE` mocht hier wél, anders dan bij 0006: de `RETURNS TABLE` blijft ongewijzigd, dus de rechten blijven staan.

## Bewijs

- **112 van 112 e2e-tests groen** in 10 suites, tegen een verse Postgres 17.6 met de volledige keten **0000 t/m 0008**
- Twee opeenvolgende runs tegen dezelfde database, beide groen
- Docker-productiebuild bouwt, start, **mapt de route** en `/health` geeft HTTP 200
- format, lint en typecheck schoon

### De eerste tegenproef mislukte, en dat is het vermelden waard

Ik heb het lek uit ontwerp §1c daadwerkelijk ingebouwd — filteren op `subject_vendor_id` in plaats van `response_id` — en **alles bleef groen**. Oorzaak: elke leverancier in de test had een eigen vendor, dus de verkeerde filter selecteerde toevallig dezelfde rij. Pas met **twee responses over dezelfde leverancier** (het echte UC1/UC2-scenario) viel testpunt 39 om.

Die opzet staat nu in de test, met een verwijzing erbij in de service zodat iemand die de query aanpast weet waar hij op moet letten.

**Tweede tegenproef:** met de oude, kapotte guard teruggezet vielen 8 van de 20 tests om, waaronder de expliciete regressietest.

## Nog niet gedaan

Het portaal is **nog niet in de browser tegen de echte backend bekeken**. De route bestaat en levert de juiste data, maar de bevestiging in het scherm vraagt een OTAP-doorloop met `NEXT_PUBLIC_API_URL` gezet. Dat kost geen code en is de eerstvolgende zichtbare stap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)