### PR TITLE
docs: sessiestand — UC1 in de browser, externe review, vendorspoor gestart

### DIFF
--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,7 +1,7 @@
 # MCM2 — actuele status
 
 ## Laatst bijgewerkt
-2026-07-29, tweede sessie (vragenlijst-tool t/m **stap 8**: import/export, beide seeds, vragen ophalen, indienlogica én bestandsupload; `contract_id` op `survey_run`; **guardbug gevonden waardoor UC2 in het geheel niet werkte**; 155 e2e-tests groen; **OTAP-doorloop uitgebreid naar 21 controles en geslaagd** — alles hieronder is geverifieerd, niet uit gespreksgeheugen)
+2026-07-30 (**UC1 is nu volledig afrondbaar in de browser** — Issue #42 en #43 gerepareerd; eerste Playwright-browsertest; **externe architectuurreview ontvangen en omgezet in negen issues**; **CSV-parser voor leveranciersimport** met de eerste unittestlaag in dit project — alles hieronder is geverifieerd, niet uit gespreksgeheugen)
 
 ## Het project bestaat uit twee repositories
 
@@ -20,7 +20,11 @@ Eigen CI en eigen releasecyclus per repo — bewust, zodat een tekstwijziging in
 2. Lees dit document (`docs/STATUS.md`) volledig — het is de enige actuele waarheid over fase en blockers.
 3. Verifieer git-status zelf (`git status`, `git branch -a`) tegen wat hieronder staat — vertrouw niet blind op deze snapshot. **Doe dat in beide repositories.**
 4. Check de open GitHub Issues (`gh issue list --repo AlingAdvies/MCM2 --state open`) voor de actuele backlog — dit document verwijst naar issue-nummers, maar de Issues zelf zijn de bron van waarheid over wat daadwerkelijk nog open staat.
-5. **Eerste concrete vervolgstap: stap 5 uit de bouwvolgorde** (`GET /survey/respond/questions`, ontwerp §10). Stap 1 t/m 4 zijn af: migratie, guard met ronde-status, import/export en beide seeds. Issue #30 (geen backups) blijft de zwaarste openstaande blokkade voor alles wat de productiedatabase raakt (#19, #25, #29), maar vraagt nu alleen nog uitvoering door de eigenaar, geen besluit — en de vragenlijst-tool loopt daar niet op vast, want die bouwt tegen wegwerpcontainers.
+5. **Eerste concrete vervolgstap: Issue #7, spoor 1 — de Entra-guard.** Dat is nu de flessenhals: de leverancierskant is compleet en in de browser bewezen, maar álles aan de beheerkant (leveranciers wegschrijven, schermen, rollen) vraagt een geverifieerde tenantcontext. Vandaag leidt de backend de tenant af uit een ongeverifieerde header — het P0-restpunt. De PoC van 2026-07-27 is end-to-end geslaagd; wat rest zijn de drie stappen onderaan `docs/architecture-review/2026-07-27/01-entra-external-id-poc-bevindingen.md`.
+
+   Issue #30 (geen backups) blijft de zwaarste openstaande blokkade voor alles wat de productiedatabase raakt (#19, #25, #29), maar vraagt nu alleen nog uitvoering door de eigenaar, geen besluit — en er wordt tegen wegwerpcontainers gebouwd.
+
+   **Nieuw sinds 2026-07-30: #46 heeft een harde datum.** De pilot start rond 1 september en geüploade certificaten staan op een containerschijf die bij de eerstvolgende image-vervanging leeg is.
 
 ### Snel weer op gang komen
 
@@ -34,6 +38,9 @@ docker exec mcm2test psql -U postgres -c "ALTER ROLE clm_migrator WITH PASSWORD 
 MIGRATION_DATABASE_URL="postgresql://clm_migrator:pw@localhost:55440/postgres" npm run migrate:deploy
 DATABASE_URL="postgresql://clm_api_runtime:pw@localhost:55440/postgres" npm run test:e2e   # 155 tests
 
+# Unittests — geen database nodig
+npx jest                                  # 59 (58 vendor + 1 bestaande)
+
 # De twee vragenlijsten inlezen (tenant moet bestaan)
 DATABASE_URL="postgresql://clm_api_runtime:pw@localhost:55440/postgres" \
   npm run seed:vragenlijsten -- <tenant-uuid>
@@ -44,6 +51,8 @@ cd ../MCM2-frontend && npm run dev
 #   andere demo-tokens: demo-nietopen, demo-verlopen, demo-ingediend
 
 # De volledige keten (beide productie-images): docs/runbooks/otap-doorloop.md
+# Daarna de browsertest, met een VERSE tokenlink (indienen is eenmalig):
+cd ../MCM2-frontend && SURVEY_TOKEN=<verse-link> npm run e2e
 ```
 
 ## Vragenlijst-tool — scope vastgesteld op 2026-07-29, ontwerp is bouwbaar
@@ -95,9 +104,29 @@ Daarmee zijn alle blokkerende ontwerpvragen beantwoord. Wat nog openstaat in §1
 
 **Drie dingen raken bestaande, groene code** en verdienen aandacht bij het bouwen: `survey_run` krijgt drie kolommen (`status`, `is_test`, `survey_kind`), `survey_response` krijgt er drie (`subject_vendor_id`, `respondent_user_id`, `respondent_label`) waarbij `vendor_id` **nullable** wordt, en de bestaande guard moet de ronde-status meewegen naast `closes_at`/`revoked_at`. Die nullable-wijziging is een versoepeling op een tabel die vanochtend gemerged is — de UC1-garantie wordt overgenomen door een partiële unieke index plus twee CHECK-constraints, en testpunten 41 t/m 43 horen te bewijzen dat er niets weglekt.
 
-## Frontend — repository aangemaakt op 2026-07-29 (ADR-012), nog geen schermen
+## Frontend — leverancierportaal werkt end-to-end (2026-07-30)
 
-**`https://github.com/AlingAdvies/MCM2-frontend`** (privé, onder AlingAdvies). Fundament staat, CI groen op beide jobs. **Nog geen schermen** — het leverancierportaal is de volgende stap.
+**`https://github.com/AlingAdvies/MCM2-frontend`** (privé, onder AlingAdvies). CI groen op beide jobs.
+
+**Het portaal is afrondbaar.** Sinds PR #1 (2026-07-30) kan een leverancier de Transdev-vragenlijst van tokenlink tot bevestiging doorlopen: vragen lezen, bevestigen, certificaat uploaden, indienen. Daarna is de link op. Gemeten in de browser tegen de productie-images:
+
+```
+/questions 200  →  /attachment 201  →  /respond 200  →  tweede poging 410
+```
+
+Twee bugs uit de OTAP-doorloop van 2026-07-29 zijn daarmee weg:
+
+- **#42** — het portaal toonde "Bestandsupload volgt in een volgende versie" terwijl de backend het wél kon. Bevestigen op de ISO-vraag gaf een 422 die als "Er ging iets mis bij het versturen" verscheen: een doodlopende weg. Nu een uploadveld begrensd op `maxFiles`, en een 422 wordt **per vraag** getoond in plaats van als paginabrede blokkade — een 422 is herstelbaar, dus die hoort niet naar het geblokkeerde scherm te leiden.
+- **#43** — het leesblok kreeg drie keuzerondjes. Nu een apart `Leesblok`-component, en de nummering slaat leesblokken over zodat "vraag 8" klopt met wat de teller zegt.
+
+**Eerste browsertest** (`e2e/portaal-uc1.spec.ts`, Playwright): de volledige UC1-flow tegen de OTAP-stack, geen mock. **Draait niet in CI** — hij vraagt een verse tokenlink per run, want indienen is eenmalig. Zonder `SURVEY_TOKEN` slaat hij zichzelf over in plaats van te falen. Zie #47 en #53.
+
+Tegenproef gedaan: met de `instruction`-tak eruit vielen drie controles om, met het uploadveld verborgen twee plus een omvallende `setInputFiles`.
+
+**Twee bekende gaten, bewust niet gedicht:**
+
+- **Gemengde taal.** De vragen zijn Engels (uit het Transdev-bronbestand), de meldingen van het portaal Nederlands. Dat is een besluit voor de eigenaar, geen bug.
+- **Een geüploade bijlage is niet te verwijderen.** De backend heeft geen `DELETE` op `/survey/respond/attachment`. Er staat een vinkje, geen kruisje — een knop die niets kan aanroepen is erger dan geen knop. Verwijderen mogelijk maken is backend-werk en een nieuw issue.
 
 Wat er staat: Next.js 15 + Tailwind 3 (**bewust dezelfde majors als MVM_V2**, niet de nieuwste — Next 16/Tailwind 4 zouden het overnemen van MVM_V2-componenten juist duurder maken), versies exact gepind conform MCM2-CLAUDE.md §11, TypeScript meteen op `strict` (in de backend is dat nog Issue #3; achteraf strict maken kost meer).
 
@@ -175,6 +204,20 @@ Transdev Vendor IT Compliance Survey als eerste verticale MVP-slice.
 
 ## Aantoonbaar werkend
 
+- **CSV-parser voor leveranciersimport (2026-07-30, PR #55).** `src/vendor/` — leest een bestand, meldt per rij wat er mis is, **schrijft niets weg**. Dat laatste is bewust: wegschrijven vraagt een geverifieerde tenantcontext (#7), en zonder die context weet een schrijfroute niet namens wie hij schrijft.
+
+  Onderscheid **blokkerend** (naam ontbreekt, dubbel in bestand) versus **waarschuwing** (KvK niet 8 cijfers, e-mail zonder apenstaartje, impactwaarde onbekend, bedrag geen getal). Dat is de kern: een fout KvK-nummer is achteraf te corrigeren, een ontbrekende naam niet. Regelnummers verwijzen naar wat de gebruiker in Excel ziet, en een dubbelmelding zegt wáár het duplicaat staat.
+
+  Tegen `db/seeds/voorbeeld-leveranciers-coupa.csv`: 28 rijen, 26 importeerbaar, 2 geblokkeerd, 3 met waarschuwing, en één gemelde onbekende kolom.
+
+  **58 unittests — de eerste echte unittestlaag in dit project** (gevraagd in #54). `npx jest` rapporteert 59: die ene extra is de bestaande `app.controller.spec.ts`. Tegenproef: ontsnapping van aanhalingstekens eruit → 2 rood; dubbelsleutel van KvK-eerst naar alleen-naam → 1 rood.
+
+  **Eigen CSV-lezer, niet die van MVM_V2.** Die wisselt `inQuotes` bij élk aanhalingsteken en kapt `Jansen "De Bouwer" B.V.` af. Deze leest ontsnapte aanhalingstekens, regeleinden binnen een veld, CRLF/LF door elkaar, en raadt het scheidingsteken — alle vier Transdev-specificatiebestanden in MVM_V2 gebruiken puntkomma's, want zo schrijft Nederlandse Excel.
+
+  **Let op — het voorbeeldbestand is zelf samengesteld.** Er staat geen echte Coupa-export in MVM_V2; het bestand is afgeleid uit `vendors.mock.ts`. De kolomkoppen zijn dus een **aanname** over wat Transdev levert. Aanpassen is één tabel wijzigen (`KOLOM_ALIASSEN`), niet de code eromheen.
+
+- **UC1 volledig afrondbaar in de browser (2026-07-30, MCM2-frontend PR #1).** Zie het frontend-blok hierboven: `/questions` 200 → `/attachment` 201 → `/respond` 200 → tweede poging 410, gemeten tegen de productie-images. Issue #42 en #43 gesloten.
+
 - **OTAP-doorloop t/m indienen en upload (2026-07-29, tweede doorloop).** Uitgebreid van 8 naar **21 controles** in negen stappen; `scripts/otap-doorloop.js` dekt nu ook de vragenlijst, de validatie, de bestandsupload en het indienen. **Vier keer gedraaid, vier keer geslaagd** — waarvan één keer volledig vanaf niets na `down -v`.
 
   **De volledige keten is in de browser bewezen:** het portaal toont de echte negen Transdev-vragen uit de database met de MVM_V2-huisstijl, en vanuit diezelfde pagina levert upload → 201 en indienen → 200. De 404 die de vorige doorloop signaleerde is weg.
@@ -185,7 +228,7 @@ Transdev Vendor IT Compliance Survey als eerste verticale MVP-slice.
   2. **Het opruimblok van het doorloopscript was niet meer idempotent** zodra er echt ingediend werd — `ON DELETE RESTRICT` blokkeerde het verwijderen van een respons met antwoorden. Dat de constraint in de weg zat, is het bewijs dat hij werkt.
   3. **De seed vraagt een bestaande tenant** op een verse database. Toegevoegd als stap 3b in het runbook.
 
-  **Twee frontend-bevindingen, vastgelegd als Issue #42 en #43:** het portaal kan nog geen bestanden uploaden (waardoor een leverancier UC1 niet via de browser kan afronden — de backend kan het wél), en het rendert het `instruction`-leesblok als een vraag met keuzerondjes. Beide met de browser vastgesteld, niet beredeneerd.
+  **Twee frontend-bevindingen, vastgelegd als Issue #42 en #43 — beide gesloten op 2026-07-30** (MCM2-frontend PR #1): het portaal kon geen bestanden uploaden (waardoor een leverancier UC1 niet via de browser kon afronden — de backend kon het wél), en het rendeerde het `instruction`-leesblok als een vraag met keuzerondjes. Beide met de browser vastgesteld, niet beredeneerd. **Dat geen van beide door een test gevonden is, was de aanleiding voor #47** — de eerste browsertest.
 
 - **Bestandsupload met inhoudscontrole (2026-07-29, stap 8, Issue #9).** `src/survey/bestand-validatie.ts`, `bestand-opslag.service.ts` en `bijlage.service.ts`, plus `POST /survey/respond/attachment`. **155 van 155 e2e-tests groen** in twaalf suites.
 
@@ -255,7 +298,7 @@ Transdev Vendor IT Compliance Survey als eerste verticale MVP-slice.
 
 - **Leverancierportaal in de browser (2026-07-29, `MCM2-frontend`).** De acht Transdev-vragen renderen met de MVM_V2-huisstijl. Geverifieerd door het scherm daadwerkelijk te doorlopen: de toelichtingsplicht schakelt om zodra een niet-bevestiging gekozen wordt, indienen met ontbrekende antwoorden wordt geweigerd en markeert elke onvolledige vraag, en een toelichting van `"   -   "` valt af op de ondergrens van tien tekens. De vierde antwoordoptie verschijnt alleen bij de uploadvraag; de draft-toestand toont een oranje klok in plaats van een rode fout.
 
-  Draait op mock data. Tegen de live backend toont het portaal de vragenlijst nog niet — `/survey/respond/questions` is stap 5 uit de bouwvolgorde en bestaat nog niet.
+  *Deze notitie beschrijft de stand op 2026-07-29, toen het portaal nog op mock data draaide.* De mock/live-schakelaar bestaat nog steeds en is nuttig om schermen zonder backend te beoordelen — maar sinds 2026-07-30 werkt het portaal ook volledig tegen de echte backend. Zie het frontend-blok bovenaan.
 
 - **Vragenlijst-datamodel niveau B (2026-07-29, PR #33, migratie `0005_vragenlijst_niveau_b.sql`).** Vier nieuwe tabellen (`survey_category`, `survey_question`, `survey_answer`, `survey_attachment`) plus `survey_kind`/`status`/`is_test` op `survey_run` en drie respondentkolommen op `survey_response`. 459 regels, waarvan ongeveer een derde gegenereerd — de rest handwerk, precies zoals ADR-010 voorspelt.
 
@@ -328,9 +371,56 @@ Drie tests in `test/schema-conformiteit.e2e-spec.ts` bewaken de kolom. De middel
 
 **Aandachtspunt voor het contractspoor:** zodra `clm.contract` bestaat, moet die tabel een eigen RLS-policy krijgen vóórdat de foreign key gelegd wordt. Een verwijzing naar een tabel zonder RLS is een lek.
 
+**Bijgewerkt 2026-07-30: het vendorspoor is nu wél gestart, contracten nog niet.** De eigenaar heeft leveranciersbeheer als volgend spoor gekozen (aanmaken en importeren). Dat verandert het besluit hierboven niet — contracten blijven een eigen bouwspoor met eigen intake — maar het maakt één vondst uit die inventarisatie belangrijk:
+
+**De tabellen bestonden al.** `clm.vendor` (25 kolommen, met RLS), `clm.vendor_contact`, `clm.vendor_tag` en drie `ref.*`-tabellen stonden er al, overgenomen uit `mvm-api-pilot/Database/migrations/004_clm_vendor.sql`. Wat ontbrak was niet het datamodel maar de laag erboven: geen `src/vendor/`-module, geen routes, geen scherm. Tot 2026-07-30 schreven alleen testscripts er rechtstreeks via SQL in.
+
+**Twee dingen die de C#-pilot wél heeft en MCM2 niet:** `vendor_address` (adressen genormaliseerd in een eigen tabel) en `parent_vendor_id` (holdingstructuur). Geen van beide is nu nodig; wel goed om te weten dat de bron ze heeft.
+
+## Externe architectuurreview — ontvangen 2026-07-29, omgezet in negen issues
+
+Op verzoek van de eigenaar is de volledige architectuur, OTAP-straat en teststrategie ter review aangeboden aan een tweede AI-model. Beide documenten staan in `docs/architecture-review/`:
+
+| Document | Wat |
+|---|---|
+| `2026-07-29/00-review-aanvraag-architectuur-otap-tests.md` | de aanvraag, 1027 regels, zelfstandig leesbaar, met negen vragen die elk om een beslissing vragen |
+| `External-2026-07-29-mcm2-architectuurreview-otap-tests.pplx.md` | het antwoord |
+
+Alle negen vragen zijn beantwoord, met het gevraagde sjabloon per bevinding: ernst, onderbouwing, aanbeveling, kosten van niets doen, en **zekerheid** (zeker/waarschijnlijk/vermoeden). Dat laatste veld bleek het nuttigst — het is eerlijk gebruikt, niet alles staat op "zeker".
+
+**Omgezet in negen issues (#46 t/m #54).** Drie als pilotblokkade:
+
+| # | Wat |
+|---|---|
+| **#46** | duurzame objectopslag voor uploads + dump buiten de brondraaimachine — **harde datum: pilot rond 1 september** |
+| **#47** | Playwright-browsertest van de volledige UC1-flow — gedeeltelijk af, zie frontend-blok |
+| **#48** | pilot-runbook en alerting: wie kijkt wanneer naar welk signaal |
+
+Vijf voor productie (#49 quotarij voor `max_files`, #50 vergrendeling bewijzen, #51 frontend-image promoveerbaar, #52 virusscan-restrisico vastleggen, #53 OTAP-doorloop automatiseren) en één later (#54 unittestlaag — daarvan is de eerste laag geleverd in PR #55).
+
+### Waar de review mij corrigeerde, en gelijk had
+
+- **Waarneembaarheid was te licht ingeschat.** Ik had geen logging/monitoring als "kleiner punt" weggezet; de review tilt het naar blokkerend. Het argument snijdt hout: een stille storing blijft dagenlang onopgemerkt bij een link met 30 dagen geldigheid.
+- **Mijn eigen vraagstelling over `NEXT_PUBLIC_API_URL` was fout.** Ik zette twee opties tegenover elkaar; de review draagt een derde, betere aan (server-side runtime-config of same-origin proxy) zonder extra publiek endpoint. Zie #51.
+- **Virusscanning stond te hoog in mijn lijst.** Ik noemde zelf drie compenserende controles en concludeerde toch "het is niet nul", zonder te vragen of nul nodig is vóór een pilot met bekende leveranciers. Zie #52.
+- **Het CREATE ROLE-risico overschatte ik.** Op Amazon RDS heeft `rds_superuser` gewoon `CREATEROLE`. Het risico is reëel bij bepaalde serverless Postgres-aanbieders, niet bij de RDS-route die ik zelf als doel noem.
+- **De concurrency-aanpak bij `max_files` was te zwak.** Een kale trigger met `COUNT(*)` lost de race niet op — twee uploads passeren allebei vóór elkaars commit. Zie #49 voor twee uitgewerkte routes; de quotarij met atomaire `UPDATE ... WHERE used_files < max_files RETURNING` is de betere.
+
+### Eén reviewbevinding is nagerekend en vervallen
+
+Vraag 5 beval een e2e-test aan voor de UC2-tokenlookup over HTTP, met als onderbouwing dat die dekking ontbrak. **Die aanname is onjuist**: `test/vragenlijst-ophalen.e2e-spec.ts` regel 437 en 465 doen dit al, beide via `request(server)` door de guard heen. De eerste is de regressietest voor de 0008-bug, de tweede sluit af dat "join op `subject_vendor_id`" niet stilzwijgend "controleer niets meer" gaat betekenen.
+
+De reviewer kon dit niet zien: de testbestanden zaten niet in Bijlage A, alleen een tabel met testtellingen. Dit stond op zekerheid **waarschijnlijk**, en het is het enige van de negen antwoorden dat op een aanname over niet-meegeleverd materiaal rustte — en het enige dat bij narekenen sneuvelt. Vastgelegd in #24.
+
+Wat er van vraag 5 wél overblijft staat als later-item in #24: een expliciete `respondent_type`-kolom zodra een derde use case ontstaat waarin deelnemer en onderwerp niet meer via `vendor_id IS NULL` te onderscheiden zijn.
+
 ## Lessen uit deze sessies die tijd besparen
 
 Praktische valkuilen die daadwerkelijk zijn tegengekomen, niet bedacht. Ze staan hier omdat ze anders opnieuw ontdekt worden.
+
+**Een regel die met geen enkele test rood te krijgen is, hoort weg — niet een derde test.** In `csv-lezer.ts` stond een losse BOM-verwijdering. Die bleek overbodig: `.trim()` op de koppen haalt U+FEFF in JavaScript óók weg. Er zijn twee tests geschreven om het mechanisme aan te tonen; beide bleven groen met de regel eruit. Toen is de regel verwijderd in plaats van een derde poging te doen. **Een regel die niets doet is erger dan geen regel**, want de volgende lezer denkt dat het probleem daar wordt afgehandeld. Kostte drie omwegen; het alternatief was code committen met een bewering die niet aantoonbaar was.
+
+**Een test die het juiste antwoord geeft, kan nog steeds het verkeerde meten.** Twee keer op één dag tegengekomen. In de browsercontrole zocht een assertie de naam van de vragenlijst in de koptekst in plaats van de titel van het leesblok — die faalde terwijl de code goed was. En `getByText(/al ingediend/i)` matchte twee elementen, want die tekst staat ook in de melding van de backend eronder. Beide keren was de fix in de test, niet in de code. Bij een falende assertie: kijk eerst wát er gemeten wordt.
 
 **`drizzle-kit` genereert migraties die op een gevulde database falen.** Bij `subject_vendor_id` produceerde het `ADD COLUMN ... NOT NULL`, wat alleen op een lege tabel slaagt. Elke nieuwe verplichte kolom vraagt handmatig de drie-stappenvorm: kolom toevoegen → backfillen → `SET NOT NULL`. Controleer dit bij **elke** gegenereerde migratie.
 
@@ -366,18 +456,25 @@ Praktische valkuilen die daadwerkelijk zijn tegengekomen, niet bedacht. Ze staan
 
 ## Huidige branch en Git-status
 
-**Stand op 2026-07-29, tweede sessie:**
+**Stand op 2026-07-30:**
 
 | Repo | Branch | Werkboom | Openstaande PR's |
 |---|---|---|---|
-| MCM2 | **`chore/otap-doorloop-stap8`** | schoon | nog niet gepusht |
+| MCM2 | `main` | schoon | geen |
 | MCM2-frontend | `main` | schoon | geen |
 
-**Drie PR'''s gemerged naar `main`:** #37 (stap 3 en 4, `ef62cd6`), #38 (migratie 0007 plus de drie bevestigde ontwerpbesluiten, `4b09026`) en #39 (stap 5 plus de UC2-guardfix, `52f41b0`). Alle drie met CI groen op alle drie de jobs, alle branches lokaal én op GitHub verwijderd. Na elke merge opnieuw geverifieerd tégen `main` zelf.
+**Geen open branches in beide repositories.** Alle gemergede branches zijn lokaal én op GitHub verwijderd.
 
-**Vijf PR's gemerged naar `main`:** #37, #38, #39, #40 en #41 (stap 8, `7c0be9b`). Alle vijf met CI groen op alle drie de jobs, alle branches lokaal én op GitHub verwijderd.
+**Gemerged op 2026-07-30:**
 
-**`chore/otap-doorloop-stap8` staat open:** de uitgebreide doorloop, de Dockerfile-fix voor de uploadmap en deze statusbijwerking. Nog niet gepusht. Lokale poorten wél gedraaid: format, lint, typecheck, 155/155 e2e tegen een verse Postgres 17.6 (twee keer), en de Docker-productiebuild die start, de uploadroute mapt en `/health` met 200 beantwoordt.
+| PR | Repo | Wat |
+|---|---|---|
+| **#55** | MCM2 | CSV-parser en validatie voor leveranciersimport (`2d9a4ad`) |
+| **#1** | MCM2-frontend | Bestandsupload en leesblok — UC1 afrondbaar in de browser (`3a8a571`) |
+
+**Gemerged op 2026-07-29:** #37, #38, #39, #40, #41 (stap 8), #42/#43 als issues, #44, #45 (reviewaanvraag). Alle met CI groen op alle jobs.
+
+**Eén onopgeruimd punt uit een eerdere sessie:** `git branch -a` toonde na de merge van MCM2-frontend#1 nog een remote branch die GitHub al had verwijderd. Dat was een verouderde lokale cache; `git fetch --prune` loste het op. Meldenswaardig omdat het er even uitzag als een mislukte opruiming.
 
 - **`docs/sessiestand-otap` is op 2026-07-29 via PR #35 gemerged naar `main`** (merge-commit `cbe6c48`) en daarna lokaal én op GitHub verwijderd. Eén commit: uitsluitend deze statusbijwerking.
 - **`feat/issue-7-leveranciertoken` is op 2026-07-29 via PR #32 gemerged naar `main`** (merge-commit `7f0cc01`) en daarna lokaal én op GitHub verwijderd. CI groen op alle drie de jobs vóór de merge, opnieuw geverifieerd met `gh pr checks 32` op de laatste commit. Vijf commits: de tokenlaag, de HTTP-routes met logmaskering en auditregels, de fix op `maskeerDiep`, plus twee documentatiecommits. **Issue #31 is bij die merge gesloten** — migratie `0004` loste hem op. Let op: die migratie is bewezen in CI, **niet toegepast op `clm-enterprise`** — net als #29 en #25 wacht dat op #30.
@@ -399,15 +496,48 @@ Praktische valkuilen die daadwerkelijk zijn tegengekomen, niet bedacht. Ze staan
 
 ## Eerstvolgende goedgekeurde stap
 
-De databaselaag is omgezet (ADR-010), spoor 2 van Issue #7 zit in `main`, en de vragenlijst-tool staat t/m stap 4: het datamodel, de guard, import/export en beide gevulde vragenlijsten.
+**De leverancierskant is klaar en in de browser bewezen.** UC1 is van tokenlink tot bevestiging afrondbaar (zie het frontend-blok hierboven). Daarmee is er voor het eerst iets demonstreerbaars voor de klant.
 
-**De backendkant van de leveranciersflow is compleet en in de keten bewezen.** De OTAP-doorloop van 2026-07-29 toont dat vragen ophalen, valideren, uploaden en indienen end-to-end werken vanuit de browser.
+**Het nieuwe spoor sinds 2026-07-30: leveranciersbeheer.** De opdrachtgever wil leveranciers kunnen aanmaken en importeren. Startpunt is Excel/CSV, daarna handinvoer; PC-only; het gaat mee in de pilot.
 
-**De eerstvolgende stap zit in de frontend, niet in de backend: Issue #42.** Het portaal kan nog geen bestanden uploaden, waardoor een leverancier de Transdev-vragenlijst niet via de browser kan afronden — bevestigen op de ISO-vraag levert een 422 op die als "Er ging iets mis" wordt getoond. Dat is nu de enige blokkade voor een werkende demonstratie aan de klant. Issue #43 (het leesblok met keuzerondjes) is cosmetisch maar verwarrend.
+**De eerstvolgende stap is Issue #7, spoor 1 — de Entra-guard.** Dat is nu de flessenhals, en dat is een verschuiving: de leverancierskant had een eigen, complete beveiliging (het token *is* de sleutel, de tenant komt uit de tokenlookup). De beheerkant heeft dat niet. Vandaag leidt de backend de tenant af uit een **ongeverifieerde header** — het P0-restpunt. Elke schrijfroute die daarop gebouwd wordt, is een route die met een verzonnen header in een andere tenant schrijft.
 
-Daarna is stap 7 (concept opslaan) de volgende inhoudelijke uitbreiding, en stap 10 (beheerroutes) wacht op spoor 1.
+De PoC van 2026-07-27 is end-to-end geslaagd (federatie, MFA, geldige authorization code). Wat rest zijn de drie stappen onderaan `docs/architecture-review/2026-07-27/01-entra-external-id-poc-bevindingen.md`: code inwisselen voor tokens, claims inspecteren, JWKS-guard bouwen. **Inspecteer de claims vóór er iets op gebouwd wordt** — dat document noemt `email`, `sub`, `oid` en `tid` als verwachting, niet als meting.
 
-**Daarnaast, en dat kost geen code:** het portaal tegen de echte backend zetten via een OTAP-doorloop. De vragen staan in de database en de route bestaat, dus dit is de eerste keer dat de klant de echte vragenlijst in de browser kan zien in plaats van mock data.
+### De vier stappen van het vendorspoor, in deze volgorde
+
+1. ~~**CSV-parser en validatie**~~ — **afgerond 2026-07-30** (PR #55). Leest een bestand, meldt per rij wat er mis is, schrijft niets weg. Raakt de tenantgrens niet en kon daarom vóór de guard.
+2. **Entra-guard (#7 spoor 1)** — identiteit en geverifieerde tenantcontext.
+3. **CATS-rollen** — zie het blok hieronder.
+4. **Wegschrijven** — de tweede helft van de import, plus formulier en lijst.
+
+### CATS-rollen — bron gevonden, nog niet gebouwd
+
+Op 2026-07-30 vastgesteld door de eigenaar: gebruikers krijgen **verschillende rollen**; of autorisatie later ook op individu gaat, is een besluit voor later.
+
+De bron is `MVM_V2/src/tenant/transdev/config/job-titles.ts`, afkomstig uit `CATS rollen.csv` (Bizaline/MyVendormanager). **Ongewijzigd actueel volgens de eigenaar.** Het bevat twee lagen, en dat onderscheid is de vondst:
+
+| Laag | Wat | Aantal |
+|---|---|---|
+| **CATS-rol** | bepaalt de rechten — platform | 5: `vraageigenaar`, `realisatie_verificatie_manager`, `inkoper`, `contractmanager`, `contractbeheerder` |
+| **Functietitel** | wat op het visitekaartje staat — tenantconfiguratie | 8 voor Transdev, elk gekoppeld aan één CATS-rol |
+
+**Niet de vier rollen uit `MVM_V2/src/core/auth/permissions.ts` overnemen** (`admin`/`manager`/`compliance_officer`/`viewer`). Dat zijn generieke applicatierollen; CATS is Transdev's eigen vakinhoudelijke model. In MVM_V2 staan ze náást elkaar en doet `canDo()` niets met CATS — daar is het gedocumenteerd maar niet aangesloten.
+
+**Twee ontwerpeisen die daaruit volgen:**
+
+- **Rol als eigen rij, niet als kolom op `clm.user`.** Zodra "autorisatie op individu" aan de orde komt, is er een plek nodig om bereik op te hangen. Een `clm.user_role`-rij geeft die; een `role`-kolom niet. Kost nu vrijwel niets en voorkomt een migratie op gevulde pilotdata.
+- **Rechten in code, niet in de database.** Rechten wijzigen hoort een codewijziging met een PR te zijn, geen `UPDATE`-statement.
+
+**`contractScope` (DOP/AOC) is een autorisatiegrens, geen label.** DOP = operationele prestatie-artikelen, AOC = prijs, boete, tekortkoming. MVM_V2's backlog B-025 is er expliciet over: *"Contract coordinator (DOP only) krijgt NOOIT toegang tot het volledige PDF-contract"*, met PDF alleen voor DOP+AOC/AOC-rollen en AOC-KPI's alleen voor AOC-geautoriseerden.
+
+Nu is er niets om dat op toe te passen — geen contracttabel, geen KPI's, geen PDF's, en bij leveranciers speelt het niet. **Kolom vastleggen, niet gebruiken**, zoals met `contract_id` op `survey_run` is gedaan. Wél als grens documenteren, anders leest een volgende ontwikkelaar het als een filtertje.
+
+**Eén aanname om te verifiëren:** B-025 stelt dat Transdev de scheiding DOP/AOC *zelf nog niet formeel kent* en dat die met AI uit contract-PDF's gehaald zou worden. Dat is een aanname over hun werkwijze uit maart 2026.
+
+### Daarna, in de vragenlijst-tool
+
+Stap 7 (concept opslaan) is de volgende inhoudelijke uitbreiding; stap 10 (beheerroutes) wacht op spoor 1.
 
 ~~1. Migratie met de vier nieuwe tabellen en de kolommen op `survey_run`/`survey_response`~~ — **afgerond 2026-07-29** (migratie 0005).
 ~~2. De bestaande guard uitbreiden met de ronde-statuscontrole~~ — **afgerond 2026-07-29** (migratie 0006).
@@ -458,7 +588,18 @@ Volledige backlog (alle 24 items, incl. Before production en Later): `gh issue l
   - `2026-07-28-vragenlijst-ontwerp.md` — vragenlijst-tool, antwoorden en certificaat-upload. **Status: bouwbaar** (niveau B, vastgesteld 2026-07-29). §0 legt de twee scopewijzigingen uit; §10 bevat de bouwvolgorde.
 - **Externe referentie:** `VendorComply Help en Manual.md` (OneDrive, `Bizaline/Producten/VendorComply/`) — handleiding van een bestaand, werkend product. Bron van de acht vraagtypen en de lifecycle. **Referentie, geen compatibiliteitseis:** geen gedeelde database, geen migratiepad. Wat is overgenomen en wat niet, staat in het ontwerp §1a.
 - **Klantaanlevering:** `Transdev Annual Vendor IT Risk SurveyV1_0.md` (repo-root) — de acht vragen die de eerste vulling van de tool vormen.
-- Architectuurreview: `docs/architecture-review/2026-07-24/` (00, 02-05, 07-09 — 06 is verplaatst naar `docs/archive/`, zie hierboven)
+- **Architectuurreviews:**
+  - `docs/architecture-review/2026-07-24/` — de oorspronkelijke review (00, 02-05, 07-09; 06 is verplaatst naar `docs/archive/`)
+  - `docs/architecture-review/2026-07-27/01-entra-external-id-poc-bevindingen.md` — **de Entra-PoC. Lees dit vóór het bouwen van de guard**; de drie concrete vervolgstappen staan onderaan.
+  - `docs/architecture-review/2026-07-29/00-review-aanvraag-architectuur-otap-tests.md` — de reviewaanvraag (1027 regels, zelfstandig leesbaar)
+  - `docs/architecture-review/External-2026-07-29-mcm2-architectuurreview-otap-tests.pplx.md` — het externe antwoord. Omgezet in #46 t/m #54; zie het reviewblok hierboven.
+- **Herbruikbaar uit MVM_V2** (`C:\dev\Work\MVM_V2`), geverifieerd op 2026-07-30:
+  - `src/tenant/transdev/config/job-titles.ts` — **de CATS-rollen en acht Transdev-functietitels.** Bron: `CATS rollen.csv`, ongewijzigd actueel volgens de eigenaar.
+  - `src/tenant/transdev/config/coupa-field-mapping.ts` — de kolomaliassen; de basis van `KOLOM_ALIASSEN` in de parser. **De CSV-lezer daarin is níét overgenomen** (kapt ontsnapte aanhalingstekens af).
+  - `src/app/vendors/` — lijst (316 regels), aanmaakformulier (272) en detailpagina (397). Vorm bruikbaar; `vendorService.ts` schrijft in localStorage en een in-memory array — dat is demo-code, geen persistentie.
+  - `BACKLOG.md` B-025 — de DOP/AOC-autorisatiegrens.
+  - `src/core/auth/permissions.ts` — **niet overnemen** als rollenmodel, zie het CATS-blok hierboven.
+- **Uit `mvm-api-pilot`:** `Database/migrations/004_clm_vendor.sql` is de bron van MCM2's vendorschema (dat werk is al binnengehaald). `Controllers/V2/VendorsController.cs` is bruikbaar als contract-referentie voor verplichte velden en defaults — **maar niet voor de tenantafleiding**, die komt daar uit `?tenant=demo`. `Database/migrations/009_staging.sql` bevat een staging-importmodel dat nooit in C# is geïmplementeerd; het idee (rijen eerst in staging met `pending/validated/imported/rejected`, ruwe rij als jsonb) is wel bruikbaar voor stap 4 van het vendorspoor.
 - Actieve ADR's: `docs/adr/`, inclusief ADR-012 (frontend-uitrol: Docker als enige weg, AWS App Runner beoogd, Vercel afgewezen), ADR-006 (CIAM-laag: Microsoft Entra External ID — herzien op 2026-07-27, AWS Cognito verworpen; bestand heette eerder `ADR-006-cognito-als-federatielaag.md`), ADR-007 (CI-platform: GitHub Actions; eerste CI-scope: format/lint/typecheck, test/build bewust uitgesteld tot na de ORM-spike), ADR-008 (P0-databaserolherstel: clm_api_runtime, ontbrekende schema-grants, tijdelijke clm_admin=clm_api-gelijkstelling), ADR-009 (migration-rol clm_migrator, rollenbootstrap, geautomatiseerde RLS-test in CI via ephemere testdatabase) ADR-010 (databaselaag Drizzle, Prisma verwijderd; inclusief de toetsing van de zeven §5-criteria) en ADR-011 (backup- en hersteleisen per fase: hoeveel dataverlies en hersteltijd acceptabel zijn tijdens ontwikkeling, pilot en productie). ADR-002 is op 2026-07-28 bijgewerkt met de werkelijke stand van de vier openstaande controls.
 - Runbooks: `docs/runbooks/` — bevat sinds 2026-07-28 `supabase-verificatie-en-restoretest.md`: vijf stappen (backupinventarisatie, restore-test, tier/garanties, Drizzle-migratiestand, provider-toets), met beproefde `pg_dump`/`pg_restore`-commando's, zes gedocumenteerde valkuilen en een meetregister voor hersteltijden.
 - Historisch projectcontextdocument: `docs/context/PROJECT-HISTORY-2026-07-24.md`

--- a/docs/architecture-review/External-2026-07-29-mcm2-architectuurreview-otap-tests.pplx.md
+++ b/docs/architecture-review/External-2026-07-29-mcm2-architectuurreview-otap-tests.pplx.md
@@ -1,0 +1,570 @@
+# Architectuurreview MCM2 — OTAP-straat en teststrategie
+
+**Datum:** 2026-07-29
+**Reviewvorm:** onafhankelijke tweede mening op `00-review-aanvraag-architectuur-otap-tests.md`, inclusief Bijlage A
+**Volgorde:** conform §11 — eerst de drie prioriteiten uit vraag 9, daarna vragen 1 t/m 8, afgesloten met tegenspraak op §8
+
+---
+
+## Deel 1 — De drie dingen die vóór de pilot af moeten (vraag 9)
+
+Precies drie. Databaseback-up is inhoudelijk aanwezig, maar samengevoegd met gegevensduurzaamheid in prioriteit 1, zodat de telling op drie blijft — bestanden en database vormen samen "kan de pilot een dataverlies overleven" en horen als één werkpakket behandeld te worden, niet als twee losse issues die apart geprioriteerd worden.
+
+### 1. Duurzame objectopslag + herstelpad/back-up voor uploads (en database)
+
+```
+Vraag:        9
+Bevinding:    Bestanden op de containerschijf en de database-dump op dezelfde machine
+              betekenen dat één ongeluk (image-vervanging, laptopstoring) al het
+              bewijsmateriaal van de pilot onherstelbaar wist.
+Ernst:        blokkerend-voor-pilot
+Onderbouwing: §8.1 en §8.2 beschrijven dit apart, maar het is één risico met twee
+              staarten. Bijlage A9 toont VOLUME ["/app/var/uploads"] met het eigen
+              commentaar "zonder volume zijn de certificaten weg zodra het image
+              vervangen wordt" — dat is geen persistente opslag, slechts een
+              waarschuwing in commentaarvorm. AWS App Runner biedt geen persistente
+              schijf tussen deployments/scale-events; het platform is voor stateless
+              containers bedoeld ([AWS App Runner-documentatie](https://docs.aws.amazon.com/apprunner/latest/dg/develop.html)). Voor de
+              huidige pilotomgeving (niet App Runner) geldt hetzelfde principe zonder
+              extern volume: het risico is er nu al, niet pas bij migratie. Daarnaast
+              meldt de huidige database-provider expliciet "does not include project
+              backups" (§8.1), en de wél gebouwde dagelijkse dump staat nog niet
+              ingepland en schrijft naar dezelfde machine als de bron.
+Aanbeveling:  Eén werkpakket vóór pilotstart: (a) verplaats uploads naar object-
+              opslag (S3 of S3-compatibel, bijvoorbeeld via MinIO die al in de
+              ontwikkelstack staat) zodat bestanden een leven hebben los van het
+              containerbestandssysteem, en (b) plan de reeds gebouwde databasedump
+              in op een cron met bestemming buiten de brondraaimachine (bijv. dezelfde
+              objectopslag-bucket). Beide routes landen in dezelfde opslag, dus dit is
+              één ontwerpbeslissing en één stuk werk, geen twee.
+Niets doen:   Bij de eerste onvermijdelijke gebeurtenis (image-redeploy, providerpauze
+              na 7 dagen inactiviteit, schijfstoring) verliest de pilot leverancier-
+              certificaten en/of complete surveydata zonder enige herstelmogelijkheid.
+              Voor een compliance-instrument waarvan het bewijsmateriaal de kern van
+              de waarde is, is dat een showstopper, geen ongemak.
+Zekerheid:    zeker
+```
+
+### 2. Geautomatiseerde minimale browser-smoketest van upload+indienen, met herstel van de twee bekende frontendblokkades
+
+```
+Vraag:        9
+Bevinding:    De twee bekende frontendbugs (ontbrekend uploadveld, leesblok met
+              keuzerondjes) maken de kernflow van UC1 — een leverancier die een
+              vragenlijst met bijlage indient — vandaag niet uitvoerbaar in de
+              browser, en niets in de CI zou een derde, nog onbekende blokkade van
+              dit type opvangen.
+Ernst:        blokkerend-voor-pilot
+Onderbouwing: §5 punt 5 en §6 bevestigen dat het portaal nog geen bestanden kan
+              uploaden waardoor een leverancier niet via de browser kan afronden;
+              §6 stelt vast dat beide bekende bugs "niet door een test gevonden maar
+              door de browser open te doen" zijn. 155 backend e2e-tests dekken dit
+              niet, want die roepen de HTTP-laag aan, niet de gerenderde pagina.
+Aanbeveling:  Eén Playwright-scenario (of vergelijkbaar) dat een geldige tokenlink
+              opent, een bestand uploadt, een vraag met leesblok correct rendert
+              (geen keuzerondjes) en de ronde indient tot en met de bevestiging.
+              Dit scenario draait tegen de al bestaande OTAP-stack (beide images als
+              productie-artefact, zoals §5 al beschrijft) en wordt — minimaal
+              handmatig vóór elke pilotrelease, idealiter als CI-stap — verplicht
+              gesteld voordat de eerste leverancier een link ontvangt.
+Niets doen:   De pilot start met een flow die vandaag aantoonbaar niet werkt voor de
+              eindgebruiker, ontdekt via een reële leverancier in plaats van vóór
+              livegang, met reputatieschade bij Transdev als gevolg.
+Zekerheid:    zeker
+```
+
+### 3. Minimale operationele waarneembaarheid en een expliciet pilot-runbook/alerting
+
+```
+Vraag:        9
+Bevinding:    Bij een incident tijdens de pilot is er niets om in te kijken behalve
+              containerlogs, en er is geen procedure die vastlegt wie wanneer moet
+              reageren op welk signaal.
+Ernst:        blokkerend-voor-pilot
+Onderbouwing: §8.7 noemt "geen logging/monitoring-laag" en "bij een incident in de
+              pilot is er niets om in te kijken behalve containerlogs" als kleiner
+              punt, maar voor een pilot met échte leveranciers en een 30-dagen-
+              geldige link is het ontbreken van élke waarneembaarheid een operationeel
+              risico van dezelfde orde als het dataverliesrisico: een stille storing
+              (bijv. de EACCES-uploadfout die §5 beschrijft, of een variant daarop)
+              kan dagenlang onopgemerkt blijven omdat niemand de logs actief bekijkt.
+Aanbeveling:  Vóór pilotstart: (1) een health-check-monitor met alert (e-mail/Slack)
+              op basis van de al bestaande `/health`-route, (2) een korte
+              pilot-runbook die vastlegt wie de containerlogs controleert, met welke
+              frequentie, en wat de eerste stappen zijn bij een 5xx-piek of een
+              gefaalde upload, (3) behoud van logs voor minstens de looptijd van een
+              ronde (30+ dagen) zodat een klacht achteraf te herleiden is.
+Niets doen:   Een storing tijdens de pilot wordt pas ontdekt wanneer een leverancier
+              klaagt dat een link niet werkt, na het verstrijken van de 30 dagen
+              geldigheid, met een dan niet meer herleidbare oorzaak.
+Zekerheid:    waarschijnlijk
+```
+
+**Waarom niet virusscanning, niet de servicelaagregels, niet de rangorde-vraag over portabiliteit.** Deze staan hieronder uitgewerkt bij vraag 1, 2 en de tegenspraak op §8.4/§8.3, maar horen niet in de top drie: virusscanning is voor-productie, geen pilotblokkade, gegeven de compenserende controles die al aanwezig zijn (zie tegenspraak-sectie); de servicelaagregels zijn een reëel maar geen acuut risico zolang de testdekking op die regels staat; en portabiliteitswerk voor AWS App Runner is pas relevant ná een succesvolle pilot op het huidige platform.
+
+---
+
+## Deel 2 — Antwoorden op vraag 1 t/m 8
+
+### Vraag 1 — Portabiliteitsrangorde: wat breekt het eerst bij AWS App Runner
+
+```
+Vraag:        1
+Bevinding:    Rangorde van wat het eerst breekt bij een verhuizing naar AWS App
+              Runner: (a) bestanden op containerschijf > (c) NEXT_PUBLIC_API_URL per
+              omgeving > (b) rollenmodel met CREATE ROLE > (d) SECURITY DEFINER-
+              functie.
+Ernst:        blokkerend-voor-pilot (voor a, ná migratiebesluit) | later (voor c, b, d)
+Onderbouwing: (a) breekt gegarandeerd en onmiddellijk: App Runner-services zijn
+              stateless containers zonder garantie van persistente lokale opslag
+              tussen requests of over herstarts/schaalacties heen ([AWS App Runner-documentatie](https://docs.aws.amazon.com/apprunner/latest/dg/develop.html)).
+              Bijlage A9 bevestigt dat de huidige VOLUME-declaratie een in-container
+              map is die alleen lokaal/in Docker Compose iets betekent — op App
+              Runner is er geen equivalent volume-mechanisme voor persistente
+              bestandsopslag. Dit breekt bij de eerste upload na de eerste
+              herstart/redeploy, dus vóór enige andere migratiestap zichtbaar wordt.
+              (c) breekt niet de werking maar het OTAP-principe zelf: met
+              NEXT_PUBLIC_API_URL ingebakken bij build (Bijlage A9) kan geen enkel
+              image gepromoveerd worden tussen App Runner-omgevingen zonder herbouw,
+              wat de kern van de gevraagde OTAP-straat ondermijnt zodra er een echte
+              acceptatieomgeving bijkomt ([Next.js self-hosting-documentatie](https://nextjs.org/docs/app/guides/self-hosting)). Dit "breekt" niet
+              functioneel, maar breekt het beloofde deployproces zodra een tweede
+              omgeving naast productie ontstaat. (b) is een reëel maar geen acuut
+              risico op Amazon RDS for PostgreSQL specifiek: het beheeraccount
+              (rds_superuser) heeft CREATEROLE en kan rollen en privileges beheren,
+              al is het geen native PostgreSQL-superuser ([AWS RDS for PostgreSQL-documentatie](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Appendix.PostgreSQL.CommonDBATasks.Roles.rds_superuser.html)).
+              Op RDS breekt dit dus vermoedelijk niet; het risico is reëel bij
+              bepaalde serverless Postgres-aanbieders die CREATE ROLE beperken, niet
+              bij RDS zelf. (d) is het minst risicovol: SECURITY DEFINER is
+              standaard-PostgreSQL-functionaliteit, geen AWS- of App-Runner-
+              specifiek obstakel, en de aangeleverde functie (Bijlage A3) past al
+              SET search_path en REVOKE ALL FROM PUBLIC toe — precies de governance
+              die dit patroon draagbaar en veilig houdt.
+Aanbeveling:  Behandel (a) als eis vóór elke AWS-migratie (S3 + presigned URLs of
+              gelijkwaardig, ongeacht of de rest van de architectuur ongewijzigd
+              blijft). Behandel (c) als ontwerpbeslissing te nemen bij het opzetten
+              van de eerste echte acceptatieomgeving, niet pas bij golive. Behandel
+              (b) als aandachtspunt bij providerkeuze (RDS is hier geen probleem;
+              een serverless Postgres-aanbieder mogelijk wel) — niet als blocker voor
+              App Runner specifiek. Beschouw (d) als afgehandeld: geen actie nodig
+              buiten het vasthouden aan de huidige governance.
+Niets doen:   Kosten nu vs. later, kwalitatief:
+              (a) Nu: laag — één service (BestandOpslagService) aanpassen naar een
+                  object-storage-client, storage_key blijft ongewijzigd (§7 stelt dit
+                  al vast). Later (na livegang met echte pilotdata op ephemere
+                  schijf): hoog — datamigratie onder tijdsdruk, mogelijk na een
+                  dataverliesincident, met leveranciers die al bestanden hebben
+                  geüpload die niet meer terug te halen zijn.
+              (c) Nu: middel — een server-side Next.js route/proxy of same-origin
+                  reverse proxy bouwen die runtime een API_BASE_URL leest, eenmalig
+                  werk. Later: middel tot hoog — niet duurder in techniek, maar
+                  duurder in proces: elke nieuwe omgeving vereist dan een aparte
+                  buildpijplijn per doel-URL, wat de OTAP-belofte ("promoveer exact
+                  dezelfde image") permanent breekt in plaats van eenmalig op te
+                  lossen.
+              (b) Nu: laag — geen actie nodig bij RDS-keuze; documenteren als
+                  aandachtspunt bij evaluatie van alternatieve providers. Later:
+                  laag tot middel — alleen relevant als bewust voor een provider
+                  zonder CREATE ROLE gekozen wordt, wat dan een rollenmodel-
+                  herontwerp vergt (rollen buiten migratiescript laten aanmaken).
+              (d) Nu: laag — niets te doen. Later: laag — blijft draagbaar zolang op
+                  PostgreSQL gebleven wordt.
+Zekerheid:    zeker voor (a) en (d); waarschijnlijk voor (b) en (c)
+```
+
+### Vraag 2 — De vijf servicelaagregels: per regel een besluit
+
+```
+Vraag:        2
+Bevinding:    Van de vijf servicelaagregels verdienen er drie "laten staan" (met
+              contract-/metadatatests als vangnet), één "anders" (max_files, niet als
+              simpele trigger maar structureel met concurrency-veilige aanpak), en
+              één "anders" (JSONB-configschema, valideren bij import/schrijven in
+              plaats van in de database bewaken).
+Ernst:        later (voor optie/rating/multi_choice) | voor-productie (voor max_files)
+              | later (voor JSONB-configschema)
+Onderbouwing: §2-tabel en Bijlage A5 tonen dat de databasegaranties werken op basis
+              van vaste kolomstructuur en enumeraties die per rij bekend zijn; de vijf
+              regels in de servicelaag hebben stuk voor stuk een gemeenschappelijk
+              kenmerk — ze vergen kennis van de vraagdefinitie (config.options[],
+              min/max, max_files) die niet in de answer-rij zelf zit, of vergen tellen
+              over rijen heen. Een trigger die dat oplost moet dus altijd een join of
+              subquery naar survey_question doen, wat de eenvoud van de bestaande
+              CHECK-constraints (die alleen binnen de eigen rij kijken, Bijlage A5)
+              doorbreekt.
+Aanbeveling:  Per regel:
+
+              1. Gekozen optie bestaat in config.options[] — LATEN STAAN in
+                 servicelaag. Dit is per-vraag-metadata die al bij het inladen van de
+                 vragenlijst bekend is aan de service; een trigger zou dezelfde JSONB
+                 moeten uitlezen die de service al in handen heeft, zonder
+                 aantoonbare winst in garantiesterkte. Vangnet: contract-/metadata-
+                 test die bij elke nieuwe vraagtype-import verifieert dat elke
+                 ingevoerde optie voorkomt in config.options[] van de bijbehorende
+                 vraag (uit te breiden in de bestaande `vragenlijst-import`-suite,
+                 §6).
+
+              2. Rating binnen min…max — LATEN STAAN in servicelaag, zelfde
+                 redenering als 1. Vangnet: grens-testgevallen (min-1, min, max,
+                 max+1) in de bestaande `antwoord-indienen`-suite, expliciet met
+                 tegenproef (validatie tijdelijk uitschakelen, test moet rood worden
+                 — conform de gewoonte uit §6).
+
+              3. multi_choice-aantallen en duplicaten — LATEN STAAN in servicelaag,
+                 zelfde redenering. Vangnet: testgeval met duplicaat in answer_codes[]
+                 en met een aantal buiten de toegestane grens, plus tegenproef.
+
+              4. Aantal bestanden per vraag ≤ max_files — ANDERS: structureel in de
+                 database, maar niet als kale trigger zonder lock (dat lost de
+                 concurrency-fout uit §8.4 niet op — twee gelijktijdige uploads die
+                 allebei de trigger vóór elkaars commit passeren, tellen allebei "nog
+                 onder de grens"). Schets van een uitvoerbare aanpak — kies één van
+                 twee routes:
+                 (i) Quotarij: maak
+                 `survey_attachment_quota(response_id, question_id, max_files,
+                 used_files)` met `CHECK (used_files BETWEEN 0 AND max_files)` en een
+                 primary key op `(response_id, question_id)`. Leg `max_files` bij het
+                 aanmaken van de respons vast als snapshot van de dan al bevroren
+                 vraagconfiguratie. Reserveer een plek met één atomair statement:
+                 `UPDATE ... SET used_files = used_files + 1
+                 WHERE used_files < max_files RETURNING used_files`, binnen dezelfde
+                 transactie als de attachment-INSERT. Nul geretourneerde rijen
+                 betekent dat de limiet is bereikt.
+                 (ii) Kleinere wijziging: laat een DB-trigger eerst de bovenliggende
+                 `survey_response`-rij (of een specifieke per-vraag lockrij) met
+                 `SELECT ... FOR UPDATE` vergrendelen, lees daarna `max_files` uit de
+                 bevroren vraag en tel de bestaande attachments. De lock serialiseert
+                 concurrerende tellingen; een kale trigger met alleen `COUNT(*)`
+                 doet dat niet. Route (i) is explicieter en beter toetsbaar, route
+                 (ii) wijzigt het model minder maar serialiseert mogelijk meer werk.
+                 Vangnet: de concurrency-test uit vraag 7, toegepast op de gekozen
+                 lock- of quotarij.
+
+              5. Inhoud van de config-JSONB — ANDERS: niet in de database bewaken via
+                 een generieke trigger (te complex voor de winst, JSONB-structuur-
+                 validatie in PL/pgSQL is onderhoudsintensief en moeilijk leesbaar),
+                 maar valideren bij import/schrijven in de servicelaag met een
+                 JSON Schema-validator (bijv. ajv), toegepast op het moment dat een
+                 vragenlijst geïmporteerd wordt, gevolgd door het "bevriezen" van
+                 templates zodra er een niet-draft-ronde aan hangt — een mechanisme
+                 dat al bestaat via de trigger in Bijlage A7. Het bevriezen is dus al
+                 opgelost; het ontbrekende stuk is uitsluitend de schemavalidatie
+                 vóór het invoerpunt, niet een doorlopende databasegarantie.
+Niets doen:   Voor 1–3: geen aanvullende actie nodig zolang de contract-/grenstests
+              bestaan; zonder die tests kan een servicelaagbug een ongeldig antwoord
+              doorlaten dat pas bij rapportage opvalt. Voor 4: zonder structurele
+              aanpak blijft de concurrency-garantie ongetoetst en potentieel
+              overtreedbaar bij gelijktijdige uploads via twee afzonderlijke
+              verbindingen (bijv. dubbele browsertabs of een client die twee keer
+              snel achter elkaar post) — precies het scenario dat §8.4 beschrijft.
+              Voor 5: zonder validatie bij import kan een malvormde JSONB-config een
+              vraag onbruikbaar maken pas bij het eerste antwoord, niet bij het
+              importeren, wat de fout laat in de verkeerde fase van de pijplijn.
+Zekerheid:    waarschijnlijk voor 1–3 en 5; zeker voor 4 (de FOR UPDATE-aanpak is
+              aantoonbaar niet bewezen werkzaam, zie §8.4 en vraag 7)
+```
+
+### Vraag 3 — Eerste frontendtestinvestering
+
+```
+Vraag:        3
+Bevinding:    De eerste en enige investering die maandag gebouwd zou moeten worden
+              is één end-to-end browsertest van de volledige UC1-flow (token openen →
+              vragen beantwoorden → bestand uploaden → indienen → bevestiging), niet
+              componenttests.
+Ernst:        blokkerend-voor-pilot
+Onderbouwing: §6 stelt vast dat de twee bekende bugs (ontbrekend uploadveld, leesblok
+              met keuzerondjes) allebei gevonden zijn door de browser open te doen,
+              niet door enige test — dat is het signaal dat het risico op
+              integratieniveau zit (rendering + backend-koppeling), niet op
+              geïsoleerd componentniveau. Componenttests zouden een leesblok-
+              component in isolatie kunnen testen, maar zouden de daadwerkelijke bug
+              (verkeerd component gekozen voor het veldtype in de rendering-keten)
+              waarschijnlijk niet vangen tenzij toevallig exact dat pad getest wordt.
+Aanbeveling:  Eén Playwright-scenario dat tegen de bestaande OTAP-stack draait (echte
+              backend-image, geen mock — conform de bestaande gewoonte in §5/§9) en
+              de volledige UC1-flow met een echte bestandsupload doorloopt tot en met
+              de bevestigingspagina. Dit dekt in één keer de twee bekende
+              blokkerende bugs en fungeert als regressienet voor toekomstige
+              rendering- of koppelingsfouten.
+Niets doen:   Zonder deze test blijft de enige manier om frontendregressies te
+              ontdekken "de browser open doen", wat niet schaalt zodra de vragenlijst
+              groeit van acht naar meer vragen of naar UC2, en wat vóór de pilot al
+              een aantoonbaar niet-werkende flow heeft laten liggen (§5, punt 5).
+Zekerheid:    zeker
+```
+
+### Vraag 4 — Is de backendverhouding (155 e2e / 1 unittest) scheef?
+
+```
+Vraag:        4
+Bevinding:    De verhouding is voor de databasegaranties verdedigbaar, maar er is één
+              concreet gat: pure, database-onafhankelijke functies verdienen een
+              eigen unittestlaag omdat e2e-tests daar onnodig traag en indirect
+              geworden zijn voor wat in feite invoer-naar-uitvoer-logica is, zonder
+              dat dit betekent dat databasegaranties gemockt moeten worden.
+Ernst:        later
+Onderbouwing: Bijlage A8 (`valideerBestand`, `maakOpslagsleutel`) en de vijf
+              servicelaagregels uit §2 (optie-, rating-, multi_choice-validatie) zijn
+              stuk voor stuk pure functies: gegeven een buffer of een antwoordwaarde
+              plus vraagconfiguratie, retourneren ze een oordeel zonder database-
+              interactie. Deze worden nu uitsluitend indirect getoetst via de
+              `bijlage-upload`- en `antwoord-indienen`-e2e-suites (§6), die voor élk
+              testgeval een wegwerp-Postgres, een HTTP-rondgang en tokenopzet nodig
+              hebben — kostbaar voor logica die geen databaseinteractie heeft. Dit
+              kost nu al tijd (CI-doorlooptijd van de e2e-suite) en dekking
+              (randgevallen zoals lege buffers, precies-op-de-grens-bytes voor
+              magic-byte-detectie, of grensgevallen van rating min/max zijn
+              omslachtiger te schrijven als e2e-testgeval dan als directe
+              functieaanroep).
+Aanbeveling:  Voeg een unittestlaag toe specifiek voor: (1) `valideerBestand` en
+              `bepaalContentType` uit Bijlage A8 — test direct met byte-buffers voor
+              elk bestandstype, corrupte headers, exact-op-de-grens groottes; (2) de
+              servicelaagvalidatiefuncties voor optie/rating/multi_choice uit §2,
+              zodra die als pure functies (input: antwoord + config-object, output:
+              geldig/ongeldig) geïsoleerd worden van de transactielaag; (3)
+              `maakOpslagsleutel` voor padveiligheid tegen padinjectie-payloads. Dit
+              zijn functies zonder databasegaranties om te mocken — de test bewijst
+              precies wat de functie zelf beweert, niets over RLS of constraints.
+              De 155 e2e-tests blijven ongewijzigd verantwoordelijk voor alles wat
+              door de database wordt afgedwongen.
+Niets doen:   Randgevallen in bestandsvalidatie en servicelaagregels blijven duurder
+              om te testen dan nodig, wat in de praktijk betekent dat ze minder vaak
+              getest worden dan wenselijk — niet omdat de e2e-aanpak fout is, maar
+              omdat de kost per testgeval de dekking drukt.
+Zekerheid:    waarschijnlijk
+```
+
+### Vraag 5 — `vendor_id` naast `subject_vendor_id`: valkuil of houdbaar?
+
+```
+Vraag:        5
+Bevinding:    Het model is houdbaar voor de huidige twee use cases en hoeft niet
+              vervangen te worden, mits het faalscenario hieronder expliciet met een
+              test wordt afgedekt — dit is geen polymorfe-relatieconstructie maar een
+              expliciete tweekolomsmodellering met een heldere betekenisscheiding.
+Ernst:        later
+Onderbouwing: Bijlage A3 en A6 tonen dat `subject_vendor_id` (over wie) en
+              `vendor_id` (wie vult in) elk een eigen, benoembare rol hebben, en dat
+              de partiële unieke index in A6 specifiek op `vendor_id` werkt om UC1's
+              garantie te bewaren zonder UC2 te belemmeren. Dit is geen polymorfe
+              relatie (waarbij één kolom naar verschillende tabellen zou kunnen
+              wijzen); het zijn twee gewone foreign keys naar dezelfde tabel met een
+              verschillende betekenis. Het concrete faalscenario: als een derde use
+              case ontstaat waarbij een leverancier een andere leverancier beoordeelt
+              (bijv. een hoofdaannemer die een onderaannemer scoort), dan is het
+              onderscheid "vendor_id = null betekent UC2" niet meer voldoende, en zou
+              er een expliciete `respondent_type`-kolom (enum: 'self' | 'internal' |
+              'vendor-on-vendor') nodig zijn om te disambigueren of `vendor_id` de
+              deelnemer of de invuller-namens-een-derde is. Bijlage A3 zelf toont al
+              een instantie van dit risico: de `LEFT JOIN` op `subject_vendor_id` was
+              tot 2026-07-29 een bug die op `vendor_id` joinde, waardoor elke UC2-link
+              410 gaf — gevonden door de OTAP-doorloop, niet door een test. Dat is
+              geen modelfout maar een teken dat de tweekoloms-betekenis makkelijk
+              door elkaar gehaald wordt in code die met beide kolommen werkt.
+Aanbeveling:  Geen migratie nu. Voeg wel een gerichte e2e-test toe die expliciet de
+              tokenlookup voor een UC2-link over HTTP test (niet alleen via directe
+              SQL) — dit exacte gat veroorzaakte de bug die A3 beschrijft en is
+              blijkbaar nog niet in de 155 tests gedekt op HTTP-niveau. Documenteer
+              in een ADR of in `docs/STATUS.md` expliciet de aanname "een use case
+              heeft precies één deelnemer en één onderwerp" zodat een toekomstige
+              derde use case bewust tegen deze aanname aangehouden wordt in plaats
+              van stilzwijgend te breken.
+Niets doen:   Zolang er twee use cases zijn, gaat niets mis. Bij een derde use case
+              met een ander deelnemer/onderwerp-patroon ontstaat een stille
+              modelleerfout die pas na livegang van die derde use case zichtbaar
+              wordt, wanneer er al gevulde rondes op het huidige model staan — de
+              migratiekost is dan een datamigratie op productiedata plus een nieuwe
+              kolom, geen databreuk maar wel plannings- en testwerk.
+Zekerheid:    waarschijnlijk
+```
+
+### Vraag 6 — Handmatige OTAP-doorloop: houdbaar?
+
+```
+Vraag:        6
+Bevinding:    Het realistische faalscenario is niet dat de doorloop "vergeten" wordt
+              in de zin van nooit uitgevoerd, maar dat hij inconsistent uitgevoerd
+              wordt — bijvoorbeeld wel bij een grote release maar niet bij een kleine
+              wijziging die toevallig net de OTAP-relevante laag raakt (permissies,
+              build-args, health-check) — waardoor precies het type fouten dat de
+              doorloop bewijsbaar vindt (§5: EACCES, routepad-lek, non-idempotentie)
+              weer binnensluipt zonder dat iemand het opmerkt tot een volgende
+              toevallige handmatige run.
+Ernst:        voor-productie
+Onderbouwing: §5 zelf erkent dat de doorloop vijf bevindingen opleverde die geen
+              enkele unit- of e2e-test zag — dat is het bewijs van waarde, niet van
+              risico. Het risico zit in de aard van "handmatig": er is geen
+              afdwingingsmechanisme dat een release tegenhoudt als de doorloop niet
+              gedraaid is, vergelijkbaar met de "geen branch protection"-situatie in
+              §6 (technisch geblokkeerd, dus een werkafspraak zonder afdwinging). Een
+              werkafspraak zonder afdwinging vervalt doorgaans niet abrupt maar
+              geleidelijk, naarmate deadlinedruk toeneemt.
+Aanbeveling:  Goedkope tussenvorm vóór volledige automatisering: verplaats de negen
+              stappen niet naar een cross-repo CI-workflow (dat vraagt inderdaad
+              beide repositories in één workflow, een grotere investering), maar
+              richt één losstaande, periodieke GitHub Actions-workflow in (bijv.
+              nachtelijk of wekelijks, en verplicht vóór elke pilotrelease) die beide
+              al bestaande productie-images pulled of bouwt, `docker-compose.otap.yml`
+              opstart, en het bestaande `scripts/otap-doorloop.js` uitvoert — zonder
+              dit te koppelen aan de PR-merge-flow van beide repositories. Dit hergebruikt
+              het bestaande script volledig, vergt geen wijziging aan twee CI-pijplijnen
+              tegelijk, en verandert de doorloop van "iemand moet eraan denken" naar
+              "draait vanzelf, mens leest de uitkomst". Volledige automatisering
+              (verplicht vóór elke merge, in beide repo's) blijft een latere stap.
+Niets doen:   Zonder afdwinging herhaalt zich het patroon uit §5 waarbij vijf reële
+              bevindingen (waaronder een permissiefout die élke upload blokkeerde)
+              alleen gevonden werden omdat iemand toevallig de moeite nam de doorloop
+              te draaien — bij toenemende tijdsdruk in de aanloop naar de pilot is
+              precies dát moment het meest waarschijnlijke om over te slaan.
+Zekerheid:    waarschijnlijk
+```
+
+### Vraag 7 — Hoe toets je de FOR UPDATE-vergrendeling?
+
+```
+Vraag:        7
+Bevinding:    De vergrendeling is met de huidige testopzetten niet aantoonbaar, omdat
+              alle drie geprobeerde opzetten via dezelfde connectiepool liepen; een
+              geldige tegenproef vereist twee fysiek gescheiden databaseverbindingen
+              die met een expliciete coördinatiebarrière gegarandeerd overlappen op
+              het kritieke moment.
+Ernst:        voor-productie
+Onderbouwing: §8.4 en §6 beschrijven exact het probleem: "twee transacties via
+              dezelfde connectiepool achter elkaar aan de beurt komen" maakt elke
+              race-conditie-test met een gedeelde pool waardeloos, want de pool
+              serialiseert de transacties toch al voordat de vergrendeling ooit een
+              rol kan spelen.
+Aanbeveling:  Test de echte uploadroute zonder productiehaak met een externe lock en
+              twee fysiek gescheiden databaseverbindingen:
+              1. Maak testdata waarbij nog precies één uploadplek beschikbaar is.
+              2. Open een losse `pg.Client` A, start `BEGIN` en vergrendel handmatig
+                 exact dezelfde rij die de productiecode met `FOR UPDATE` hoort te
+                 vergrendelen. Laat A de transactie openhouden.
+              3. Start daarna via HTTP een echte uploadrequest. Die request gebruikt
+                 de normale applicatiepool, dus een andere fysieke verbinding. Als
+                 de productielogica dezelfde lock neemt, blijft de HTTP-promise
+                 pending zolang A de lock vasthoudt.
+              4. Controleer eerst deterministisch dat de request na een korte, ruime
+                 wachttijd nog niet is voltooid; commit vervolgens A en controleer
+                 dat de request nu wel voltooit. Gebruik daarnaast `lock_timeout` of
+                 een Jest-timeout zodat een fout de suite nooit onbeperkt laat hangen.
+              5. Start voor de functionele raceproef twee echte uploadrequests terwijl
+                 nog één plek vrij is. Na het vrijgeven van A moet precies één request
+                 slagen en één de limiet krijgen, en de database moet precies
+                 `max_files` attachmentrijen bevatten.
+              6. Tegenproef: verwijder `FOR UPDATE` tijdelijk. De eerste blokkeer-
+                 assertie moet dan rood worden doordat de HTTP-request voltooit
+                 terwijl A de rij nog vasthoudt. Daarmee bewijst de test de
+                 aanwezigheid van het productiemechanisme, niet alleen algemeen
+                 PostgreSQL-lockgedrag.
+              Deze opzet vraagt geen wijziging aan productiecode. Het testbestand
+              creëert alleen een externe transactie die de bestaande lockrij bezet
+              en observeert vervolgens de echte HTTP-route.
+Niets doen:   Zonder deze test blijft de claim "twee gelijktijdige uploads worden
+              geserialiseerd" ongetoetst in productiecode die wél bestaat en wél
+              onderhouden wordt — bij een toekomstige refactor van de transactielaag
+              kan de vergrendeling stilzwijgend verdwijnen zonder dat een enkele test
+              het opmerkt, identiek aan wat er nu al drie keer is gebeurd.
+Zekerheid:    zeker (de opzet is technisch standaard voor het testen van
+              rijvergrendeling in PostgreSQL); vermoeden voor de exacte
+              timingdrempel, die per testomgeving gekalibreerd moet worden
+```
+
+### Vraag 8 — Wat is te veel?
+
+```
+Vraag:        8
+Bevinding:    Geen van de drie genoemde kandidaten (38-regelconstraint, zeven
+              survey-tabellen, twaalf ADR's) is overbodig; het zijn stuk voor stuk
+              proportionele investeringen voor een compliance-instrument, en het
+              risico van "te veel" zit niet hier maar is elders in het document al
+              correct benoemd (zie tegenspraak-sectie).
+Ernst:        cosmetisch
+Onderbouwing: De vormconstraint (Bijlage A5) is één CHECK die acht antwoordtypen
+              onderscheidt — de lengte komt voort uit het aantal typen, niet uit
+              overbodige complexiteit per type; elke tak is een simpele kolom-
+              aanwezigheidscontrole. Dit vervangt bovendien precies het soort bug
+              (rating als tekst weggeschreven, keuzecode in answer_number) dat pas
+              maanden later bij rapportage ontdekt zou worden — de asymmetrie tussen
+              "nu 38 regels SQL" en "straks onherleidbare foutieve rapportagedata" is
+              scherp in het voordeel van de constraint. Zeven tabellen voor de
+              survey-cluster (§3: template, category, question, run, response,
+              answer, attachment) is een normale genormaliseerde structuur voor een
+              domeinmodel met vragenlijst-definitie, uitvoeringsronde, antwoord én
+              bijlage als afzonderlijke concepten — samenvoegen zou de heldere
+              scheiding tussen "wat is de vraag" en "wat is het antwoord" opofferen
+              voor een schijnbare eenvoud die de CHECK-constraints en RLS-policies
+              juist ingewikkelder zou maken. Twaalf ADR's voor een project van deze
+              omvang (twee repositories, een expliciete portabiliteitseis, een
+              beveiligingsmodel zonder gebruikersaccounts) is niet excessief:
+              ADR-012 (containerimages i.p.v. Vercel) alleen al voorkomt dat een
+              toekomstige ontwikkelaar dezelfde afweging opnieuw moet maken.
+Aanbeveling:  Geen actie op deze drie kandidaten. Richt de "wat is te veel"-vraag in
+              plaats daarvan op kandidaten die wél degelijk overengineering kunnen
+              zijn zodra ze zonder scherpe noodzaak verder uitgebreid worden: een
+              generieke DB-trigger voor JSONB-configvalidatie (zie vraag 2, regel 5)
+              zou wél overbodige complexiteit toevoegen ten opzichte van validatie
+              bij import, en zou als kandidaat voor "te veel" moeten gelden als die
+              ooit gebouwd wordt.
+Niets doen:   Geen gevolg — er is hier niets om weg te gooien; tijd besteed aan het
+              vereenvoudigen van deze drie zou tijd zijn die niet aan een reëel
+              risico besteed wordt.
+Zekerheid:    waarschijnlijk voor de constraint en de tabellen; vermoeden voor de
+              ADR's, omdat de inhoudelijke kwaliteit van de twaalf ADR's niet is
+              meegeleverd in Bijlage A en dus niet individueel beoordeeld kon worden
+```
+
+---
+
+## Tegenspraak op §8
+
+Waar de eigen inschatting van de opsteller overschat, onderschat of verkeerd gerangschikt is.
+
+**§8.1 en §8.2 zijn niet twee losse punten — en de rangorde "zwaarste eerst" klopt, maar de scheiding niet.** Het ontbreken van databaseback-ups en het ontbreken van bestandsback-ups zijn twee symptomen van hetzelfde onderliggende probleem: er is geen duurzame opslag met herstelpad voor pilotdata, punt. Door ze als twee aparte punten (8.1, 8.2) te behandelen ontstaat het risico dat ze als twee aparte werkpakketten ingepland worden, terwijl de oplossing (objectopslag + ingeplande dump naar een externe bestemming) in de praktijk één ontwerpbeslissing is. Dit is in Deel 1, prioriteit 1 hierboven, samengevoegd — niet om het risico te verkleinen, maar om de aanpak te verscherpen.
+
+**§8.3 (geen virusscan) staat op plek drie in de eigen lijst; dat is een overschatting van de urgentie voor de pilot.** De opsteller noemt zelf drie compenserende feiten — het bestand wordt nooit uitgevoerd, de opslagnaam is servergegenereerd (Bijlage A8: `maakOpslagsleutel` bevat geen teken uit de invoer), en er is geen route die inline serveert — en concludeert dan toch "het is niet nul" zonder de vervolgvraag te stellen of nul nodig is vóór een gecontroleerde pilot met een beperkt aantal bekende leveranciers. Voor een pilot waarin downloads uitsluitend door bevoegde, geïdentificeerde Transdev-gebruikers gebeuren (niet door anonieme derden) en bestanden nooit inline worden geserveerd of uitgevoerd, is dit een voor-productie-risico, geen pilotblokkade. Wat wél vastgelegd moet worden — en dat ontbreekt nu — zijn deze compenserende controles expliciet als bewuste beslissing (niet als vergeten punt), plus een harde eis dat vóór een bredere rollout (buiten de pilot) een virusscanstap (bijv. ClamAV als sidecar, of een S3-integratie met scanning) toegevoegd wordt vóórdat het aantal onbekende uploaders groeit.
+
+```
+Vraag:        extra
+Bevinding:    Virusscanning is voor-productie, niet blokkerend voor een gecontroleerde
+              pilot, mits de bestaande compenserende controles expliciet vastgelegd
+              worden.
+Ernst:        voor-productie
+Onderbouwing: §8.3 zelf noemt drie compenserende factoren (nooit uitgevoerd,
+              servergegenereerde opslagnaam via Bijlage A8, geen inline-serveerroute)
+              maar plaatst het punt toch op ernst-niveau vlak onder de twee
+              back-uppunten. Het faalscenario dat overblijft — een besmet bestand
+              wordt door een bevoegde Transdev-medewerker gedownload en lokaal
+              geopend — vereist twee dingen tegelijk: een kwaadwillende of
+              gecompromitteerde leverancier én een medewerker die het bestand direct
+              opent zonder eigen endpointbescherming. Voor een pilot met een klein,
+              bekend aantal leveranciers is dit een acceptabel restrisico, mits
+              gedocumenteerd.
+Aanbeveling:  Leg de drie compenserende controles vast als expliciete, bewuste
+              pilotbeslissing (bijv. in `docs/STATUS.md` of een ADR), met een
+              expliciete voorwaarde: vóór opschaling naar een grotere leveranciers-
+              populatie of een tweede tenant moet een virusscanstap toegevoegd
+              worden.
+Niets doen:   Als dit ongedocumenteerd blijft, wordt het bij een toekomstige audit of
+              beveiligingsincident gelezen als "vergeten" in plaats van "bewust
+              geaccepteerd met compenserende controles" — een reputatie- en
+              verantwoordingsrisico dat losstaat van het technische risico zelf.
+Zekerheid:    waarschijnlijk
+```
+
+**Het Postgres/RLS/constraints-ontwerp wordt in §7 vraag 3 als mogelijke "te ver doorgeschoten"-vergrendeling neergezet; dat is een onderschatting van de eigen waarde van de keuze.** Het document vraagt "is dat een aanvaardbare vergrendeling, of te ver doorgeschoten?" alsof het een open vraag is, maar het antwoord ligt al besloten in het eigen bewijs uit §7: MCM2 draaide zonder enige codewijziging op Neon, een andere Postgres-provider. Dat is precies het soort tegenproef dat het risico van lock-in weerlegt — de vergrendeling is naar PostgreSQL, niet naar één provider, en dat is een bewuste, aanvaardbare keuze zolang de garanties (RLS, constraints, triggers) een aantoonbare functionele meerwaarde leveren ten opzichte van applicatiecode, wat ze doen (Bijlage A1, A5, A7 tonen stuk voor stuk garanties die een servicelaagbug niet kan omzeilen). Dit is geen overengineering; het is een doelbewuste architecturale keuze met een gemeten tegenproef. Het enige aandachtspunt is dat toekomstige migraties (nieuwe kolommen, nieuwe constraints) even zorgvuldig tegen zowel de standaard-Postgres-provider als een alternatief geverifieerd blijven worden, zoals nu met Neon is gedaan.
+
+**§7 vraag 2 (rollenmodel/CREATE ROLE) overschat het risico voor de meest waarschijnlijke AWS-route.** Het document formuleert "hoe reëel is dat risico?" in algemene termen, maar voor de meest voor de hand liggende AWS-doelomgeving — Amazon RDS for PostgreSQL — is CREATE ROLE geen blokkade: het rds_superuser-beheeraccount beschikt over CREATEROLE en kan rollen en privileges volledig beheren, ook al is het geen native superuser ([AWS RDS-documentatie](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Appendix.PostgreSQL.CommonDBATasks.Roles.rds_superuser.html)). Het risico is wél reëel, maar dan specifiek bij bepaalde serverless Postgres-aanbieders die rolbeheer beperken — niet bij de RDS-route die het document zelf als beoogd doel noemt (§5: AWS App Runner, wat typisch met RDS gecombineerd wordt). Dit punt verdient dus een lagere plaats in de portabiliteitszorgen dan het nu impliciet krijgt door naast de bestandsopslag-vraag gesteld te worden — zie ook de rangorde in vraag 1 hierboven, waar (b) op plek drie van vier staat, niet plek één.
+
+**SECURITY DEFINER wordt in §7 vraag 2 op één hoop gegooid met het rollenmodel, terwijl het een apart en kleiner risico is dat al grotendeels correct is afgehandeld.** Het document formuleert de vraag als "de hele tenant-isolatie hangt aan zes rollen én een SECURITY DEFINER-functie", maar behandelt beide even zwaar. SECURITY DEFINER is op zichzelf volledig draagbaar binnen elke PostgreSQL-omgeving; het risico zit vrijwel uitsluitend in governance rond de functie-eigenaar, de `search_path` en wie EXECUTE-rechten heeft — niet in het mechanisme zelf. Bijlage A3 toont dat de aangeleverde functie dit al correct doet: `SET search_path = clm, pg_temp` voorkomt search-path-manipulatie, en `REVOKE ALL ON FUNCTION ... FROM PUBLIC` gevolgd door gerichte `GRANT EXECUTE ... TO clm_api, clm_admin` voorkomt dat een willekeurige rol de functie kan aanroepen. Dit verdient in het document een positieve vermelding als correct toegepaste governance, niet een vraagteken naast het rollenmodel-risico.
+
+**§7 vraag 4 (NEXT_PUBLIC_API_URL) suggereert twee gelijkwaardige opties ("runtime-configuratie via een endpoint, of per omgeving bouwen"); dat is verkeerd gerangschikt, want de twee opties zijn niet gelijkwaardig.** Een publiek runtime-configuratie-endpoint dat de browser bij het laden bevraagt voor de API-URL voegt een extra netwerklaag, een nieuw aanvalsoppervlak (een endpoint dat aangeeft waar de backend leeft) en een race-conditie bij het laden toe. De nettere oplossing, die het document niet als aparte optie noemt, is een server-side Next.js route of same-origin reverse proxy: Next.js ondersteunt bij self-hosting server-side runtime-omgevingsvariabelen, zodat één Docker-image over meerdere omgevingen gepromoveerd kan worden zonder dat de browser ooit een cross-origin publiek endpoint hoeft te bevragen ([Next.js self-hosting-documentatie](https://nextjs.org/docs/app/guides/self-hosting)). Dit is alleen geschikt als de browser niet noodzakelijk rechtstreeks cross-origin met de backend hoeft te praten — wat voor MCM2 het geval lijkt, aangezien frontend en backend samen uitgerold worden. Dit is een derde, betere optie dan de twee die het document tegenover elkaar zet, en zou de primaire aanbeveling moeten zijn (zie ook vraag 1 hierboven).
+
+**§6 rangschikt de teststrategie-asymmetrie (155 e2e / 0 frontendtests) mogelijk correct qua ernst, maar de vraag "mis ik de snelheid en precisie van een unittestlaag" wordt te beperkt beantwoord door alleen "ja/nee" te verwachten.** Het juiste antwoord is genuanceerder dan het document suggereert: niet "voeg een unittestlaag toe" in algemene zin, en niet "nee, de verhouding is prima" — specifiek de pure, database-onafhankelijke functies (bestandsvalidatie, servicelaagregels) verdienen unittests, terwijl alles wat een databasegarantie toetst dat terecht via e2e blijft doen. Dit is uitgewerkt bij vraag 4 hierboven.
+
+**Wat niet overschat, onderschat of verkeerd gerangschikt is: de kernarchitectuur van tenant-isolatie (§9), de schemaconformiteitstest, en de OTAP-doorloop als concept.** Deze zijn terecht in het "vertrouwen"-hoofdstuk geplaatst; er is in Bijlage A geen aanleiding om aan de RLS-opzet (A1, A2), de guard (A4) of de tegenproef-gewoonte (A10) te twijfelen. De enige aanvulling is dat de handmatige uitvoering van de OTAP-doorloop een lagere ernst verdient dan "blokkerend" maar een hogere prioriteit dan "later" — zie vraag 6 hierboven, waar dit als voor-productie met een concrete, goedkope tussenvorm is beantwoord.
+
+---
+
+*Einde review. Alle negen vragen uit §10 zijn beantwoord; de drie prioriteiten uit vraag 9 staan vooraan conform §11.*

--- a/docs/runbooks/otap-doorloop.md
+++ b/docs/runbooks/otap-doorloop.md
@@ -2,7 +2,7 @@
 
 **Type:** D (routineoperatie)
 **Eigenaar:** projecteigenaar
-**Laatste update:** 2026-07-29 (tweede doorloop: uitgebreid t/m indienen en upload)
+**Laatste update:** 2026-07-30 (frontend-bevindingen gerepareerd; browsertest toegevoegd)
 **Vereiste toegang:** Docker Desktop, beide repositories lokaal
 **Raakt:** Issue #18 (volledige OTAP-doorloop minimaal één keer bewezen)
 
@@ -200,24 +200,42 @@ zat, is het bewijs dat hij werkt.**
 `seed-vragenlijsten.js` op de foreign key naar `clm.tenant`. Opgelost door stap
 3b aan dit runbook toe te voegen.
 
-### Twee frontend-bevindingen — nog niet gerepareerd
+### Twee frontend-bevindingen — gerepareerd op 2026-07-30
 
-Deze zitten in `MCM2-frontend` en zijn met de browser vastgesteld, niet
-beredeneerd:
+Deze zaten in `MCM2-frontend` en zijn met de browser vastgesteld, niet
+beredeneerd. Beide zijn opgelost in `MCM2-frontend` PR #1 (Issue #42 en #43):
 
-- **Het portaal kan nog niet uploaden.** Het toont letterlijk "Bestandsupload
-  volgt in een volgende versie", terwijl de backend het sinds stap 8 wél kan.
-  Gevolg: bevestigen op de ISO-vraag levert een 422 `file_required` op, die het
-  portaal toont als "Er ging iets mis bij het versturen". **Een leverancier kan
-  de vragenlijst daardoor nog niet via de browser afronden.**
-- **Het leesblok krijgt keuzerondjes.** De backend levert het correct als
-  `answerType: 'instruction'` en de voortgangsteller telt het terecht niet mee
-  ("0 van 8" bij negen vragen), maar het renderen behandelt het als een gewone
-  `confirmation`-vraag.
+- **Het portaal kon niet uploaden.** Het toonde letterlijk "Bestandsupload
+  volgt in een volgende versie", terwijl de backend het sinds stap 8 wél kon.
+  Gevolg: bevestigen op de ISO-vraag leverde een 422 `file_required` op, die het
+  portaal toonde als "Er ging iets mis bij het versturen". Nu een uploadveld
+  begrensd op `maxFiles`, en de 422 wordt **per vraag** getoond — een 422 is
+  herstelbaar, dus die hoort niet naar het geblokkeerde scherm te leiden.
+- **Het leesblok kreeg keuzerondjes.** Nu een apart `Leesblok`-component, en de
+  nummering slaat leesblokken over zodat "vraag 8" klopt met de teller.
 
-De backend-kant van de keten is wél volledig bewezen: vragen ophalen, valideren,
-uploaden en indienen werken end-to-end vanuit de browser (gemeten via
-`fetch` op de portaalpagina).
+**De volledige keten is nu in de browser bewezen**, van tokenlink tot
+bevestiging: `/questions` 200 → `/attachment` 201 → `/respond` 200 → tweede
+poging 410.
+
+### Wat hieruit is geleerd over deze doorloop
+
+**Geen van beide bugs is door een test gevonden** — de 155 backend-e2e-tests
+roepen de HTTP-laag aan, niet de gerenderde pagina. Dat was de aanleiding voor
+Issue #47: `MCM2-frontend/e2e/portaal-uc1.spec.ts`, een Playwright-test die de
+volledige UC1-flow tegen déze OTAP-stack doorloopt.
+
+Die test draait **niet in CI** en vraagt een verse tokenlink per run, want
+indienen is eenmalig:
+
+```bash
+cd ../MCM2-frontend
+SURVEY_TOKEN=<verse UC1-link> npm run e2e
+```
+
+Zonder `SURVEY_TOKEN` slaat hij zichzelf over in plaats van te falen.
+Automatiseren vraagt beide repositories in één workflow (#53) plus een script
+dat vooraf een tokenlink aanmaakt — dat laatste bestaat nog niet.
 
 ---
 
@@ -225,7 +243,18 @@ uploaden en indienen werken end-to-end vanuit de browser (gemeten via
 
 - **Acceptatie en Productie ontbreken** — die omgevingen bestaan nog niet
   (Issue #12). Deze doorloop dekt O en T.
-- **De frontend kan de keten nog niet volledig afronden** — zie de twee
-  frontend-bevindingen hierboven.
-- **De doorloop draait handmatig.** Automatiseren in CI vraagt beide
-  repositories in één workflow; nu de moeite niet waard.
+- **De doorloop draait handmatig.** De externe architectuurreview van
+  2026-07-29 noemt dit een reëel risico: niet dat de doorloop vergeten wordt,
+  maar dat hij **inconsistent** wordt uitgevoerd — wel bij een grote release,
+  niet bij een kleine wijziging die net de OTAP-laag raakt (permissies,
+  build-args, health-check). Een werkafspraak zonder afdwinging vervalt
+  geleidelijk onder deadlinedruk.
+
+  Opgevolgd in **#53**: een losstaande periodieke workflow die dit script
+  draait, zónder de cross-repo koppeling waarop volledige automatisering eerder
+  is afgeschreven.
+- **Uploads staan op een containerschijf.** De `VOLUME`-declaratie in de
+  `Dockerfile` is een map ín de container, geen persistente opslag. Bij
+  image-vervanging zijn de certificaten weg — en dat zijn
+  compliance-bewijsstukken. Zie **#46**; dat heeft een harde datum, want de
+  pilot start rond 1 september.


### PR DESCRIPTION
Documentatiebijwerking, geen code. `STATUS.md` liep op vier punten achter:

- de kop noemde stap 8 als laatste wapenfeit
- "eerstvolgende stap: stap 5 uit de bouwvolgorde" — die is al af
- het frontend-blok heette *"nog geen schermen"*
- de git-tabel noemde `chore/otap-doorloop-stap8` als open branch

## Wat er inhoudelijk bij komt

**De externe architectuurreview** krijgt een eigen blok: beide documenten, de negen issues (#46 t/m #54), en vijf punten waar de review mij corrigeerde en gelijk had. Inclusief de ene bevinding die ik heb **nagerekend en die vervalt** — de UC2-tokenlookup ís op HTTP-niveau gedekt (regel 437 en 465). Dat stond op zekerheid *waarschijnlijk*, en het is het enige van de negen antwoorden dat op een aanname over niet-meegeleverd materiaal rustte.

**De CATS-rollen** met de twee lagen: vijf rollen als platform, acht functietitels als tenantconfiguratie. Plus twee ontwerpeisen — rol als eigen rij (niet als kolom, want "autorisatie op individu" komt later) en rechten in code (rechten wijzigen hoort een PR te zijn, geen `UPDATE`). En de vaststelling dat **DOP/AOC een autorisatiegrens is, geen label**: MVM_V2's B-025 zegt letterlijk dat een DOP-only rol nooit het volledige PDF-contract mag zien.

**De eerstvolgende stap is herschreven** naar de Entra-guard. Dat is een verschuiving die uitleg verdient: de leverancierskant had een eigen, complete beveiliging — het token *is* de sleutel. De beheerkant heeft dat niet, en leidt de tenant vandaag af uit een ongeverifieerde header.

**Twee lessen toegevoegd**, beide vandaag geleerd:

- een regel die met geen enkele test rood te krijgen is hoort weg — niet een derde test
- een test die het juiste antwoord geeft kan nog steeds het verkeerde meten

## Geverifieerd, niet aangenomen

| Claim | Hoe gecontroleerd |
|---|---|
| #42 en #43 gesloten | `gh issue view` — beide `CLOSED` |
| 30 open issues | geteld via `gh issue list` |
| 58 unittests | gemeten; `npx jest` zegt 59, die ene extra is `app.controller.spec.ts` — staat als voetnoot in het document |
| regel 437/465 in de e2e-spec | nagekeken in `test/vragenlijst-ophalen.e2e-spec.ts` |
| de twee nieuwe snelstartcommando's | beide gedraaid, inclusief dat de browsertest zichzelf overslaat zonder `SURVEY_TOKEN` |

## Eén toevoeging buiten de bijwerking

Het **externe reviewdocument** (`External-2026-07-29-...pplx.md`) stond untracked in de werkboom. Het is nu meegenomen, want `STATUS.md` verwijst ernaar en de aanvraag staat al op `main` — één helft zonder de andere is lastig te volgen. Zeg het als je dat liever buiten de repo houdt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)