### PR TITLE
feat(vendor): CSV-parser en validatie voor leveranciersimport

### DIFF
--- a/db/seeds/voorbeeld-leveranciers-coupa.csv
+++ b/db/seeds/voorbeeld-leveranciers-coupa.csv
@@ -1,0 +1,29 @@
+Supplier ID,Supplier Name,Impact Classification,Primary Contact Name,Primary Contact Email,KvK Number,Country,City,Annual Spend EUR,Supplier Status
+COUPA-SIE-001,Siemens Mobility B.V.,High Impact,Daan Hoekstra,d.hoekstra@siemens.com,34212178,NL,Den Haag,4800000,Active
+COUPA-ALS-002,Alstom Transport Nederland,High Impact,Laura Peeters,l.peeters@alstom.com,27302140,NL,Ridderkerk,3100000,Active
+COUPA-CAP-003,Capgemini Nederland B.V.,Medium Impact,Anne de Vries,a.devries@capgemini.com,33200803,NL,Utrecht,1250000,Active
+COUPA-THA-004,Thales Nederland B.V.,High Impact,Robert Smit,r.smit@thales.com,27119080,NL,Hengelo,2200000,Active
+COUPA-STR-005,Strukton Rail B.V.,Medium Impact,Joost Willems,j.willems@strukton.nl,30155768,NL,Utrecht,1800000,Active
+COUPA-MSFT-006,Microsoft Nederland B.V.,High Impact,Iris van Dijk,iris.vandijk@microsoft.com,33032887,NL,Amsterdam,950000,Active
+COUPA-SAP-007,SAP Nederland B.V.,Medium Impact,Thomas Bakker,t.bakker@sap.com,33223688,NL,'s-Hertogenbosch,780000,Active
+COUPA-HEI-008,Heijmans Infrastructuur B.V.,Medium Impact,Frank Verhoeven,f.verhoeven@heijmans.nl,17227994,NL,Rosmalen,2600000,Active
+COUPA-AON-009,Aon Risk Solutions Nederland,Low Impact,Sylvia Hendriks,s.hendriks@aon.com,33238179,NL,Rotterdam,320000,Active
+COUPA-VOD-010,Vodafone Ziggo B.V.,Medium Impact,Nina Groot,n.groot@vodafone.com,17270860,NL,Utrecht,410000,Active
+COUPA-ISS-011,ISS Facility Services B.V.,Low Impact,Paul Vermeer,p.vermeer@iss.com,27303994,NL,Utrecht,890000,Active
+COUPA-TIC-012,"TIC Group (Ticketing)",Medium Impact,Kevin Lammers,k.lammers@tic.nl,58012934,NL,Amsterdam,540000,Active
+COUPA-SHE-013,Shell Energy Nederland,Medium Impact,Emma Bos,e.bos@shell.com,27002690,NL,Den Haag,3400000,Active
+COUPA-DEL-014,Deloitte Nederland N.V.,Low Impact,Pieter van Dalen,p.vandalen@deloitte.nl,24362837,NL,Amsterdam,275000,Active
+COUPA-IDE-015,Identiv Security B.V.,Medium Impact,Chris de Jong,c.dejong@identiv.com,68012456,NL,Eindhoven,190000,Active
+COUPA-NS-016,"NS Groep N.V. (infra-delen)",High Impact,Hanne Visser,h.visser@ns.nl,30124359,NL,Utrecht,5200000,Active
+COUPA-ATO-017,Atos IT Solutions and Services B.V.,Medium Impact,Diana Schippers,d.schippers@atos.net,33155709,NL,Amstelveen,1100000,Active
+COUPA-ENE-018,Enel X Nederland B.V.,Low Impact,Marco de Graaf,m.degraaf@enelx.com,75104322,NL,Amsterdam,230000,Active
+COUPA-SOG-019,Sogeti Nederland B.V.,Medium Impact,Bas Meijer,b.meijer@sogeti.nl,34292289,NL,Vianen,670000,Active
+COUPA-PRO-020,"ProRail B.V. (capaciteitsmanagement)",High Impact,Jos van Loon,j.vanloon@prorail.nl,18079800,NL,Utrecht,4100000,Active
+COUPA-HIT-021,Hitachi Rail GTS Netherlands B.V.,High Impact,Kenji Watanabe,kenji.watanabe@hitachirail.com,34198412,NL,Amersfoort,2900000,Active
+COUPA-DUP-001,Siemens Mobility B.V.,High Impact,Daan Hoekstra,d.hoekstra@siemens.com,34212178,NL,Den Haag,4800000,Active
+COUPA-NON-022,,Medium Impact,Onbekend Persoon,geen.naam@voorbeeld.nl,99887766,NL,Rotterdam,150000,Active
+COUPA-QUO-023,"Jansen ""De Bouwer"" B.V.",Low Impact,Wim Jansen,w.jansen@jansenbouw.nl,12345678,NL,Zwolle,95000,Active
+COUPA-MAIL-024,Bakker Techniek B.V.,Medium Impact,Sanne Bakker,geen-apenstaartje,45678901,NL,Apeldoorn,88000,Active
+COUPA-KVK-025,Van Leeuwen Installaties B.V.,Low Impact,Piet van Leeuwen,p.vanleeuwen@vlinstall.nl,123,NL,Breda,62000,Active
+COUPA-IMP-026,Groen Advies B.V.,Onbekende Waarde,Marieke Groen,m.groen@groenadvies.nl,23456789,NL,Nijmegen,45000,Active
+COUPA-INA-027,Oude Leverancier B.V.,Low Impact,Jan Oud,j.oud@oudeleverancier.nl,34567890,NL,Tilburg,0,Inactive

--- a/src/vendor/csv-lezer.ts
+++ b/src/vendor/csv-lezer.ts
@@ -1,0 +1,173 @@
+/**
+ * CSV inlezen — één taak, geen kennis van leveranciers.
+ *
+ * Bewust een eigen lezer en geen bibliotheek: het formaat is klein en scherp
+ * begrensd (RFC 4180), en dit vermijdt een afhankelijkheid in een project dat
+ * er nu tien heeft. Zodra er iets bijkomt wat hier niet in past —
+ * meerdere bladen, formules, opmaak — is dat het signaal om naar een echte
+ * bibliotheek te gaan, niet om deze te laten uitgroeien.
+ *
+ * WAAROM NIET DE VERSIE UIT MVM_V2 (`coupa-field-mapping.ts`):
+ * die wisselt `inQuotes` bij élk aanhalingsteken, dus een ontsnapt
+ * aanhalingsteken (`""` binnen een veld) leest hij verkeerd. Een leverancier
+ * als `Jansen "De Bouwer" B.V.` — die bestaat in het voorbeeldbestand — wordt
+ * dan afgekapt. Voor een demo onzichtbaar, bij 142 echte rijen niet.
+ *
+ * Wat deze lezer WEL doet:
+ *   - velden tussen dubbele aanhalingstekens, met `""` als ontsnapt teken
+ *   - regeleinden binnen een veld tussen aanhalingstekens
+ *   - CRLF en LF door elkaar
+ *   - een UTF-8 BOM aan het begin (Excel zet die er standaard voor)
+ *
+ * Wat deze lezer NIET doet: een ander scheidingsteken dan de komma raden.
+ * Zie `bepaalScheidingsteken` — dat is een aparte, expliciete stap.
+ */
+
+/** Een ingelezen bestand: koppen plus de rijen eronder. */
+export interface CsvInhoud {
+  koppen: string[];
+  /** Eén array per rij, in kolomvolgorde. Niet uitgelijnd op `koppen`. */
+  rijen: string[][];
+  /** Het teken dat als scheiding is gebruikt. */
+  scheidingsteken: string;
+}
+
+/**
+ * Raadt het scheidingsteken uit de eerste regel.
+ *
+ * Nederlandse Excel-installaties schrijven puntkomma's in plaats van komma's —
+ * de Transdev-specificaties in MVM_V2 gebruiken alle vier puntkomma's. Zonder
+ * deze stap leest zo'n bestand als één kolom, en dan is de melding "geen
+ * kolom 'Supplier Name' gevonden" terwijl het bestand op zich klopt.
+ *
+ * Het teken dat buiten aanhalingstekens het vaakst voorkomt wint. Bij een
+ * gelijkspel of nul treffers valt het terug op de komma.
+ */
+export function bepaalScheidingsteken(eersteRegel: string): string {
+  const kandidaten = [',', ';', '\t', '|'];
+  let beste = ',';
+  let hoogste = 0;
+
+  for (const teken of kandidaten) {
+    let aantal = 0;
+    let inAanhaling = false;
+
+    for (const char of eersteRegel) {
+      if (char === '"') inAanhaling = !inAanhaling;
+      else if (char === teken && !inAanhaling) aantal++;
+    }
+
+    if (aantal > hoogste) {
+      hoogste = aantal;
+      beste = teken;
+    }
+  }
+
+  return beste;
+}
+
+/**
+ * Leest een CSV-tekst in.
+ *
+ * Verwacht een koprij. Een bestand zonder koprij is niet te onderscheiden van
+ * een bestand waarvan de eerste leverancier per ongeluk als kop wordt gelezen,
+ * dus dat raden we niet — de koppen zijn nodig om kolommen te herkennen.
+ */
+export function leesCsv(tekst: string): CsvInhoud {
+  // GEEN losse BOM-verwijdering hier, en dat is een gemeten keuze.
+  //
+  // Excel zet bij "CSV UTF-8" een BOM (U+FEFF) voor de eerste kop. Ik had daar
+  // een losse `replace` op U+FEFF voor staan, tot bleek dat die regel met geen
+  // enkele test rood te krijgen was: `.trim()` op de koppen hieronder haalt
+  // U+FEFF in JavaScript óók weg, en `bepaalScheidingsteken` telt alleen
+  // scheidingstekens en struikelt er niet over.
+  //
+  // Twee tests geschreven om het mechanisme aan te tonen, beide bleven groen
+  // met de regel eruit. Toen was de conclusie dat de regel niets deed wat de
+  // trim niet al doet — en een regel die niets doet is erger dan geen regel,
+  // want de volgende lezer denkt dat de BOM hier wordt afgehandeld.
+  //
+  // De BOM wordt dus verwijderd door de `.trim()` onderaan deze functie. Zie
+  // de test 'verwijdert de UTF-8 BOM die Excel voor de eerste kop zet'.
+  const eersteRegeleinde = tekst.search(/\r?\n/);
+  const eersteRegel =
+    eersteRegeleinde === -1 ? tekst : tekst.slice(0, eersteRegeleinde);
+  const scheidingsteken = bepaalScheidingsteken(eersteRegel);
+
+  const alleRijen = splitsRijen(tekst, scheidingsteken);
+
+  // Volledig lege rijen weglaten. Een bestand eindigt vaak op een regeleinde,
+  // en een laatste rij met één leeg veld is geen leverancier.
+  const gevuld = alleRijen.filter(
+    (rij) => rij.length > 0 && rij.some((cel) => cel.trim().length > 0),
+  );
+
+  if (gevuld.length === 0) {
+    return { koppen: [], rijen: [], scheidingsteken };
+  }
+
+  return {
+    koppen: gevuld[0].map((k) => k.trim()),
+    rijen: gevuld.slice(1),
+    scheidingsteken,
+  };
+}
+
+/**
+ * Splitst de volledige tekst in rijen en velden, in één doorloop.
+ *
+ * In één keer en niet eerst op regels splitsen: een veld tussen
+ * aanhalingstekens mag een regeleinde bevatten, en dan is "een regel" niet
+ * hetzelfde als "een rij". De Transdev-specificaties in MVM_V2 doen dit
+ * daadwerkelijk — meerregelige beschrijvingen binnen één cel.
+ */
+function splitsRijen(tekst: string, scheidingsteken: string): string[][] {
+  const rijen: string[][] = [];
+  let rij: string[] = [];
+  let veld = '';
+  let inAanhaling = false;
+
+  for (let i = 0; i < tekst.length; i++) {
+    const char = tekst[i];
+
+    if (inAanhaling) {
+      if (char === '"') {
+        // Twee aanhalingstekens op een rij: één ontsnapt teken in de waarde.
+        // Dít is wat de MVM_V2-versie mist.
+        if (tekst[i + 1] === '"') {
+          veld += '"';
+          i++;
+        } else {
+          inAanhaling = false;
+        }
+      } else {
+        veld += char;
+      }
+      continue;
+    }
+
+    if (char === '"') {
+      inAanhaling = true;
+    } else if (char === scheidingsteken) {
+      rij.push(veld);
+      veld = '';
+    } else if (char === '\n') {
+      rij.push(veld);
+      rijen.push(rij);
+      rij = [];
+      veld = '';
+    } else if (char === '\r') {
+      // Deel van een CRLF; het regeleinde volgt op de \n.
+    } else {
+      veld += char;
+    }
+  }
+
+  // Wat er na het laatste regeleinde nog staat.
+  if (veld.length > 0 || rij.length > 0) {
+    rij.push(veld);
+    rijen.push(rij);
+  }
+
+  return rijen;
+}

--- a/src/vendor/leverancier-import-schema.spec.ts
+++ b/src/vendor/leverancier-import-schema.spec.ts
@@ -1,0 +1,334 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import {
+  bepaalScheidingsteken,
+  beoordeelImportbestand,
+  duidImpact,
+  emailGeldig,
+  kvkGeldig,
+  leesBedrag,
+  leesCsv,
+} from './leverancier-import-schema';
+
+/**
+ * Unittests op een pure functie: geen database, geen HTTP, geen tenant.
+ *
+ * Dit is de laag die de architectuurreview van 2026-07-29 miste (Issue #54):
+ * randgevallen als een leeg veld, een bedrag met duizendtalscheiding of een
+ * ontsnapt aanhalingsteken zijn hier drie regels, en als e2e-testgeval een
+ * wegwerp-Postgres plus een HTTP-rondgang. Wat de database afdwingt blijft
+ * e2e; dit hoort hier.
+ */
+
+const VOORBEELD = join(
+  __dirname,
+  '..',
+  '..',
+  'db',
+  'seeds',
+  'voorbeeld-leveranciers-coupa.csv',
+);
+
+describe('bepaalScheidingsteken', () => {
+  it('herkent de komma', () => {
+    expect(bepaalScheidingsteken('a,b,c')).toBe(',');
+  });
+
+  it('herkent de puntkomma van een Nederlandse Excel', () => {
+    // Alle vier Transdev-specificatiebestanden in MVM_V2 gebruiken puntkomma's.
+    expect(bepaalScheidingsteken('Object;Naam;Beschrijving')).toBe(';');
+  });
+
+  it('negeert scheidingstekens binnen aanhalingstekens', () => {
+    // Eén echte puntkomma, drie komma's tussen aanhalingstekens: de puntkomma
+    // wint. Zonder de aanhalingstekencontrole zou dit de komma opleveren.
+    expect(bepaalScheidingsteken('"a,b,c,d";tweede')).toBe(';');
+  });
+
+  it('valt terug op de komma bij één kolom', () => {
+    expect(bepaalScheidingsteken('alleen-een-kop')).toBe(',');
+  });
+});
+
+describe('leesCsv', () => {
+  it('leest koppen en rijen', () => {
+    const r = leesCsv('naam,plaats\nSiemens,Den Haag\nAlstom,Ridderkerk');
+    expect(r.koppen).toEqual(['naam', 'plaats']);
+    expect(r.rijen).toEqual([
+      ['Siemens', 'Den Haag'],
+      ['Alstom', 'Ridderkerk'],
+    ]);
+  });
+
+  it('leest een ontsnapt aanhalingsteken binnen een veld', () => {
+    // Dít is het geval waarop de parser in MVM_V2 stukloopt: die wisselt
+    // `inQuotes` bij élk aanhalingsteken en kapt de naam af.
+    const r = leesCsv('naam\n"Jansen ""De Bouwer"" B.V."');
+    expect(r.rijen[0][0]).toBe('Jansen "De Bouwer" B.V.');
+  });
+
+  it('leest een regeleinde binnen een veld tussen aanhalingstekens', () => {
+    const r = leesCsv('naam,tekst\nSiemens,"regel 1\nregel 2"');
+    expect(r.rijen).toHaveLength(1);
+    expect(r.rijen[0][1]).toBe('regel 1\nregel 2');
+  });
+
+  it('verwijdert de UTF-8 BOM die Excel voor de eerste kop zet', () => {
+    // Deze test legt het gedr\u00E1g vast, niet het mechanisme: de BOM verdwijnt
+    // door de `.trim()` op de koppen, niet door een eigen regel daarvoor. Zie
+    // de toelichting in `leesCsv` \u2014 een losse `replace` bleek nergens rood te
+    // krijgen en is daarom verwijderd.
+    const r = leesCsv('\uFEFFnaam,plaats\nSiemens,Den Haag');
+    expect(r.koppen[0]).toBe('naam');
+    expect(r.koppen[0].charCodeAt(0)).toBe('n'.charCodeAt(0));
+  });
+
+  it('leest CRLF en LF door elkaar', () => {
+    const r = leesCsv('a,b\r\n1,2\n3,4\r\n');
+    expect(r.rijen).toEqual([
+      ['1', '2'],
+      ['3', '4'],
+    ]);
+  });
+
+  it('laat volledig lege rijen weg', () => {
+    const r = leesCsv('a,b\n1,2\n\n,\n3,4');
+    expect(r.rijen).toEqual([
+      ['1', '2'],
+      ['3', '4'],
+    ]);
+  });
+
+  it('geeft een lege uitkomst bij een leeg bestand', () => {
+    expect(leesCsv('').rijen).toEqual([]);
+    expect(leesCsv('').koppen).toEqual([]);
+  });
+
+  it('leest een bestand met alleen een koprij', () => {
+    const r = leesCsv('naam,plaats');
+    expect(r.koppen).toEqual(['naam', 'plaats']);
+    expect(r.rijen).toEqual([]);
+  });
+});
+
+describe('leesBedrag', () => {
+  it.each([
+    ['4800000', 4800000],
+    ['4.800.000,00', 4800000],
+    ['4,800,000.00', 4800000],
+    ['€ 4800000', 4800000],
+    ['1.234', 1234],
+    ['1234,56', 1234.56],
+    ['0', 0],
+  ])('leest %s als %s', (ruw, verwacht) => {
+    expect(leesBedrag(ruw)).toEqual({ waarde: verwacht, geldig: true });
+  });
+
+  it('geeft leeg terug bij een leeg veld, zonder dat fout te noemen', () => {
+    expect(leesBedrag('')).toEqual({ waarde: null, geldig: true });
+    expect(leesBedrag(null)).toEqual({ waarde: null, geldig: true });
+  });
+
+  it('meldt tekst als ongeldig', () => {
+    expect(leesBedrag('n.v.t.')).toEqual({ waarde: null, geldig: false });
+    expect(leesBedrag('circa 40k')).toEqual({ waarde: null, geldig: false });
+  });
+});
+
+describe('kvkGeldig', () => {
+  it('accepteert acht cijfers', () => {
+    expect(kvkGeldig('34212178')).toBe(true);
+  });
+
+  it('accepteert leeg — niet elke leverancier is Nederlands', () => {
+    expect(kvkGeldig('')).toBe(true);
+    expect(kvkGeldig(null)).toBe(true);
+  });
+
+  it.each(['123', '123456789', '3421217a', '34 212 178'])(
+    'weigert %s',
+    (ruw) => {
+      expect(kvkGeldig(ruw)).toBe(false);
+    },
+  );
+});
+
+describe('emailGeldig', () => {
+  it.each(['d.hoekstra@siemens.com', 'kenji.watanabe@hitachirail.com'])(
+    'accepteert %s',
+    (e) => expect(emailGeldig(e)).toBe(true),
+  );
+
+  it.each([
+    'geen-apenstaartje',
+    'twee@@apenstaartjes.nl',
+    'geen@punt',
+    '@begint-met-apenstaartje.nl',
+  ])('weigert %s', (e) => expect(emailGeldig(e)).toBe(false));
+
+  it('accepteert leeg', () => {
+    expect(emailGeldig('')).toBe(true);
+    expect(emailGeldig(null)).toBe(true);
+  });
+});
+
+describe('duidImpact', () => {
+  it.each([
+    ['High Impact', 'high'],
+    ['high', 'high'],
+    ['Hoog', 'high'],
+    ['Medium Impact', 'medium'],
+    ['Midden', 'medium'],
+    ['Low Impact', 'low'],
+    ['Laag', 'low'],
+  ])('duidt %s als %s', (ruw, verwacht) => {
+    expect(duidImpact(ruw)).toBe(verwacht);
+  });
+
+  it('geeft null bij een onbekende waarde in plaats van te gokken', () => {
+    // Gokken zou een leverancier stil de verkeerde impact geven, en dat is
+    // erger dan een waarschuwing die iemand moet oplossen.
+    expect(duidImpact('Onbekende Waarde')).toBeNull();
+    expect(duidImpact('')).toBeNull();
+    expect(duidImpact(null)).toBeNull();
+  });
+});
+
+describe('beoordeelImportbestand — het voorbeeldbestand', () => {
+  const beoordeling = beoordeelImportbestand(readFileSync(VOORBEELD, 'utf8'));
+
+  it('herkent alle negen gemapte kolommen', () => {
+    expect(Object.keys(beoordeling.herkendeKolommen)).toHaveLength(9);
+    expect(beoordeling.herkendeKolommen['Supplier Name']).toBe('name');
+    expect(beoordeling.herkendeKolommen['KvK Number']).toBe('kvkNumber');
+  });
+
+  it('meldt de onbekende kolom in plaats van hem stil te laten vallen', () => {
+    expect(beoordeling.onbekendeKolommen).toEqual(['Supplier Status']);
+  });
+
+  it('bewaart élke kolom in rawAttributes, ook de gemapte', () => {
+    const siemens = beoordeling.rijen.find(
+      (r) => r.invoer.externalCode === 'COUPA-SIE-001',
+    );
+    // Tien koppen in het bestand, dus tien sleutels — verrijken later vraagt
+    // dan geen herimport.
+    expect(Object.keys(siemens!.invoer.rawAttributes)).toHaveLength(10);
+    expect(siemens!.invoer.rawAttributes['Supplier Status']).toBe('Active');
+  });
+
+  it('telt 28 rijen, 26 importeerbaar, 2 geblokkeerd', () => {
+    expect(beoordeling.samenvatting.totaal).toBe(28);
+    expect(beoordeling.samenvatting.importeerbaar).toBe(26);
+    expect(beoordeling.samenvatting.geblokkeerd).toBe(2);
+  });
+
+  it('blokkeert de rij zonder naam', () => {
+    const rij = beoordeling.rijen.find((r) => r.invoer.name === '');
+    expect(rij!.importeerbaar).toBe(false);
+    expect(rij!.bevindingen.map((b) => b.code)).toContain('naam_ontbreekt');
+  });
+
+  it('blokkeert de dubbele leverancier en wijst naar de eerste regel', () => {
+    const dubbel = beoordeling.rijen.filter((r) =>
+      r.bevindingen.some((b) => b.code === 'dubbel_in_bestand'),
+    );
+    expect(dubbel).toHaveLength(1);
+    expect(dubbel[0].importeerbaar).toBe(false);
+    // De melding moet zeggen wáár het duplicaat staat, anders moet iemand
+    // 142 regels doorzoeken.
+    expect(dubbel[0].bevindingen[0].melding).toContain('regel 2');
+  });
+
+  it('waarschuwt zonder te blokkeren bij een fout KvK-nummer, e-mail of impact', () => {
+    for (const code of [
+      'kvk_ongeldig',
+      'email_ongeldig',
+      'impact_onbekend',
+    ] as const) {
+      const rij = beoordeling.rijen.find((r) =>
+        r.bevindingen.some((b) => b.code === code),
+      );
+      expect(rij).toBeDefined();
+      // Waarschuwen en niet blokkeren: een fout KvK-nummer is achteraf te
+      // corrigeren, een ontbrekende naam niet.
+      expect(rij!.importeerbaar).toBe(true);
+    }
+  });
+
+  it('leest de leverancier met aanhalingstekens in de naam correct', () => {
+    const rij = beoordeling.rijen.find((r) => r.invoer.name.includes('Jansen'));
+    expect(rij!.invoer.name).toBe('Jansen "De Bouwer" B.V.');
+    expect(rij!.importeerbaar).toBe(true);
+  });
+
+  it('verwijst met regelnummers naar wat de gebruiker in Excel ziet', () => {
+    // Eerste gegevensrij is regel 2, want de koprij is regel 1.
+    expect(beoordeling.rijen[0].regel).toBe(2);
+    expect(beoordeling.rijen[0].invoer.name).toBe('Siemens Mobility B.V.');
+  });
+});
+
+describe('beoordeelImportbestand — dubbelherkenning', () => {
+  it('ziet twee vestigingen met dezelfde naam en ander KvK-nummer als twee leveranciers', () => {
+    // Dit is waarom de sleutel KvK vóór naam gebruikt: een holding met twee
+    // vestigingen is geen duplicaat.
+    const b = beoordeelImportbestand(
+      'Supplier Name,KvK Number\nHolding B.V.,11111111\nHolding B.V.,22222222',
+    );
+    expect(b.samenvatting.geblokkeerd).toBe(0);
+  });
+
+  it('valt terug op de naam als er geen KvK-nummer is', () => {
+    const b = beoordeelImportbestand(
+      'Supplier Name,KvK Number\nZonder Nummer B.V.,\nZonder Nummer B.V.,',
+    );
+    expect(b.samenvatting.geblokkeerd).toBe(1);
+  });
+
+  it('negeert verschil in hoofdletters bij de naamvergelijking', () => {
+    const b = beoordeelImportbestand(
+      'Supplier Name\nSiemens Mobility B.V.\nSIEMENS MOBILITY B.V.',
+    );
+    expect(b.samenvatting.geblokkeerd).toBe(1);
+  });
+});
+
+describe('beoordeelImportbestand — Nederlandse koppen en puntkomma', () => {
+  it("leest een Nederlandse export met puntkomma's", () => {
+    const b = beoordeelImportbestand(
+      'Leveranciersnaam;KvK-nummer;Plaats;Jaarbedrag\nSiemens Mobility B.V.;34212178;Den Haag;4.800.000,00',
+    );
+    expect(b.scheidingsteken).toBe(';');
+    expect(b.samenvatting.importeerbaar).toBe(1);
+    expect(b.rijen[0].invoer.name).toBe('Siemens Mobility B.V.');
+    expect(b.rijen[0].invoer.kvkNumber).toBe('34212178');
+    expect(b.rijen[0].invoer.annualSpendEur).toBe(4800000);
+  });
+});
+
+describe('beoordeelImportbestand — grensgevallen', () => {
+  it('geeft nul rijen bij een leeg bestand in plaats van te falen', () => {
+    const b = beoordeelImportbestand('');
+    expect(b.samenvatting.totaal).toBe(0);
+    expect(b.koppen).toEqual([]);
+  });
+
+  it('meldt alle kolommen als onbekend wanneer de koprij niet klopt', () => {
+    // Het scenario dat in MVM_V2 stil 142 leveranciers zonder naam oplevert:
+    // een bestand met verkeerde koppen. Hier is elke rij geblokkeerd én is
+    // zichtbaar dat geen enkele kolom herkend is.
+    const b = beoordeelImportbestand('kolom1,kolom2\nSiemens,Den Haag');
+    expect(Object.keys(b.herkendeKolommen)).toHaveLength(0);
+    expect(b.onbekendeKolommen).toEqual(['kolom1', 'kolom2']);
+    expect(b.samenvatting.importeerbaar).toBe(0);
+  });
+
+  it('verwerkt een rij met minder cellen dan koppen', () => {
+    const b = beoordeelImportbestand('Supplier Name,City,KvK Number\nSiemens');
+    expect(b.rijen[0].invoer.name).toBe('Siemens');
+    expect(b.rijen[0].invoer.city).toBeNull();
+    expect(b.rijen[0].importeerbaar).toBe(true);
+  });
+});

--- a/src/vendor/leverancier-import-schema.ts
+++ b/src/vendor/leverancier-import-schema.ts
@@ -1,0 +1,428 @@
+import { bepaalScheidingsteken, leesCsv } from './csv-lezer';
+
+/**
+ * Een leveranciersbestand inlezen, herkennen en beoordelen — zonder iets weg
+ * te schrijven.
+ *
+ * Dit is de eerste helft van de import: vertel wat er in het bestand staat en
+ * wat er mis is, zodat een mens kan besluiten. De tweede helft (wegschrijven)
+ * wacht op de geverifieerde tenantcontext uit Issue #7 — zonder die context
+ * weet een schrijfroute niet namens wie hij schrijft.
+ *
+ * GEEN database, GEEN NestJS, GEEN tenant. Dezelfde opzet als
+ * `survey/vragenlijst-schema.ts`: een pure functie die los te testen is. Dat
+ * was ook de aanbeveling uit de architectuurreview (Issue #54).
+ *
+ * ── Wat hiervan uit MVM_V2 komt ────────────────────────────────────────────
+ * De kolomaliassen en de ene ontwerpkeuze die het overnemen waard is: alleen
+ * de kernvelden mappen, en **élke overige kolom onaangeroerd bewaren**. Later
+ * verrijken (SBI, rechtsvorm, adres) vraagt dan geen herimport — de gegevens
+ * zijn al binnen, alleen de mapping volgt later.
+ *
+ * Wat er NIET uit MVM_V2 komt: daar wordt niets gevalideerd. `parseCoupaCsv`
+ * levert rijen, `mapCoupaRowToVendor` maakt er leveranciers van, en dat gaat
+ * rechtstreeks de opslag in. Klopt de koprij niet, dan krijg je 142
+ * leveranciers zonder naam. Dat is precies wat deze laag voorkomt.
+ */
+
+/** De velden die MCM2 uit een importbestand haalt. */
+export interface LeverancierInvoer {
+  /** Bronsleutel uit het systeem van herkomst (Coupa `Supplier ID`). */
+  externalCode: string | null;
+  name: string;
+  kvkNumber: string | null;
+  country: string | null;
+  city: string | null;
+  website: string | null;
+  annualSpendEur: number | null;
+  /** Ruwe impactwaarde uit de bron, nog niet omgezet. */
+  impactRuw: string | null;
+  contactNaam: string | null;
+  contactEmail: string | null;
+  /**
+   * Elke kolom uit het bestand, ongewijzigd, op de originele kopnaam.
+   *
+   * Hier staat óók wat wél gemapt is. Dat is bewust: bij een vraag over de
+   * herkomst van een waarde is de ruwe rij het antwoord, en dan wil je niet
+   * hoeven weten welke kolommen destijds gemapt waren.
+   */
+  rawAttributes: Record<string, string>;
+}
+
+/** Waarom een rij niet gebruikt kan worden, of aandacht vraagt. */
+export type BevindingCode =
+  | 'naam_ontbreekt'
+  | 'dubbel_in_bestand'
+  | 'kvk_ongeldig'
+  | 'email_ongeldig'
+  | 'impact_onbekend'
+  | 'bedrag_ongeldig';
+
+/** Blokkerend = deze rij kan niet geïmporteerd worden. */
+const BLOKKEREND: ReadonlySet<BevindingCode> = new Set<BevindingCode>([
+  'naam_ontbreekt',
+  'dubbel_in_bestand',
+]);
+
+export interface Bevinding {
+  code: BevindingCode;
+  /** Voor een mens leesbaar, in het Nederlands. */
+  melding: string;
+  blokkerend: boolean;
+}
+
+export interface BeoordeeldeRij {
+  /** Regelnummer in het bestand, koprij meegeteld. Zo verwijst het naar wat de gebruiker in Excel ziet. */
+  regel: number;
+  invoer: LeverancierInvoer;
+  bevindingen: Bevinding[];
+  /** Geen blokkerende bevinding: deze rij zou geïmporteerd worden. */
+  importeerbaar: boolean;
+}
+
+export interface ImportBeoordeling {
+  /** Kolomkoppen zoals ze in het bestand staan. */
+  koppen: string[];
+  /** Welke kopnaam op welk MCM2-veld is uitgekomen. */
+  herkendeKolommen: Record<string, string>;
+  /** Koppen die op geen enkel bekend veld uitkwamen. Blijven in `rawAttributes`. */
+  onbekendeKolommen: string[];
+  scheidingsteken: string;
+  rijen: BeoordeeldeRij[];
+  samenvatting: {
+    totaal: number;
+    importeerbaar: number;
+    geblokkeerd: number;
+    metWaarschuwing: number;
+    perCode: Record<string, number>;
+  };
+}
+
+/**
+ * Kopnaam → veld. Kleine letters, want kopteksten variëren in schrijfwijze.
+ *
+ * Zowel de Coupa-namen (uit MVM_V2) als de Nederlandse varianten, omdat een
+ * export uit een Nederlands systeem er anders uitziet dan één uit Coupa. Dit
+ * is de tabel die je aanpast als het echte bestand andere koppen blijkt te
+ * hebben — niet de code eromheen.
+ */
+const KOLOM_ALIASSEN: Record<
+  string,
+  keyof Omit<LeverancierInvoer, 'rawAttributes'>
+> = {
+  // Bronsleutel
+  'supplier id': 'externalCode',
+  'supplier number': 'externalCode',
+  leveranciersnummer: 'externalCode',
+  crediteurnummer: 'externalCode',
+  // Naam
+  'supplier name': 'name',
+  leverancier: 'name',
+  leveranciersnaam: 'name',
+  naam: 'name',
+  bedrijfsnaam: 'name',
+  // KvK
+  'kvk number': 'kvkNumber',
+  kvknummer: 'kvkNumber',
+  'kvk-nummer': 'kvkNumber',
+  kvk: 'kvkNumber',
+  // Land en plaats
+  country: 'country',
+  land: 'country',
+  city: 'city',
+  plaats: 'city',
+  stad: 'city',
+  vestigingsplaats: 'city',
+  website: 'website',
+  // Bedrag
+  'annual spend': 'annualSpendEur',
+  'annual spend eur': 'annualSpendEur',
+  jaarbedrag: 'annualSpendEur',
+  jaaromzet: 'annualSpendEur',
+  // Impact
+  'impact classification': 'impactRuw',
+  'impact tier': 'impactRuw',
+  impact: 'impactRuw',
+  // Contactpersoon
+  'primary contact name': 'contactNaam',
+  'contact name': 'contactNaam',
+  contactpersoon: 'contactNaam',
+  'primary contact email': 'contactEmail',
+  'contact email': 'contactEmail',
+  'e-mail': 'contactEmail',
+  email: 'contactEmail',
+  emailadres: 'contactEmail',
+};
+
+/** De impactwaarden die de bron kan leveren. `null` = niet herkend. */
+export function duidImpact(
+  ruw: string | null,
+): 'high' | 'medium' | 'low' | null {
+  if (ruw === null) return null;
+  const genormaliseerd = ruw.trim().toLowerCase();
+  if (genormaliseerd === '') return null;
+  if (genormaliseerd.startsWith('high') || genormaliseerd.startsWith('hoog'))
+    return 'high';
+  if (
+    genormaliseerd.startsWith('medium') ||
+    genormaliseerd.startsWith('midden')
+  )
+    return 'medium';
+  if (genormaliseerd.startsWith('low') || genormaliseerd.startsWith('laag'))
+    return 'low';
+  return null;
+}
+
+/**
+ * Leest een bedrag uit een tekstveld.
+ *
+ * Zowel `4800000` als `4.800.000,00` als `€ 4,800,000.00` komen voor. De
+ * laatste twee zijn niet met één regel te onderscheiden — `1.234` is duizend
+ * tweehonderdvierendertig in Nederland en één-komma-tweehonderdvierendertig
+ * elders. De regel hier: het laatste scheidingsteken met precies twee cijfers
+ * erachter is de decimaalkomma; al het andere is duizendtalscheiding.
+ */
+export function leesBedrag(ruw: string | null): {
+  waarde: number | null;
+  geldig: boolean;
+} {
+  if (ruw === null) return { waarde: null, geldig: true };
+
+  const schoon = ruw.replace(/[€$\s]/g, '').trim();
+  if (schoon === '') return { waarde: null, geldig: true };
+
+  const laatsteKomma = schoon.lastIndexOf(',');
+  const laatstePunt = schoon.lastIndexOf('.');
+  const laatste = Math.max(laatsteKomma, laatstePunt);
+
+  let genormaliseerd: string;
+  if (laatste !== -1 && schoon.length - laatste - 1 === 2) {
+    // Twee cijfers achter het laatste scheidingsteken: decimalen.
+    genormaliseerd =
+      schoon.slice(0, laatste).replace(/[.,]/g, '') +
+      '.' +
+      schoon.slice(laatste + 1);
+  } else {
+    genormaliseerd = schoon.replace(/[.,]/g, '');
+  }
+
+  if (!/^-?\d+(\.\d+)?$/.test(genormaliseerd)) {
+    return { waarde: null, geldig: false };
+  }
+
+  const getal = Number(genormaliseerd);
+  return Number.isFinite(getal)
+    ? { waarde: getal, geldig: true }
+    : { waarde: null, geldig: false };
+}
+
+/**
+ * Een KvK-nummer is acht cijfers.
+ *
+ * Alleen de vorm, niet het bestaan — dat vraagt de KvK-API en dat is een
+ * aparte beslissing. Leeg is geldig: niet elke leverancier is Nederlands.
+ */
+export function kvkGeldig(ruw: string | null): boolean {
+  if (ruw === null || ruw.trim() === '') return true;
+  return /^\d{8}$/.test(ruw.trim());
+}
+
+/**
+ * Grove vormcontrole op een e-mailadres.
+ *
+ * Bewust grof: een sluitende controle bestaat niet, en het adres wordt hier
+ * niet gebruikt om iets te versturen. Het doel is een typefout opmerken —
+ * een ontbrekend apenstaartje — niet RFC 5322 nabouwen.
+ */
+export function emailGeldig(ruw: string | null): boolean {
+  if (ruw === null || ruw.trim() === '') return true;
+  const t = ruw.trim();
+  return /^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(t);
+}
+
+/** Leest de tekst in en beoordeelt elke rij. Schrijft niets weg. */
+export function beoordeelImportbestand(tekst: string): ImportBeoordeling {
+  const inhoud = leesCsv(tekst);
+
+  const herkendeKolommen: Record<string, string> = {};
+  const onbekendeKolommen: string[] = [];
+
+  // Kop-index → veldnaam, zodat elke cel weet waar hij hoort.
+  const veldPerIndex: (
+    keyof Omit<LeverancierInvoer, 'rawAttributes'> | null
+  )[] = inhoud.koppen.map((kop) => {
+    const veld = KOLOM_ALIASSEN[kop.toLowerCase()] ?? null;
+    if (veld) herkendeKolommen[kop] = veld;
+    else if (kop.trim() !== '') onbekendeKolommen.push(kop);
+    return veld;
+  });
+
+  // Dubbele leveranciers opsporen. Sleutel: KvK-nummer als dat er is, anders
+  // de naam in kleine letters. Op KvK vóór naam, want twee vestigingen van
+  // dezelfde holding kunnen dezelfde naam hebben en een ander KvK-nummer —
+  // dat zijn twee leveranciers, geen duplicaat.
+  const eerderGezien = new Map<string, number>();
+
+  const rijen: BeoordeeldeRij[] = inhoud.rijen.map((cellen, index) => {
+    const regel = index + 2; // koprij is regel 1
+    const invoer = maakInvoer(cellen, inhoud.koppen, veldPerIndex);
+    const bevindingen: Bevinding[] = [];
+
+    if (invoer.name.trim() === '') {
+      bevindingen.push({
+        code: 'naam_ontbreekt',
+        melding: 'Deze rij heeft geen leveranciersnaam.',
+        blokkerend: true,
+      });
+    }
+
+    const sleutel =
+      invoer.kvkNumber && invoer.kvkNumber.trim() !== ''
+        ? `kvk:${invoer.kvkNumber.trim()}`
+        : `naam:${invoer.name.trim().toLowerCase()}`;
+
+    if (invoer.name.trim() !== '') {
+      const eerder = eerderGezien.get(sleutel);
+      if (eerder !== undefined) {
+        bevindingen.push({
+          code: 'dubbel_in_bestand',
+          melding: `Deze leverancier staat ook op regel ${eerder}.`,
+          blokkerend: true,
+        });
+      } else {
+        eerderGezien.set(sleutel, regel);
+      }
+    }
+
+    if (!kvkGeldig(invoer.kvkNumber)) {
+      bevindingen.push({
+        code: 'kvk_ongeldig',
+        melding: `'${invoer.kvkNumber}' is geen KvK-nummer van acht cijfers.`,
+        blokkerend: false,
+      });
+    }
+
+    if (!emailGeldig(invoer.contactEmail)) {
+      bevindingen.push({
+        code: 'email_ongeldig',
+        melding: `'${invoer.contactEmail}' lijkt geen e-mailadres.`,
+        blokkerend: false,
+      });
+    }
+
+    if (invoer.impactRuw !== null && invoer.impactRuw.trim() !== '') {
+      if (duidImpact(invoer.impactRuw) === null) {
+        bevindingen.push({
+          code: 'impact_onbekend',
+          melding: `Impactwaarde '${invoer.impactRuw}' is niet herkend.`,
+          blokkerend: false,
+        });
+      }
+    }
+
+    const bedrag = leesBedrag(
+      rauweWaarde(cellen, veldPerIndex, 'annualSpendEur'),
+    );
+    if (!bedrag.geldig) {
+      bevindingen.push({
+        code: 'bedrag_ongeldig',
+        melding: 'Het jaarbedrag is geen getal.',
+        blokkerend: false,
+      });
+    }
+
+    return {
+      regel,
+      invoer,
+      bevindingen,
+      importeerbaar: !bevindingen.some((b) => b.blokkerend),
+    };
+  });
+
+  const perCode: Record<string, number> = {};
+  for (const rij of rijen) {
+    for (const b of rij.bevindingen) {
+      perCode[b.code] = (perCode[b.code] ?? 0) + 1;
+    }
+  }
+
+  return {
+    koppen: inhoud.koppen,
+    herkendeKolommen,
+    onbekendeKolommen,
+    scheidingsteken: inhoud.scheidingsteken,
+    rijen,
+    samenvatting: {
+      totaal: rijen.length,
+      importeerbaar: rijen.filter((r) => r.importeerbaar).length,
+      geblokkeerd: rijen.filter((r) => !r.importeerbaar).length,
+      metWaarschuwing: rijen.filter(
+        (r) => r.importeerbaar && r.bevindingen.length > 0,
+      ).length,
+      perCode,
+    },
+  };
+}
+
+/** Haalt de ruwe waarde van één veld uit een rij, vóór omzetting. */
+function rauweWaarde(
+  cellen: string[],
+  veldPerIndex: (keyof Omit<LeverancierInvoer, 'rawAttributes'> | null)[],
+  veld: keyof Omit<LeverancierInvoer, 'rawAttributes'>,
+): string | null {
+  const index = veldPerIndex.indexOf(veld);
+  if (index === -1) return null;
+  const waarde = cellen[index];
+  return waarde === undefined ? null : waarde;
+}
+
+function maakInvoer(
+  cellen: string[],
+  koppen: string[],
+  veldPerIndex: (keyof Omit<LeverancierInvoer, 'rawAttributes'> | null)[],
+): LeverancierInvoer {
+  const invoer: LeverancierInvoer = {
+    externalCode: null,
+    name: '',
+    kvkNumber: null,
+    country: null,
+    city: null,
+    website: null,
+    annualSpendEur: null,
+    impactRuw: null,
+    contactNaam: null,
+    contactEmail: null,
+    rawAttributes: {},
+  };
+
+  cellen.forEach((cel, i) => {
+    const waarde = cel.trim();
+
+    // Élke kolom bewaren, ook de gemapte. Zie de toelichting bij
+    // `rawAttributes`.
+    const kop = koppen[i];
+    if (kop !== undefined && kop.trim() !== '') {
+      invoer.rawAttributes[kop] = waarde;
+    }
+
+    const veld = veldPerIndex[i];
+    if (!veld) return;
+
+    if (veld === 'name') {
+      invoer.name = waarde;
+    } else if (veld === 'annualSpendEur') {
+      invoer.annualSpendEur = leesBedrag(waarde).waarde;
+    } else {
+      invoer[veld] = waarde === '' ? null : waarde;
+    }
+  });
+
+  return invoer;
+}
+
+/** Alleen voor tests en foutmeldingen: welke bevindingcodes blokkeren. */
+export function isBlokkerend(code: BevindingCode): boolean {
+  return BLOKKEREND.has(code);
+}
+
+export { bepaalScheidingsteken, leesCsv };


### PR DESCRIPTION
Eerste stap naar leveranciersbeheer: een CSV-bestand inlezen en beoordelen. **Schrijft niets weg.**

Dat is bewust. Wegschrijven vraagt een geverifieerde tenantcontext, en die bestaat nog niet — vandaag leidt de backend de tenant af uit een ongeverifieerde header (P0-restpunt in `STATUS.md`, op te lossen in #7). Zou ik nu een importroute bouwen, dan bouw ik hem op die header, en dan is het een leverancierslijst die je met een verzonnen header in een andere tenant kunt schrijven.

Deze laag raakt die grens niet: hij leest een bestand en zegt wat erin staat.

## Wat het doet

Per rij: wat erin staat, wat eruit komt, en welke bevindingen er zijn.

| Blokkerend | Waarschuwing |
|---|---|
| naam ontbreekt | KvK-nummer niet 8 cijfers |
| dubbel in bestand | e-mailadres zonder apenstaartje |
| | impactwaarde niet herkend |
| | jaarbedrag geen getal |

Dat onderscheid is de kern: **een fout KvK-nummer is achteraf te corrigeren, een ontbrekende naam niet.** Plus een samenvatting en een lijst van kolommen die niet herkend zijn — zodat een verkeerde koprij zichtbaar is in plaats van stil.

Tegen het voorbeeldbestand:
```
28 rijen | 26 importeerbaar | 2 geblokkeerd | 3 met waarschuwing
onbekende kolom: Supplier Status
```

## Twee dingen uit MVM_V2, en één niet

**Overgenomen:** de kolomaliassen, en de ontwerpkeuze om alleen kernvelden te mappen en **élke overige kolom onaangeroerd te bewaren**. Later verrijken (SBI, rechtsvorm, adres) vraagt dan geen herimport.

**Niet overgenomen — de CSV-lezer.** Die van MVM_V2 wisselt `inQuotes` bij élk aanhalingsteken, dus `Jansen "De Bouwer" B.V.` wordt afgekapt. Deze lezer doet ontsnapte aanhalingstekens, regeleinden binnen een veld, CRLF/LF door elkaar, en raadt het scheidingsteken — alle vier Transdev-specificatiebestanden in MVM_V2 gebruiken puntkomma's, want Nederlandse Excel doet dat.

**Ook niet overgenomen — het ontbreken van validatie.** In MVM_V2 gaat `parseCoupaCsv` → `mapCoupaRowToVendor` → opslag, zonder controle. Klopt de koprij niet, dan krijg je 142 leveranciers zonder naam. Daar is nu een test voor.

## Tegenproef — gemeten, niet aangenomen

| Teruggedraaid | Gevolg |
|---|---|
| ontsnapping van aanhalingstekens eruit (MVM_V2-gedrag) | 2 tests rood |
| dubbelsleutel van KvK-eerst naar alleen-naam | 1 test rood |

Die tweede is het interessantst: met alleen-naam wordt een holding met twee vestigingen en verschillende KvK-nummers onterecht als duplicaat geblokkeerd.

## Eerlijk over één regel die er níét staat

Er stond een losse BOM-verwijdering in `leesCsv` — Excel zet die voor de eerste kop bij "CSV UTF-8". Die bleek **met geen enkele test rood te krijgen**: `.trim()` op de koppen haalt U+FEFF in JavaScript óók weg.

Ik heb twee tests geschreven om het mechanisme aan te tonen. Beide bleven groen met de regel eruit. Toen heb ik de regel verwijderd in plaats van een derde poging te doen — een regel die niets doet is erger dan geen regel, want de volgende lezer denkt dat de BOM daar wordt afgehandeld. Het gedrag is nog getest, het mechanisme staat in het commentaar.

## Verificatie

- **58 unittests** — de eerste unittestlaag in dit project, gevraagd in #54
- **155 e2e-tests** nog groen: niets bestaands geraakt
- typecheck, lint, format groen

## Wat hierna komt

1. **#7** — Entra-guard. De PoC van 27 juli is end-to-end geslaagd; wat rest zijn de drie stappen uit `docs/architecture-review/2026-07-27/`.
2. **CATS-rollen** — vijf rollen (`vraageigenaar`, `realisatie_verificatie_manager`, `inkoper`, `contractmanager`, `contractbeheerder`) uit `CATS rollen.csv`, plus acht Transdev-functietitels als tenantconfiguratie. Bron: `MVM_V2/src/tenant/transdev/config/job-titles.ts`.
3. **Wegschrijven** — de tweede helft van deze import.
4. **Handinvoer** — formulier en lijst.

## Let op bij review

Het voorbeeldbestand in `db/seeds/` is **door mij samengesteld** uit `vendors.mock.ts` van MVM_V2 — er is geen echte Coupa-export in dat project. De kolomkoppen zijn dus een aanname over wat Transdev daadwerkelijk levert. Aanpassen is één tabel wijzigen (`KOLOM_ALIASSEN`), niet de code eromheen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
