### PR TITLE
fix(db): FORCE ROW LEVEL SECURITY en drie bewakingstests

### DIFF
--- a/docs/architectuur-en-verificatie.md
+++ b/docs/architectuur-en-verificatie.md
@@ -1,6 +1,6 @@
 # MCM2 — de tenantgrens, en hoe elke laag ervan bewezen wordt
 
-**Opgesteld:** 2026-07-31
+**Opgesteld:** 2026-07-31 · **Bijgewerkt:** 2026-07-31 na externe review
 **Bedoeld voor:** de eigenaar en een externe reviewer
 **Leesbare webversie:** https://claude.ai/code/artifact/31d7819a-a7d9-4079-b224-c51d08497450
 
@@ -13,9 +13,9 @@ overgenomen uit eerdere verslagen.
 
 | | |
 |---|---|
-| E2e-tests | 205 in 15 suites |
+| E2e-tests | 210 in 15 suites |
 | Unittests | 161 in 8 suites |
-| Migraties | 0000 t/m 0010 |
+| Migraties | 0000 t/m 0011 |
 
 > **Onderhoud.** Dit document veroudert zodra de code verandert. Bij een wijziging
 > aan de tenantgrens, de testopzet of de verificatiepoort hoort een wijziging hier.
@@ -120,6 +120,59 @@ en drie tests bewaken hem:
 2. elke uitzondering moet volledig afgesloten zijn voor de runtime-rol;
 3. een rechtstreekse `SELECT`/`INSERT` moet stuklopen op "permission denied".
 
+### De tweede manier waarop RLS stil niets doet (migratie 0011)
+
+Aangedragen door de externe review van 2026-07-31, en het bleek terecht.
+PostgreSQL onderwerpt de **eigenaar** van een tabel standaard niet aan row security.
+Geen `BYPASSRLS` nodig, geen foutmelding — de policies worden overgeslagen.
+
+Gemeten vóór migratie 0011, met de tenantcontext op een vreemde tenant:
+
+```
+clm_migrator (eigenaar)    → 1 rij     RLS doet niets
+clm_api_runtime (runtime)  → 0 rijen   RLS werkt
+```
+
+Vandaag was dat geen lek: de eigenaar is `clm_migrator`, de applicatie draait als
+`clm_api_runtime`, en die scheiding is een bewuste keuze (ADR-009). Maar **niets dwong
+hem af**. Wie ooit `DATABASE_URL` op de migratierol zet — bij een herstelactie, in een
+script, tijdens debuggen — verliest RLS zonder waarschuwing.
+
+`FORCE ROW LEVEL SECURITY` staat nu op **acht** van de dertien tenanttabellen. Vijf
+tabellen kunnen het niet krijgen, en dat is geen slordigheid maar hetzelfde
+kip-ei-probleem in een nieuwe vorm:
+
+| Tabel | Wordt gelezen door |
+|---|---|
+| `user`, `tenant_membership` | `gebruiker_bij_subject()`, `sessie_aanmaken()` |
+| `survey_response`, `survey_run`, `vendor` | `resolve_survey_token()` |
+
+Die `SECURITY DEFINER`-functies zijn eigendom van `clm_migrator` en draaien juist
+vóórdat er tenantcontext bestaat. Met `FORCE` erop vallen zij óók onder RLS, en dan is
+het gevolg niet "minder rijen" maar **nul**: geen login, geen surveylink die nog opent.
+Gemeten: eerst 90, daarna 77 falende e2e-tests.
+
+**Wat deze maatregel dus waard is — eerlijk gezegd minder dan de review suggereerde.**
+De vijf tabellen die overblijven zijn juist die rond identiteit en toegang. De winst zit
+in de acht die wél afgedekt zijn, en vooral hierin: de uitzonderingen staan nu op één
+plek met motivatie (`FORCE_RLS_UITZONDERINGEN`), en drie tests bewaken ze. Waar het
+eerder een eigenschap was die niemand had opgemerkt, is het nu een expliciete keuze die
+niet stilzwijgend kan groeien.
+
+Volledig sluiten vraagt een aparte eigenaarsrol voor de functies. Dat raakt het
+rollenmodel uit ADR-008 en hoort bij een eigen afweging — **Issue #65**.
+
+### `search_path` op de SECURITY DEFINER-functies
+
+De review noemde dit als openstaand punt. Dat is **feitelijk onjuist**: alle vijf
+functies hebben `SET search_path = clm, pg_temp`, al sinds migratie 0003, met uitleg ter
+plekke over waarom dat geen detail is.
+
+Wat wél ontbrak was een **test** die het afdwingt. Een nieuwe functie zonder
+`search_path` zou er doorheen zijn geglipt. De hardening was er, de bewaking niet — en
+dat verschil is precies de categorie fout die dit project probeert uit te bannen. Nu
+afgedekt.
+
 ---
 
 ## 4. Het principe achter de testopzet
@@ -196,7 +249,7 @@ Entra-tenant, en dat is *strenger* in plaats van losser. Een echte provider geef
 verlopen token af, of een token met een vervalste handtekening — en juist dat zijn de
 aanvallen. Met een lokaal gegenereerd sleutelpaar zijn die wél te maken.
 
-### E2e-tests — 205, tegen een wegwerpdatabase
+### E2e-tests — 210, tegen een wegwerpdatabase
 
 | Suite | Bewaakt | Tests |
 |---|---|---:|
@@ -209,7 +262,7 @@ aanvallen. Met een lokaal gegenereerd sleutelpaar zijn die wél te maken.
 | `vragenlijst-seed` | Inlezen van de acht Transdev-vragen | 15 |
 | `sessie` | Aanmaken, verlopen, intrekken; de tabel is afgesloten | 14 |
 | `membership-isolatie` | Lidmaatschap bepaalt de tenant, niet de invoer | 13 |
-| `schema-conformiteit` | Elke tenanttabel heeft een policy — uit het schema afgeleid | 12 |
+| `schema-conformiteit` | Policies, FORCE RLS, tabeleigenaarschap en `search_path` — uit het schema afgeleid | 17 |
 | `survey-routes` | De volledige UC1-flow over HTTP | 12 |
 | `drizzle-tenant-context` | Isolatie ook via de querylaag, niet alleen ruwe SQL | 6 |
 | `tenant-rls-isolation` | Lezen én schrijven over de tenantgrens heen | 5 |
@@ -310,7 +363,8 @@ moeten lezen. Alles hierboven is gemeten; alles hieronder is dat niet.
 | Gelijktijdige uploads | **Onbewezen** | De `FOR UPDATE`-vergrendeling is er, maar met die vergrendeling verwijderd bleven alle tests groen. De race was niet uit te lokken zonder kunstgrepen in productiecode. |
 | Gezondheid van een uitgerolde omgeving | **Bestaat niet** | De e2e-tests beantwoorden dit nooit — ze zijn destructief van aard. Er is een aparte, alleen-lezende rookproef nodig: **Issue #61**. |
 | Virusscan op bijlagen | **Niet gebouwd** | De klant heeft er niets over gezegd (OV-7); het ontwerp benoemt dit expliciet als openstaand risico. |
-| Branch protection op `main` | **Technisch geblokkeerd** | Vereist een betaald GitHub-plan. Tot dan is "nooit rechtstreeks op main werken" een werkafspraak, geen afdwinging. |
+| Eigenaarsgat op vijf tabellen | **Deels afgedekt** | `FORCE RLS` kon niet op `user`, `tenant_membership`, `survey_response`, `survey_run` en `vendor` — de `SECURITY DEFINER`-functies moeten die lezen vóór er tenantcontext is. Bewaakt door een test op tabeleigenaarschap; volledig sluiten vraagt een aparte eigenaarsrol (**Issue #65**). |
+| Branch protection op `main` | **Bewust niet geregeld** | Vereist GitHub Team (~$4 per gebruiker per maand). Op 2026-07-31 als kostenafweging voorgelegd aan de eigenaar en bewust zo gelaten. "Nooit rechtstreeks op main werken" blijft daarmee een werkafspraak zonder technische afdwinging — een keuze, geen technische blokkade zoals eerder in dit document stond. |
 
 > **Over de dekking van `verify`.** De poort dekt de Docker-productiebuild *niet* — die
 > draait alleen in CI (job `docker-build`). Een geslaagde `nest build` bewijst bovendien
@@ -341,6 +395,53 @@ Vijf vragen waarvan het antwoord het meest zegt over de houdbaarheid van dit ont
 5. **Wat gebeurt er bij de tweede klant?** Alles hierboven is gebouwd voor meerdere
    klanten, maar er draait er nu één. De eerste echte tweede klant is de werkelijke test
    van dit ontwerp.
+
+---
+
+## 10. Uit de externe review van 2026-07-31
+
+De review leverde twee concrete aanbevelingen op. Beide zijn getoetst vóórdat er iets
+werd gebouwd — dat toetsen was zinvol, want de uitkomst verschilde per punt.
+
+| Aanbeveling | Uitkomst |
+|---|---|
+| `FORCE ROW LEVEL SECURITY` en tabeleigenaarschap | **Terecht.** Gemeten en verholpen (migratie 0011), met drie bewakingstests. Deels — zie §3 en Issue #65. |
+| `search_path` op de `SECURITY DEFINER`-functies | **Feitelijk onjuist.** Stond er al sinds migratie 0003. Wat ontbrak was de *test*; die is toegevoegd. |
+
+De overige punten uit de review — de guard die nergens op hangt, de vier verbindingen als
+testfix, en branch protection — stonden al in §8 en zijn daar aangescherpt.
+
+### Over mutation testing (Stryker)
+
+De review merkte terecht op dat de tegenproefmethode in feite handmatige mutation testing
+is, en stelde voor dat te automatiseren met Stryker.
+
+**Overwogen en voorlopig niet gedaan, om één inhoudelijke reden:** Stryker muteert
+TypeScript, en de tenantgrens zit grotendeels niet in TypeScript. De guards zijn samen
+230 regels; de migraties 1631. Geen van de vier gaten die de tegenproef vond, zou door
+Stryker gevonden zijn:
+
+| Gat | Waar het zat | Binnen Stryker's bereik? |
+|---|---|---|
+| Guard viel terug op een kopregel | Ontbrekende testdekking, niet muteerbare code | Nee |
+| RLS-policy zonder `WITH CHECK` | SQL in een migratie | Nee |
+| Conformiteitstest las de verkeerde systeemweergave | Testcode zelf | Nee |
+| `CHECK`-constraint te streng | SQL-constraint | Nee |
+
+Dat is geen toeval maar een gevolg van het ontwerpprincipe uit §1: de garantie ligt in de
+database. Een mutatietester op de applicatielaag meet dan het dunste deel van de
+verdediging.
+
+**Twee praktische bezwaren daarbovenop.** Stryker draait de testsuite per mutatie; met een
+e2e-suite die een database nodig heeft wordt dat een run van uren, en dus een eigen
+CI-baan. En het risico dat het zwaarst weegt: een mutatiescore van 85% *voelt* als bewijs,
+terwijl hij niets zegt over de vier gaten hierboven. **Een cijfer dat de verkeerde laag
+meet, is gevaarlijker dan geen cijfer.**
+
+**Wanneer het wél zinvol wordt:** zodra er substantiële applicatielogica bijkomt die niet
+op de database steunt. De CSV-parser (58 unittests) en de validatieregels zijn daar al
+kandidaten voor; de vendorlogica uit fase 2 wordt dat ook. Daar meet een mutatiescore wél
+wat hij belooft.
 
 ---
 

--- a/drizzle/0011_force_row_level_security.sql
+++ b/drizzle/0011_force_row_level_security.sql
@@ -1,0 +1,121 @@
+-- =============================================================================
+-- FORCE ROW LEVEL SECURITY: RLS geldt ook voor de eigenaar van de tabel.
+--
+-- Aanleiding: externe review van 2026-07-31 op
+-- docs/architectuur-en-verificatie.md.
+--
+-- ── Het gat ──────────────────────────────────────────────────────────────────
+--
+-- De applicatie draait als clm_api_runtime, een rol zónder BYPASSRLS, en
+-- DatabaseService weigert op te starten als die vlag er wél is. Dat dekt één
+-- manier waarop RLS stilzwijgend niets doet.
+--
+-- Er is een tweede, en die stond nergens beschreven: PostgreSQL onderwerpt de
+-- *eigenaar* van een tabel standaard niet aan row security. Geen BYPASSRLS
+-- nodig, geen foutmelding — de policies worden simpelweg overgeslagen.
+--
+-- Gemeten op een verse database vóór deze migratie, met de tenantcontext op
+-- een tenant die de rij níét bezit:
+--
+--   clm_migrator (eigenaar)    → 1 rij   RLS doet niets
+--   clm_api_runtime (runtime)  → 0 rijen RLS werkt
+--
+-- ── Waarom dit vandaag geen lek is, en toch moet ─────────────────────────────
+--
+-- De eigenaar is clm_migrator en de applicatie draait als clm_api_runtime.
+-- Die scheiding is een bewuste keuze (ADR-009) en op dit moment intact.
+--
+-- Maar niets dwingt hem af. Wie ooit DATABASE_URL op de migratierol zet — bij
+-- een herstelactie, in een script, tijdens debuggen — verliest RLS zonder
+-- enige waarschuwing. Geen foutmelding, geen falende test. Precies de
+-- faalvorm waar dit project op let: stil, en pas zichtbaar wanneer het al mis
+-- is gegaan.
+--
+-- FORCE ROW LEVEL SECURITY haalt die voorwaarde weg. Daarna geldt RLS voor
+-- iedereen behalve rollen met BYPASSRLS, en dát wordt al bewaakt.
+--
+-- ── Wat dit betekent voor migraties ──────────────────────────────────────────
+--
+-- clm_migrator kan hierna geen tenantgebonden rijen meer lezen of schrijven
+-- zonder tenantcontext. Dat is geen bezwaar: migraties wijzigen structuur, geen
+-- klantgegevens. Zou een toekomstige migratie tóch rijen moeten aanraken, dan
+-- is `SET LOCAL app.current_tenant_id` de weg — dezelfde weg als de applicatie.
+--
+-- clm.sessie staat er bewust niet bij: die heeft geen RLS (migratie 0010) en
+-- FORCE zonder policies zou elke toegang blokkeren, ook via de drie
+-- SECURITY DEFINER-functies. Die tabel is op een andere manier dicht.
+-- =============================================================================
+
+-- ── Vijf tabellen krijgen bewust GEEN force ──────────────────────────────────
+--
+--   clm."user"             clm.survey_response
+--   clm.tenant_membership  clm.survey_run
+--                          clm.vendor
+--
+-- Bij het bouwen bleek FORCE op deze tabellen de applicatie te breken: eerst
+-- 90, daarna 77 falende e2e-tests. Geen testartefact maar een echte botsing,
+-- en dezelfde kip-ei-vorm als in migratie 0009 en 0010.
+--
+-- De vijf SECURITY DEFINER-functies zijn eigendom van clm_migrator. Met FORCE
+-- vallen díé functies óók onder RLS — en zij draaien juist vóórdat er
+-- tenantcontext bestaat, want de tenant volgt uit wat ze opzoeken. Het gevolg
+-- is niet "minder rijen" maar nul: geen login, en geen enkele surveylink die
+-- nog opent.
+--
+-- Welke functie welke tabel leest (afgeleid uit pg_proc, niet uit geheugen):
+--
+--   resolve_survey_token()   survey_response, survey_run, vendor
+--   gebruiker_bij_subject()  user, tenant_membership
+--   sessie_aanmaken()        user, tenant_membership, sessie
+--
+-- ── Wat deze migratie daarmee waard is ───────────────────────────────────────
+--
+-- Eerlijk gezegd minder dan de review suggereerde. Acht van de dertien
+-- tenanttabellen krijgen FORCE; de vijf die overblijven zijn juist de tabellen
+-- rond identiteit en toegang. Dat is geen toeval maar een gevolg van het
+-- ontwerp: precies die tabellen moeten vóór de tenantcontext leesbaar zijn.
+--
+-- De winst zit in de acht die wél afgedekt zijn, en vooral hierin: de
+-- uitzonderingen staan nu op één plek met motivatie, en drie tests bewaken ze.
+-- Waar het eerder een eigenschap was die niemand had opgemerkt, is het nu een
+-- expliciete keuze die niet stilzwijgend kan groeien.
+--
+-- ── Het restrisico, en waar het wordt afgedekt ───────────────────────────────
+--
+-- De bescherming voor de runtime-rol blijft volledig intact: clm_api_runtime is
+-- geen eigenaar en valt gewoon onder de policies. Wat blijft bestaan is dat een
+-- verbinding als clm_migrator deze vijf tabellen ongefilterd ziet.
+--
+-- Dat wordt afgedekt door de tweede test uit deze ronde — "draait niet als de
+-- rol die eigenaar is van de tabellen". Die valt om zodra de applicatie op de
+-- migratierol draait, en dát is de situatie waarin het eigenaarsgat pas
+-- schadelijk wordt.
+--
+-- ── Het alternatief, overwogen en verworpen ──────────────────────────────────
+--
+-- De functies laten toebehoren aan een aparte rol die geen eigenaar is van de
+-- tabellen. Dan kan FORCE overal aan. Dat werkt, maar voegt een vijfde rol toe
+-- aan een rollenmodel dat er al vier kent (ADR-008) en verplaatst de vraag naar
+-- "wie is eigenaar van de functies". Dat hoort bij een herziening van het
+-- rollenmodel, met een eigen afweging — niet bij deze review-opvolging.
+-- Vastgelegd als vervolgpunt.
+
+ALTER TABLE clm.tenant            FORCE ROW LEVEL SECURITY;--> statement-breakpoint
+ALTER TABLE clm.vendor_contact    FORCE ROW LEVEL SECURITY;--> statement-breakpoint
+ALTER TABLE clm.vendor_tag        FORCE ROW LEVEL SECURITY;--> statement-breakpoint
+ALTER TABLE clm.survey_template   FORCE ROW LEVEL SECURITY;--> statement-breakpoint
+ALTER TABLE clm.survey_category   FORCE ROW LEVEL SECURITY;--> statement-breakpoint
+ALTER TABLE clm.survey_question   FORCE ROW LEVEL SECURITY;--> statement-breakpoint
+ALTER TABLE clm.survey_answer     FORCE ROW LEVEL SECURITY;--> statement-breakpoint
+ALTER TABLE clm.survey_attachment FORCE ROW LEVEL SECURITY;--> statement-breakpoint
+
+-- audit.audit_event staat in een ánder schema en werd bij het opstellen van
+-- deze migratie over het hoofd gezien — de eerste versie keek alleen naar clm.
+-- De nieuwe conformiteitstest wees hem meteen aan, want die leest de lijst uit
+-- het schema in plaats van uit een handmatige opsomming. Precies waarvoor die
+-- opzet bedoeld is (§4 van docs/architectuur-en-verificatie.md).
+--
+-- Uitgerekend de audittrail: de tabel die vastlegt wie wat deed. Als daar rijen
+-- van andere tenants zichtbaar zijn, lekt niet alleen data maar ook het
+-- gedragspatroon van een andere klant.
+ALTER TABLE audit.audit_event     FORCE ROW LEVEL SECURITY;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -78,6 +78,13 @@
       "when": 1785416400000,
       "tag": "0010_sessie",
       "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "7",
+      "when": 1785499200000,
+      "tag": "0011_force_row_level_security",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema-inventory.ts
+++ b/src/db/schema-inventory.ts
@@ -91,3 +91,51 @@ export const TENANT_SCHEMAS = ['clm', 'audit'] as const;
  * "permission denied".
  */
 export const RLS_UITZONDERINGEN: ReadonlySet<string> = new Set(['clm.sessie']);
+
+/**
+ * Tabellen met RLS maar bewust ZONDER `FORCE ROW LEVEL SECURITY`
+ * (migratie 0011).
+ *
+ * Een aparte lijst, niet samengevoegd met `RLS_UITZONDERINGEN`: dit is een
+ * andere en veel smallere uitzondering. Deze tabellen hébben RLS en policies;
+ * alleen de eigenaar van de tabel wordt er niet aan onderworpen.
+ *
+ * ── Waarom deze vijf ─────────────────────────────────────────────────────────
+ *
+ * De vijf SECURITY DEFINER-functies zijn eigendom van `clm_migrator`. Met FORCE
+ * op deze tabellen vallen díé functies óók onder RLS — en zij draaien juist
+ * vóórdat er tenantcontext bestaat, want de tenant volgt uit wat ze opzoeken.
+ * Gemeten gevolg: eerst 90, daarna 77 falende e2e-tests. In productie zou het
+ * betekenen: geen login, en geen surveylink die nog opent.
+ *
+ * Welke functie welke tabel leest, afgeleid uit `pg_proc`:
+ *
+ *   resolve_survey_token()   survey_response, survey_run, vendor
+ *   gebruiker_bij_subject()  user, tenant_membership
+ *   sessie_aanmaken()        user, tenant_membership
+ *
+ * Dat het juist deze vijf zijn, is geen toeval: het zijn de tabellen rond
+ * identiteit en toegang, en precies die moeten vóór de tenantcontext leesbaar
+ * zijn.
+ *
+ * ── Wat het restrisico is, en waar het wordt afgedekt ────────────────────────
+ *
+ * De bescherming voor de runtime-rol blijft volledig intact: `clm_api_runtime`
+ * is geen eigenaar en valt dus gewoon onder de policies. Wat blijft bestaan is
+ * dat een verbinding als `clm_migrator` deze vijf tabellen ongefilterd ziet.
+ *
+ * Dat wordt afgedekt door de test "draait niet als de rol die eigenaar is van
+ * de tabellen" in `test/schema-conformiteit.e2e-spec.ts`. Die valt om zodra de
+ * applicatie op de migratierol draait — precies de situatie waarin dit gat pas
+ * schadelijk wordt.
+ *
+ * Volledig sluiten vraagt een aparte eigenaarsrol voor de functies. Dat werkt,
+ * maar raakt het rollenmodel uit ADR-008 en hoort bij een eigen afweging.
+ */
+export const FORCE_RLS_UITZONDERINGEN: ReadonlySet<string> = new Set([
+  'clm.user',
+  'clm.tenant_membership',
+  'clm.survey_response',
+  'clm.survey_run',
+  'clm.vendor',
+]);

--- a/test/schema-conformiteit.e2e-spec.ts
+++ b/test/schema-conformiteit.e2e-spec.ts
@@ -1,6 +1,7 @@
 import { Client } from 'pg';
 
 import {
+  FORCE_RLS_UITZONDERINGEN,
   RLS_UITZONDERINGEN,
   TENANT_SCHEMAS,
   inventariseerSchema,
@@ -101,6 +102,151 @@ describe('Schema-conformiteit (e2e)', () => {
       .filter((naam) => rlsPerTabel.get(naam) !== true);
 
     expect(zonderRls).toEqual([]);
+  });
+
+  it('heeft FORCE ROW LEVEL SECURITY op elke tenantgebonden tabel', async () => {
+    // Toegevoegd na de externe review van 2026-07-31 (migratie 0011).
+    //
+    // RLS inschakelen is niet genoeg: PostgreSQL onderwerpt de *eigenaar* van
+    // een tabel standaard niet aan row security. Geen BYPASSRLS nodig, geen
+    // foutmelding — de policies worden simpelweg overgeslagen.
+    //
+    // Gemeten vóór 0011, met de tenantcontext op een vreemde tenant:
+    //   clm_migrator (eigenaar)   → 1 rij
+    //   clm_api_runtime (runtime) → 0 rijen
+    //
+    // Vandaag is dat geen lek omdat eigenaar en runtime gescheiden zijn
+    // (ADR-009). Deze test bestaat omdat niets dát afdwingt: wie ooit
+    // DATABASE_URL op de migratierol zet, verliest RLS zonder waarschuwing.
+    const { rows } = await client.query<{
+      volledige_naam: string;
+      force_aan: boolean;
+    }>(
+      `SELECT n.nspname || '.' || c.relname AS volledige_naam,
+              c.relforcerowsecurity        AS force_aan
+         FROM pg_class c
+         JOIN pg_namespace n ON n.oid = c.relnamespace
+        WHERE n.nspname = ANY($1) AND c.relkind = 'r'`,
+      [TENANT_SCHEMAS],
+    );
+
+    const forcePerTabel = new Map(
+      rows.map((r) => [r.volledige_naam, r.force_aan]),
+    );
+
+    const zonderForce = verwachteTabellen
+      .filter((t) => t.tenantgebonden)
+      .map((t) => t.volledigeNaam)
+      // clm.sessie heeft bewust geen RLS; FORCE zonder policies zou élke
+      // toegang blokkeren, ook via de SECURITY DEFINER-functies.
+      .filter((naam) => !RLS_UITZONDERINGEN.has(naam))
+      // Vijf tabellen die een SECURITY DEFINER-functie moet kunnen lezen
+      // vóórdat er tenantcontext is. FORCE brak daar de inlogflow en de
+      // surveylinks. Zie de motivatie bij FORCE_RLS_UITZONDERINGEN.
+      .filter((naam) => !FORCE_RLS_UITZONDERINGEN.has(naam))
+      .filter((naam) => forcePerTabel.get(naam) !== true);
+
+    expect(zonderForce).toEqual([]);
+  });
+
+  it('houdt de lijst met FORCE-uitzonderingen kort en bewust', () => {
+    // Zelfde reden als bij de RLS-uitzonderingen: zonder deze test wordt de
+    // lijst een achterdeur waar een tabel stilletjes in verdwijnt zodra een
+    // andere test rood staat. Uitbreiden hoort een expliciete afweging te zijn.
+    expect([...FORCE_RLS_UITZONDERINGEN].sort()).toEqual([
+      'clm.survey_response',
+      'clm.survey_run',
+      'clm.tenant_membership',
+      'clm.user',
+      'clm.vendor',
+    ]);
+  });
+
+  it('heeft op elke FORCE-uitzondering wél gewoon RLS met policies', async () => {
+    // De uitzondering gaat uitsluitend over de eigenaar. Zou op deze tabellen
+    // ook RLS zelf wegvallen, dan staan ze volledig open voor de runtime-rol —
+    // een heel ander verhaal dan waar deze uitzondering voor bedoeld is.
+    for (const volledigeNaam of FORCE_RLS_UITZONDERINGEN) {
+      const [schemaNaam, tabelNaam] = volledigeNaam.split('.');
+
+      const { rows } = await client.query<{
+        rls_aan: boolean;
+        aantal_policies: string;
+      }>(
+        `SELECT c.relrowsecurity AS rls_aan,
+                (SELECT count(*) FROM pg_policy p WHERE p.polrelid = c.oid)
+                  AS aantal_policies
+           FROM pg_class c
+           JOIN pg_namespace n ON n.oid = c.relnamespace
+          WHERE n.nspname = $1 AND c.relname = $2`,
+        [schemaNaam, tabelNaam],
+      );
+
+      expect(rows).toHaveLength(1);
+      expect(rows[0].rls_aan).toBe(true);
+      expect(Number(rows[0].aantal_policies)).toBeGreaterThan(0);
+    }
+  });
+
+  it('draait niet als de rol die eigenaar is van de tabellen', async () => {
+    // De tweede helft van dezelfde garantie. FORCE ROW LEVEL SECURITY dekt het
+    // eigenaarsgat af, maar deze scheiding is de eerste verdedigingslinie en
+    // een expliciete keuze uit ADR-009: migreren en draaien zijn twee rollen.
+    //
+    // Deze test valt om zodra iemand de applicatie op de migratierol laat
+    // draaien — precies het scenario waarin het stil misgaat.
+    const { rows } = await client.query<{
+      eigenaar: string;
+      huidige_rol: string;
+    }>(
+      `SELECT DISTINCT c.relowner::regrole::text AS eigenaar,
+              current_user                       AS huidige_rol
+         FROM pg_class c
+         JOIN pg_namespace n ON n.oid = c.relnamespace
+        WHERE n.nspname = ANY($1) AND c.relkind = 'r'`,
+      [TENANT_SCHEMAS],
+    );
+
+    expect(rows.length).toBeGreaterThan(0);
+
+    for (const rij of rows) {
+      expect(rij.eigenaar).not.toBe(rij.huidige_rol);
+    }
+  });
+
+  it('zet op elke SECURITY DEFINER-functie een expliciete search_path', async () => {
+    // Een SECURITY DEFINER-functie draait met de rechten van de eigenaar.
+    // Zonder vaste search_path kan wie schrijfrechten heeft op een schema in
+    // dat pad een gelijknamig object plaatsen en de functie kapen.
+    //
+    // Alle elf functies hebben dit al sinds migratie 0003, met uitleg ter
+    // plekke. Wat ontbrak was deze bewaking: een nieuwe functie zónder
+    // search_path zou er nu doorheen glippen. De hardening was er, de
+    // controle niet — dat verschil is precies wat de review blootlegde.
+    const { rows } = await client.query<{
+      functie: string;
+      instellingen: string[] | null;
+    }>(
+      `SELECT n.nspname || '.' || p.proname AS functie,
+              p.proconfig                   AS instellingen
+         FROM pg_proc p
+         JOIN pg_namespace n ON n.oid = p.pronamespace
+        WHERE n.nspname = ANY($1) AND p.prosecdef`,
+      [TENANT_SCHEMAS],
+    );
+
+    expect(rows.length).toBeGreaterThan(0);
+
+    const zonderSearchPath = rows
+      .filter(
+        (r) =>
+          !(r.instellingen ?? []).some((waarde) =>
+            waarde.startsWith('search_path='),
+          ),
+      )
+      .map((r) => r.functie);
+
+    expect(zonderSearchPath).toEqual([]);
   });
 
   it('houdt de lijst met RLS-uitzonderingen kort en bewust', () => {


### PR DESCRIPTION
Opvolging van de externe review. Twee aanbevelingen, **allebei eerst getoetst** voordat er iets gebouwd werd — en dat toetsen was zinvol, want de uitkomst verschilde per punt.

| Aanbeveling | Uitkomst |
|---|---|
| `FORCE ROW LEVEL SECURITY` / tabeleigenaarschap | **Terecht** — gemeten en verholpen |
| `search_path` op `SECURITY DEFINER`-functies | **Feitelijk onjuist** — stond er al sinds migratie 0003 |

## 1. Het eigenaarsgat was echt

PostgreSQL onderwerpt de **eigenaar** van een tabel standaard niet aan row security. Geen `BYPASSRLS` nodig, geen foutmelding — de policies worden overgeslagen.

Gemeten op een verse database, context op een vreemde tenant:

```
clm_migrator (eigenaar)    ziet 1 rij     RLS doet niets
clm_api_runtime (runtime)  ziet 0 rijen   RLS werkt
```

Vandaag geen lek: eigenaar en runtime zijn gescheiden (ADR-009). Maar **niets dwong dat af** — wie ooit `DATABASE_URL` op de migratierol zet, verliest RLS zonder waarschuwing.

## 2. search_path was al goed, de bewaking niet

Alle vijf functies hebben `SET search_path = clm, pg_temp`, al sinds migratie 0003, mét uitleg ter plekke. Wat ontbrak was een **test** die het afdwingt: een nieuwe functie zonder `search_path` zou er doorheen zijn geglipt.

De hardening was er, de bewaking niet. Dat verschil is precies de categorie fout die dit project probeert uit te bannen.

## Waarom vijf tabellen geen FORCE kunnen krijgen

Migratie 0011 zet FORCE op **acht van de dertien** tenanttabellen. De vijf die overblijven zijn geen slordigheid maar hetzelfde kip-ei-probleem in een nieuwe vorm — de `SECURITY DEFINER`-functies zijn eigendom van `clm_migrator` en moeten die tabellen lezen *vóórdat* er tenantcontext is:

| Functie | Leest |
|---|---|
| `resolve_survey_token()` | `survey_response`, `survey_run`, `vendor` |
| `gebruiker_bij_subject()` | `user`, `tenant_membership` |
| `sessie_aanmaken()` | `user`, `tenant_membership` |

Met FORCE erop werkte er niets meer: eerst **90**, daarna **77** falende e2e-tests. In productie: geen login, geen surveylink die nog opent. De lijst is afgeleid uit `pg_proc`, niet uit geheugen.

**Eerlijk over wat dit waard is — minder dan de review suggereerde.** De vijf tabellen die overblijven zijn juist die rond identiteit en toegang. De winst zit in de acht die wél afgedekt zijn, en vooral hierin: de uitzonderingen staan nu op één plek met motivatie (`FORCE_RLS_UITZONDERINGEN`), en drie tests bewaken ze. Volledig sluiten vraagt een aparte eigenaarsrol — **Issue #65**, raakt ADR-008.

## Vijf nieuwe tests (205 → 210 e2e)

- FORCE op elke tenanttabel behalve de uitzonderingen
- de FORCE-uitzonderingenlijst mag niet groeien
- elke FORCE-uitzondering heeft wél gewoon RLS met policies
- de applicatie draait niet als de rol die eigenaar is van de tabellen
- elke `SECURITY DEFINER`-functie heeft een expliciete `search_path`

## Bijvangst die de opzet bevestigt

De eerste versie van de migratie keek alleen naar `clm` en miste **`audit.audit_event`** — uitgerekend de audittrail, de tabel die vastlegt wie wat deed.

De nieuwe test wees hem meteen aan, omdat die de lijst *uit het schema* leest in plaats van uit een handmatige opsomming. Precies waarvoor die opzet bedoeld is (§4 van het architectuurdocument).

## Tegenproef

Vier sabotages, allemaal geslaagd:

1. FORCE weghalen op één tabel → de FORCE-test valt om, noemt de tabel bij naam
2. RLS uitzetten op een FORCE-uitzondering → de uitzonderingentest valt om
3. De applicatie op de eigenaarsrol draaien → de eigenaarstest valt om
4. Een `SECURITY DEFINER`-functie zonder `search_path` toevoegen → de search_path-test valt om

Elke sabotage liet precies de bedoelde test omvallen; daarna teruggedraaid.

## Verificatie

`npm run verify` groen: **161 unittests**, **210 e2e-tests** tegen een database die vanaf niets is opgebouwd (migraties 0000 t/m 0011).

🤖 Generated with [Claude Code](https://claude.com/claude-code)