### PR TITLE
chore(otap): doorloop uitgebreid t/m indienen en upload + uploadmap-fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,6 +63,25 @@ COPY package.json ./
 COPY drizzle ./drizzle
 COPY scripts ./scripts
 
+# Map voor geüploade bijlagen (vragenlijst-ontwerp §6).
+#
+# Moet vóór `USER node` aangemaakt worden én van die gebruiker zijn: /app is
+# eigendom van root, dus een non-root proces kan er geen submap in maken. Zonder
+# deze twee regels faalt élke upload met "EACCES: permission denied, mkdir
+# '/app/var'" — gevonden tijdens de OTAP-doorloop van 2026-07-29, niet door de
+# e2e-tests, want die draaien met UPLOAD_DIR naar een tijdelijke map.
+#
+# UPLOAD_DIR staat expliciet in het image in plaats van te leunen op de default
+# in BestandOpslagService: het pad hoort bij het uitrolbare artefact, niet bij
+# de code.
+RUN mkdir -p /app/var/uploads && chown -R node:node /app/var
+ENV UPLOAD_DIR=/app/var/uploads
+
+# LET OP BIJ UITROL: dit is een map ín de container. Zonder volume zijn de
+# certificaten weg zodra het image vervangen wordt — en het zijn
+# compliance-bewijsstukken. Zie ADR-012 en Issue #30.
+VOLUME ["/app/var/uploads"]
+
 # Non-root: de node-image levert een 'node'-gebruiker (uid 1000) mee.
 USER node
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,7 +1,7 @@
 # MCM2 — actuele status
 
 ## Laatst bijgewerkt
-2026-07-29, tweede sessie (vragenlijst-tool t/m **stap 8**: import/export, beide seeds, vragen ophalen, indienlogica én bestandsupload; `contract_id` op `survey_run`; **guardbug gevonden waardoor UC2 in het geheel niet werkte**; 155 e2e-tests groen — alles hieronder is geverifieerd, niet uit gespreksgeheugen)
+2026-07-29, tweede sessie (vragenlijst-tool t/m **stap 8**: import/export, beide seeds, vragen ophalen, indienlogica én bestandsupload; `contract_id` op `survey_run`; **guardbug gevonden waardoor UC2 in het geheel niet werkte**; 155 e2e-tests groen; **OTAP-doorloop uitgebreid naar 21 controles en geslaagd** — alles hieronder is geverifieerd, niet uit gespreksgeheugen)
 
 ## Het project bestaat uit twee repositories
 
@@ -174,6 +174,18 @@ Transdev Vendor IT Compliance Survey als eerste verticale MVP-slice.
   Ook nieuw vastgelegd: de vragenlijst is **alleen Engels**. Geen vertaallaag.
 
 ## Aantoonbaar werkend
+
+- **OTAP-doorloop t/m indienen en upload (2026-07-29, tweede doorloop).** Uitgebreid van 8 naar **21 controles** in negen stappen; `scripts/otap-doorloop.js` dekt nu ook de vragenlijst, de validatie, de bestandsupload en het indienen. **Vier keer gedraaid, vier keer geslaagd** — waarvan één keer volledig vanaf niets na `down -v`.
+
+  **De volledige keten is in de browser bewezen:** het portaal toont de echte negen Transdev-vragen uit de database met de MVM_V2-huisstijl, en vanuit diezelfde pagina levert upload → 201 en indienen → 200. De 404 die de vorige doorloop signaleerde is weg.
+
+  **Drie bevindingen die geen enkele test zag:**
+
+  1. **Élke upload faalde in het productie-image** — `EACCES: permission denied, mkdir '/app/var'`. Het image draait als non-root, maar `/app` is eigendom van root. De e2e-tests misten dit omdat die met `UPLOAD_DIR` naar een tijdelijke map draaien. Gerepareerd in de `Dockerfile`: map aanmaken en overdragen vóór `USER node`, `UPLOAD_DIR` expliciet in het image, plus een `VOLUME`-declaratie als waarschuwing bij uitrol.
+  2. **Het opruimblok van het doorloopscript was niet meer idempotent** zodra er echt ingediend werd — `ON DELETE RESTRICT` blokkeerde het verwijderen van een respons met antwoorden. Dat de constraint in de weg zat, is het bewijs dat hij werkt.
+  3. **De seed vraagt een bestaande tenant** op een verse database. Toegevoegd als stap 3b in het runbook.
+
+  **Twee frontend-bevindingen, vastgelegd als Issue #42 en #43:** het portaal kan nog geen bestanden uploaden (waardoor een leverancier UC1 niet via de browser kan afronden — de backend kan het wél), en het rendert het `instruction`-leesblok als een vraag met keuzerondjes. Beide met de browser vastgesteld, niet beredeneerd.
 
 - **Bestandsupload met inhoudscontrole (2026-07-29, stap 8, Issue #9).** `src/survey/bestand-validatie.ts`, `bestand-opslag.service.ts` en `bijlage.service.ts`, plus `POST /survey/respond/attachment`. **155 van 155 e2e-tests groen** in twaalf suites.
 
@@ -358,14 +370,14 @@ Praktische valkuilen die daadwerkelijk zijn tegengekomen, niet bedacht. Ze staan
 
 | Repo | Branch | Werkboom | Openstaande PR's |
 |---|---|---|---|
-| MCM2 | **`feat/bijlage-upload`** | schoon | nog niet gepusht |
+| MCM2 | **`chore/otap-doorloop-stap8`** | schoon | nog niet gepusht |
 | MCM2-frontend | `main` | schoon | geen |
 
 **Drie PR'''s gemerged naar `main`:** #37 (stap 3 en 4, `ef62cd6`), #38 (migratie 0007 plus de drie bevestigde ontwerpbesluiten, `4b09026`) en #39 (stap 5 plus de UC2-guardfix, `52f41b0`). Alle drie met CI groen op alle drie de jobs, alle branches lokaal én op GitHub verwijderd. Na elke merge opnieuw geverifieerd tégen `main` zelf.
 
-**Vier PR's gemerged naar `main`:** #37, #38, #39 en #40 (stap 6, `7756b25`). Alle vier met CI groen op alle drie de jobs, alle branches lokaal én op GitHub verwijderd.
+**Vijf PR's gemerged naar `main`:** #37, #38, #39, #40 en #41 (stap 8, `7c0be9b`). Alle vijf met CI groen op alle drie de jobs, alle branches lokaal én op GitHub verwijderd.
 
-**`feat/bijlage-upload` staat open met één commit:** stap 8 plus deze statusbijwerking. Nog niet gepusht. Lokale poorten wél gedraaid: format, lint, typecheck, 155/155 e2e tegen een verse Postgres 17.6 (twee keer), en de Docker-productiebuild die start, de uploadroute mapt en `/health` met 200 beantwoordt.
+**`chore/otap-doorloop-stap8` staat open:** de uitgebreide doorloop, de Dockerfile-fix voor de uploadmap en deze statusbijwerking. Nog niet gepusht. Lokale poorten wél gedraaid: format, lint, typecheck, 155/155 e2e tegen een verse Postgres 17.6 (twee keer), en de Docker-productiebuild die start, de uploadroute mapt en `/health` met 200 beantwoordt.
 
 - **`docs/sessiestand-otap` is op 2026-07-29 via PR #35 gemerged naar `main`** (merge-commit `cbe6c48`) en daarna lokaal én op GitHub verwijderd. Eén commit: uitsluitend deze statusbijwerking.
 - **`feat/issue-7-leveranciertoken` is op 2026-07-29 via PR #32 gemerged naar `main`** (merge-commit `7f0cc01`) en daarna lokaal én op GitHub verwijderd. CI groen op alle drie de jobs vóór de merge, opnieuw geverifieerd met `gh pr checks 32` op de laatste commit. Vijf commits: de tokenlaag, de HTTP-routes met logmaskering en auditregels, de fix op `maskeerDiep`, plus twee documentatiecommits. **Issue #31 is bij die merge gesloten** — migratie `0004` loste hem op. Let op: die migratie is bewezen in CI, **niet toegepast op `clm-enterprise`** — net als #29 en #25 wacht dat op #30.
@@ -389,9 +401,11 @@ Praktische valkuilen die daadwerkelijk zijn tegengekomen, niet bedacht. Ze staan
 
 De databaselaag is omgezet (ADR-010), spoor 2 van Issue #7 zit in `main`, en de vragenlijst-tool staat t/m stap 4: het datamodel, de guard, import/export en beide gevulde vragenlijsten.
 
-**De leverancierskant is functioneel compleet.** Een leverancier kan de link openen, de vragen zien, bestanden uploaden en indienen — met alle validatie en garanties eromheen.
+**De backendkant van de leveranciersflow is compleet en in de keten bewezen.** De OTAP-doorloop van 2026-07-29 toont dat vragen ophalen, valideren, uploaden en indienen end-to-end werken vanuit de browser.
 
-**De eerstvolgende stap is geen code maar een OTAP-doorloop:** het portaal met `NEXT_PUBLIC_API_URL` tegen de echte backend zetten. Dat is de eerste keer dat de klant de volledige keten in de browser ziet in plaats van mock data, en het is nu voor het eerst mogelijk. Daarna is stap 7 (concept opslaan) de volgende inhoudelijke uitbreiding, en stap 10 (beheerroutes) wacht op spoor 1.
+**De eerstvolgende stap zit in de frontend, niet in de backend: Issue #42.** Het portaal kan nog geen bestanden uploaden, waardoor een leverancier de Transdev-vragenlijst niet via de browser kan afronden — bevestigen op de ISO-vraag levert een 422 op die als "Er ging iets mis" wordt getoond. Dat is nu de enige blokkade voor een werkende demonstratie aan de klant. Issue #43 (het leesblok met keuzerondjes) is cosmetisch maar verwarrend.
+
+Daarna is stap 7 (concept opslaan) de volgende inhoudelijke uitbreiding, en stap 10 (beheerroutes) wacht op spoor 1.
 
 **Daarnaast, en dat kost geen code:** het portaal tegen de echte backend zetten via een OTAP-doorloop. De vragen staan in de database en de route bestaat, dus dit is de eerste keer dat de klant de echte vragenlijst in de browser kan zien in plaats van mock data.
 

--- a/docs/runbooks/otap-doorloop.md
+++ b/docs/runbooks/otap-doorloop.md
@@ -2,7 +2,7 @@
 
 **Type:** D (routineoperatie)
 **Eigenaar:** projecteigenaar
-**Laatste update:** 2026-07-29
+**Laatste update:** 2026-07-29 (tweede doorloop: uitgebreid t/m indienen en upload)
 **Vereiste toegang:** Docker Desktop, beide repositories lokaal
 **Raakt:** Issue #18 (volledige OTAP-doorloop minimaal één keer bewezen)
 
@@ -89,6 +89,29 @@ docker compose -f docker-compose.otap.yml restart api
 
 ---
 
+## Stap 3b — Tenant en vragenlijsten inladen
+
+Zonder deze stap staat er geen vragenlijst en faalt stap 7 van de doorloop.
+
+**De tenant moet er vóór de seed zijn.** `seed-vragenlijsten.js` schrijft binnen
+een tenantcontext; zonder bestaande tenantrij weigert de foreign key. Dat is bij
+de doorloop van 2026-07-29 tegengekomen op een verse database.
+
+```bash
+docker compose -f docker-compose.otap.yml exec -T db psql -U postgres -q -c \
+  "INSERT INTO clm.tenant (tenant_id, name)
+   VALUES ('11111111-1111-1111-1111-111111111111','OTAP')
+   ON CONFLICT DO NOTHING;"
+
+DATABASE_URL="postgresql://clm_api_runtime:otap_pw@localhost:55500/postgres" \
+  node scripts/seed-vragenlijsten.js 11111111-1111-1111-1111-111111111111
+```
+
+**Verwacht resultaat:** negen vragen voor `transdev-annual-vendor-it-risk`, en
+29 vragen met zes categorieën voor `transdev-leveranciersbeoordeling`.
+
+---
+
 ## Stap 4 — De doorloop draaien
 
 ```bash
@@ -97,7 +120,7 @@ node scripts/otap-doorloop.js
 
 **Verwacht resultaat:** `OTAP-doorloop GESLAAGD — de volledige keten werkt.`
 
-Acht stappen, elk met eigen controles:
+Negen stappen, 21 controles:
 
 | # | Wat |
 |---|---|
@@ -107,10 +130,13 @@ Acht stappen, elk met eigen controles:
 | 4 | Onbekend token → 404 |
 | 5 | Geldig token → 200, en de respons lekt geen tenant-ID |
 | 6 | Draft-ronde → 410, met een melding die "nog niet open" onderscheidt van "gesloten" |
-| 7 | Frontend-image draait en serveert het portaal |
-| 8 | Frontend praat met de echte backend, niet met mock data |
+| 7 | De vragenlijst komt uit de database: negen vragen, leesblok als `instruction`, uploadvraag met max 2 |
+| 8 | Bevestigen zonder certificaat → 422; nep-PDF geweigerd op de bytes; upload → 201; indienen → 200; tweede poging → 410; alles vastgelegd inclusief auditregel |
+| 9 | Frontend-image draait, serveert het portaal en praat met de echte backend |
 
-Het script is idempotent: het ruimt zijn eigen testdata op vóór elke run.
+Het script is idempotent: het ruimt zijn eigen testdata op vóór elke run —
+antwoorden en bijlagen eerst, want alle survey-tabellen hebben
+`ON DELETE RESTRICT`.
 
 ---
 
@@ -145,12 +171,61 @@ zichtbaar in unit- of e2e-tests.
 
 ---
 
+## Wat de tweede doorloop opleverde (2026-07-29, na bouwvolgorde stap 5–8)
+
+De doorloop is uitgebreid van 8 naar 21 controles, zodat hij ook de vragenlijst,
+de validatie, de upload en het indienen dekt. Dat leverde **drie bevindingen** op
+die geen enkele unit- of e2e-test zag.
+
+**1. Élke upload faalde in het productie-image.** `EACCES: permission denied,
+mkdir '/app/var'`. Het image draait als non-root (`USER node`), maar `/app` is
+eigendom van root, dus het proces kon er geen uploadmap in aanmaken. De e2e-tests
+misten dit omdat die met `UPLOAD_DIR` naar een tijdelijke map draaien —
+**precies het soort verschil tussen "werkt op mijn machine" en "het artefact
+werkt" waar deze doorloop voor bestaat.**
+
+Gerepareerd in de `Dockerfile`: de map wordt vóór `USER node` aangemaakt en
+overgedragen, met `UPLOAD_DIR` expliciet in het image en een `VOLUME`-declaratie.
+Dat laatste is een waarschuwing bij uitrol: zonder volume zijn de certificaten
+weg zodra het image vervangen wordt.
+
+**2. Het opruimblok van het script was niet meer idempotent.** Zodra de doorloop
+ook echt ging indienen, viel de tweede run om op
+`survey_answer_response_id_..._fk`. Alle survey-tabellen hebben
+`ON DELETE RESTRICT` omdat een ingediende response bewijsmateriaal is; antwoorden
+en bijlagen moeten dus vóór de response weg. **Dat de constraint hier in de weg
+zat, is het bewijs dat hij werkt.**
+
+**3. De seed vraagt een bestaande tenant.** Op een verse database faalt
+`seed-vragenlijsten.js` op de foreign key naar `clm.tenant`. Opgelost door stap
+3b aan dit runbook toe te voegen.
+
+### Twee frontend-bevindingen — nog niet gerepareerd
+
+Deze zitten in `MCM2-frontend` en zijn met de browser vastgesteld, niet
+beredeneerd:
+
+- **Het portaal kan nog niet uploaden.** Het toont letterlijk "Bestandsupload
+  volgt in een volgende versie", terwijl de backend het sinds stap 8 wél kan.
+  Gevolg: bevestigen op de ISO-vraag levert een 422 `file_required` op, die het
+  portaal toont als "Er ging iets mis bij het versturen". **Een leverancier kan
+  de vragenlijst daardoor nog niet via de browser afronden.**
+- **Het leesblok krijgt keuzerondjes.** De backend levert het correct als
+  `answerType: 'instruction'` en de voortgangsteller telt het terecht niet mee
+  ("0 van 8" bij negen vragen), maar het renderen behandelt het als een gewone
+  `confirmation`-vraag.
+
+De backend-kant van de keten is wél volledig bewezen: vragen ophalen, valideren,
+uploaden en indienen werken end-to-end vanuit de browser (gemeten via
+`fetch` op de portaalpagina).
+
+---
+
 ## Bekende beperkingen
 
 - **Acceptatie en Productie ontbreken** — die omgevingen bestaan nog niet
   (Issue #12). Deze doorloop dekt O en T.
-- **`/survey/respond/questions` bestaat nog niet**, dus het portaal kan de
-  vragenlijst nog niet echt tonen tegen de live backend. Dat is stap 5 uit de
-  bouwvolgorde; de mockmodus toont het scherm wél volledig.
+- **De frontend kan de keten nog niet volledig afronden** — zie de twee
+  frontend-bevindingen hierboven.
 - **De doorloop draait handmatig.** Automatiseren in CI vraagt beide
   repositories in één workflow; nu de moeite niet waard.

--- a/scripts/otap-doorloop.js
+++ b/scripts/otap-doorloop.js
@@ -14,8 +14,10 @@
  *   4. Backend weigert een onbekend token met 404
  *   5. Backend accepteert een geldig token en geeft de juiste status
  *   6. Backend weigert een ronde die niet 'active' is (migratie 0006)
- *   7. Frontend-image draait en serveert het portaal
- *   8. De frontend praat met de echte backend, niet met mock data
+ *   7. De vragenlijst komt uit de database (stap 5 uit de bouwvolgorde)
+ *   8. Validatie, bestandsupload en indienen werken end-to-end (stap 6 en 8)
+ *   9. Frontend-image draait en serveert het portaal
+ *  10. De frontend praat met de echte backend, niet met mock data
  *
  * Elke stap faalt hard. Een groene doorloop betekent dat de keten
  * browser → frontend → backend → database aantoonbaar werkt.
@@ -152,6 +154,17 @@ async function main() {
   // ON CONFLICT DO NOTHING de insert stilzwijgend over — de rij bestaat dan
   // nog met de tokenhash van de vórige run, en de doorloop faalt met een
   // misleidende "geldig token gaf 404". Zelf tegengekomen bij de tweede run.
+  // Volgorde is niet vrij: alle survey-tabellen hebben ON DELETE RESTRICT,
+  // want een ingediende response is bewijsmateriaal en mag nooit stilzwijgend
+  // meeverdwijnen. Antwoorden en bijlagen dus vóór de response zelf.
+  //
+  // Dit brak bij de doorloop van 2026-07-29, zodra die ook daadwerkelijk ging
+  // indienen: de tweede run viel om op de foreign key. Dat de constraint
+  // hier in de weg zit, is het bewijs dat hij werkt.
+  sql(`DELETE FROM clm.survey_answer
+        WHERE tenant_id = '11111111-1111-1111-1111-111111111111'`);
+  sql(`DELETE FROM clm.survey_attachment
+        WHERE tenant_id = '11111111-1111-1111-1111-111111111111'`);
   sql(`DELETE FROM clm.survey_response
         WHERE tenant_id = '11111111-1111-1111-1111-111111111111'`);
 
@@ -159,6 +172,15 @@ async function main() {
   const hash = crypto.createHash('sha256').update(token).digest('hex');
   const tokenDraft = crypto.randomBytes(32).toString('base64url');
   const hashDraft = crypto.createHash('sha256').update(tokenDraft).digest('hex');
+  // Derde token voor de frontendcontrole: het eerste wordt verbruikt door de
+  // indiening in stap 8, en het portaal heeft een openstaande link nodig.
+  // Eigen leverancier, want UNIQUE (run_id, vendor_id) staat twee responses
+  // voor dezelfde leverancier in één ronde niet toe — precies de UC1-garantie.
+  const tokenPortaal = crypto.randomBytes(32).toString('base64url');
+  const hashPortaal = crypto
+    .createHash('sha256')
+    .update(tokenPortaal)
+    .digest('hex');
 
   sql(`
     INSERT INTO clm.tenant (tenant_id, name)
@@ -204,6 +226,20 @@ async function main() {
             '22222222-2222-2222-2222-222222222222',
             '${hashDraft}', now() + interval '30 days')
     ON CONFLICT DO NOTHING;
+
+    INSERT INTO clm.vendor (vendor_id, tenant_id, name)
+    VALUES ('66666666-6666-6666-6666-666666666666',
+            '11111111-1111-1111-1111-111111111111', 'OTAP Leverancier 2')
+    ON CONFLICT DO NOTHING;
+
+    INSERT INTO clm.survey_response
+      (tenant_id, run_id, vendor_id, subject_vendor_id, token_hash, expires_at)
+    VALUES ('11111111-1111-1111-1111-111111111111',
+            '44444444-4444-4444-4444-444444444444',
+            '66666666-6666-6666-6666-666666666666',
+            '66666666-6666-6666-6666-666666666666',
+            '${hashPortaal}', now() + interval '30 days')
+    ON CONFLICT DO NOTHING;
   `);
 
   kop('Backend accepteert een geldig token');
@@ -234,7 +270,184 @@ async function main() {
     fout(`draft-ronde gaf ${draft.status}, verwacht 410`);
   }
 
-  // ── 7-8. Frontend ───────────────────────────────────────────────────────
+  // ── 7. De vragenlijst komt uit de database ──────────────────────────────
+  //
+  // Toegevoegd na de doorloop van 2026-07-29. Tot dan bewees de doorloop
+  // alleen dat de tokenlaag werkte; de vragen, de validatie en de upload
+  // bestonden nog niet. Zonder deze stappen zegt een groene doorloop niets
+  // over wat een leverancier daadwerkelijk doet.
+  kop('De vragenlijst komt uit de database (bouwvolgorde stap 5)');
+
+  // De OTAP-testrun wijst standaard naar een lege template. Koppel hem aan de
+  // geseede Transdev-vragenlijst — dezelfde weg als een echte tenant: via het
+  // importpad, niet via losse INSERTs.
+  const templateId = sql(`
+    SELECT template_id FROM clm.survey_template
+     WHERE tenant_id = '11111111-1111-1111-1111-111111111111'
+       AND name = 'transdev-annual-vendor-it-risk'
+     LIMIT 1`);
+
+  if (!templateId) {
+    fout(
+      'vragenlijst niet geseed — draai eerst: ' +
+        'DATABASE_URL=... npm run seed:vragenlijsten -- 11111111-1111-1111-1111-111111111111',
+    );
+  } else {
+    sql(`UPDATE clm.survey_run SET template_id = '${templateId}'
+          WHERE run_id = '44444444-4444-4444-4444-444444444444'`);
+
+    const vragen = await http(`${API}/survey/respond/questions?t=${token}`);
+
+    if (vragen.status !== 200) {
+      fout(`/questions gaf ${vragen.status}, verwacht 200`);
+    } else {
+      ok('/questions antwoordt 200');
+
+      const lijst = JSON.parse(vragen.tekst);
+
+      if (lijst.questions.length === 9) {
+        ok('negen vragen: de acht Transdev-vragen plus het leesblok');
+      } else {
+        fout(`${lijst.questions.length} vragen, verwacht 9`);
+      }
+
+      // Testpunt 32 op ketenniveau: een leesblok hoort als instruction door te
+      // komen, anders is de vragenlijst nooit compleet in te dienen.
+      if (lijst.questions[0].answerType === 'instruction') {
+        ok('het leesblok komt door als instruction');
+      } else {
+        fout('het leesblok heeft niet het type instruction');
+      }
+
+      const upload = lijst.questions.find((v) => v.allowsUpload);
+      if (upload && upload.maxFiles === 2) {
+        ok(`uploadvraag '${upload.questionKey}' met maximaal 2 bestanden`);
+      } else {
+        fout('de uploadvraag ontbreekt of heeft een ander maximum');
+      }
+
+      if (!vragen.tekst.includes('11111111')) {
+        ok('de vragenlijst lekt geen tenant-ID');
+      } else {
+        fout('de vragenlijst bevat een tenant-ID');
+      }
+    }
+  }
+
+  // ── 8. Validatie, upload en indienen ────────────────────────────────────
+  kop('Validatie, bestandsupload en indienen (bouwvolgorde stap 6 en 8)');
+
+  const alleBevestigd = ['q1', 'q2', 'q3', 'q4', 'q5', 'q6', 'q7', 'q8'].map(
+    (k) => ({ questionKey: k, answerType: 'confirmation', answerCode: 'confirmed' }),
+  );
+
+  const jsonPost = (pad, body) =>
+    http(`${API}${pad}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+
+  // Bevestigen op de uploadvraag zonder bestand moet falen. Dat is de regel
+  // waar stap 8 om gebouwd is.
+  const zonderBestand = await jsonPost(`/survey/respond?t=${token}`, {
+    answers: alleBevestigd,
+  });
+
+  if (zonderBestand.status === 422 && zonderBestand.tekst.includes('file_required')) {
+    ok('bevestigen zonder certificaat → 422 file_required');
+  } else {
+    fout(`indienen zonder bestand gaf ${zonderBestand.status}, verwacht 422`);
+  }
+
+  // Een bestand dat geen PDF of PNG is, wordt op de inhoud geweigerd — niet op
+  // de naam of de meegestuurde Content-Type.
+  const nep = new FormData();
+  nep.append(
+    'file',
+    new Blob([Buffer.from('dit is gewoon tekst')], { type: 'application/pdf' }),
+    'nep.pdf',
+  );
+  const nepUpload = await http(
+    `${API}/survey/respond/attachment?t=${token}&question=q1`,
+    { method: 'POST', body: nep },
+  );
+
+  if (nepUpload.status === 422) {
+    ok('tekstbestand met .pdf-naam → 422, geweigerd op de bytes');
+  } else {
+    fout(`nep-PDF gaf ${nepUpload.status}, verwacht 422`);
+  }
+
+  // Het echte certificaat. Deze stap legde in de eerste uitvoering een fout
+  // bloot die geen enkele test zag: het productie-image draait als non-root en
+  // kon geen map aanmaken onder /app. Zie het runbook.
+  const echt = new FormData();
+  echt.append(
+    'file',
+    new Blob([Buffer.from('%PDF-1.7\nISO27001 certificaat')], {
+      type: 'application/pdf',
+    }),
+    'certificaat.pdf',
+  );
+  const upload = await http(
+    `${API}/survey/respond/attachment?t=${token}&question=q1`,
+    { method: 'POST', body: echt },
+  );
+
+  if (upload.status === 201) {
+    ok('certificaat geüpload → 201');
+    if (upload.tekst.includes('application/pdf')) {
+      ok('de server bepaalt zelf het content-type uit de bytes');
+    } else {
+      fout('het vastgestelde content-type ontbreekt in de respons');
+    }
+  } else {
+    fout(
+      `upload gaf ${upload.status}, verwacht 201 — ` +
+        `controleer of de uploadmap schrijfbaar is voor de node-gebruiker`,
+    );
+  }
+
+  const ingediend = await jsonPost(`/survey/respond?t=${token}`, {
+    answers: alleBevestigd,
+  });
+
+  if (ingediend.status === 200) {
+    ok('indienen mét certificaat → 200');
+  } else {
+    fout(`indienen gaf ${ingediend.status}, verwacht 200`);
+  }
+
+  // Éénmaligheid: dezelfde link werkt daarna niet meer.
+  const nogmaals = await jsonPost(`/survey/respond?t=${token}`, {
+    answers: alleBevestigd,
+  });
+
+  if (nogmaals.status === 410) {
+    ok('tweede indiening → 410, de link is verbruikt');
+  } else {
+    fout(`tweede indiening gaf ${nogmaals.status}, verwacht 410`);
+  }
+
+  // En alles staat er ook echt: antwoorden, bijlage en auditregel.
+  const opgeslagen = sql(`
+    SELECT (SELECT count(*) FROM clm.survey_answer)     || '/' ||
+           (SELECT count(*) FROM clm.survey_attachment) || '/' ||
+           (SELECT count(*) FROM audit.audit_event
+             WHERE action_type = 'survey_response_ingediend')`);
+
+  const [antwoorden, bijlagen, audit] = opgeslagen.split('/').map(Number);
+
+  if (antwoorden >= 8 && bijlagen >= 1 && audit >= 1) {
+    ok(`vastgelegd: ${antwoorden} antwoorden, ${bijlagen} bijlage(n), ${audit} auditregel(s)`);
+  } else {
+    fout(
+      `onvolledig vastgelegd: ${antwoorden} antwoorden, ${bijlagen} bijlagen, ${audit} auditregels`,
+    );
+  }
+
+  // ── 9-10. Frontend ──────────────────────────────────────────────────────
   kop('Frontend-image draait en serveert het portaal');
 
   const home = await http(FRONTEND);
@@ -250,7 +463,10 @@ async function main() {
     fout('frontend draait op mock data — NEXT_PUBLIC_API_URL niet ingebakken');
   }
 
-  const portaal = await http(`${FRONTEND}/portal/survey/${token}`);
+  // Bewust een ánder token: het eerste is hierboven verbruikt door de
+  // indiening, en een verbruikte link hoort in het portaal een 410-scherm te
+  // geven. Voor deze controle is een openstaande link nodig.
+  const portaal = await http(`${FRONTEND}/portal/survey/${tokenPortaal}`);
   if (portaal.status === 200) {
     ok('portaalroute antwoordt 200');
   } else {


### PR DESCRIPTION
De OTAP-doorloop dekte alleen de tokenlaag — de vragenlijst, validatie, upload en indienen bestonden nog niet toen hij geschreven werd. **Uitgebreid van 8 naar 21 controles** in negen stappen.

**Vier keer gedraaid, vier keer geslaagd**, waarvan één keer volledig vanaf niets na `down -v`.

## De volledige keten is in de browser bewezen

Het portaal toont de echte negen Transdev-vragen uit de database, met de MVM_V2-huisstijl. Vanaf diezelfde pagina: upload → **201**, indienen → **200**. De 404 die de vorige doorloop signaleerde is weg.

## Drie bevindingen die geen enkele test zag

**1. Élke upload faalde in het productie-image.**

```
EACCES: permission denied, mkdir '/app/var'
```

Het image draait als non-root (`USER node`), maar `/app` is eigendom van root — het proces kon er geen uploadmap in aanmaken. De e2e-tests misten dit omdat die met `UPLOAD_DIR` naar een tijdelijke map draaien. **Dit is precies het verschil tussen "werkt op mijn machine" en "het artefact werkt" waar deze doorloop voor bestaat.**

Gerepareerd in de `Dockerfile`: map aanmaken en overdragen vóór `USER node`, `UPLOAD_DIR` expliciet in het image, plus een `VOLUME`-declaratie — zonder volume zijn de certificaten weg zodra het image vervangen wordt.

**2. Het opruimblok van het script was niet meer idempotent** zodra de doorloop echt ging indienen. De tweede run viel om op de foreign key naar `survey_answer`. Alle survey-tabellen hebben `ON DELETE RESTRICT` omdat een ingediende response bewijsmateriaal is. **Dat de constraint hier in de weg zat, is het bewijs dat hij werkt.**

**3. De seed vraagt een bestaande tenant** op een verse database. Toegevoegd als stap 3b in het runbook.

## Twee frontend-bevindingen, als issue vastgelegd

Met de browser vastgesteld, niet beredeneerd:

| Issue | Wat |
|---|---|
| **#42** | Het portaal kan geen bestanden uploaden ("volgt in een volgende versie"), terwijl de backend het sinds stap 8 wél kan. Bevestigen op de ISO-vraag geeft een 422 `file_required` die als "Er ging iets mis" wordt getoond. **Een leverancier kan de vragenlijst dus niet via de browser afronden** — nu de enige blokkade voor een demonstratie aan de klant. |
| **#43** | Het `instruction`-leesblok krijgt keuzerondjes. De backend levert het correct en de voortgangsteller telt het niet mee ("0 van 8" bij negen vragen), maar het renderen behandelt het als een gewone vraag. Precies testpunt 32, alleen aan de frontendkant. |

## Wat de doorloop nu controleert

| # | Wat |
|---|---|
| 1–2 | Rollen, geen BYPASSRLS, migratieketen, RLS met `USING` én `WITH CHECK` |
| 3–6 | Backend-image, `/health`, onbekend token → 404, geldig token → 200, draft-ronde → 410 |
| **7** | De vragenlijst komt uit de database: negen vragen, leesblok als `instruction`, uploadvraag met max 2, geen tenant-ID in de respons |
| **8** | Bevestigen zonder certificaat → 422; nep-PDF geweigerd op de bytes; upload → 201; indienen → 200; tweede poging → 410; alles vastgelegd inclusief auditregel |
| 9 | Frontend-image draait, serveert het portaal, praat met de echte backend |

## Bewijs

- 21 van 21 controles groen, vier opeenvolgende runs
- Eén run volledig vanaf niets: `down -v` → `up` → rollen → migraties → seed → doorloop
- **155 van 155 e2e-tests nog groen** na de Dockerfile-wijziging
- format, lint en typecheck schoon

🤖 Generated with [Claude Code](https://claude.com/claude-code)