### PR TITLE
feat(vragenlijst): bestandsupload met inhoudscontrole (stap 8, Issue #9)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,8 @@ pids
 
 # Diagnostic reports
 report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json
+
+# Geuploade bijlagen (vragenlijst-ontwerp §6). Staan bewust buiten de repo:
+# het zijn compliance-bewijsstukken van leveranciers. Let op — deze map valt
+# ook buiten `npm run backup:dump`, zie Issue #30.
+/var/uploads/

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,7 +1,7 @@
 # MCM2 — actuele status
 
 ## Laatst bijgewerkt
-2026-07-29, tweede sessie (vragenlijst-tool t/m **stap 6**: import/export, beide seeds, `GET /survey/respond/questions` én de volledige indienlogica; `contract_id` op `survey_run`; **guardbug gevonden waardoor UC2 in het geheel niet werkte**; 137 e2e-tests groen — alles hieronder is geverifieerd, niet uit gespreksgeheugen)
+2026-07-29, tweede sessie (vragenlijst-tool t/m **stap 8**: import/export, beide seeds, vragen ophalen, indienlogica én bestandsupload; `contract_id` op `survey_run`; **guardbug gevonden waardoor UC2 in het geheel niet werkte**; 155 e2e-tests groen — alles hieronder is geverifieerd, niet uit gespreksgeheugen)
 
 ## Het project bestaat uit twee repositories
 
@@ -32,7 +32,7 @@ docker run -d --name mcm2test -e POSTGRES_PASSWORD=pw -p 55440:5432 postgres:17.
 docker exec -i mcm2test psql -U postgres -q < db/roles/bootstrap-roles.sql
 docker exec mcm2test psql -U postgres -c "ALTER ROLE clm_migrator WITH PASSWORD 'pw'; ALTER ROLE clm_api_runtime WITH PASSWORD 'pw';"
 MIGRATION_DATABASE_URL="postgresql://clm_migrator:pw@localhost:55440/postgres" npm run migrate:deploy
-DATABASE_URL="postgresql://clm_api_runtime:pw@localhost:55440/postgres" npm run test:e2e   # 137 tests
+DATABASE_URL="postgresql://clm_api_runtime:pw@localhost:55440/postgres" npm run test:e2e   # 155 tests
 
 # De twee vragenlijsten inlezen (tenant moet bestaan)
 DATABASE_URL="postgresql://clm_api_runtime:pw@localhost:55440/postgres" \
@@ -174,6 +174,22 @@ Transdev Vendor IT Compliance Survey als eerste verticale MVP-slice.
   Ook nieuw vastgelegd: de vragenlijst is **alleen Engels**. Geen vertaallaag.
 
 ## Aantoonbaar werkend
+
+- **Bestandsupload met inhoudscontrole (2026-07-29, stap 8, Issue #9).** `src/survey/bestand-validatie.ts`, `bestand-opslag.service.ts` en `bijlage.service.ts`, plus `POST /survey/respond/attachment`. **155 van 155 e2e-tests groen** in twaalf suites.
+
+  Hiermee is de leverancierskant compleet: de validatie uit stap 6 eist een bestand bij `confirmed` op een uploadvraag, en de acht Transdev-vragen hebben er één. Zonder deze route was q1 niet bevestigend te beantwoorden.
+
+  **De inhoud telt, niet de naam.** Extensie en de meegestuurde `Content-Type` komen allebei van de client; de server stelt het type vast uit de eerste bytes (`%PDF-`, de acht PNG-bytes) en slaat díé waarde op. Een `.pdf` met PNG-inhoud wordt geweigerd in plaats van stilzwijgend als PNG opgeslagen — anders verbergt het systeem dat de leverancier iets anders aanleverde dan hij dacht (testpunt 20).
+
+  **De groottegrens ligt in de ontvangstlaag**, niet erna (testpunt 21). `storage_key` is servergegenereerd en bevat geen enkel teken uit de invoer, dus `../../etc/passwd.pdf` kan geen pad worden (testpunt 22).
+
+  **Eerst naar schijf, dan de databaserij.** Andersom zou een rij zonder bestand kunnen bestaan — een dode verwijzing die pas bij downloaden opvalt. De faalvorm is nu een bestand zonder rij, en dat wordt opgeruimd in een `finally`.
+
+  **Eerlijk over wat níét bewezen is:** de `FOR UPDATE`-vergrendeling zou twee gelijktijdige uploads serialiseren. Met die vergrendeling verwijderd bleven **alle tests groen** — gemeten, niet aangenomen. Twee transacties via dezelfde pg-`Pool` komen in de praktijk achter elkaar aan de beurt, dus de race was niet uit te lokken zonder een wachtpunt in productiecode te bouwen. `FOR UPDATE` blijft staan als bescherming voor het geval de transacties wél overlappen; de tests claimen nu alleen wat ze aantonen (het maximum houdt stand), en het commentaar zegt dat expliciet.
+
+  **`multer` is directe dependency geworden** (exact gepind, 2.2.0). Zat er al transitief via `@nestjs/platform-express`; zelfde patroon als `pg` bij Issue #2.
+
+  **Raakt Issue #30:** de database gaat mee in `npm run backup:dump`, bestanden op schijf niet. De certificaten zijn daarmee het enige onderdeel zonder backup — en juist het onderdeel met bewijsmateriaal.
 
 - **Validatie- en indienlogica (2026-07-29, stap 6).** `src/survey/antwoord-validatie.ts` (de regelset, zonder database en zonder NestJS) plus `src/survey/antwoord-indienen.service.ts` (valideren, schrijven, afsluiten, auditeren — alles in één transactie). **137 van 137 e2e-tests groen** in elf suites.
 
@@ -322,6 +338,8 @@ Praktische valkuilen die daadwerkelijk zijn tegengekomen, niet bedacht. Ze staan
 
 **Een tegenproef kan zélf onvoldoende zijn — controleer of de testopzet het lek kán zien.** Bij stap 5 is het lek uit ontwerp §1c daadwerkelijk ingebouwd (filteren op `subject_vendor_id` in plaats van `response_id`) en **bleef alles groen**. Oorzaak: elke leverancier in de test had een eigen vendor, dus de verkeerde filter selecteerde toevallig dezelfde rij. Pas met **twee responses over dezelfde leverancier** — het echte UC1/UC2-scenario — viel testpunt 39 om. Een tegenproef die niet faalt betekent dus niet automatisch dat de code goed is; het kan ook zijn dat de opzet het probleem niet kan aantonen.
 
+**Een race is niet uit te lokken met twee gewone requests of twee service-aanroepen.** Bij stap 8 zijn drie testopzetten geprobeerd om te bewijzen dat een `FOR UPDATE` nodig was: supertest via `Promise.all`, de service rechtstreeks, en een handmatig vastgehouden transactie. **Alle drie bleven groen mét de vergrendeling verwijderd.** Twee transacties via dezelfde pg-`Pool` komen achter elkaar aan de beurt zodra de eerste zijn connectie teruggeeft. Wie een vergrendeling echt wil toetsen heeft twee losse verbindingen én een wachtpunt binnen de transactie nodig — en dat kost een haak in productiecode. De les: **stel de claim bij naar wat de test aantoont**, in plaats van de test te laten suggereren dat een mechanisme bewezen is.
+
 **Drizzle geeft een JS-array door als `record`, niet als `text[]`.** Een `INSERT` in een array-kolom faalt met "column X is of type text[] but expression is of type record". Werkende vorm: `ARRAY(SELECT jsonb_array_elements_text(${JSON.stringify(waarden)}::jsonb))`. Zelf een array-literal opbouwen kan ook, maar vraagt quoting van komma's, aanhalingstekens en accolades die in de waarden kunnen voorkomen — precies waar een injectiefout in sluipt.
 
 **Een nullable kolom maken raakt méér dan de tabel.** Migratie 0005 maakte `survey_response.vendor_id` nullable voor UC2, maar `resolve_survey_token()` joinde daar nog op — waardoor elke interne beoordeling 410 gaf. Bij het versoepelen van een kolom hoort een zoektocht naar elke plek die hem gebruikt: functies, views, policies. `grep -rn "vendor_id" drizzle/` had dit gevonden.
@@ -340,12 +358,14 @@ Praktische valkuilen die daadwerkelijk zijn tegengekomen, niet bedacht. Ze staan
 
 | Repo | Branch | Werkboom | Openstaande PR's |
 |---|---|---|---|
-| MCM2 | **`feat/antwoorden-indienen`** | schoon | nog niet gepusht |
+| MCM2 | **`feat/bijlage-upload`** | schoon | nog niet gepusht |
 | MCM2-frontend | `main` | schoon | geen |
 
 **Drie PR'''s gemerged naar `main`:** #37 (stap 3 en 4, `ef62cd6`), #38 (migratie 0007 plus de drie bevestigde ontwerpbesluiten, `4b09026`) en #39 (stap 5 plus de UC2-guardfix, `52f41b0`). Alle drie met CI groen op alle drie de jobs, alle branches lokaal én op GitHub verwijderd. Na elke merge opnieuw geverifieerd tégen `main` zelf.
 
-**`feat/antwoorden-indienen` staat open met één commit:** stap 6 (validatie- en indienlogica) plus deze statusbijwerking. Nog niet gepusht. Lokale poorten wél gedraaid: format, lint, typecheck, 137/137 e2e tegen een verse Postgres 17.6 (twee keer), en de Docker-productiebuild die start en `/health` met 200 beantwoordt.
+**Vier PR's gemerged naar `main`:** #37, #38, #39 en #40 (stap 6, `7756b25`). Alle vier met CI groen op alle drie de jobs, alle branches lokaal én op GitHub verwijderd.
+
+**`feat/bijlage-upload` staat open met één commit:** stap 8 plus deze statusbijwerking. Nog niet gepusht. Lokale poorten wél gedraaid: format, lint, typecheck, 155/155 e2e tegen een verse Postgres 17.6 (twee keer), en de Docker-productiebuild die start, de uploadroute mapt en `/health` met 200 beantwoordt.
 
 - **`docs/sessiestand-otap` is op 2026-07-29 via PR #35 gemerged naar `main`** (merge-commit `cbe6c48`) en daarna lokaal én op GitHub verwijderd. Eén commit: uitsluitend deze statusbijwerking.
 - **`feat/issue-7-leveranciertoken` is op 2026-07-29 via PR #32 gemerged naar `main`** (merge-commit `7f0cc01`) en daarna lokaal én op GitHub verwijderd. CI groen op alle drie de jobs vóór de merge, opnieuw geverifieerd met `gh pr checks 32` op de laatste commit. Vijf commits: de tokenlaag, de HTTP-routes met logmaskering en auditregels, de fix op `maskeerDiep`, plus twee documentatiecommits. **Issue #31 is bij die merge gesloten** — migratie `0004` loste hem op. Let op: die migratie is bewezen in CI, **niet toegepast op `clm-enterprise`** — net als #29 en #25 wacht dat op #30.
@@ -369,7 +389,9 @@ Praktische valkuilen die daadwerkelijk zijn tegengekomen, niet bedacht. Ze staan
 
 De databaselaag is omgezet (ADR-010), spoor 2 van Issue #7 zit in `main`, en de vragenlijst-tool staat t/m stap 4: het datamodel, de guard, import/export en beide gevulde vragenlijsten.
 
-**De eerstvolgende inhoudelijke stap is stap 8: bestandsupload met inhoudscontrole** (ontwerp §6, Issue #9). Stap 7 (concept opslaan) is bruikbaar maar niet blokkerend; stap 8 wél — de acht Transdev-vragen hebben een uploadvraag, en zonder upload is die niet bevestigend te beantwoorden. Dat raakt de productiedatabase niet; de hele e2e-keten draait tegen wegwerpcontainers, dus #30 blokkeert dit spoor niet.
+**De leverancierskant is functioneel compleet.** Een leverancier kan de link openen, de vragen zien, bestanden uploaden en indienen — met alle validatie en garanties eromheen.
+
+**De eerstvolgende stap is geen code maar een OTAP-doorloop:** het portaal met `NEXT_PUBLIC_API_URL` tegen de echte backend zetten. Dat is de eerste keer dat de klant de volledige keten in de browser ziet in plaats van mock data, en het is nu voor het eerst mogelijk. Daarna is stap 7 (concept opslaan) de volgende inhoudelijke uitbreiding, en stap 10 (beheerroutes) wacht op spoor 1.
 
 **Daarnaast, en dat kost geen code:** het portaal tegen de echte backend zetten via een OTAP-doorloop. De vragen staan in de database en de route bestaat, dus dit is de eerste keer dat de klant de echte vragenlijst in de browser kan zien in plaats van mock data.
 
@@ -381,11 +403,12 @@ De databaselaag is omgezet (ADR-010), spoor 2 van Issue #7 zit in `main`, en de 
 ~~5. `GET /survey/respond/questions`~~ — **afgerond 2026-07-29**, zie "Aantoonbaar werkend". Legde en passant de UC2-guardbug bloot.
 
 ~~6. Validatie- en indienlogica~~ — **afgerond 2026-07-29**, zie "Aantoonbaar werkend".
+~~8. Bestandsupload met inhoudscontrole~~ — **afgerond 2026-07-29**, idem.
 
-**Nu aan de beurt — stap 7 t/m 9 uit ontwerp §10:**
-7. `PUT /survey/respond/answers` — concept opslaan, expliciet (geen auto-save).
-8. Bestandsupload met inhoudscontrole (ontwerp §6, Issue #9).
-9. Tests 14 t/m 48.
+**Nu aan de beurt:**
+7. `PUT /survey/respond/answers` — concept opslaan, expliciet (geen auto-save). Bruikbaar bij acht vragen met verplichte toelichtingen, maar blokkeert niets.
+9. De resterende testpunten uit ontwerp §8.
+10. Beheerroutes — wacht op spoor 1 (Entra-guard).
 
 **De 404 die de OTAP-doorloop signaleerde is weg:** `/survey/respond/questions` bestaat en levert de vragenlijst uit de database. **Nog niet in de browser bekeken** — het portaal draait nog op mock data tot iemand het met `NEXT_PUBLIC_API_URL` tegen de backend zet. Dat is de eerstvolgende zichtbare stap en kost geen code, alleen een OTAP-doorloop.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "class-transformer": "^0.5.1",
         "class-validator": "^0.15.1",
         "drizzle-orm": "0.45.2",
+        "multer": "2.2.0",
         "pg": "8.22.0",
         "reflect-metadata": "^0.2.2",
         "rxjs": "^7.8.1"
@@ -27,6 +28,7 @@
         "@nestjs/testing": "^11.0.1",
         "@types/express": "^5.0.0",
         "@types/jest": "^30.0.0",
+        "@types/multer": "2.0.0",
         "@types/node": "^24.0.0",
         "@types/pg": "8.20.0",
         "@types/supertest": "^7.0.0",
@@ -3704,6 +3706,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/multer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/multer/-/multer-2.0.0.tgz",
+      "integrity": "sha512-C3Z9v9Evij2yST3RSBktxP9STm6OdMc5uR1xF1SGr98uv8dUlAL2hqwrZ3GVB3uyMyiegnscEK6PGtYvNrjTjw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/express": "*"
+      }
+    },
     "node_modules/@types/node": {
       "version": "24.13.3",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
@@ -5642,7 +5654,7 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -5769,7 +5781,7 @@
       "version": "17.4.2",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
       "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
-      "devOptional": true,
+      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
@@ -6470,7 +6482,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-diff": {
@@ -6504,7 +6516,7 @@
       "version": "3.1.4",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
       "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
-      "devOptional": true,
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -6639,7 +6651,7 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
       "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "cross-spawn": "^7.0.6",
@@ -7008,7 +7020,7 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/handlebars": {
@@ -7346,7 +7358,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/istanbul-lib-coverage": {
@@ -8394,7 +8406,7 @@
       "version": "4.18.1",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
       "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.memoize": {
@@ -9189,7 +9201,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -9695,7 +9707,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -9903,7 +9915,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -9916,7 +9928,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -9998,7 +10010,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
       "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=14"
@@ -11379,7 +11391,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -11810,7 +11822,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "class-transformer": "^0.5.1",
     "class-validator": "^0.15.1",
     "drizzle-orm": "0.45.2",
+    "multer": "2.2.0",
     "pg": "8.22.0",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1"
@@ -46,6 +47,7 @@
     "@nestjs/testing": "^11.0.1",
     "@types/express": "^5.0.0",
     "@types/jest": "^30.0.0",
+    "@types/multer": "2.0.0",
     "@types/node": "^24.0.0",
     "@types/pg": "8.20.0",
     "@types/supertest": "^7.0.0",

--- a/src/survey/bestand-opslag.service.ts
+++ b/src/survey/bestand-opslag.service.ts
@@ -1,0 +1,81 @@
+import { mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { dirname, join, resolve, sep } from 'node:path';
+
+import { Injectable, Logger } from '@nestjs/common';
+
+/**
+ * Bewaart geüploade bestanden op schijf (vragenlijst-ontwerp §6).
+ *
+ * Fase 1 van het ontwerp: onder een pad dat niet publiek bereikbaar is, met
+ * `storage_key` als relatief pad. Er is geen URL die een bestand rechtstreeks
+ * serveert — downloaden loopt altijd via een route die de tokencontrole of de
+ * beheerdersauthenticatie passeert.
+ *
+ * Objectopslag (S3, Supabase Storage) is de logische volgende stap, maar voegt
+ * in de pilot een externe afhankelijkheid toe zonder een probleem op te lossen
+ * dat we nu hebben. `storage_key` is zo gekozen dat die verhuizing geen
+ * schemawijziging vereist: alleen deze service wordt dan vervangen.
+ *
+ * **Let op — dit raakt Issue #30.** De database gaat mee in
+ * `npm run backup:dump`; bestanden op schijf niet. Zonder aanvulling zijn de
+ * certificaten het enige onderdeel zonder backup, en juist het onderdeel dat
+ * bewijsmateriaal bevat.
+ */
+@Injectable()
+export class BestandOpslagService {
+  private readonly logger = new Logger(BestandOpslagService.name);
+  private readonly hoofdmap: string;
+
+  constructor() {
+    // Default binnen de projectmap, zodat een ontwikkelaar niets hoeft in te
+    // stellen. In een container hoort dit een volume te zijn — anders zijn de
+    // bestanden weg zodra het image vervangen wordt.
+    this.hoofdmap = resolve(process.env.UPLOAD_DIR ?? './var/uploads');
+  }
+
+  /**
+   * Schrijft een bestand weg onder de opgegeven sleutel.
+   *
+   * De sleutel komt uit `maakOpslagsleutel()` en bevat geen enkel teken uit de
+   * invoer. Toch wordt hier nóg een keer gecontroleerd dat het uiteindelijke
+   * pad binnen de hoofdmap valt: dit is de laatste plek waar een padfout tot
+   * schrijven buiten de map zou leiden, en zo'n controle hoort te staan waar de
+   * schade zou ontstaan — niet alleen waar de waarde gemaakt wordt.
+   */
+  async bewaar(storageKey: string, inhoud: Buffer): Promise<void> {
+    const pad = this.volledigPad(storageKey);
+
+    await mkdir(dirname(pad), { recursive: true });
+    await writeFile(pad, inhoud, { flag: 'wx' });
+
+    this.logger.log(`Bestand opgeslagen (${inhoud.length} bytes).`);
+  }
+
+  async lees(storageKey: string): Promise<Buffer> {
+    return readFile(this.volledigPad(storageKey));
+  }
+
+  /**
+   * Verwijdert een bestand.
+   *
+   * Stil bij een ontbrekend bestand: deze methode wordt aangeroepen om op te
+   * ruimen nadat een databaseschrijfactie is teruggedraaid, en dan is "het
+   * bestand staat er niet" precies de gewenste eindtoestand.
+   */
+  async verwijder(storageKey: string): Promise<void> {
+    await rm(this.volledigPad(storageKey), { force: true });
+  }
+
+  private volledigPad(storageKey: string): string {
+    const pad = resolve(join(this.hoofdmap, storageKey));
+
+    // Padtraversal-controle. `storageKey` is servergegenereerd, dus dit hoort
+    // nooit af te gaan — maar het is één regel, en het verschil tussen "hoort
+    // niet" en "kan niet" is precies waar dit soort fouten in zit.
+    if (pad !== this.hoofdmap && !pad.startsWith(this.hoofdmap + sep)) {
+      throw new Error(`Ongeldige opslagsleutel: '${storageKey}'`);
+    }
+
+    return pad;
+  }
+}

--- a/src/survey/bestand-validatie.ts
+++ b/src/survey/bestand-validatie.ts
@@ -1,0 +1,153 @@
+import { createHash, randomUUID } from 'node:crypto';
+
+/**
+ * Bestandsvalidatie op de inhoud, niet op de naam (vragenlijst-ontwerp §6).
+ *
+ * Een bestand heet `certificaat.pdf` en bevat een uitvoerbaar programma. De
+ * extensie zegt niets, en de door de browser meegestuurde `Content-Type` ook
+ * niet — beide komen van de client. Wat de server vaststelt uit de eerste bytes
+ * is het enige dat telt, en dát is wat er in `content_type` belandt.
+ *
+ * Geen database en geen NestJS: pure functies over bytes, zodat elke regel los
+ * te toetsen is.
+ */
+
+/** OV-7: maximaal 5 MB per bestand. Gelijk aan de CHECK in migratie 0005. */
+export const MAX_BESTANDSGROOTTE = 5 * 1024 * 1024;
+
+/**
+ * De twee toegestane typen (OV-7), met hun kenmerk aan het begin van het
+ * bestand. Gelijk aan de CHECK-constraint op `content_type`.
+ */
+const HANDTEKENINGEN = [
+  {
+    contentType: 'application/pdf',
+    // '%PDF-'
+    bytes: [0x25, 0x50, 0x44, 0x46, 0x2d],
+  },
+  {
+    contentType: 'image/png',
+    // \x89PNG\r\n\x1a\n — de volledige acht bytes, niet alleen 'PNG'. De
+    // \r\n en \x1a zitten er in het formaat juist om te merken dat een bestand
+    // onderweg door een tekstconversie is gehaald.
+    bytes: [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a],
+  },
+] as const;
+
+export type ToegestaanContentType =
+  (typeof HANDTEKENINGEN)[number]['contentType'];
+
+export type BestandAfkeurReden =
+  'leeg' | 'te-groot' | 'onbekend-type' | 'type-komt-niet-overeen';
+
+export type BestandUitkomst =
+  | { geldig: true; contentType: ToegestaanContentType; sha256: string }
+  | { geldig: false; reden: BestandAfkeurReden };
+
+/**
+ * Stelt het type vast uit de eerste bytes.
+ *
+ * Geeft `null` wanneer de inhoud met geen enkel toegestaan formaat begint. Dat
+ * is geen "onbekend maar mogelijk goed" — het is een weigering: alleen PDF en
+ * PNG zijn toegestaan.
+ */
+export function bepaalContentType(
+  inhoud: Buffer,
+): ToegestaanContentType | null {
+  for (const handtekening of HANDTEKENINGEN) {
+    if (inhoud.length < handtekening.bytes.length) continue;
+
+    const komtOvereen = handtekening.bytes.every(
+      (byte, i) => inhoud[i] === byte,
+    );
+
+    if (komtOvereen) return handtekening.contentType;
+  }
+
+  return null;
+}
+
+/**
+ * Toetst een ontvangen bestand.
+ *
+ * `beweerdType` is wat de client meestuurde. Het wordt uitsluitend gebruikt om
+ * een mismatch te *melden* — de opgeslagen waarde komt altijd uit de bytes.
+ * Zonder die vergelijking zou een `.pdf` met PNG-inhoud stilzwijgend als PNG
+ * worden opgeslagen; dat is technisch veilig, maar het verbergt dat de
+ * leverancier iets anders aanleverde dan hij dacht (testpunt 20).
+ */
+export function valideerBestand(
+  inhoud: Buffer,
+  beweerdType?: string,
+): BestandUitkomst {
+  if (inhoud.length === 0) {
+    return { geldig: false, reden: 'leeg' };
+  }
+
+  // Dit is het vangnet, niet de grens. De echte begrenzing zit in de
+  // ontvangstlaag (limits.fileSize), anders is een upload van 500 MB een
+  // geheugenprobleem in plaats van een validatieregel — zie §6.
+  if (inhoud.length > MAX_BESTANDSGROOTTE) {
+    return { geldig: false, reden: 'te-groot' };
+  }
+
+  const vastgesteld = bepaalContentType(inhoud);
+
+  if (vastgesteld === null) {
+    return { geldig: false, reden: 'onbekend-type' };
+  }
+
+  if (beweerdType !== undefined && beweerdType !== vastgesteld) {
+    return { geldig: false, reden: 'type-komt-niet-overeen' };
+  }
+
+  return {
+    geldig: true,
+    contentType: vastgesteld,
+    // Bij een compliance-bewijsstuk moet later aantoonbaar zijn dat het bestand
+    // niet gewijzigd is sinds indiening. Zelfde redenering als achter de
+    // append-only audit trail.
+    sha256: createHash('sha256').update(inhoud).digest('hex'),
+  };
+}
+
+/**
+ * Bouwt de opslagsleutel: `<tenant>/<response>/<uuid>`.
+ *
+ * **Geen enkel teken uit de invoer.** Een bestandsnaam als `../../etc/passwd`
+ * is volstrekt geldig en zou anders een pad worden (testpunt 22). De originele
+ * naam wordt apart bewaard in `original_name` en is uitsluitend bedoeld om te
+ * tonen — nooit om mee te schrijven of te lezen.
+ */
+export function maakOpslagsleutel(
+  tenantId: string,
+  responseId: string,
+): string {
+  return `${tenantId}/${responseId}/${randomUUID()}`;
+}
+
+/**
+ * Maakt een bestandsnaam veilig om te tónen.
+ *
+ * Niet om mee te schrijven — daarvoor is `maakOpslagsleutel`. Deze functie
+ * bestaat omdat de naam terugkomt in een overzicht en in de download-header,
+ * en een naam met een regeleinde daar een header-injectie zou opleveren.
+ */
+export function veiligeWeergavenaam(naam: string): string {
+  // Splitsen op beide padscheidingstekens: een naam die op Windows is
+  // aangemaakt kan backslashes bevatten, ook als de server op Linux draait.
+  const zonderPad = naam.split('/').pop()?.split('\\').pop() ?? 'bestand';
+
+  const opgeschoond = [...zonderPad]
+    // Stuurtekens eruit: een regeleinde in een bestandsnaam levert bij het
+    // downloaden een header-injectie op in Content-Disposition.
+    .filter((teken) => {
+      const code = teken.codePointAt(0) ?? 0;
+      return code >= 0x20 && code !== 0x7f;
+    })
+    .join('')
+    .trim()
+    .slice(0, 255);
+
+  return opgeschoond.length > 0 ? opgeschoond : 'bestand';
+}

--- a/src/survey/bijlage.service.ts
+++ b/src/survey/bijlage.service.ts
@@ -1,0 +1,190 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { sql } from 'drizzle-orm';
+
+import { DatabaseService } from '../db/database.service';
+import { BestandOpslagService } from './bestand-opslag.service';
+import {
+  maakOpslagsleutel,
+  valideerBestand,
+  veiligeWeergavenaam,
+} from './bestand-validatie';
+import type { BestandAfkeurReden } from './bestand-validatie';
+
+export type BijlageUitkomst =
+  | { status: 'opgeslagen'; attachmentId: string; contentType: string }
+  | { status: 'afgekeurd'; reden: BestandAfkeurReden }
+  | { status: 'onbekende-vraag' }
+  | { status: 'geen-upload-vraag' }
+  | { status: 'te-veel-bestanden'; maximum: number }
+  | { status: 'niet-meer-open' };
+
+interface VraagRij extends Record<string, unknown> {
+  question_id: string;
+  allows_upload: boolean;
+  max_files: number;
+}
+
+/**
+ * Neemt bijlagen aan bij een openstaande response (vragenlijst-ontwerp §6).
+ *
+ * Uploaden gebeurt vóór het indienen, per bestand. Dat is bewust geen onderdeel
+ * van de indien-POST: acht vragen met certificaten in één request zou betekenen
+ * dat een mislukte upload de hele indiening ongedaan maakt, en dat de
+ * groottegrens per request in plaats van per bestand zou gelden.
+ */
+@Injectable()
+export class BijlageService {
+  private readonly logger = new Logger(BijlageService.name);
+
+  constructor(
+    private readonly db: DatabaseService,
+    private readonly opslag: BestandOpslagService,
+  ) {}
+
+  async voegToe(
+    tenantId: string,
+    responseId: string,
+    questionKey: string,
+    bestand: { originalname: string; mimetype?: string; buffer: Buffer },
+  ): Promise<BijlageUitkomst> {
+    // Vóór de database: de inhoudscontrole heeft geen tenantcontext nodig, en
+    // een afgekeurd bestand hoort geen transactie te openen.
+    const gecontroleerd = valideerBestand(bestand.buffer, bestand.mimetype);
+
+    if (!gecontroleerd.geldig) {
+      return { status: 'afgekeurd', reden: gecontroleerd.reden };
+    }
+
+    const storageKey = maakOpslagsleutel(tenantId, responseId);
+
+    // Eerst naar schijf, dan pas de databaserij. Andersom zou een rij kunnen
+    // bestaan zonder bestand — een dode verwijzing die pas bij downloaden
+    // opvalt. Nu is de faalvorm een bestand zonder rij, en dat is een
+    // opruimkwestie in plaats van kapotte data. De rollback hieronder haalt
+    // het alsnog weg.
+    await this.opslag.bewaar(storageKey, bestand.buffer);
+
+    try {
+      return await this.db.withTenant<BijlageUitkomst>(tenantId, async (tx) => {
+        // FOR UPDATE op de responserij, zodat twee overlappende uploads niet
+        // allebei hetzelfde aantal tellen en samen over max_files heen gaan.
+        // Een CHECK kan dit niet afvangen: die kan noch over meerdere rijen
+        // tellen noch survey_question raadplegen.
+        //
+        // EERLIJK OVER WAT BEWEZEN IS: de tests tonen dat het maximum
+        // standhoudt, niet dat déze vergrendeling daarvoor nodig is. Met de
+        // FOR UPDATE verwijderd bleven ze groen — gemeten, niet aangenomen.
+        // Twee transacties via dezelfde pg-Pool komen in de praktijk achter
+        // elkaar aan de beurt, dus de race was niet uit te lokken zonder een
+        // wachtpunt in deze code te bouwen. Dat is de prijs niet waard voor
+        // een vergrendeling die goedkoop en correct is; hij blijft staan voor
+        // het geval de transacties wél overlappen (meerdere processen).
+        const response = await tx.execute<{ status: string }>(
+          sql`SELECT status FROM clm.survey_response
+                 WHERE response_id = ${responseId}
+                 FOR UPDATE`,
+        );
+
+        const status = response.rows[0]?.status;
+
+        // Na indienen geen uploads meer. De RLS-policy weigert dit ook, maar
+        // dan als databasefout; hier wordt het een nette 410.
+        if (status !== 'pending') {
+          return { status: 'niet-meer-open' };
+        }
+
+        const vraag = await tx.execute<VraagRij>(
+          sql`SELECT q.question_id, q.allows_upload, q.max_files
+                  FROM clm.survey_response r
+                  JOIN clm.survey_run      run ON run.run_id    = r.run_id
+                  JOIN clm.survey_question q   ON q.template_id = run.template_id
+                 WHERE r.response_id = ${responseId}
+                   AND q.question_key = ${questionKey}`,
+        );
+
+        const rij = vraag.rows[0];
+
+        // Geen rij betekent: deze vraag hoort niet bij de vragenlijst van
+        // déze run. Dezelfde regel als bij het indienen — RLS beschermt
+        // tegen een andere tenant, deze join tegen een andere template.
+        if (!rij) {
+          return { status: 'onbekende-vraag' };
+        }
+
+        if (!rij.allows_upload || rij.max_files < 1) {
+          return { status: 'geen-upload-vraag' };
+        }
+
+        const aantal = await tx.execute<{ n: string }>(
+          sql`SELECT count(*)::text AS n FROM clm.survey_attachment
+                 WHERE response_id = ${responseId}
+                   AND question_id = ${rij.question_id}`,
+        );
+
+        if (Number(aantal.rows[0].n) >= rij.max_files) {
+          return { status: 'te-veel-bestanden', maximum: rij.max_files };
+        }
+
+        const bijlage = await tx.execute<{ attachment_id: string }>(
+          sql`INSERT INTO clm.survey_attachment
+                    (tenant_id, response_id, question_id, original_name,
+                     storage_key, content_type, byte_size, sha256)
+                VALUES (${tenantId}, ${responseId}, ${rij.question_id},
+                        ${veiligeWeergavenaam(bestand.originalname)},
+                        ${storageKey}, ${gecontroleerd.contentType},
+                        ${bestand.buffer.length}, ${gecontroleerd.sha256})
+                RETURNING attachment_id`,
+        );
+
+        this.logger.log(
+          `Bijlage toegevoegd aan response ${responseId} (${gecontroleerd.contentType}, ${bestand.buffer.length} bytes).`,
+        );
+
+        return {
+          status: 'opgeslagen',
+          attachmentId: bijlage.rows[0].attachment_id,
+          contentType: gecontroleerd.contentType,
+        };
+      });
+    } finally {
+      // Elke uitkomst behalve 'opgeslagen' laat een bestand achter zonder rij.
+      // Dat opruimen gebeurt hier, ook wanneer de transactie een fout gooide.
+      await this.ruimOpIndienNodig(tenantId, responseId, storageKey);
+    }
+  }
+
+  /**
+   * Verwijdert het bestand van schijf wanneer er geen rij naar verwijst.
+   *
+   * Vraagt de database in plaats van te vertrouwen op de returnwaarde: als de
+   * transactie is teruggedraaid door een fout, is de rij er niet — ook al leek
+   * de INSERT te slagen.
+   */
+  private async ruimOpIndienNodig(
+    tenantId: string,
+    responseId: string,
+    storageKey: string,
+  ): Promise<void> {
+    try {
+      const bestaat = await this.db.withTenant(tenantId, (tx) =>
+        tx.execute<{ n: string }>(
+          sql`SELECT count(*)::text AS n FROM clm.survey_attachment
+               WHERE storage_key = ${storageKey}`,
+        ),
+      );
+
+      if (Number(bestaat.rows[0].n) === 0) {
+        await this.opslag.verwijder(storageKey);
+      }
+    } catch (fout) {
+      // Opruimen mag de uitkomst van de upload nooit veranderen. Een
+      // achtergebleven bestand is hinderlijk; een mislukte upload die wél
+      // geslaagd was, is erger.
+      this.logger.warn(
+        `Opruimen van '${storageKey}' voor response ${responseId} mislukt: ${
+          fout instanceof Error ? fout.message : String(fout)
+        }`,
+      );
+    }
+  }
+}

--- a/src/survey/survey-response.controller.ts
+++ b/src/survey/survey-response.controller.ts
@@ -1,17 +1,25 @@
 import {
+  BadRequestException,
   Body,
   Controller,
   Get,
   HttpCode,
   NotFoundException,
+  PayloadTooLargeException,
   Post,
+  Query,
   Req,
   UnprocessableEntityException,
+  UploadedFile,
   UseGuards,
+  UseInterceptors,
   GoneException,
 } from '@nestjs/common';
+import { FileInterceptor } from '@nestjs/platform-express';
 
 import { AntwoordIndienService } from './antwoord-indienen.service';
+import { BijlageService } from './bijlage.service';
+import { MAX_BESTANDSGROOTTE } from './bestand-validatie';
 import { SurveyTokenGuard, type RequestMetToken } from './survey-token.guard';
 import { SurveyTokenService } from './survey-token.service';
 import { VragenlijstLeesService } from './vragenlijst-lezen.service';
@@ -34,6 +42,7 @@ export class SurveyResponseController {
     private readonly tokens: SurveyTokenService,
     private readonly vragenlijst: VragenlijstLeesService,
     private readonly indienen: AntwoordIndienService,
+    private readonly bijlagen: BijlageService,
   ) {}
 
   /**
@@ -146,5 +155,96 @@ export class SurveyResponseController {
     }
 
     return { status: 'ingediend' as const };
+  }
+
+  /**
+   * Neemt één bijlage aan bij een vraag, vóór het indienen.
+   *
+   * Per bestand en niet als onderdeel van de indien-POST: acht certificaten in
+   * één request zou betekenen dat één mislukte upload de hele indiening ongedaan
+   * maakt, en dat de groottegrens per request in plaats van per bestand geldt.
+   *
+   * **De grens ligt in de ontvangstlaag, niet erna** (§6). `limits.fileSize`
+   * breekt de upload af zodra 5 MB gepasseerd is; zonder dat zou een upload van
+   * 500 MB eerst volledig in het geheugen komen en daarna pas geweigerd worden
+   * — een geheugenprobleem in plaats van een validatieregel.
+   *
+   * Bewust in het geheugen en niet naar een tijdelijke map: bij 5 MB is dat
+   * goedkoop, en het scheelt een tweede plek waar een bestand kan achterblijven
+   * als er iets misgaat.
+   */
+  @Post('attachment')
+  @HttpCode(201)
+  @UseInterceptors(
+    FileInterceptor('file', {
+      limits: { fileSize: MAX_BESTANDSGROOTTE, files: 1 },
+    }),
+  )
+  async voegBijlageToe(
+    @Req() request: RequestMetToken,
+    @Query('question') questionKey: string | undefined,
+    @UploadedFile()
+    bestand:
+      { originalname: string; mimetype?: string; buffer: Buffer } | undefined,
+  ) {
+    const context = request.surveyToken!;
+
+    if (!questionKey) {
+      throw new BadRequestException(
+        'Geef met de parameter `question` aan bij welke vraag dit bestand hoort.',
+      );
+    }
+
+    if (!bestand) {
+      throw new BadRequestException('Er is geen bestand meegestuurd.');
+    }
+
+    const uitkomst = await this.bijlagen.voegToe(
+      context.tenantId,
+      context.responseId,
+      questionKey,
+      bestand,
+    );
+
+    switch (uitkomst.status) {
+      case 'opgeslagen':
+        return {
+          status: 'opgeslagen' as const,
+          attachmentId: uitkomst.attachmentId,
+          // Wat de server heeft vastgesteld uit de bytes, niet wat de client
+          // beweerde. Teruggeven maakt zichtbaar dat er gecontroleerd is.
+          contentType: uitkomst.contentType,
+        };
+
+      case 'afgekeurd':
+        if (uitkomst.reden === 'te-groot') {
+          throw new PayloadTooLargeException('Dit bestand is groter dan 5 MB.');
+        }
+        throw new UnprocessableEntityException({
+          status: 'invalid_file',
+          reason: uitkomst.reden,
+        });
+
+      case 'onbekende-vraag':
+        throw new NotFoundException(
+          'Deze vraag hoort niet bij deze vragenlijst.',
+        );
+
+      case 'geen-upload-vraag':
+        throw new UnprocessableEntityException({
+          status: 'invalid_file',
+          reason: 'question_accepts_no_files',
+        });
+
+      case 'te-veel-bestanden':
+        throw new UnprocessableEntityException({
+          status: 'invalid_file',
+          reason: 'too_many_files',
+          maximum: uitkomst.maximum,
+        });
+
+      case 'niet-meer-open':
+        throw new GoneException('Deze vragenlijst is al ingediend.');
+    }
   }
 }

--- a/src/survey/survey.module.ts
+++ b/src/survey/survey.module.ts
@@ -5,6 +5,8 @@ import { SurveyResponseController } from './survey-response.controller';
 import { SurveyTokenGuard } from './survey-token.guard';
 import { SurveyTokenService } from './survey-token.service';
 import { AntwoordIndienService } from './antwoord-indienen.service';
+import { BestandOpslagService } from './bestand-opslag.service';
+import { BijlageService } from './bijlage.service';
 import { VragenlijstImportService } from './vragenlijst-import.service';
 import { VragenlijstLeesService } from './vragenlijst-lezen.service';
 
@@ -17,6 +19,8 @@ import { VragenlijstLeesService } from './vragenlijst-lezen.service';
     VragenlijstImportService,
     VragenlijstLeesService,
     AntwoordIndienService,
+    BestandOpslagService,
+    BijlageService,
   ],
   exports: [
     SurveyAuditService,
@@ -25,6 +29,8 @@ import { VragenlijstLeesService } from './vragenlijst-lezen.service';
     VragenlijstImportService,
     VragenlijstLeesService,
     AntwoordIndienService,
+    BestandOpslagService,
+    BijlageService,
   ],
 })
 export class SurveyModule {}

--- a/test/bijlage-upload.e2e-spec.ts
+++ b/test/bijlage-upload.e2e-spec.ts
@@ -1,0 +1,446 @@
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { INestApplication } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import { sql } from 'drizzle-orm';
+import request from 'supertest';
+import type { App } from 'supertest/types';
+
+import { AppModule } from '../src/app.module';
+import { DatabaseService } from '../src/db/database.service';
+import {
+  berekenVervalmoment,
+  genereerToken,
+  hashToken,
+} from '../src/survey/survey-token';
+
+const TENANT = '00000000-0000-0000-0000-0000000000a5';
+
+/** Een minimaal geldig PDF-bestand: de handtekening plus wat inhoud. */
+const PDF = Buffer.concat([
+  Buffer.from('%PDF-1.7\n'),
+  Buffer.from('certificaatinhoud'),
+]);
+
+/** Een minimaal geldig PNG-bestand: de acht handtekeningbytes plus inhoud. */
+const PNG = Buffer.concat([
+  Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+  Buffer.from('beeldinhoud'),
+]);
+
+let teller = 0;
+
+/**
+ * Toetst de bijlage-upload van buitenaf (vragenlijst-ontwerp §6, Issue #9).
+ *
+ * De regel die alles bepaalt: **de inhoud telt, niet de naam.** Een bestand
+ * heet `certificaat.pdf` en bevat iets heel anders; extensie en de door de
+ * browser meegestuurde Content-Type komen allebei van de client.
+ */
+describe('Bijlage-upload (e2e)', () => {
+  let app: INestApplication<App>;
+  let db: DatabaseService;
+  let server: App;
+  let uploadMap: string;
+
+  async function maakRonde(opties: {
+    upload?: boolean;
+    maxFiles?: number;
+    responseStatus?: string;
+  }): Promise<{ token: string; responseId: string }> {
+    const token = genereerToken();
+    const naam = `b${teller++}-${Date.now()}`;
+
+    const responseId = await db.withTenant(TENANT, async (tx) => {
+      const vendor = await tx.execute<{ vendor_id: string }>(
+        sql`INSERT INTO clm.vendor (tenant_id, name)
+            VALUES (${TENANT}, ${`v-${naam}`}) RETURNING vendor_id`,
+      );
+      const template = await tx.execute<{ template_id: string }>(
+        sql`INSERT INTO clm.survey_template (tenant_id, name, version)
+            VALUES (${TENANT}, ${`t-${naam}`}, 1) RETURNING template_id`,
+      );
+      const templateId = template.rows[0].template_id;
+
+      await tx.execute(
+        sql`INSERT INTO clm.survey_question
+                (tenant_id, template_id, position, question_key, title, body,
+                 answer_type, is_required, allows_upload, max_files)
+            VALUES (${TENANT}, ${templateId}, 1, 'q1', 'Certificaat',
+                    'Bevestigt u dit?', 'confirmation', true,
+                    ${opties.upload ?? true}, ${opties.maxFiles ?? 2})`,
+      );
+      // Tweede vraag zonder upload, om te toetsen dat een bestand daar wordt
+      // geweigerd.
+      await tx.execute(
+        sql`INSERT INTO clm.survey_question
+                (tenant_id, template_id, position, question_key, title, body,
+                 answer_type, is_required, allows_upload, max_files)
+            VALUES (${TENANT}, ${templateId}, 2, 'q2', 'Zonder upload',
+                    'Bevestigt u dit?', 'confirmation', true, false, 0)`,
+      );
+
+      const run = await tx.execute<{ run_id: string }>(
+        sql`INSERT INTO clm.survey_run (tenant_id, template_id, status)
+            VALUES (${TENANT}, ${templateId}, 'active') RETURNING run_id`,
+      );
+
+      const response = await tx.execute<{ response_id: string }>(
+        sql`INSERT INTO clm.survey_response
+                (tenant_id, run_id, vendor_id, subject_vendor_id, token_hash,
+                 status, expires_at, submitted_at)
+            VALUES (${TENANT}, ${run.rows[0].run_id},
+                    ${vendor.rows[0].vendor_id}, ${vendor.rows[0].vendor_id},
+                    ${hashToken(token)}, ${opties.responseStatus ?? 'pending'},
+                    ${berekenVervalmoment().toISOString()},
+                    ${opties.responseStatus === 'submitted' ? new Date() : null})
+            RETURNING response_id`,
+      );
+
+      return response.rows[0].response_id;
+    });
+
+    return { token, responseId };
+  }
+
+  const upload = (token: string, vraag: string) =>
+    request(server).post(
+      `/survey/respond/attachment?t=${token}&question=${vraag}`,
+    );
+
+  beforeAll(async () => {
+    // Eigen tijdelijke map per run: de tests schrijven echte bestanden, en die
+    // horen niet in de projectmap achter te blijven.
+    uploadMap = await mkdtemp(join(tmpdir(), 'mcm2-uploads-'));
+    process.env.UPLOAD_DIR = uploadMap;
+
+    const moduleRef = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleRef.createNestApplication();
+    await app.init();
+    server = app.getHttpServer();
+    db = moduleRef.get(DatabaseService);
+
+    await db.withTenant(TENANT, async (tx) => {
+      await tx.execute(
+        sql`INSERT INTO clm.tenant (tenant_id, name)
+            VALUES (${TENANT}, 'bijlage-test')
+            ON CONFLICT (tenant_id) DO NOTHING`,
+      );
+    });
+  });
+
+  afterAll(async () => {
+    await app.close();
+    await rm(uploadMap, { recursive: true, force: true });
+    delete process.env.UPLOAD_DIR;
+  });
+
+  // ── De gelukkige weg ──────────────────────────────────────────────────────
+
+  it('neemt een PDF aan en bewaart wat de server heeft vastgesteld', async () => {
+    const { token, responseId } = await maakRonde({});
+
+    const res = await upload(token, 'q1')
+      .attach('file', PDF, 'certificaat.pdf')
+      .expect(201);
+
+    expect((res.body as { contentType: string }).contentType).toBe(
+      'application/pdf',
+    );
+
+    const rij = await db.withTenant(TENANT, (tx) =>
+      tx.execute<{
+        content_type: string;
+        byte_size: number;
+        sha256: string;
+        original_name: string;
+        storage_key: string;
+      }>(
+        sql`SELECT content_type, byte_size, sha256, original_name, storage_key
+              FROM clm.survey_attachment WHERE response_id = ${responseId}`,
+      ),
+    );
+
+    expect(rij.rows).toHaveLength(1);
+    expect(rij.rows[0].content_type).toBe('application/pdf');
+    expect(rij.rows[0].byte_size).toBe(PDF.length);
+    expect(rij.rows[0].sha256).toMatch(/^[0-9a-f]{64}$/);
+
+    // Het bestand staat er ook echt, met exact dezelfde bytes.
+    const opSchijf = await readFile(join(uploadMap, rij.rows[0].storage_key));
+    expect(opSchijf.equals(PDF)).toBe(true);
+  });
+
+  it('neemt ook een PNG aan', async () => {
+    const { token } = await maakRonde({});
+
+    const res = await upload(token, 'q1')
+      .attach('file', PNG, 'bewijs.png')
+      .expect(201);
+
+    expect((res.body as { contentType: string }).contentType).toBe('image/png');
+  });
+
+  // ── Inhoud boven naam (testpunt 20) ───────────────────────────────────────
+
+  it('weigert een .pdf met PNG-inhoud op de bytes, niet op de naam (testpunt 20)', async () => {
+    const { token, responseId } = await maakRonde({});
+
+    const res = await upload(token, 'q1')
+      .attach('file', PNG, {
+        filename: 'certificaat.pdf',
+        contentType: 'application/pdf',
+      })
+      .expect(422);
+
+    expect(res.body).toMatchObject({
+      status: 'invalid_file',
+      reason: 'type-komt-niet-overeen',
+    });
+
+    // Niets weggeschreven, en geen bestand achtergebleven.
+    const aantal = await db.withTenant(TENANT, (tx) =>
+      tx.execute<{ n: string }>(
+        sql`SELECT count(*)::text AS n FROM clm.survey_attachment
+             WHERE response_id = ${responseId}`,
+      ),
+    );
+    expect(aantal.rows[0].n).toBe('0');
+  });
+
+  it('weigert een bestand dat geen PDF of PNG is', async () => {
+    const { token } = await maakRonde({});
+
+    const res = await upload(token, 'q1')
+      .attach('file', Buffer.from('gewoon een tekstbestand'), 'notitie.pdf')
+      .expect(422);
+
+    expect(res.body).toMatchObject({ reason: 'onbekend-type' });
+  });
+
+  it('weigert een leeg bestand', async () => {
+    const { token } = await maakRonde({});
+
+    await upload(token, 'q1')
+      .attach('file', Buffer.alloc(0), 'leeg.pdf')
+      .expect(422);
+  });
+
+  // ── Grenzen (testpunt 19, 21) ─────────────────────────────────────────────
+
+  it('weigert een bestand van 5 MB + 1 byte tijdens ontvangst (testpunt 21)', async () => {
+    // De grens ligt in de ontvangstlaag, niet erna: multer breekt af zodra de
+    // limiet gepasseerd is, dus dit bestand komt nooit volledig binnen.
+    const { token } = await maakRonde({});
+
+    const teGroot = Buffer.concat([
+      Buffer.from('%PDF-1.7\n'),
+      Buffer.alloc(5 * 1024 * 1024 + 1 - 9, 0x41),
+    ]);
+
+    await upload(token, 'q1').attach('file', teGroot, 'groot.pdf').expect(413);
+  });
+
+  it('weigert meer bestanden dan max_files (testpunt 19)', async () => {
+    const { token } = await maakRonde({ maxFiles: 2 });
+
+    await upload(token, 'q1').attach('file', PDF, 'een.pdf').expect(201);
+    await upload(token, 'q1').attach('file', PDF, 'twee.pdf').expect(201);
+
+    const res = await upload(token, 'q1')
+      .attach('file', PDF, 'drie.pdf')
+      .expect(422);
+
+    expect(res.body).toMatchObject({ reason: 'too_many_files', maximum: 2 });
+  });
+
+  it('houdt het maximum aan bij herhaalde uploads (testpunt 19)', async () => {
+    // Het maximum per vraag komt uit survey_question.max_files en kan niet in
+    // een CHECK: die kan noch over meerdere rijen tellen noch een andere tabel
+    // raadplegen. De telling gebeurt daarom in de transactie.
+    const { token, responseId } = await maakRonde({ maxFiles: 2 });
+
+    await upload(token, 'q1').attach('file', PDF, 'een.pdf').expect(201);
+    await upload(token, 'q1').attach('file', PDF, 'twee.pdf').expect(201);
+    await upload(token, 'q1').attach('file', PDF, 'drie.pdf').expect(422);
+
+    const aantal = await db.withTenant(TENANT, (tx) =>
+      tx.execute<{ n: string }>(
+        sql`SELECT count(*)::text AS n FROM clm.survey_attachment
+             WHERE response_id = ${responseId}`,
+      ),
+    );
+    expect(aantal.rows[0].n).toBe('2');
+  });
+
+  it('laat twee tegelijk gestarte uploads het maximum niet overschrijden', async () => {
+    // BEPERKING VAN DEZE TEST, expliciet vastgelegd zodat niemand hem
+    // overschat: hij toont dat het maximum standhoudt bij twee aanroepen die
+    // tegelijk gestart worden, maar hij bewijst NIET dat de FOR UPDATE in
+    // BijlageService daarvoor nodig is. Met die vergrendeling verwijderd loopt
+    // deze test namelijk ook groen — gemeten, niet aangenomen.
+    //
+    // De reden is dat twee transacties via dezelfde pg-Pool in de praktijk
+    // achter elkaar aan de beurt komen zodra de eerste zijn connectie
+    // teruggeeft. Een echte overlap uitlokken vraagt twee losse verbindingen
+    // en een gecontroleerd wachtpunt binnen de transactie — dat zou een haak in
+    // productiecode kosten, en dat is de prijs niet waard voor een
+    // vergrendeling die goedkoop en correct is.
+    //
+    // FOR UPDATE blijft dus staan als bescherming tegen het geval dat de
+    // transacties wél overlappen (meerdere processen, tragere schijf); wat
+    // hier bewezen wordt is uitsluitend de uitkomst, niet het mechanisme.
+    const { token, responseId } = await maakRonde({ maxFiles: 1 });
+
+    const uitkomsten = await Promise.all([
+      upload(token, 'q1').attach('file', PDF, 'a.pdf'),
+      upload(token, 'q1').attach('file', PDF, 'b.pdf'),
+    ]);
+
+    expect(uitkomsten.map((r) => r.status).sort()).toEqual([201, 422]);
+
+    const aantal = await db.withTenant(TENANT, (tx) =>
+      tx.execute<{ n: string }>(
+        sql`SELECT count(*)::text AS n FROM clm.survey_attachment
+             WHERE response_id = ${responseId}`,
+      ),
+    );
+    expect(aantal.rows[0].n).toBe('1');
+  });
+
+  it('weigert een derde bestand wanneer max_files 2 is, ook na herhaalde pogingen', async () => {
+    // De praktische kant van dezelfde regel: het maximum houdt stand.
+    const { token, responseId } = await maakRonde({ maxFiles: 1 });
+
+    await upload(token, 'q1').attach('file', PDF, 'een.pdf').expect(201);
+    await upload(token, 'q1').attach('file', PDF, 'twee.pdf').expect(422);
+    await upload(token, 'q1').attach('file', PDF, 'drie.pdf').expect(422);
+
+    const aantal = await db.withTenant(TENANT, (tx) =>
+      tx.execute<{ n: string }>(
+        sql`SELECT count(*)::text AS n FROM clm.survey_attachment
+             WHERE response_id = ${responseId}`,
+      ),
+    );
+    expect(aantal.rows[0].n).toBe('1');
+  });
+
+  // ── Padveiligheid (testpunt 22) ───────────────────────────────────────────
+
+  it('maakt van een bestandsnaam met ../ een storage_key zonder padverwijzing (testpunt 22)', async () => {
+    const { token, responseId } = await maakRonde({});
+
+    await upload(token, 'q1')
+      .attach('file', PDF, '../../etc/passwd.pdf')
+      .expect(201);
+
+    const rij = await db.withTenant(TENANT, (tx) =>
+      tx.execute<{ storage_key: string; original_name: string }>(
+        sql`SELECT storage_key, original_name FROM clm.survey_attachment
+             WHERE response_id = ${responseId}`,
+      ),
+    );
+
+    // De opslagsleutel bevat geen enkel teken uit de invoer.
+    expect(rij.rows[0].storage_key).not.toContain('..');
+    expect(rij.rows[0].storage_key).toMatch(
+      new RegExp(`^${TENANT}/${responseId}/[0-9a-f-]{36}$`),
+    );
+    // De getoonde naam is ontdaan van het pad.
+    expect(rij.rows[0].original_name).toBe('passwd.pdf');
+
+    // En het bestand staat binnen de uploadmap, niet erbuiten.
+    const opSchijf = await readFile(join(uploadMap, rij.rows[0].storage_key));
+    expect(opSchijf.equals(PDF)).toBe(true);
+  });
+
+  // ── Toegang en toestand ───────────────────────────────────────────────────
+
+  it('weigert een bestand bij een vraag die geen upload toestaat', async () => {
+    const { token } = await maakRonde({});
+
+    const res = await upload(token, 'q2')
+      .attach('file', PDF, 'ergens.pdf')
+      .expect(422);
+
+    expect(res.body).toMatchObject({ reason: 'question_accepts_no_files' });
+  });
+
+  it('weigert een vraag die niet bij deze vragenlijst hoort', async () => {
+    const { token } = await maakRonde({});
+
+    await upload(token, 'van-een-andere-lijst')
+      .attach('file', PDF, 'ergens.pdf')
+      .expect(404);
+  });
+
+  it('weigert een upload zonder question-parameter', async () => {
+    const { token } = await maakRonde({});
+
+    await request(server)
+      .post(`/survey/respond/attachment?t=${token}`)
+      .attach('file', PDF, 'ergens.pdf')
+      .expect(400);
+  });
+
+  it('weigert een upload zonder bestand', async () => {
+    const { token } = await maakRonde({});
+
+    await upload(token, 'q1').expect(400);
+  });
+
+  it('weigert uploaden na indienen met 410', async () => {
+    const { token } = await maakRonde({ responseStatus: 'submitted' });
+
+    // De guard grijpt hier al in — een ingediende response geeft 410 op elke
+    // route van deze controller.
+    await upload(token, 'q1').attach('file', PDF, 'te-laat.pdf').expect(410);
+  });
+
+  it('weigert een upload met een onbekend token', async () => {
+    await request(server)
+      .post(`/survey/respond/attachment?t=${genereerToken()}&question=q1`)
+      .attach('file', PDF, 'ergens.pdf')
+      .expect(404);
+  });
+
+  // ── Samenspel met indienen ────────────────────────────────────────────────
+
+  it('maakt indienen met confirmed op een uploadvraag mogelijk zodra er een bestand is', async () => {
+    // Dit is waarom stap 8 nodig was: de validatie eist een bestand bij
+    // 'confirmed' op een uploadvraag (testpunt 18). Zonder upload was die vraag
+    // niet bevestigend te beantwoorden.
+    const { token } = await maakRonde({});
+
+    // Eerst zonder bestand: geweigerd.
+    await request(server)
+      .post(`/survey/respond?t=${token}`)
+      .send({
+        answers: [
+          { questionKey: 'q1', answerCode: 'confirmed' },
+          { questionKey: 'q2', answerCode: 'confirmed' },
+        ],
+      })
+      .expect(422);
+
+    await upload(token, 'q1')
+      .attach('file', PDF, 'certificaat.pdf')
+      .expect(201);
+
+    // Met bestand: aanvaard.
+    await request(server)
+      .post(`/survey/respond?t=${token}`)
+      .send({
+        answers: [
+          { questionKey: 'q1', answerCode: 'confirmed' },
+          { questionKey: 'q2', answerCode: 'confirmed' },
+        ],
+      })
+      .expect(200);
+  });
+});


### PR DESCRIPTION
De laatste stap die de leverancierskant compleet maakt. De validatie uit stap 6 eist een bestand bij `confirmed` op een uploadvraag, en de acht Transdev-vragen hebben er één — zonder deze route was q1 dus niet bevestigend te beantwoorden.

## De inhoud telt, niet de naam

Een bestand heet `certificaat.pdf` en bevat iets heel anders. Extensie en de meegestuurde `Content-Type` komen allebei van de client, dus de server stelt het type vast uit de eerste bytes (`%PDF-`, de acht PNG-bytes) en slaat **die** waarde op.

Een `.pdf` met PNG-inhoud wordt **geweigerd**, niet stilzwijgend als PNG opgeslagen. Dat laatste zou technisch veilig zijn, maar het verbergt dat de leverancier iets anders aanleverde dan hij dacht (testpunt 20).

| Regel | Waar afgedwongen |
|---|---|
| Max 5 MB | ontvangstlaag (`limits.fileSize`), niet erna — anders is het een geheugenprobleem in plaats van een validatieregel (testpunt 21) |
| Alleen PDF/PNG | magic bytes + CHECK-constraint |
| Max aantal per vraag | telling in de transactie; een CHECK kan niet over rijen tellen (testpunt 19) |
| Geen pad uit invoer | `storage_key` is servergegenereerd (testpunt 22) |

**Eerst naar schijf, dan de databaserij.** Andersom zou een rij zonder bestand kunnen bestaan — een dode verwijzing die pas bij downloaden opvalt. De faalvorm is nu een bestand zonder rij, opgeruimd in een `finally`.

## Waar ik mijn eigen claim heb bijgesteld

Ik had geschreven dat de `FOR UPDATE`-vergrendeling twee gelijktijdige uploads serialiseert. **Dat is niet bewezen.** Met de vergrendeling verwijderd bleven alle tests groen — gemeten, niet aangenomen.

Drie testopzetten geprobeerd, alle drie waardeloos als tegenproef:

1. twee supertest-requests via `Promise.all`
2. de service rechtstreeks, beide aanroepen tegelijk gestart
3. een handmatig vastgehouden transactie ernaast

De oorzaak: twee transacties via dezelfde pg-`Pool` komen achter elkaar aan de beurt zodra de eerste zijn connectie teruggeeft. Een echte overlap uitlokken vraagt twee losse verbindingen én een wachtpunt binnen de transactie — dus een haak in productiecode, en dat is de prijs niet waard.

**Wat ik heb gedaan:** de tests claimen nu alleen wat ze aantonen (het maximum houdt stand). `FOR UPDATE` blijft staan als bescherming voor het geval de transacties wél overlappen, en zowel de test als het commentaar in de service zeggen expliciet dat het mechanisme niet getoetst is.

## `multer` als directe dependency

Zat er al transitief via `@nestjs/platform-express`. Exact gepind (2.2.0 / `@types` 2.0.0) — zelfde patroon als `pg` bij Issue #2: een pakket waar de code rechtstreeks op leunt hoort in `package.json`.

## Bewijs

- **155 van 155 e2e-tests groen** in 12 suites, tegen een verse Postgres 17.6 met de keten 0000 t/m 0008
- Twee opeenvolgende runs tegen dezelfde database, beide groen
- Docker-productiebuild bouwt, start, **mapt de uploadroute** en `/health` geeft 200
- format, lint en typecheck schoon

**Tegenproef die wél werkte:** met de magic-bytes-controle vervangen door de client-mimetype vielen testpunt 20 en de onbekend-type-test om.

## Let op — raakt Issue #30

De database gaat mee in `npm run backup:dump`; **bestanden op schijf niet.** De certificaten zijn daarmee het enige onderdeel zonder backup, en juist het onderdeel dat bewijsmateriaal bevat. De uploadmap staat in `.gitignore` met die waarschuwing erbij.

## Hierna

De leverancierskant is functioneel compleet. De volgende stap is **geen code maar een OTAP-doorloop**: het portaal met `NEXT_PUBLIC_API_URL` tegen de echte backend zetten. Dat is de eerste keer dat de volledige keten in de browser te zien is in plaats van mock data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)