### PR TITLE
feat(vragenlijst): validatie- en indienlogica (stap 6)

### DIFF
--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,7 +1,7 @@
 # MCM2 — actuele status
 
 ## Laatst bijgewerkt
-2026-07-29, tweede sessie (vragenlijst-tool t/m **stap 5**: import/export, beide seeds én `GET /survey/respond/questions`; `contract_id` op `survey_run`; **guardbug gevonden waardoor UC2 in het geheel niet werkte**; 112 e2e-tests groen — alles hieronder is geverifieerd, niet uit gespreksgeheugen)
+2026-07-29, tweede sessie (vragenlijst-tool t/m **stap 6**: import/export, beide seeds, `GET /survey/respond/questions` én de volledige indienlogica; `contract_id` op `survey_run`; **guardbug gevonden waardoor UC2 in het geheel niet werkte**; 137 e2e-tests groen — alles hieronder is geverifieerd, niet uit gespreksgeheugen)
 
 ## Het project bestaat uit twee repositories
 
@@ -32,7 +32,7 @@ docker run -d --name mcm2test -e POSTGRES_PASSWORD=pw -p 55440:5432 postgres:17.
 docker exec -i mcm2test psql -U postgres -q < db/roles/bootstrap-roles.sql
 docker exec mcm2test psql -U postgres -c "ALTER ROLE clm_migrator WITH PASSWORD 'pw'; ALTER ROLE clm_api_runtime WITH PASSWORD 'pw';"
 MIGRATION_DATABASE_URL="postgresql://clm_migrator:pw@localhost:55440/postgres" npm run migrate:deploy
-DATABASE_URL="postgresql://clm_api_runtime:pw@localhost:55440/postgres" npm run test:e2e   # 112 tests
+DATABASE_URL="postgresql://clm_api_runtime:pw@localhost:55440/postgres" npm run test:e2e   # 137 tests
 
 # De twee vragenlijsten inlezen (tenant moet bestaan)
 DATABASE_URL="postgresql://clm_api_runtime:pw@localhost:55440/postgres" \
@@ -175,6 +175,20 @@ Transdev Vendor IT Compliance Survey als eerste verticale MVP-slice.
 
 ## Aantoonbaar werkend
 
+- **Validatie- en indienlogica (2026-07-29, stap 6).** `src/survey/antwoord-validatie.ts` (de regelset, zonder database en zonder NestJS) plus `src/survey/antwoord-indienen.service.ts` (valideren, schrijven, afsluiten, auditeren — alles in één transactie). **137 van 137 e2e-tests groen** in elf suites.
+
+  `POST /survey/respond` accepteerde een lege body en zette alleen de status; nu komen de antwoorden mee en wordt de volledige regelset uit ontwerp §5 toegepast. Drie uitkomsten: **200** ingediend, **422** met per vraag de reden, **410** bij een tweede poging.
+
+  **De volgorde is de garantie:** eerst álles valideren, dan pas `submitted`. Faalt de validatie, dan is er niets weggeschreven en blijft de link bruikbaar (testpunt 25). Dat is essentieel — het token is gehasht en niet opnieuw te versturen, dus een half verbruikte link zou onherstelbaar zijn.
+
+  **De drie regels die een CHECK niet kan afdwingen zitten hier**, precies zoals §3a voorspelde: geldige optiecode, rating binnen bereik, `multi_choice`-aantallen. Een CHECK kan de vraagrij niet raadplegen.
+
+  **Tegenproef:** met drie regels uitgeschakeld (optiecode, rating-bereik, toelichtingsplicht) vielen 6 van de 25 tests om — precies de testpunten die ze bewaken.
+
+  **Bug die het draaien blootlegde:** Drizzle geeft een JS-array door als `record` waar Postgres `text[]` verwacht. Opgelost met `ARRAY(SELECT jsonb_array_elements_text(…))`; een array-literal opbouwen zou quoting vereisen van komma's en aanhalingstekens die in een optiecode kunnen voorkomen.
+
+  **Aangepast:** `survey-routes.e2e-spec.ts` gebruikte een template zónder vragen en kreeg daarvoor één minimale vraag. Een lege vragenlijst hoort niets af te sluiten — dat is bewust gedrag, geen bijvangst. De teardown daar moest mee: alle survey-tabellen hebben `ON DELETE RESTRICT`.
+
 - **`GET /survey/respond/questions` (2026-07-29, stap 5).** `src/survey/vragenlijst-lezen.service.ts` plus de route op de bestaande `SurveyResponseController`, dus automatisch achter dezelfde guard. **112 van 112 e2e-tests groen** in tien suites, tegen een verse Postgres 17.6 met de volledige keten 0000 t/m 0008.
 
   De vorm sluit aan op het model dat het portaal al gebruikt (`MCM2-frontend/src/core/models/survey.ts`): categorieën en losse vragen gescheiden. De `config`-jsonb wordt in de **backend** naar camelCase vertaald — een frontend die dat zelf doet gaat afwijken zodra er een veld bijkomt. Alleen bekende sleutels gaan mee: `config` is een vrij veld dat de database niet bewaakt, en alles doorgeven zou betekenen dat wat daar ooit in belandt automatisch bij de leverancier terechtkomt.
@@ -308,6 +322,8 @@ Praktische valkuilen die daadwerkelijk zijn tegengekomen, niet bedacht. Ze staan
 
 **Een tegenproef kan zélf onvoldoende zijn — controleer of de testopzet het lek kán zien.** Bij stap 5 is het lek uit ontwerp §1c daadwerkelijk ingebouwd (filteren op `subject_vendor_id` in plaats van `response_id`) en **bleef alles groen**. Oorzaak: elke leverancier in de test had een eigen vendor, dus de verkeerde filter selecteerde toevallig dezelfde rij. Pas met **twee responses over dezelfde leverancier** — het echte UC1/UC2-scenario — viel testpunt 39 om. Een tegenproef die niet faalt betekent dus niet automatisch dat de code goed is; het kan ook zijn dat de opzet het probleem niet kan aantonen.
 
+**Drizzle geeft een JS-array door als `record`, niet als `text[]`.** Een `INSERT` in een array-kolom faalt met "column X is of type text[] but expression is of type record". Werkende vorm: `ARRAY(SELECT jsonb_array_elements_text(${JSON.stringify(waarden)}::jsonb))`. Zelf een array-literal opbouwen kan ook, maar vraagt quoting van komma's, aanhalingstekens en accolades die in de waarden kunnen voorkomen — precies waar een injectiefout in sluipt.
+
 **Een nullable kolom maken raakt méér dan de tabel.** Migratie 0005 maakte `survey_response.vendor_id` nullable voor UC2, maar `resolve_survey_token()` joinde daar nog op — waardoor elke interne beoordeling 410 gaf. Bij het versoepelen van een kolom hoort een zoektocht naar elke plek die hem gebruikt: functies, views, policies. `grep -rn "vendor_id" drizzle/` had dit gevonden.
 
 ## Niet als bewezen beschouwen
@@ -324,12 +340,12 @@ Praktische valkuilen die daadwerkelijk zijn tegengekomen, niet bedacht. Ze staan
 
 | Repo | Branch | Werkboom | Openstaande PR's |
 |---|---|---|---|
-| MCM2 | **`feat/vragenlijst-ophalen`** | schoon | nog niet gepusht |
+| MCM2 | **`feat/antwoorden-indienen`** | schoon | nog niet gepusht |
 | MCM2-frontend | `main` | schoon | geen |
 
-**Twee PR's gemerged naar `main`:** #37 (stap 3 en 4, merge-commit `ef62cd6`) en #38 (migratie 0007 plus de drie bevestigde ontwerpbesluiten, merge-commit `4b09026`). Beide met CI groen op alle drie de jobs, beide branches lokaal én op GitHub verwijderd. Na elke merge opnieuw geverifieerd tégen `main` zelf.
+**Drie PR'''s gemerged naar `main`:** #37 (stap 3 en 4, `ef62cd6`), #38 (migratie 0007 plus de drie bevestigde ontwerpbesluiten, `4b09026`) en #39 (stap 5 plus de UC2-guardfix, `52f41b0`). Alle drie met CI groen op alle drie de jobs, alle branches lokaal én op GitHub verwijderd. Na elke merge opnieuw geverifieerd tégen `main` zelf.
 
-**`feat/vragenlijst-ophalen` staat open met één commit:** stap 5 (`GET /survey/respond/questions`) plus migratie 0008 die de UC2-guardbug repareert, en deze statusbijwerking. Nog niet gepusht. Lokale poorten wél gedraaid: format, lint, typecheck, 112/112 e2e tegen een verse Postgres 17.6, en de Docker-productiebuild die start, de route mapt en `/health` met 200 beantwoordt.
+**`feat/antwoorden-indienen` staat open met één commit:** stap 6 (validatie- en indienlogica) plus deze statusbijwerking. Nog niet gepusht. Lokale poorten wél gedraaid: format, lint, typecheck, 137/137 e2e tegen een verse Postgres 17.6 (twee keer), en de Docker-productiebuild die start en `/health` met 200 beantwoordt.
 
 - **`docs/sessiestand-otap` is op 2026-07-29 via PR #35 gemerged naar `main`** (merge-commit `cbe6c48`) en daarna lokaal én op GitHub verwijderd. Eén commit: uitsluitend deze statusbijwerking.
 - **`feat/issue-7-leveranciertoken` is op 2026-07-29 via PR #32 gemerged naar `main`** (merge-commit `7f0cc01`) en daarna lokaal én op GitHub verwijderd. CI groen op alle drie de jobs vóór de merge, opnieuw geverifieerd met `gh pr checks 32` op de laatste commit. Vijf commits: de tokenlaag, de HTTP-routes met logmaskering en auditregels, de fix op `maskeerDiep`, plus twee documentatiecommits. **Issue #31 is bij die merge gesloten** — migratie `0004` loste hem op. Let op: die migratie is bewezen in CI, **niet toegepast op `clm-enterprise`** — net als #29 en #25 wacht dat op #30.
@@ -353,7 +369,7 @@ Praktische valkuilen die daadwerkelijk zijn tegengekomen, niet bedacht. Ze staan
 
 De databaselaag is omgezet (ADR-010), spoor 2 van Issue #7 zit in `main`, en de vragenlijst-tool staat t/m stap 4: het datamodel, de guard, import/export en beide gevulde vragenlijsten.
 
-**De eerstvolgende inhoudelijke stap is stap 6: validatie- en indienlogica** (ontwerp §5, §10). `POST /survey/respond` accepteert nu een lege body; daar komen de antwoorden bij, met de tienstappenvalidatie uit §5. Dat raakt de productiedatabase niet; de hele e2e-keten draait tegen wegwerpcontainers, dus #30 blokkeert dit spoor niet.
+**De eerstvolgende inhoudelijke stap is stap 8: bestandsupload met inhoudscontrole** (ontwerp §6, Issue #9). Stap 7 (concept opslaan) is bruikbaar maar niet blokkerend; stap 8 wél — de acht Transdev-vragen hebben een uploadvraag, en zonder upload is die niet bevestigend te beantwoorden. Dat raakt de productiedatabase niet; de hele e2e-keten draait tegen wegwerpcontainers, dus #30 blokkeert dit spoor niet.
 
 **Daarnaast, en dat kost geen code:** het portaal tegen de echte backend zetten via een OTAP-doorloop. De vragen staan in de database en de route bestaat, dus dit is de eerste keer dat de klant de echte vragenlijst in de browser kan zien in plaats van mock data.
 
@@ -364,15 +380,16 @@ De databaselaag is omgezet (ADR-010), spoor 2 van Issue #7 zit in `main`, en de 
 
 ~~5. `GET /survey/respond/questions`~~ — **afgerond 2026-07-29**, zie "Aantoonbaar werkend". Legde en passant de UC2-guardbug bloot.
 
-**Nu aan de beurt — stap 6 t/m 9 uit ontwerp §10:**
-6. Validatie- en indienlogica; `POST /survey/respond` uitbreiden met de antwoordbody (ontwerp §5).
+~~6. Validatie- en indienlogica~~ — **afgerond 2026-07-29**, zie "Aantoonbaar werkend".
+
+**Nu aan de beurt — stap 7 t/m 9 uit ontwerp §10:**
 7. `PUT /survey/respond/answers` — concept opslaan, expliciet (geen auto-save).
 8. Bestandsupload met inhoudscontrole (ontwerp §6, Issue #9).
 9. Tests 14 t/m 48.
 
 **De 404 die de OTAP-doorloop signaleerde is weg:** `/survey/respond/questions` bestaat en levert de vragenlijst uit de database. **Nog niet in de browser bekeken** — het portaal draait nog op mock data tot iemand het met `NEXT_PUBLIC_API_URL` tegen de backend zet. Dat is de eerstvolgende zichtbare stap en kost geen code, alleen een OTAP-doorloop.
 
-**Aandachtspunt bij stap 6:** de bestaande `POST /survey/respond` accepteert nu een lege body. Zodra daar antwoorden bij komen, moet `test/survey-routes.e2e-spec.ts` mee — dat is geen ontwerpkwestie maar werk dat vergeten wordt als het niet ergens staat.
+**Stap 8 (bestandsupload) is de laatste die nog echt iets toevoegt aan de leverancierskant.** Zonder die stap kan een uploadvraag niet bevestigend beantwoord worden: de validatie eist een bestand bij `confirmed` op een uploadvraag. De acht Transdev-vragen hebben er één (q1), dus dit blokkeert een volledige UC1-indiening met bewijsstuk. `cannot_upload` met toelichting werkt wél al.
 
 Daarna, in volgorde van afhankelijkheid:
 

--- a/src/survey/antwoord-indienen.service.ts
+++ b/src/survey/antwoord-indienen.service.ts
@@ -1,0 +1,279 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { sql } from 'drizzle-orm';
+import type { SQL } from 'drizzle-orm';
+
+import { DatabaseService } from '../db/database.service';
+import type { TenantTransaction } from '../db/database.service';
+import { SurveyAuditService } from './survey-audit.service';
+import { valideerAntwoorden } from './antwoord-validatie';
+import type {
+  AntwoordFout,
+  GeldigAntwoord,
+  VraagVoorValidatie,
+} from './antwoord-validatie';
+import type { AntwoordType } from './vragenlijst-schema';
+
+/** Waarom een indiening niet is doorgegaan. Bepaalt de HTTP-status. */
+export type IndienUitkomst =
+  | { status: 'ingediend' }
+  | { status: 'ongeldig'; fouten: AntwoordFout[] }
+  | { status: 'niet-meer-open' };
+
+interface VraagRij extends Record<string, unknown> {
+  question_id: string;
+  question_key: string;
+  answer_type: string;
+  is_required: boolean;
+  allows_upload: boolean;
+  max_files: number;
+  config: Record<string, unknown> | null;
+}
+
+/**
+ * Neemt een volledige indiening aan: valideren, wegschrijven, afsluiten.
+ *
+ * De volgorde uit ontwerp §5 is niet vrijblijvend. **Eerst alles valideren, dan
+ * pas de status op `submitted` zetten.** Faalt de validatie halverwege, dan mag
+ * de response niet half ingediend achterblijven — de link is dan verbruikt
+ * terwijl er niets bruikbaars staat, en dat is onherstelbaar omdat het token
+ * gehasht is en niet opnieuw te versturen.
+ *
+ * Alles gebeurt in één transactie: antwoorden, statuswijziging en auditregel.
+ * Faalt er iets, dan blijft de link gewoon werken.
+ */
+@Injectable()
+export class AntwoordIndienService {
+  private readonly logger = new Logger(AntwoordIndienService.name);
+
+  constructor(
+    private readonly db: DatabaseService,
+    private readonly audit: SurveyAuditService,
+  ) {}
+
+  async dienIn(
+    tenantId: string,
+    responseId: string,
+    invoer: unknown,
+  ): Promise<IndienUitkomst> {
+    return this.db
+      .withTenant<IndienUitkomst>(tenantId, async (tx) => {
+        const vragen = await this.haalVragen(tx, responseId);
+
+        // Geen vragen betekent: er valt niets in te dienen. Behandeld als
+        // "niet meer open" in plaats van als lege geldige indiening — anders
+        // zou een lege template een response kunnen afsluiten zonder inhoud.
+        if (vragen.length === 0) {
+          return { status: 'niet-meer-open' };
+        }
+
+        const bestanden = await this.telBestanden(tx, responseId);
+
+        const uitkomst = valideerAntwoorden(
+          vragen.map(naarValidatievraag),
+          invoer,
+          bestanden,
+        );
+
+        if (!uitkomst.geldig) {
+          // Bewust vóór elke schrijfactie. De transactie heeft nog niets
+          // gewijzigd, dus er valt niets terug te draaien en de link blijft
+          // bruikbaar (testpunt 25).
+          return { status: 'ongeldig', fouten: uitkomst.fouten };
+        }
+
+        const idPerSleutel = new Map(
+          vragen.map((v) => [v.question_key, v.question_id]),
+        );
+
+        await this.schrijfAntwoorden(
+          tx,
+          tenantId,
+          responseId,
+          uitkomst.antwoorden,
+          idPerSleutel,
+        );
+
+        // Pas hierna afsluiten. Eén atomair statement met de status als
+        // voorwaarde, net als in SurveyTokenService.dienIn(): de database
+        // beslist wie wint bij gelijktijdige verzoeken, niet de volgorde waarin
+        // ze toevallig aankomen.
+        const afgesloten = await tx.execute<{ response_id: string }>(
+          sql`UPDATE clm.survey_response AS r
+               SET status = 'submitted', submitted_at = now()
+             WHERE r.response_id = ${responseId}
+               AND r.status = 'pending'
+               AND r.expires_at > now()
+               AND EXISTS (
+                     SELECT 1 FROM clm.survey_run run
+                      WHERE run.run_id = r.run_id
+                        AND run.status = 'active'
+                   )
+         RETURNING r.response_id`,
+        );
+
+        if (afgesloten.rows.length !== 1) {
+          // Iemand was eerder, of de ronde is inmiddels dicht. De transactie
+          // rolt terug door de fout hieronder niet te gooien maar de uitkomst
+          // te melden — Drizzle commit anders de zojuist geschreven antwoorden.
+          throw new NietMeerOpenError();
+        }
+
+        await this.audit.leg(tx, {
+          tenantId,
+          actie: 'survey_response_ingediend',
+          responseId,
+          details: { aantalAntwoorden: uitkomst.antwoorden.length },
+        });
+
+        this.logger.log(
+          `Response ${responseId} ingediend met ${uitkomst.antwoorden.length} antwoorden.`,
+        );
+
+        return { status: 'ingediend' };
+      })
+      .catch((fout: unknown) => {
+        // NietMeerOpenError is geen storing maar het verwachte gedrag bij een
+        // tweede poging. Door hem als fout te gooien rolt de transactie terug;
+        // hier wordt hij weer een gewone uitkomst.
+        if (fout instanceof NietMeerOpenError) {
+          this.logger.warn(
+            `Indienen geweigerd voor response ${responseId}: al ingediend, verlopen of ronde gesloten.`,
+          );
+          return { status: 'niet-meer-open' };
+        }
+        throw fout;
+      });
+  }
+
+  private async haalVragen(
+    tx: TenantTransaction,
+    responseId: string,
+  ): Promise<VraagRij[]> {
+    // Van response naar template, nooit andersom — dezelfde regel als in
+    // VragenlijstLeesService. Hiermee is stap 4 uit ontwerp §5 automatisch
+    // gedekt: `vragen` bevat uitsluitend de vragen van déze run, dus een
+    // question_key van een andere template is per definitie onbekend.
+    const resultaat = await tx.execute<VraagRij>(
+      sql`SELECT q.question_id, q.question_key, q.answer_type, q.is_required,
+                 q.allows_upload, q.max_files, q.config
+            FROM clm.survey_response r
+            JOIN clm.survey_run      run ON run.run_id    = r.run_id
+            JOIN clm.survey_question q   ON q.template_id = run.template_id
+           WHERE r.response_id = ${responseId}
+           ORDER BY q.position`,
+    );
+
+    return resultaat.rows;
+  }
+
+  /** Aantal reeds geüploade bijlagen per question_key. */
+  private async telBestanden(
+    tx: TenantTransaction,
+    responseId: string,
+  ): Promise<Map<string, number>> {
+    const resultaat = await tx.execute<{
+      question_key: string;
+      aantal: string;
+    }>(
+      sql`SELECT q.question_key, count(*)::text AS aantal
+            FROM clm.survey_attachment a
+            JOIN clm.survey_question q ON q.question_id = a.question_id
+           WHERE a.response_id = ${responseId}
+           GROUP BY q.question_key`,
+    );
+
+    return new Map(
+      resultaat.rows.map((rij) => [rij.question_key, Number(rij.aantal)]),
+    );
+  }
+
+  /**
+   * Schrijft de antwoorden weg.
+   *
+   * `ON CONFLICT ... DO UPDATE` omdat er al een concept kan staan (§7): de
+   * leverancier vulde vraag 1 t/m 3 in, sloeg op, en dient later alles in. Een
+   * gewone INSERT zou dan botsen op UNIQUE (response_id, question_id).
+   */
+  private async schrijfAntwoorden(
+    tx: TenantTransaction,
+    tenantId: string,
+    responseId: string,
+    antwoorden: GeldigAntwoord[],
+    idPerSleutel: Map<string, string>,
+  ): Promise<void> {
+    for (const antwoord of antwoorden) {
+      const questionId = idPerSleutel.get(antwoord.questionKey);
+
+      if (!questionId) {
+        // De validatie heeft al vastgesteld dat elke sleutel bekend is; komt
+        // hij hier alsnog niet uit de map, dan is er iets grondiger mis.
+        throw new Error(
+          `Vraag '${antwoord.questionKey}' is gevalideerd maar heeft geen question_id — dit is een programmeerfout.`,
+        );
+      }
+
+      await tx.execute(
+        sql`INSERT INTO clm.survey_answer
+                (tenant_id, response_id, question_id, answer_type,
+                 answer_code, answer_codes, answer_text, answer_number, comment)
+            VALUES (${tenantId}, ${responseId}, ${questionId},
+                    ${antwoord.answerType},
+                    ${antwoord.answerCode},
+                    ${codesAlsArray(antwoord.answerCodes)},
+                    ${antwoord.answerText},
+                    ${antwoord.answerNumber},
+                    ${antwoord.comment})
+            ON CONFLICT (response_id, question_id) DO UPDATE
+               SET answer_code   = EXCLUDED.answer_code,
+                   answer_codes  = EXCLUDED.answer_codes,
+                   answer_text   = EXCLUDED.answer_text,
+                   answer_number = EXCLUDED.answer_number,
+                   comment       = EXCLUDED.comment,
+                   updated_at    = now()`,
+      );
+    }
+  }
+}
+
+/**
+ * Intern signaal dat de response niet meer openstond.
+ *
+ * Als fout gegooid en niet als returnwaarde, omdat alleen een fout de
+ * transactie terugdraait. Zonder dat zouden de zojuist geschreven antwoorden
+ * blijven staan bij een response die iemand anders al had ingediend.
+ */
+class NietMeerOpenError extends Error {
+  constructor() {
+    super('De response stond niet meer open.');
+    this.name = 'NietMeerOpenError';
+  }
+}
+
+/**
+ * Zet een lijst codes om naar iets dat Postgres als `text[]` accepteert.
+ *
+ * Drizzle geeft een JS-array door als `record` — de INSERT faalt dan met
+ * "column answer_codes is of type text[] but expression is of type record".
+ * De omweg via een JSON-array met `jsonb_array_elements_text` is bewust: een
+ * array-literal opbouwen zou quoting vereisen van komma's, aanhalingstekens en
+ * accolades die in een optiecode kunnen voorkomen, en dat is precies het soort
+ * handwerk waar een injectiefout in sluipt.
+ */
+function codesAlsArray(codes: string[] | null): SQL {
+  if (codes === null) {
+    return sql`NULL::text[]`;
+  }
+
+  return sql`ARRAY(SELECT jsonb_array_elements_text(${JSON.stringify(codes)}::jsonb))`;
+}
+
+function naarValidatievraag(rij: VraagRij): VraagVoorValidatie {
+  return {
+    questionKey: rij.question_key,
+    answerType: rij.answer_type as AntwoordType,
+    isRequired: rij.is_required,
+    allowsUpload: rij.allows_upload,
+    maxFiles: rij.max_files,
+    config: rij.config ?? {},
+  };
+}

--- a/src/survey/antwoord-validatie.ts
+++ b/src/survey/antwoord-validatie.ts
@@ -1,0 +1,480 @@
+/**
+ * De regelset die bepaalt of een set antwoorden ingediend mag worden
+ * (vragenlijst-ontwerp §5, stap 2 t/m 10).
+ *
+ * Bevat geen database en geen NestJS: het is pure logica over vragen en
+ * antwoorden. Dat is bewust — dit is de laag waar de beslissing valt, en die
+ * moet los te toetsen zijn van een draaiende applicatie.
+ *
+ * De browserlaag telt niet mee als beveiliging (§5): een leverancier kan de
+ * POST direct sturen. De database is het vangnet eronder; deze laag levert de
+ * leesbare fout.
+ */
+
+import type { AntwoordType } from './vragenlijst-schema';
+
+/** De vier opties bij een confirmation-vraag (ontwerp §3). */
+const BEVESTIGINGSCODES = [
+  'confirmed',
+  'not_confirmed',
+  'not_applicable',
+  'cannot_upload',
+] as const;
+
+/** Minimale lengte van een verplichte toelichting, na wegstrepen van spaties. */
+export const TOELICHTING_MINIMUM = 10;
+
+/** Bovengrens, gelijk aan de CHECK-constraint in migratie 0005. */
+export const TOELICHTING_MAXIMUM = 2000;
+
+/** Eén vraag zoals de validatie hem nodig heeft. */
+export interface VraagVoorValidatie {
+  questionKey: string;
+  answerType: AntwoordType;
+  isRequired: boolean;
+  allowsUpload: boolean;
+  maxFiles: number;
+  config: Record<string, unknown>;
+}
+
+/** Eén antwoord zoals de leverancier het instuurt. */
+export interface AntwoordInvoer {
+  questionKey?: unknown;
+  answerType?: unknown;
+  answerCode?: unknown;
+  answerCodes?: unknown;
+  answerText?: unknown;
+  answerNumber?: unknown;
+  comment?: unknown;
+}
+
+/**
+ * Eén afgekeurd punt.
+ *
+ * `question` is de question_key en niet de UUID: leesbaar voor een mens en het
+ * lekt geen intern ID (ontwerp §5).
+ */
+export interface AntwoordFout {
+  question: string;
+  reason: string;
+}
+
+/** Een gevalideerd antwoord, klaar om weggeschreven te worden. */
+export interface GeldigAntwoord {
+  questionKey: string;
+  answerType: AntwoordType;
+  answerCode: string | null;
+  answerCodes: string[] | null;
+  answerText: string | null;
+  answerNumber: number | null;
+  comment: string | null;
+}
+
+export type ValidatieUitkomst =
+  | { geldig: true; antwoorden: GeldigAntwoord[] }
+  | { geldig: false; fouten: AntwoordFout[] };
+
+function isObject(waarde: unknown): waarde is Record<string, unknown> {
+  return (
+    typeof waarde === 'object' && waarde !== null && !Array.isArray(waarde)
+  );
+}
+
+function getal(waarde: unknown): number | undefined {
+  return typeof waarde === 'number' && Number.isFinite(waarde)
+    ? waarde
+    : undefined;
+}
+
+/** Aantal decimalen in een getal, zonder afrondingsruis van toFixed. */
+function decimalen(waarde: number): number {
+  const tekst = String(waarde);
+  const punt = tekst.indexOf('.');
+  return punt === -1 ? 0 : tekst.length - punt - 1;
+}
+
+/**
+ * Toetst één antwoord tegen zijn vraag.
+ *
+ * Vult `doel` met een schrijfbare rij wanneer alles klopt, en `fouten` met de
+ * reden wanneer niet. Geeft de eerste fout per vraag — meer dan één reden per
+ * vraag helpt de leverancier niet en maakt de melding onleesbaar.
+ */
+function toetsAntwoord(
+  vraag: VraagVoorValidatie,
+  antwoord: AntwoordInvoer,
+  aantalBestanden: number,
+  fouten: AntwoordFout[],
+  doel: GeldigAntwoord[],
+): void {
+  const meld = (reden: string) =>
+    fouten.push({ question: vraag.questionKey, reason: reden });
+
+  // Stap 5: het type in het antwoord moet overeenkomen met dat van de vraag.
+  // De samengestelde foreign key uit §4 vangt dit ook af, maar dan als
+  // databasefout in plaats van een leesbare 422.
+  if (
+    antwoord.answerType !== undefined &&
+    antwoord.answerType !== vraag.answerType
+  ) {
+    meld('answer_type_mismatch');
+    return;
+  }
+
+  const config = vraag.config ?? {};
+  const rij: GeldigAntwoord = {
+    questionKey: vraag.questionKey,
+    answerType: vraag.answerType,
+    answerCode: null,
+    answerCodes: null,
+    answerText: null,
+    answerNumber: null,
+    comment: null,
+  };
+
+  // Stap 6: waarde geldig voor dít type (§3a-tabel).
+  switch (vraag.answerType) {
+    case 'confirmation': {
+      const code = antwoord.answerCode;
+      if (
+        typeof code !== 'string' ||
+        !(BEVESTIGINGSCODES as readonly string[]).includes(code)
+      ) {
+        meld('invalid_code');
+        return;
+      }
+      // De vierde optie hoort alleen bij een vraag die een upload vraagt.
+      // Zonder deze controle kan iemand "ik kan niet uploaden" antwoorden op
+      // een vraag waar niets te uploaden viel.
+      if (code === 'cannot_upload' && !vraag.allowsUpload) {
+        meld('upload_option_not_available');
+        return;
+      }
+      rij.answerCode = code;
+      break;
+    }
+
+    case 'yes_no': {
+      const code = antwoord.answerCode;
+      if (code !== 'yes' && code !== 'no') {
+        meld('invalid_code');
+        return;
+      }
+      rij.answerCode = code;
+      break;
+    }
+
+    case 'single_choice': {
+      const code = antwoord.answerCode;
+      if (typeof code !== 'string' || code.length === 0) {
+        meld('invalid_code');
+        return;
+      }
+      // Testpunt 33. Dit kan een CHECK niet: de toegestane codes staan in de
+      // config van de vraag, en een CHECK mag geen andere tabel raadplegen.
+      if (!kentCode(config, code)) {
+        meld('unknown_option');
+        return;
+      }
+      rij.answerCode = code;
+      break;
+    }
+
+    case 'multi_choice': {
+      const codes = antwoord.answerCodes;
+      if (!Array.isArray(codes) || codes.some((c) => typeof c !== 'string')) {
+        meld('invalid_codes');
+        return;
+      }
+      if (codes.length === 0) {
+        // Alleen een probleem als de vraag verplicht is; dat wordt hieronder
+        // afgehandeld door de aanwezigheidscontrole.
+        meld('invalid_codes');
+        return;
+      }
+      // Testpunt 35: duplicaten en de min/max-grenzen.
+      if (new Set(codes).size !== codes.length) {
+        meld('duplicate_options');
+        return;
+      }
+      const onbekend = (codes as string[]).find((c) => !kentCode(config, c));
+      if (onbekend !== undefined) {
+        meld('unknown_option');
+        return;
+      }
+      const minSelect = getal(config.min_select);
+      const maxSelect = getal(config.max_select);
+      if (minSelect !== undefined && codes.length < minSelect) {
+        meld('too_few_options');
+        return;
+      }
+      if (maxSelect !== undefined && codes.length > maxSelect) {
+        meld('too_many_options');
+        return;
+      }
+      rij.answerCodes = codes as string[];
+      break;
+    }
+
+    case 'open_text': {
+      const tekst = antwoord.answerText;
+      if (typeof tekst !== 'string' || tekst.trim().length === 0) {
+        meld('empty_text');
+        return;
+      }
+      const minLengte = getal(config.min_length) ?? 1;
+      const maxLengte = getal(config.max_length);
+      if (tekst.trim().length < minLengte) {
+        meld('text_too_short');
+        return;
+      }
+      if (maxLengte !== undefined && tekst.length > maxLengte) {
+        meld('text_too_long');
+        return;
+      }
+      rij.answerText = tekst;
+      break;
+    }
+
+    case 'rating': {
+      const waarde = getal(antwoord.answerNumber);
+      if (waarde === undefined) {
+        meld('invalid_number');
+        return;
+      }
+      // Testpunt 34: geheel getal binnen min…max.
+      if (!Number.isInteger(waarde)) {
+        meld('not_an_integer');
+        return;
+      }
+      const min = getal(config.min);
+      const max = getal(config.max);
+      if (
+        (min !== undefined && waarde < min) ||
+        (max !== undefined && waarde > max)
+      ) {
+        meld('out_of_range');
+        return;
+      }
+      rij.answerNumber = waarde;
+      break;
+    }
+
+    case 'number': {
+      const waarde = getal(antwoord.answerNumber);
+      if (waarde === undefined) {
+        meld('invalid_number');
+        return;
+      }
+      const min = getal(config.min);
+      const max = getal(config.max);
+      if (
+        (min !== undefined && waarde < min) ||
+        (max !== undefined && waarde > max)
+      ) {
+        meld('out_of_range');
+        return;
+      }
+      const toegestaneDecimalen = getal(config.decimals);
+      if (
+        toegestaneDecimalen !== undefined &&
+        decimalen(waarde) > toegestaneDecimalen
+      ) {
+        meld('too_many_decimals');
+        return;
+      }
+      // Een percentage buiten 0–100 is onzin, ook zonder expliciete min/max.
+      if (config.format === 'pct' && (waarde < 0 || waarde > 100)) {
+        meld('out_of_range');
+        return;
+      }
+      rij.answerNumber = waarde;
+      break;
+    }
+
+    case 'file_upload': {
+      // Geen waarde, alleen bijlagen (ontwerp §2a). Stap 9b.
+      if (aantalBestanden < 1) {
+        meld('file_required');
+        return;
+      }
+      break;
+    }
+
+    case 'instruction':
+      // Een leesblok levert geen antwoordrij op. Wie er toch een instuurt,
+      // krijgt dat expliciet terug in plaats van een stilzwijgend genegeerde
+      // waarde.
+      meld('instruction_has_no_answer');
+      return;
+  }
+
+  // Stap 7 en 8: de toelichting.
+  const toelichting =
+    typeof antwoord.comment === 'string' ? antwoord.comment : null;
+  const verplicht = toelichtingVerplicht(vraag, rij);
+
+  if (toelichting !== null && toelichting.length > TOELICHTING_MAXIMUM) {
+    meld('comment_too_long');
+    return;
+  }
+
+  if (verplicht) {
+    if (toelichting === null || toelichting.trim().length === 0) {
+      meld('comment_required');
+      return;
+    }
+    // De ondergrens houdt "n/a" en "-" tegen: die maken het veld formeel
+    // gevuld en inhoudelijk leeg, en zijn daarmee erger dan een leeg veld —
+    // in een overzicht zien ze eruit als een antwoord.
+    if (toelichting.trim().length < TOELICHTING_MINIMUM) {
+      meld('comment_too_short');
+      return;
+    }
+  }
+
+  if (
+    toelichting !== null &&
+    toelichting.trim().length > 0 &&
+    config.comment !== 'none'
+  ) {
+    rij.comment = toelichting;
+  }
+
+  // Stap 9: een bevestiging op een uploadvraag vraagt om het bewijsstuk.
+  if (
+    vraag.allowsUpload &&
+    rij.answerCode === 'confirmed' &&
+    aantalBestanden < 1
+  ) {
+    meld('file_required');
+    return;
+  }
+
+  // Stap 10: nooit meer bestanden dan de vraag toestaat.
+  if (aantalBestanden > vraag.maxFiles) {
+    meld('too_many_files');
+    return;
+  }
+
+  doel.push(rij);
+}
+
+function kentCode(config: Record<string, unknown>, code: string): boolean {
+  const opties = config.options;
+  if (!Array.isArray(opties)) return false;
+  return opties.some(
+    (optie) =>
+      isObject(optie) && typeof optie.code === 'string' && optie.code === code,
+  );
+}
+
+/**
+ * Bepaalt of een toelichting verplicht is.
+ *
+ * Bij `confirmation` is dat inhoudelijk bepaald en niet instelbaar: alles
+ * behalve een bevestiging vereist uitleg (ontwerp §3, bevestigd 2026-07-29).
+ * Diezelfde regel staat als CHECK-constraint in migratie 0005, dus de database
+ * weigert het ook als deze functie zou falen.
+ *
+ * Bij de andere zeven typen is het per vraag instelbaar via `config.comment`
+ * en staat het standaard op optioneel (§3a).
+ */
+function toelichtingVerplicht(
+  vraag: VraagVoorValidatie,
+  rij: GeldigAntwoord,
+): boolean {
+  if (vraag.answerType === 'confirmation') {
+    return rij.answerCode !== 'confirmed';
+  }
+  return vraag.config?.comment === 'required';
+}
+
+/**
+ * Valideert een volledige indiening.
+ *
+ * Verzamelt álle fouten in plaats van bij de eerste te stoppen: wie acht vragen
+ * invult wil niet acht keer opnieuw proberen.
+ *
+ * @param vragen alle vragen van de template, in volgorde
+ * @param invoer wat de leverancier instuurde
+ * @param bestandenPerVraag aantal reeds geüploade bijlagen per question_key
+ */
+export function valideerAntwoorden(
+  vragen: VraagVoorValidatie[],
+  invoer: unknown,
+  bestandenPerVraag: Map<string, number> = new Map(),
+): ValidatieUitkomst {
+  const fouten: AntwoordFout[] = [];
+
+  if (!Array.isArray(invoer)) {
+    return {
+      geldig: false,
+      fouten: [{ question: '(body)', reason: 'answers_must_be_a_list' }],
+    };
+  }
+
+  const perSleutel = new Map<string, AntwoordInvoer>();
+
+  for (const item of invoer) {
+    if (!isObject(item) || typeof item.questionKey !== 'string') {
+      fouten.push({ question: '(body)', reason: 'invalid_answer_entry' });
+      continue;
+    }
+    if (perSleutel.has(item.questionKey)) {
+      fouten.push({ question: item.questionKey, reason: 'duplicate_answer' });
+      continue;
+    }
+    perSleutel.set(item.questionKey, item);
+  }
+
+  const bekend = new Map(vragen.map((v) => [v.questionKey, v]));
+
+  // Stap 3 en 4: een sleutel die niet bij deze vragenlijst hoort. Stap 4 uit
+  // het ontwerp — hoort de vraag bij de template van déze run — valt hier
+  // samen met stap 3, omdat `vragen` al uitsluitend de vragen van deze run
+  // bevat. RLS beschermt tegen een andere tenant, dit tegen een andere
+  // template binnen dezelfde tenant.
+  for (const sleutel of perSleutel.keys()) {
+    if (!bekend.has(sleutel)) {
+      fouten.push({ question: sleutel, reason: 'unknown_question' });
+    }
+  }
+
+  const antwoorden: GeldigAntwoord[] = [];
+
+  for (const vraag of vragen) {
+    const antwoord = perSleutel.get(vraag.questionKey);
+    const bestanden = bestandenPerVraag.get(vraag.questionKey) ?? 0;
+
+    // Stap 2, met de twee uitzonderingen die makkelijk vergeten worden: een
+    // instruction is een leesblok en levert nooit een antwoord op, en een
+    // vraag met is_required = false mag leeg blijven. Wie beide vergeet, bouwt
+    // een vragenlijst die met een inleidend tekstblok nooit in te dienen is
+    // (testpunt 32).
+    if (vraag.answerType === 'instruction') {
+      if (antwoord !== undefined) {
+        fouten.push({
+          question: vraag.questionKey,
+          reason: 'instruction_has_no_answer',
+        });
+      }
+      continue;
+    }
+
+    if (antwoord === undefined) {
+      if (vraag.isRequired) {
+        fouten.push({ question: vraag.questionKey, reason: 'answer_required' });
+      }
+      continue;
+    }
+
+    toetsAntwoord(vraag, antwoord, bestanden, fouten, antwoorden);
+  }
+
+  if (fouten.length > 0) {
+    return { geldig: false, fouten };
+  }
+
+  return { geldig: true, antwoorden };
+}

--- a/src/survey/survey-response.controller.ts
+++ b/src/survey/survey-response.controller.ts
@@ -1,14 +1,17 @@
 import {
+  Body,
   Controller,
   Get,
   HttpCode,
   NotFoundException,
   Post,
   Req,
+  UnprocessableEntityException,
   UseGuards,
   GoneException,
 } from '@nestjs/common';
 
+import { AntwoordIndienService } from './antwoord-indienen.service';
 import { SurveyTokenGuard, type RequestMetToken } from './survey-token.guard';
 import { SurveyTokenService } from './survey-token.service';
 import { VragenlijstLeesService } from './vragenlijst-lezen.service';
@@ -30,6 +33,7 @@ export class SurveyResponseController {
   constructor(
     private readonly tokens: SurveyTokenService,
     private readonly vragenlijst: VragenlijstLeesService,
+    private readonly indienen: AntwoordIndienService,
   ) {}
 
   /**
@@ -94,27 +98,50 @@ export class SurveyResponseController {
   }
 
   /**
-   * Dient de response definitief in.
+   * Dient de response definitief in, met de antwoorden.
    *
    * Eenmalig en onomkeerbaar (OV-3, AC12). De atomaire update in de service
    * bepaalt wie wint bij gelijktijdige verzoeken; hier wordt alleen het
    * resultaat vertaald naar een HTTP-status.
    *
-   * 200 bij succes, 410 Gone bij een tweede poging — dezelfde status die de
-   * guard geeft voor een al ingediende link, zodat het gedrag consistent is
-   * ongeacht welke laag het opmerkt.
+   * Drie uitkomsten:
+   *
+   *   200  ingediend
+   *   422  de antwoorden voldoen niet — met per vraag de reden
+   *   410  al ingediend, verlopen of ronde gesloten
+   *
+   * 410 is dezelfde status die de guard geeft voor een al ingediende link,
+   * zodat het gedrag consistent is ongeacht welke laag het opmerkt.
+   *
+   * Bij een 422 is er niets weggeschreven en blijft de link bruikbaar
+   * (testpunt 25). Dat is essentieel: het token is gehasht en dus niet opnieuw
+   * te versturen, dus een half verbruikte link zou onherstelbaar zijn.
    */
   @Post()
   @HttpCode(200)
-  async dienIn(@Req() request: RequestMetToken) {
+  async dienIn(
+    @Req() request: RequestMetToken,
+    @Body() body: { answers?: unknown } | undefined,
+  ) {
     const context = request.surveyToken!;
 
-    const gelukt = await this.tokens.dienIn(
+    const uitkomst = await this.indienen.dienIn(
       context.tenantId,
       context.responseId,
+      body?.answers ?? [],
     );
 
-    if (!gelukt) {
+    if (uitkomst.status === 'ongeldig') {
+      // De vorm uit ontwerp §5: question_key en een machineleesbare reden.
+      // Een 422 die alleen "validation failed" zegt, is voor een leverancier
+      // onbruikbaar.
+      throw new UnprocessableEntityException({
+        status: 'invalid',
+        errors: uitkomst.fouten,
+      });
+    }
+
+    if (uitkomst.status === 'niet-meer-open') {
       throw new GoneException('Deze vragenlijst is al ingediend.');
     }
 

--- a/src/survey/survey-token.service.ts
+++ b/src/survey/survey-token.service.ts
@@ -179,7 +179,14 @@ export class SurveyTokenService {
   }
 
   /**
-   * Dient een response definitief in.
+   * Dient een response definitief in, zónder antwoorden.
+   *
+   * Sinds stap 6 loopt de HTTP-route via AntwoordIndienService, die valideert
+   * en de antwoorden wegschrijft vóórdat hij afsluit. Deze methode blijft
+   * bestaan als de kale afsluitoperatie en is de plek waar de éénmaligheid en
+   * het gelijktijdigheidsgedrag getoetst worden (survey-token-isolatie.e2e).
+   * Beide gebruiken hetzelfde atomaire statement, dus die tests bewaken ook
+   * het gedrag van de indienroute.
    *
    * De volgorde is niet vrijblijvend. Dit zou fout zijn:
    *

--- a/src/survey/survey.module.ts
+++ b/src/survey/survey.module.ts
@@ -4,6 +4,7 @@ import { SurveyAuditService } from './survey-audit.service';
 import { SurveyResponseController } from './survey-response.controller';
 import { SurveyTokenGuard } from './survey-token.guard';
 import { SurveyTokenService } from './survey-token.service';
+import { AntwoordIndienService } from './antwoord-indienen.service';
 import { VragenlijstImportService } from './vragenlijst-import.service';
 import { VragenlijstLeesService } from './vragenlijst-lezen.service';
 
@@ -15,6 +16,7 @@ import { VragenlijstLeesService } from './vragenlijst-lezen.service';
     SurveyTokenGuard,
     VragenlijstImportService,
     VragenlijstLeesService,
+    AntwoordIndienService,
   ],
   exports: [
     SurveyAuditService,
@@ -22,6 +24,7 @@ import { VragenlijstLeesService } from './vragenlijst-lezen.service';
     SurveyTokenGuard,
     VragenlijstImportService,
     VragenlijstLeesService,
+    AntwoordIndienService,
   ],
 })
 export class SurveyModule {}

--- a/test/antwoord-indienen.e2e-spec.ts
+++ b/test/antwoord-indienen.e2e-spec.ts
@@ -1,0 +1,609 @@
+import { INestApplication } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import { sql } from 'drizzle-orm';
+import request from 'supertest';
+import type { App } from 'supertest/types';
+
+import { AppModule } from '../src/app.module';
+import { DatabaseService } from '../src/db/database.service';
+import {
+  berekenVervalmoment,
+  genereerToken,
+  hashToken,
+} from '../src/survey/survey-token';
+
+const TENANT = '00000000-0000-0000-0000-0000000000b1';
+
+interface VraagOpzet {
+  key: string;
+  type: string;
+  verplicht?: boolean;
+  upload?: boolean;
+  maxFiles?: number;
+  config?: Record<string, unknown>;
+}
+
+interface FoutBody {
+  status?: string;
+  errors?: { question: string; reason: string }[];
+  message?: {
+    status?: string;
+    errors?: { question: string; reason: string }[];
+  };
+}
+
+let teller = 0;
+
+/** De redenen uit een 422, als "vraag:reden" — dat leest prettiger in asserties. */
+function redenen(res: { body: unknown }): string[] {
+  const body = res.body as FoutBody;
+  const fouten = body.errors ?? body.message?.errors ?? [];
+  return fouten.map((f) => `${f.question}:${f.reason}`);
+}
+
+/**
+ * Toetst POST /survey/respond met antwoorden (ontwerp §5).
+ *
+ * Van buitenaf via HTTP, precies zoals het portaal hem aanroept. De browserlaag
+ * telt niet mee als beveiliging — een leverancier kan deze POST direct sturen,
+ * en dat is geen aanval maar normaal gedrag van iemand met een script.
+ */
+describe('Antwoorden indienen (e2e)', () => {
+  let app: INestApplication<App>;
+  let db: DatabaseService;
+  let server: App;
+
+  /** Zet een ronde neer met de opgegeven vragen en levert het token. */
+  async function maakRonde(
+    vragen: VraagOpzet[],
+    opties: { rondeStatus?: string } = {},
+  ): Promise<{ token: string; responseId: string }> {
+    const token = genereerToken();
+    const naam = `r${teller++}-${Date.now()}`;
+
+    const responseId = await db.withTenant(TENANT, async (tx) => {
+      const vendor = await tx.execute<{ vendor_id: string }>(
+        sql`INSERT INTO clm.vendor (tenant_id, name)
+            VALUES (${TENANT}, ${`v-${naam}`}) RETURNING vendor_id`,
+      );
+      const template = await tx.execute<{ template_id: string }>(
+        sql`INSERT INTO clm.survey_template (tenant_id, name, version)
+            VALUES (${TENANT}, ${`t-${naam}`}, 1) RETURNING template_id`,
+      );
+      const templateId = template.rows[0].template_id;
+
+      let positie = 0;
+      for (const vraag of vragen) {
+        positie += 1;
+        await tx.execute(
+          sql`INSERT INTO clm.survey_question
+                  (tenant_id, template_id, position, question_key, title, body,
+                   answer_type, is_required, allows_upload, max_files, config)
+              VALUES (${TENANT}, ${templateId}, ${positie}, ${vraag.key},
+                      ${`Titel ${vraag.key}`}, ${`Tekst ${vraag.key}`},
+                      ${vraag.type}, ${vraag.verplicht ?? true},
+                      ${vraag.upload ?? false}, ${vraag.maxFiles ?? 0},
+                      ${JSON.stringify(vraag.config ?? {})}::jsonb)`,
+        );
+      }
+
+      const run = await tx.execute<{ run_id: string }>(
+        sql`INSERT INTO clm.survey_run (tenant_id, template_id, status)
+            VALUES (${TENANT}, ${templateId}, ${opties.rondeStatus ?? 'active'})
+            RETURNING run_id`,
+      );
+
+      const response = await tx.execute<{ response_id: string }>(
+        sql`INSERT INTO clm.survey_response
+                (tenant_id, run_id, vendor_id, subject_vendor_id, token_hash,
+                 expires_at)
+            VALUES (${TENANT}, ${run.rows[0].run_id},
+                    ${vendor.rows[0].vendor_id}, ${vendor.rows[0].vendor_id},
+                    ${hashToken(token)}, ${berekenVervalmoment().toISOString()})
+            RETURNING response_id`,
+      );
+
+      return response.rows[0].response_id;
+    });
+
+    return { token, responseId };
+  }
+
+  const dienIn = (token: string, answers: unknown) =>
+    request(server).post(`/survey/respond?t=${token}`).send({ answers });
+
+  beforeAll(async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleRef.createNestApplication();
+    await app.init();
+    server = app.getHttpServer();
+    db = moduleRef.get(DatabaseService);
+
+    await db.withTenant(TENANT, async (tx) => {
+      await tx.execute(
+        sql`INSERT INTO clm.tenant (tenant_id, name)
+            VALUES (${TENANT}, 'indienen-test')
+            ON CONFLICT (tenant_id) DO NOTHING`,
+      );
+    });
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  // ── Volledigheid (testpunt 14, 32) ────────────────────────────────────────
+
+  it('weigert indienen met een ontbrekend verplicht antwoord; response blijft pending', async () => {
+    // Testpunt 14. De link moet daarna nog werken: het token is gehasht en dus
+    // niet opnieuw te versturen, dus een half verbruikte link is onherstelbaar.
+    const { token, responseId } = await maakRonde([
+      { key: 'q1', type: 'yes_no' },
+      { key: 'q2', type: 'yes_no' },
+    ]);
+
+    const res = await dienIn(token, [
+      { questionKey: 'q1', answerCode: 'yes' },
+    ]).expect(422);
+
+    expect(redenen(res)).toContain('q2:answer_required');
+
+    const status = await db.withTenant(TENANT, (tx) =>
+      tx.execute<{ status: string }>(
+        sql`SELECT status FROM clm.survey_response
+             WHERE response_id = ${responseId}`,
+      ),
+    );
+    expect(status.rows[0].status).toBe('pending');
+  });
+
+  it('laat een instruction-blok buiten beschouwing bij de volledigheid (testpunt 32)', async () => {
+    // De waarschijnlijkste bug van het hele ontwerp: een leesblok dat meetelt
+    // als onbeantwoorde vraag maakt de vragenlijst onindienbaar.
+    const { token } = await maakRonde([
+      { key: 'intro', type: 'instruction', verplicht: false },
+      { key: 'q1', type: 'yes_no' },
+    ]);
+
+    await dienIn(token, [{ questionKey: 'q1', answerCode: 'yes' }]).expect(200);
+  });
+
+  it('weigert een antwoord op een instruction-blok', async () => {
+    const { token } = await maakRonde([
+      { key: 'intro', type: 'instruction', verplicht: false },
+      { key: 'q1', type: 'yes_no' },
+    ]);
+
+    const res = await dienIn(token, [
+      { questionKey: 'intro', answerText: 'iets' },
+      { questionKey: 'q1', answerCode: 'yes' },
+    ]).expect(422);
+
+    expect(redenen(res)).toContain('intro:instruction_has_no_answer');
+  });
+
+  it('laat een niet-verplichte vraag leeg blijven', async () => {
+    const { token } = await maakRonde([
+      { key: 'q1', type: 'yes_no' },
+      { key: 'q2', type: 'open_text', verplicht: false },
+    ]);
+
+    await dienIn(token, [{ questionKey: 'q1', answerCode: 'yes' }]).expect(200);
+  });
+
+  // ── Toelichting (testpunt 15, 16) ─────────────────────────────────────────
+
+  it('eist een toelichting bij elke niet-bevestiging (testpunt 15)', async () => {
+    const { token } = await maakRonde([{ key: 'q1', type: 'confirmation' }]);
+
+    for (const code of ['not_confirmed', 'not_applicable']) {
+      const res = await dienIn(token, [
+        { questionKey: 'q1', answerCode: code },
+      ]).expect(422);
+
+      expect(redenen(res)).toContain('q1:comment_required');
+    }
+  });
+
+  it('weigert een toelichting van "   -   " op de ondergrens (testpunt 16)', async () => {
+    // Formeel gevuld, inhoudelijk leeg — erger dan een leeg veld, want in een
+    // overzicht ziet het eruit als een antwoord.
+    const { token } = await maakRonde([{ key: 'q1', type: 'confirmation' }]);
+
+    const res = await dienIn(token, [
+      { questionKey: 'q1', answerCode: 'not_confirmed', comment: '   -   ' },
+    ]).expect(422);
+
+    expect(redenen(res)).toContain('q1:comment_too_short');
+  });
+
+  it('accepteert een bevestiging zonder toelichting', async () => {
+    const { token } = await maakRonde([{ key: 'q1', type: 'confirmation' }]);
+
+    await dienIn(token, [
+      { questionKey: 'q1', answerCode: 'confirmed' },
+    ]).expect(200);
+  });
+
+  it('weigert een toelichting boven 2.000 tekens', async () => {
+    const { token } = await maakRonde([{ key: 'q1', type: 'confirmation' }]);
+
+    const res = await dienIn(token, [
+      {
+        questionKey: 'q1',
+        answerCode: 'not_confirmed',
+        comment: 'x'.repeat(2001),
+      },
+    ]).expect(422);
+
+    expect(redenen(res)).toContain('q1:comment_too_long');
+  });
+
+  // ── Uploadregels (testpunt 17, 18) ────────────────────────────────────────
+
+  it('weigert cannot_upload op een vraag zonder upload (testpunt 17)', async () => {
+    const { token } = await maakRonde([{ key: 'q1', type: 'confirmation' }]);
+
+    const res = await dienIn(token, [
+      {
+        questionKey: 'q1',
+        answerCode: 'cannot_upload',
+        comment: 'Het certificaat ligt bij een andere afdeling.',
+      },
+    ]).expect(422);
+
+    expect(redenen(res)).toContain('q1:upload_option_not_available');
+  });
+
+  it('weigert confirmed op een uploadvraag zonder bestand (testpunt 18)', async () => {
+    const { token } = await maakRonde([
+      { key: 'q1', type: 'confirmation', upload: true, maxFiles: 2 },
+    ]);
+
+    const res = await dienIn(token, [
+      { questionKey: 'q1', answerCode: 'confirmed' },
+    ]).expect(422);
+
+    expect(redenen(res)).toContain('q1:file_required');
+  });
+
+  it('staat cannot_upload met toelichting toe op een uploadvraag', async () => {
+    // De reden dat deze optie bestaat: een upload kan mislukken om redenen die
+    // niets met compliance te maken hebben.
+    const { token } = await maakRonde([
+      { key: 'q1', type: 'confirmation', upload: true, maxFiles: 2 },
+    ]);
+
+    await dienIn(token, [
+      {
+        questionKey: 'q1',
+        answerCode: 'cannot_upload',
+        comment: 'Ons certificaat valt onder een NDA met de certificeerder.',
+      },
+    ]).expect(200);
+  });
+
+  // ── Waardevalidatie per type (testpunt 33, 34, 35, 36) ────────────────────
+
+  it('weigert een single_choice-code die niet in config.options staat (testpunt 33)', async () => {
+    // Dit kan een CHECK niet: de toegestane codes staan in de config van de
+    // vraag, en een CHECK mag geen andere tabel raadplegen.
+    const { token } = await maakRonde([
+      {
+        key: 'q1',
+        type: 'single_choice',
+        config: {
+          options: [
+            { code: 'a', label: 'A' },
+            { code: 'b', label: 'B' },
+          ],
+        },
+      },
+    ]);
+
+    const res = await dienIn(token, [
+      { questionKey: 'q1', answerCode: 'z' },
+    ]).expect(422);
+
+    expect(redenen(res)).toContain('q1:unknown_option');
+  });
+
+  it('weigert een rating buiten bereik en een niet-geheel getal (testpunt 34)', async () => {
+    const { token } = await maakRonde([
+      { key: 'q1', type: 'rating', config: { min: 1, max: 5 } },
+    ]);
+
+    const buiten = await dienIn(token, [
+      { questionKey: 'q1', answerNumber: 9 },
+    ]).expect(422);
+    expect(redenen(buiten)).toContain('q1:out_of_range');
+
+    const gebroken = await dienIn(token, [
+      { questionKey: 'q1', answerNumber: 3.5 },
+    ]).expect(422);
+    expect(redenen(gebroken)).toContain('q1:not_an_integer');
+
+    // En de tegenproef: binnen bereik werkt wél.
+    await dienIn(token, [{ questionKey: 'q1', answerNumber: 4 }]).expect(200);
+  });
+
+  it('weigert multi_choice met duplicaten of buiten min/max (testpunt 35)', async () => {
+    const { token } = await maakRonde([
+      {
+        key: 'q1',
+        type: 'multi_choice',
+        config: {
+          options: [
+            { code: 'a', label: 'A' },
+            { code: 'b', label: 'B' },
+            { code: 'c', label: 'C' },
+          ],
+          min_select: 2,
+          max_select: 3,
+        },
+      },
+    ]);
+
+    const dubbel = await dienIn(token, [
+      { questionKey: 'q1', answerCodes: ['a', 'a'] },
+    ]).expect(422);
+    expect(redenen(dubbel)).toContain('q1:duplicate_options');
+
+    const teWeinig = await dienIn(token, [
+      { questionKey: 'q1', answerCodes: ['a'] },
+    ]).expect(422);
+    expect(redenen(teWeinig)).toContain('q1:too_few_options');
+
+    await dienIn(token, [
+      { questionKey: 'q1', answerCodes: ['a', 'b'] },
+    ]).expect(200);
+  });
+
+  it('weigert een answerType dat afwijkt van de vraag (testpunt 36)', async () => {
+    // De samengestelde foreign key vangt dit ook af, maar dan als databasefout
+    // in plaats van een leesbare 422.
+    const { token } = await maakRonde([{ key: 'q1', type: 'yes_no' }]);
+
+    const res = await dienIn(token, [
+      { questionKey: 'q1', answerType: 'rating', answerNumber: 3 },
+    ]).expect(422);
+
+    expect(redenen(res)).toContain('q1:answer_type_mismatch');
+  });
+
+  it('weigert een number met te veel decimalen en een pct buiten 0–100', async () => {
+    const { token } = await maakRonde([
+      {
+        key: 'q1',
+        type: 'number',
+        config: { format: 'pct', decimals: 1, min: 0, max: 100 },
+      },
+    ]);
+
+    const tePrecies = await dienIn(token, [
+      { questionKey: 'q1', answerNumber: 12.345 },
+    ]).expect(422);
+    expect(redenen(tePrecies)).toContain('q1:too_many_decimals');
+
+    const buiten = await dienIn(token, [
+      { questionKey: 'q1', answerNumber: 150 },
+    ]).expect(422);
+    expect(redenen(buiten)).toContain('q1:out_of_range');
+
+    await dienIn(token, [{ questionKey: 'q1', answerNumber: 99.5 }]).expect(
+      200,
+    );
+  });
+
+  // ── Onbekende en dubbele vragen (testpunt 26) ─────────────────────────────
+
+  it('weigert een question_key die niet bij deze ronde hoort (testpunt 26)', async () => {
+    // RLS beschermt tegen een andere tenant, dit tegen een andere template
+    // binnen dezelfde tenant.
+    const { token } = await maakRonde([{ key: 'q1', type: 'yes_no' }]);
+
+    const res = await dienIn(token, [
+      { questionKey: 'q1', answerCode: 'yes' },
+      { questionKey: 'van-een-andere-lijst', answerCode: 'yes' },
+    ]).expect(422);
+
+    expect(redenen(res)).toContain('van-een-andere-lijst:unknown_question');
+  });
+
+  it('weigert twee antwoorden op dezelfde vraag', async () => {
+    const { token } = await maakRonde([{ key: 'q1', type: 'yes_no' }]);
+
+    const res = await dienIn(token, [
+      { questionKey: 'q1', answerCode: 'yes' },
+      { questionKey: 'q1', answerCode: 'no' },
+    ]).expect(422);
+
+    expect(redenen(res)).toContain('q1:duplicate_answer');
+  });
+
+  it('meldt álle fouten tegelijk in plaats van alleen de eerste', async () => {
+    // Wie acht vragen invult wil niet acht keer opnieuw proberen.
+    const { token } = await maakRonde([
+      { key: 'q1', type: 'confirmation' },
+      { key: 'q2', type: 'rating', config: { min: 1, max: 5 } },
+      { key: 'q3', type: 'yes_no' },
+    ]);
+
+    const res = await dienIn(token, [
+      { questionKey: 'q1', answerCode: 'not_confirmed' },
+      { questionKey: 'q2', answerNumber: 99 },
+    ]).expect(422);
+
+    expect(redenen(res).sort()).toEqual([
+      'q1:comment_required',
+      'q2:out_of_range',
+      'q3:answer_required',
+    ]);
+  });
+
+  // ── Wegschrijven en afsluiten (testpunt 23, 25) ───────────────────────────
+
+  it('schrijft niets weg bij een afgekeurde indiening (testpunt 25)', async () => {
+    // Een mislukte validatie mag geen halve antwoordset achterlaten.
+    const { token, responseId } = await maakRonde([
+      { key: 'q1', type: 'yes_no' },
+      { key: 'q2', type: 'confirmation' },
+    ]);
+
+    await dienIn(token, [
+      { questionKey: 'q1', answerCode: 'yes' },
+      { questionKey: 'q2', answerCode: 'not_confirmed' },
+    ]).expect(422);
+
+    const aantal = await db.withTenant(TENANT, (tx) =>
+      tx.execute<{ n: string }>(
+        sql`SELECT count(*)::text AS n FROM clm.survey_answer
+             WHERE response_id = ${responseId}`,
+      ),
+    );
+
+    expect(aantal.rows[0].n).toBe('0');
+  });
+
+  it('schrijft elk antwoord in de juiste kolom weg', async () => {
+    const { token, responseId } = await maakRonde([
+      { key: 'bevestig', type: 'confirmation' },
+      { key: 'tekst', type: 'open_text' },
+      { key: 'cijfer', type: 'rating', config: { min: 1, max: 5 } },
+      {
+        key: 'meerkeuze',
+        type: 'multi_choice',
+        config: {
+          options: [
+            { code: 'a', label: 'A' },
+            { code: 'b', label: 'B' },
+          ],
+        },
+      },
+    ]);
+
+    await dienIn(token, [
+      { questionKey: 'bevestig', answerCode: 'confirmed' },
+      { questionKey: 'tekst', answerText: 'Een toelichting van enige lengte.' },
+      { questionKey: 'cijfer', answerNumber: 4 },
+      { questionKey: 'meerkeuze', answerCodes: ['a', 'b'] },
+    ]).expect(200);
+
+    const rijen = await db.withTenant(TENANT, (tx) =>
+      tx.execute<{
+        question_key: string;
+        answer_code: string | null;
+        answer_codes: string[] | null;
+        answer_text: string | null;
+        answer_number: string | null;
+      }>(
+        sql`SELECT q.question_key, a.answer_code, a.answer_codes,
+                   a.answer_text, a.answer_number
+              FROM clm.survey_answer a
+              JOIN clm.survey_question q ON q.question_id = a.question_id
+             WHERE a.response_id = ${responseId}
+             ORDER BY q.position`,
+      ),
+    );
+
+    expect(rijen.rows).toHaveLength(4);
+    expect(rijen.rows[0].answer_code).toBe('confirmed');
+    expect(rijen.rows[1].answer_text).toBe('Een toelichting van enige lengte.');
+    expect(Number(rijen.rows[2].answer_number)).toBe(4);
+    expect(rijen.rows[3].answer_codes).toEqual(['a', 'b']);
+
+    // De vormconstraint: elk type vult precies één kolom en laat de rest leeg.
+    expect(rijen.rows[0].answer_text).toBeNull();
+    expect(rijen.rows[2].answer_code).toBeNull();
+  });
+
+  it('weigert een tweede indiening met 410 en laat de eerste ongemoeid', async () => {
+    const { token, responseId } = await maakRonde([
+      { key: 'q1', type: 'yes_no' },
+    ]);
+
+    await dienIn(token, [{ questionKey: 'q1', answerCode: 'yes' }]).expect(200);
+    await dienIn(token, [{ questionKey: 'q1', answerCode: 'no' }]).expect(410);
+
+    const rij = await db.withTenant(TENANT, (tx) =>
+      tx.execute<{ answer_code: string }>(
+        sql`SELECT answer_code FROM clm.survey_answer
+             WHERE response_id = ${responseId}`,
+      ),
+    );
+
+    // De tweede poging mag het eerste antwoord niet overschrijven.
+    expect(rij.rows[0].answer_code).toBe('yes');
+  });
+
+  it('blokkeert schrijven na indienen op de RLS-policy zelf (testpunt 23)', async () => {
+    // Niet de applicatie maar de database weigert dit. Getoetst met directe
+    // SQL die de servicelaag overslaat — anders test je je eigen code en niet
+    // de garantie.
+    const { token, responseId } = await maakRonde([
+      { key: 'q1', type: 'yes_no' },
+    ]);
+
+    await dienIn(token, [{ questionKey: 'q1', answerCode: 'yes' }]).expect(200);
+
+    const questionId = await db.withTenant(TENANT, async (tx) => {
+      const r = await tx.execute<{ question_id: string }>(
+        sql`SELECT a.question_id FROM clm.survey_answer a
+             WHERE a.response_id = ${responseId}`,
+      );
+      return r.rows[0].question_id;
+    });
+
+    const geweigerd = await db
+      .withTenant(TENANT, async (tx) => {
+        await tx.execute(
+          sql`INSERT INTO clm.survey_answer
+                  (tenant_id, response_id, question_id, answer_type, answer_code)
+              VALUES (${TENANT}, ${responseId}, ${questionId}, 'yes_no', 'no')`,
+        );
+        return null;
+      })
+      .catch((fout: Error) => fout);
+
+    expect(geweigerd).toBeInstanceOf(Error);
+    const oorzaak = (geweigerd as Error & { cause?: Error }).cause;
+    expect(oorzaak?.message).toMatch(/row-level security/i);
+  });
+
+  it('legt het aantal antwoorden vast in de audit trail', async () => {
+    const { token, responseId } = await maakRonde([
+      { key: 'q1', type: 'yes_no' },
+      { key: 'q2', type: 'yes_no' },
+    ]);
+
+    await dienIn(token, [
+      { questionKey: 'q1', answerCode: 'yes' },
+      { questionKey: 'q2', answerCode: 'no' },
+    ]).expect(200);
+
+    const regels = await db.withTenant(TENANT, (tx) =>
+      tx.execute<{ new_values: { aantalAntwoorden?: number } }>(
+        sql`SELECT new_values FROM audit.audit_event
+             WHERE entity_id = ${responseId}
+               AND action_type = 'survey_response_ingediend'`,
+      ),
+    );
+
+    expect(regels.rows).toHaveLength(1);
+    expect(regels.rows[0].new_values.aantalAntwoorden).toBe(2);
+  });
+
+  it('weigert een body zonder answers-lijst', async () => {
+    const { token } = await maakRonde([{ key: 'q1', type: 'yes_no' }]);
+
+    const res = await request(server)
+      .post(`/survey/respond?t=${token}`)
+      .send({ answers: 'geen lijst' })
+      .expect(422);
+
+    expect(redenen(res)).toContain('(body):answers_must_be_a_list');
+  });
+});

--- a/test/survey-routes.e2e-spec.ts
+++ b/test/survey-routes.e2e-spec.ts
@@ -59,6 +59,18 @@ describe('Leverancierroutes (e2e)', () => {
         sql`INSERT INTO clm.survey_template (tenant_id, name) VALUES (${TENANT}, ${`t-${opties.naam}`})
             RETURNING template_id`,
       );
+      // Sinds stap 6 valideert POST /survey/respond de antwoorden tegen de
+      // vragen van de ronde. Een template zonder vragen levert daardoor niets
+      // op om in te dienen; deze suite gaat over toegang en éénmaligheid, dus
+      // één minimale vraag volstaat. De inhoudelijke validatieregels worden
+      // getoetst in antwoord-indienen.e2e-spec.ts.
+      await tx.execute(
+        sql`INSERT INTO clm.survey_question
+                (tenant_id, template_id, position, question_key, title, body,
+                 answer_type, is_required)
+            VALUES (${TENANT}, ${template.rows[0].template_id}, 1, 'q1',
+                    'Bevestiging', 'Bevestigt u dit?', 'yes_no', true)`,
+      );
       // Sinds migratie 0005 heeft survey_run een expliciete lifecycle met
       // 'draft' als default (ontwerp §2b). Standaard 'active': dat is de
       // toestand waarin een leverancier de link daadwerkelijk gebruikt.
@@ -101,8 +113,13 @@ describe('Leverancierroutes (e2e)', () => {
       // daar alleen INSERT en SELECT (MCM2-CLAUDE.md §7.7, migratie 0001).
       // Append-only is het punt — een test die dat omzeilt zou de garantie
       // ondermijnen die hij hoort te bewaken.
+      // Volgorde is niet vrij: alle survey-tabellen hebben ON DELETE RESTRICT,
+      // want een ingediende response is bewijsmateriaal en mag nooit
+      // stilzwijgend meeverdwijnen. Antwoorden en vragen dus vóór de template.
+      await tx.execute(sql`DELETE FROM clm.survey_answer`);
       await tx.execute(sql`DELETE FROM clm.survey_response`);
       await tx.execute(sql`DELETE FROM clm.survey_run`);
+      await tx.execute(sql`DELETE FROM clm.survey_question`);
       await tx.execute(sql`DELETE FROM clm.survey_template`);
       await tx.execute(sql`DELETE FROM clm.vendor`);
       await tx.execute(sql`DELETE FROM clm.tenant`);
@@ -191,6 +208,7 @@ describe('Leverancierroutes (e2e)', () => {
 
     const eerste = await request(server)
       .post(`/survey/respond?t=${token}`)
+      .send({ answers: [{ questionKey: 'q1', answerCode: 'yes' }] })
       .expect(200);
     expect(body(eerste).status).toBe('ingediend');
 
@@ -207,7 +225,10 @@ describe('Leverancierroutes (e2e)', () => {
   it('legt het indienen vast in de audit trail, zonder het ruwe token', async () => {
     const token = await maakLink({ naam: 'audit' });
 
-    await request(server).post(`/survey/respond?t=${token}`).expect(200);
+    await request(server)
+      .post(`/survey/respond?t=${token}`)
+      .send({ answers: [{ questionKey: 'q1', answerCode: 'yes' }] })
+      .expect(200);
 
     const regels = await db.withTenant(TENANT, async (tx) => {
       const r = await tx.execute<{ action_type: string; new_values: unknown }>(


### PR DESCRIPTION
De kern van de tool. `POST /survey/respond` accepteerde een lege body en zette alleen de status; nu komen de antwoorden mee, wordt de volledige regelset uit ontwerp §5 toegepast en worden ze weggeschreven.

## Wat erin zit

**`antwoord-validatie.ts`** — de regelset, zonder database en zonder NestJS. Dit is de laag waar de beslissing valt, en die moet los te toetsen zijn van een draaiende applicatie. Dekt stap 2 t/m 10: volledigheid, onbekende vragen, type-overeenkomst, waardevalidatie per type, toelichtingsplicht en de uploadregels.

**`antwoord-indienen.service.ts`** — valideren, schrijven, afsluiten, auditeren. Alles in één transactie.

Drie uitkomsten:

| | |
|---|---|
| **200** | ingediend |
| **422** | per vraag de reden, met `question_key` (leesbaar, lekt geen intern ID) |
| **410** | tweede poging, verlopen of ronde gesloten |

**De volgorde is de garantie.** Eerst álles valideren, dan pas `submitted`. Faalt de validatie, dan is er niets weggeschreven en blijft de link bruikbaar (testpunt 25). Dat is essentieel: het token is gehasht en niet opnieuw te versturen, dus een half verbruikte link zou onherstelbaar zijn.

**De drie regels die een CHECK niet kan afdwingen zitten hier**, precies zoals §3a voorspelde: geldige optiecode, rating binnen bereik, `multi_choice`-aantallen. Een CHECK kan de vraagrij niet raadplegen.

## Bestaande tests aangepast — bewust

`survey-routes.e2e-spec.ts` gebruikte een template **zónder vragen**. Die geeft nu 410 in plaats van 200, en dat is een keuze: een lege vragenlijst hoort niets af te sluiten. De suite krijgt daarom één minimale vraag — hij gaat over toegang en éénmaligheid, niet over validatie.

Dit is precies het werk dat het ontwerp had gemarkeerd als "vergeten als het niet ergens staat".

De teardown daar moest mee: alle survey-tabellen hebben `ON DELETE RESTRICT`, dus antwoorden en vragen moeten vóór de template weg.

## Bewijs

- **137 van 137 e2e-tests groen** in 11 suites, tegen een verse Postgres 17.6 met de keten 0000 t/m 0008
- Twee opeenvolgende runs tegen dezelfde database, beide groen
- Docker-productiebuild bouwt, start en `/health` geeft HTTP 200
- format, lint en typecheck schoon

**Tegenproef:** met drie regels uitgeschakeld — optiecode-controle, rating-bereik en toelichtingsplicht — vielen 6 van de 25 nieuwe tests om, precies de testpunten die ze horen te bewaken.

**Getoetste testpunten:** 14, 15, 16, 17, 18, 23, 25, 26, 32, 33, 34, 35, 36. Testpunt 23 (schrijven na indienen faalt op de RLS-policy) is getoetst met directe SQL die de servicelaag overslaat — anders test je je eigen validatiecode en niet de garantie.

## Eén bug die het draaien blootlegde

Drizzle geeft een JS-array door als `record`, waar Postgres `text[]` verwacht: *"column answer_codes is of type text[] but expression is of type record"*. Opgelost met `ARRAY(SELECT jsonb_array_elements_text(…))`. Zelf een array-literal opbouwen zou quoting vereisen van komma's en aanhalingstekens die in een optiecode kunnen voorkomen — precies het soort handwerk waar een injectiefout in sluipt.

## Wat hierna nog nodig is

**Stap 8 (bestandsupload) is de laatste die echt iets toevoegt aan de leverancierskant.** De validatie eist een bestand bij `confirmed` op een uploadvraag, en de acht Transdev-vragen hebben er één (q1). Zonder upload is die vraag dus niet bevestigend te beantwoorden. `cannot_upload` met toelichting werkt wél al — dat is de optie die bestaat omdat een upload kan mislukken om redenen die niets met compliance te maken hebben.

🤖 Generated with [Claude Code](https://claude.com/claude-code)