### PR TITLE
chore: npm run verify als enige poort naar "groen"

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,32 @@
+# Regeleindes zijn een eigenschap van deze repository, niet van de machine
+# waarop iemand werkt.
+#
+# ── Waarom dit bestand er is ─────────────────────────────────────────────────
+#
+# Op 2026-07-31 bleek `npm run format:check` op Windows structureel rood, ook
+# op bestanden die niemand had aangeraakt — terwijl CI groen was. Oorzaak:
+# git staat hier op core.autocrlf=true (CRLF in de werkmap, LF in de opslag),
+# en prettier valt zonder instelling terug op endOfLine: "lf". Die twee spreken
+# elkaar dan tegen.
+#
+# Het gevolg was erger dan een rode stap: het maakt het verificatiescript
+# onbetrouwbaar. Wie went aan "die meldingen horen erbij", ziet de echte fout
+# ook niet meer.
+#
+# `text=auto eol=lf` dwingt LF af in de werkmap én in de opslag, ongeacht de
+# git-instelling van de gebruiker. Daarmee zien Windows, Linux en CI hetzelfde.
+* text=auto eol=lf
+
+# Binaire bestanden nooit converteren: dat beschadigt ze.
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.pdf binary
+
+# Windows-scripts moeten CRLF houden. Bewust een uitzondering: cmd.exe leest
+# een .cmd-bestand met LF-regeleindes niet betrouwbaar. Dezelfde valkuil die
+# bij de backup-taak toesloeg — zie docs/runbooks, stap 0.
+*.cmd text eol=crlf
+*.bat text eol=crlf

--- a/MCM2-CLAUDE.md
+++ b/MCM2-CLAUDE.md
@@ -463,7 +463,7 @@ Een wijziging is pas “klaar” wanneer:
 [ ] Relevante architectuur- en securityregels toegepast
 [ ] Geen secrets hardcoded of zichtbaar gemaakt
 [ ] Lokaal getest in de Docker-werkwijze, waar van toepassing
-[ ] Format, lint, typecheck en relevante tests groen
+[ ] `npm run verify` groen — NIET losse commando's, zie §15a
 [ ] RLS read/write-isolatietest toegevoegd bij tenantdata
 [ ] Migratie getest op lege database, indien schema gewijzigd
 [ ] Docker production build geslaagd
@@ -472,6 +472,45 @@ Een wijziging is pas “klaar” wanneer:
 [ ] Crosscheck uitgevoerd bij architectuur-, security- of scopewijziging
 [ ] OTAP-route gevolgd vóór productie wordt voorgesteld
 ```
+
+### 15a. "Groen" wordt vastgesteld met `npm run verify` — nooit met losse commando's
+
+```bash
+npm run verify        # alle vijf poorten, vraagt DATABASE_URL
+npm run verify:snel   # zonder e2e — meldt zelf dat het onvolledig is
+```
+
+**Waarom dit een harde regel is en geen aanbeveling.** Op 2026-07-31 faalde CI
+op de lintstap terwijl lokaal alles groen leek. De oorzaak was geen typefout
+maar een naamsverwarring: er bestaan drie paren scripts waarvan de "gewone"
+variant iets anders doet dan wat CI draait.
+
+| Lokaal gedraaid | Wat CI draait | Verschil |
+|---|---|---|
+| `npm run lint` | `npm run lint:check` | `--fix` en waarschuwingen toegestaan versus `--max-warnings=0` |
+| `npm run format` | `npm run format:check` | schrijft weg versus controleert |
+| `npm test` | `npm test` **plus** de e2e-suite | unittests dekken de tenantgrens niet |
+
+Wie moet onthouden welke variant CI gebruikt, gaat dat een keer mis hebben —
+en dan is "groen" een mening in plaats van een meting. `scripts/verify.js`
+draait ze in dezelfde volgorde als de workflow en stopt bij de eerste rode
+stap. Elke stap noemt bij een fout de bijbehorende CI-job.
+
+**Wat `verify` bewust niet dekt:** de Docker-productiebuild. Die draait alleen
+in CI (job `docker-build`). Bij een wijziging aan de `Dockerfile` of aan
+runtime-dependencies hoort een lokale `docker build` — een geslaagde
+`nest build` bewijst niet dat het artefact werkt (zie `src/auth/README.md`).
+
+**De veiligheidsklep.** `verify` weigert te draaien wanneer `DATABASE_URL` niet
+naar een lokale wegwerpdatabase wijst. De e2e-suite maakt tenants aan en
+verwijdert rijen; tegen `clm-enterprise` gedraaid is dat onherstelbaar, en de
+productie-URL staat in `.env`. Dit is de laatste plek waar die vergissing nog
+te vangen is.
+
+**De e2e-tests draaien nooit tegen productie, en dat blijft zo.** Ze zijn
+destructief van aard. De vraag "draait de uitgerolde omgeving en klopt hij" is
+een andere controle — een leesbare rookproef, Issue #61 — die bij de
+OTAP-doorloop hoort (#18), niet hier.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -25,7 +25,9 @@
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
-    "test:e2e": "jest --config ./test/jest-e2e.json"
+    "test:e2e": "jest --config ./test/jest-e2e.json",
+    "verify": "node scripts/verify.js",
+    "verify:snel": "node scripts/verify.js --snel"
   },
   "dependencies": {
     "@nestjs/common": "^11.0.1",

--- a/scripts/verify.js
+++ b/scripts/verify.js
@@ -1,0 +1,205 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * Bootst de CI-poort lokaal na (`npm run verify`).
+ *
+ * ── Waarom dit bestaat ───────────────────────────────────────────────────────
+ *
+ * Op 2026-07-31 faalde CI op de lintstap terwijl lokaal alles groen leek. De
+ * oorzaak was geen typefout maar een naamsverwarring: `npm run lint` fixt en
+ * staat waarschuwingen toe, `npm run lint:check` faalt op elke waarschuwing.
+ * CI draait de tweede. Er waren 16 waarschuwingen, allemaal blokkerend.
+ *
+ * Datzelfde valstrikje bestaat bij `format` versus `format:check`, en bij
+ * `test` (alleen unittests) versus de e2e-suite die CI apart draait. Wie moet
+ * onthouden welke variant CI gebruikt, gaat dat een keer mis hebben.
+ *
+ * Dit script haalt die kennis uit iemands hoofd en zet hem in code. Eén
+ * commando, één antwoord op "is dit groen", en dat antwoord komt overeen met
+ * dat van CI.
+ *
+ * ── De bron van waarheid blijft .github/workflows/ci.yml ─────────────────────
+ *
+ * Dit script is een kopie van die stappen, geen afleiding ervan. Verandert de
+ * workflow, dan verandert dit script mee — de lijst STAPPEN hieronder verwijst
+ * per stap naar de job waar hij vandaan komt, zodat die vergelijking te maken
+ * is zonder beide bestanden uit het hoofd te kennen.
+ */
+
+const { spawnSync } = require('node:child_process');
+
+/**
+ * De stappen, in de volgorde waarin CI ze draait.
+ *
+ * `ci` benoemt de job en stap in .github/workflows/ci.yml. Bij een wijziging
+ * daar hoort een wijziging hier; die verwijzing maakt dat controleerbaar.
+ */
+const STAPPEN = [
+  {
+    naam: 'format',
+    omschrijving: 'Opmaak controleren',
+    ci: 'quality → Format controleren',
+    commando: ['npm', 'run', 'format:check'],
+  },
+  {
+    naam: 'lint',
+    omschrijving: 'Lint (waarschuwingen tellen als fout)',
+    ci: 'quality → Lint',
+    commando: ['npm', 'run', 'lint:check'],
+  },
+  {
+    naam: 'typecheck',
+    omschrijving: 'Typecontrole',
+    ci: 'quality → Typecheck',
+    commando: ['npm', 'run', 'typecheck'],
+  },
+  {
+    naam: 'unit',
+    omschrijving: 'Unittests',
+    ci: 'quality → Unit tests',
+    commando: ['npm', 'test'],
+  },
+  {
+    naam: 'e2e',
+    omschrijving: 'E2e-tests (vraagt een wegwerpdatabase)',
+    ci: 'rls-isolation → Tenant- en token-isolatietests',
+    commando: ['npx', 'jest', '--config', './test/jest-e2e.json', '--forceExit'],
+    vraagtDatabase: true,
+  },
+];
+
+/** Hosts die als wegwerpomgeving gelden. */
+const LOKALE_HOSTS = new Set(['localhost', '127.0.0.1', '::1', 'host.docker.internal']);
+
+/**
+ * Controleert dat DATABASE_URL naar een wegwerpdatabase wijst.
+ *
+ * Dit is geen formaliteit. De e2e-suite maakt tenants aan, verwijdert rijen en
+ * trekt sessies in. Tegen `clm-enterprise` gedraaid is dat onherstelbaar — en
+ * de productie-URL staat in `.env`, dus één verkeerd gekopieerde regel is
+ * genoeg. Dit is de laatste plek waar die vergissing nog te vangen is.
+ *
+ * @returns {{ok: true} | {ok: false, reden: string}}
+ */
+function controleerDatabaseUrl(waarde) {
+  let url;
+
+  try {
+    url = new URL(waarde);
+  } catch {
+    return { ok: false, reden: 'DATABASE_URL is geen geldige URL.' };
+  }
+
+  if (!LOKALE_HOSTS.has(url.hostname)) {
+    return {
+      ok: false,
+      reden:
+        `DATABASE_URL wijst naar '${url.hostname}'.\n\n` +
+        '  De e2e-tests maken tenants aan en verwijderen rijen. Ze horen\n' +
+        '  uitsluitend tegen een wegwerpcontainer te draaien, nooit tegen een\n' +
+        '  database met echte gegevens.\n\n' +
+        '  Een verse testdatabase opzetten: zie docs/STATUS.md, "Snel weer op\n' +
+        '  gang komen".',
+    };
+  }
+
+  return { ok: true };
+}
+
+function draai(commando) {
+  const [uitvoerbaar, ...argumenten] = commando;
+
+  const resultaat = spawnSync(uitvoerbaar, argumenten, {
+    stdio: 'inherit',
+    // Op Windows zijn npm en npx .cmd-bestanden; zonder shell vindt spawnSync
+    // ze niet. Zelfde reden als in scripts/backup-dump.js.
+    shell: process.platform === 'win32',
+  });
+
+  return resultaat.status === 0;
+}
+
+function main() {
+  const alleenSnel = process.argv.includes('--snel');
+  const stappen = alleenSnel
+    ? STAPPEN.filter((stap) => !stap.vraagtDatabase)
+    : STAPPEN;
+
+  console.log('');
+  console.log('Verificatie — dezelfde poorten als CI (.github/workflows/ci.yml)');
+  if (alleenSnel) {
+    console.log('Modus: --snel, de e2e-stap wordt overgeslagen.');
+  }
+  console.log('');
+
+  // --snel telt als overslaan, niet als een kleinere volledige controle. Zonder
+  // deze regel meldde het script "GROEN — alle poorten die CI ook draait"
+  // terwijl de e2e-stap bewust was overgeslagen: precies de valse zekerheid
+  // die dit script hoort uit te bannen.
+  const overgeslagen = alleenSnel
+    ? STAPPEN.filter((stap) => stap.vraagtDatabase).map((s) => s.omschrijving)
+    : [];
+  let nummer = 0;
+
+  for (const stap of stappen) {
+    nummer += 1;
+    const kop = `${nummer}/${stappen.length}  ${stap.omschrijving}`;
+
+    if (stap.vraagtDatabase) {
+      const url = process.env.DATABASE_URL;
+
+      if (!url) {
+        // Overslaan en dat luid melden, niet falen. Zelfde patroon als de
+        // browsertest in de frontend (#47): een stap die zijn omgeving niet
+        // heeft, hoort niet te doen alsof hij iets bewezen heeft.
+        console.log(`${kop}\n  OVERGESLAGEN — DATABASE_URL ontbreekt.\n`);
+        overgeslagen.push(stap.omschrijving);
+        continue;
+      }
+
+      const oordeel = controleerDatabaseUrl(url);
+
+      if (!oordeel.ok) {
+        console.error(`${kop}\n`);
+        console.error(`  GESTOPT: ${oordeel.reden}\n`);
+        process.exit(1);
+      }
+    }
+
+    console.log(kop);
+
+    if (!draai(stap.commando)) {
+      console.error('');
+      console.error(`ROOD op: ${stap.omschrijving}`);
+      console.error(`CI draait deze stap als: ${stap.ci}`);
+      console.error('');
+      // Stoppen bij de eerste rode stap: de volgende stappen zeggen niets
+      // zolang deze faalt, en een lange lijst uitvoer verbergt de oorzaak.
+      process.exit(1);
+    }
+
+    console.log('');
+  }
+
+  if (overgeslagen.length > 0) {
+    console.log('GROEN, met overgeslagen stappen:');
+    for (const naam of overgeslagen) {
+      console.log(`  - ${naam}`);
+    }
+    console.log('');
+    console.log('Dit is dus GEEN volledige CI-gelijkwaardige controle.');
+    console.log('Zet DATABASE_URL naar een wegwerpcontainer voor de rest.');
+    // Bewust exitcode 0: overslaan is geen fout. De melding hierboven is het
+    // signaal, niet de exitcode — anders wordt `--snel` onbruikbaar.
+  } else {
+    console.log('GROEN — alle poorten die CI ook draait.');
+    console.log('');
+    console.log('Let op: dit dekt niet de Docker-productiebuild.');
+    console.log('Die draait alleen in CI (job: docker-build).');
+  }
+
+  console.log('');
+}
+
+main();


### PR DESCRIPTION
Naar aanleiding van de vraag: *"de test doet wat hij moet doen, maar die fout zat er door slordigheid in — hoe voorkomen we die slordigheid?"*

## Wat er misging

CI faalde op de lintstap terwijl lokaal alles groen leek. Geen typefout, maar een naamsverwarring: `npm run lint` fixt en staat waarschuwingen toe, `npm run lint:check` faalt op elke waarschuwing. CI draait de tweede.

Erger dan de fout was hoe hij werd weggeredeneerd: die 16 waarschuwingen waren gezien en afgedaan als "pre-existing" zonder controle. Ze zaten allemaal in code uit diezelfde sessie. Daarmee was "groen" een mening geworden in plaats van een meting.

Er zijn **drie** van deze valstrikjes:

| Lokaal gedraaid | Wat CI draait | Verschil |
|---|---|---|
| `npm run lint` | `lint:check` | `--fix` + warnings toegestaan vs `--max-warnings=0` |
| `npm run format` | `format:check` | schrijft weg vs controleert |
| `npm test` | `npm test` **+ e2e** | unittests dekken de tenantgrens niet |

## De oplossing

`scripts/verify.js` draait dezelfde vijf stappen in dezelfde volgorde als de workflow, stopt bij de eerste rode stap, en noemt daarbij de bijbehorende CI-job.

```
npm run verify        # alle vijf poorten
npm run verify:snel   # zonder e2e — meldt zelf dat het onvolledig is
```

Twee dingen die het script bewust doet:

- **Het weigert te draaien** wanneer `DATABASE_URL` niet naar een lokale wegwerpdatabase wijst. De e2e-suite maakt tenants aan en verwijdert rijen; tegen `clm-enterprise` gedraaid is dat onherstelbaar, en de productie-URL staat in `.env`.
- **Het meldt eerlijk wat het heeft overgeslagen.** `--snel` zei eerst "GROEN — alle poorten die CI ook draait" terwijl de e2e-stap was overgeslagen. Dat is precies de valse zekerheid die dit moet uitbannen; nu staat er "GROEN, met overgeslagen stappen".

## Bijvangst: `format:check` was op Windows structureel rood

Ook op bestanden die niemand had aangeraakt — terwijl CI groen was. Oorzaak: `core.autocrlf=true` zet CRLF in de werkmap, prettier valt zonder instelling terug op LF.

Opgelost met `.gitattributes` (`text=auto eol=lf`), met `.cmd`/`.bat` als expliciete uitzondering: `cmd.exe` leest die niet betrouwbaar met LF — dezelfde valkuil die bij de backup-taak toesloeg.

**Geen enkel bestaand bestand veranderde van inhoud**; ze stonden al als LF in de opslag. Alleen de werkmap is rechtgezet.

## Tegenproef

De eerste poging was **ongeldig**, en dat is het vermelden waard: een geëxporteerde functie met `any` die niemand aanroept triggert de regel niet, dus verify bleef terecht groen. Met een `any` op een plek waar de regel wél vuurt: rood op stap 2, exitcode 1.

Tweede tegenproef — de guard alles laten doorlaten: vier poorten groen, dan **26 falende e2e-tests**, exitcode 1. Beide daarna teruggedraaid en geverifieerd dat er niets van achterbleef.

## Wat verify níét dekt, expliciet benoemd

- **De Docker-productiebuild.** Draait alleen in CI (job `docker-build`).
- **Of een uitgerolde omgeving gezond is.** Dat is een leesbare rookproef die nog niet bestaat — **Issue #61**, hoort bij fase 4 en #18. De e2e-tests gaan die vraag nooit beantwoorden: ze zijn destructief van aard en horen uitsluitend tegen een wegwerpcontainer te draaien.

Vastgelegd als harde regel in `MCM2-CLAUDE.md` §15a; de Definition of Done verwijst er nu naar in plaats van naar losse commando's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)