### PR TITLE
feat(vendor): beheerroutes, doorlooptest en een werkende Entra-login (#7)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,16 +28,24 @@ PORT=5001
 # Een verhuizing naar een Bizaline-tenant blijft daarmee een
 # configuratiewijziging, geen codewijziging.
 #
-# Vervang <tenant-id> door de tenant-ID van de external tenant. Ontbreekt één
+# Vervang 17b5535b-0a0b-4025-b381-b50b462496bc door de tenant-ID van de external tenant. Ontbreekt één
 # van deze waarden, dan faalt /auth/login hard met een melding die precies
 # noemt wat er mist — de rest van de backend blijft werken. Bewust zo: de
 # e2e-tests en de leverancierskant draaien zonder identity-configuratie.
-OIDC_ISSUER="https://mcm2ciam.ciamlogin.com/<tenant-id>/v2.0"
-OIDC_TOKEN_ENDPOINT="https://mcm2ciam.ciamlogin.com/<tenant-id>/oauth2/v2.0/token"
-OIDC_JWKS_URI="https://mcm2ciam.ciamlogin.com/<tenant-id>/discovery/v2.0/keys"
+# LET OP — de issuer wijkt af van de andere endpoints: hier staat het
+# TENANT-ID vóór .ciamlogin.com, niet de tenantnaam. Dat is geen typefout maar
+# wat Entra werkelijk in de `iss`-claim zet, gemeten op 2026-07-31 via
+# .well-known/openid-configuration.
+#
+# De verificatie vergelijkt deze waarde exact. Met de voor de hand liggende
+# variant (mcm2ciam.ciamlogin.com) faalt élke login, met een melding die niet
+# verklapt dat het om de issuer gaat.
+OIDC_ISSUER="https://17b5535b-0a0b-4025-b381-b50b462496bc.ciamlogin.com/17b5535b-0a0b-4025-b381-b50b462496bc/v2.0"
+OIDC_TOKEN_ENDPOINT="https://mcm2ciam.ciamlogin.com/17b5535b-0a0b-4025-b381-b50b462496bc/oauth2/v2.0/token"
+OIDC_JWKS_URI="https://mcm2ciam.ciamlogin.com/17b5535b-0a0b-4025-b381-b50b462496bc/discovery/v2.0/keys"
 
 # De app-registratie van de BACKEND (niet die van de federatie-trust).
-OIDC_CLIENT_ID="<client-id-van-de-backend-app-registratie>"
+OIDC_CLIENT_ID="12020e2b-93f1-4401-ae05-4937d5338dee"
 
 # NOOIT committen. Waarde uit de "Value"-kolom van het client secret, niet de
 # "Secret ID" — die verwisseling kostte tijdens de PoC al een keer een middag.

--- a/docker-compose.otap.yml
+++ b/docker-compose.otap.yml
@@ -42,6 +42,15 @@ services:
       # De runtime-rol, nooit postgres en nooit clm_migrator (ADR-009).
       DATABASE_URL: postgresql://clm_api_runtime:otap_pw@db:5432/postgres
       PORT: "5001"
+      # Zonder deze waarde stuurt de browser het sessiecookie niet mee naar een
+      # andere herkomst — frontend op 3000, backend op 5001 — en geeft élk
+      # beheerscherm een 401. De combinatie `origin: *` met credentials wordt
+      # door elke browser geweigerd, dus de herkomst moet expliciet zijn.
+      CORS_ORIGIN: http://localhost:3000
+      # Het sessiecookie is standaard Secure en draagt de __Host--prefix. Deze
+      # doorloop draait over http, en dan weigert de browser zo'n cookie. Alleen
+      # hier uit; in productie faalt dit naar de veilige kant (zie sessie.ts).
+      SESSIE_COOKIE_INSECURE: "true"
     ports:
       - "5001:5001"
     depends_on:

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
     "test:e2e": "jest --config ./test/jest-e2e.json",
     "verify": "node scripts/verify.js",
-    "verify:snel": "node scripts/verify.js --snel"
+    "verify:snel": "node scripts/verify.js --snel",
+    "verify:volledig": "node scripts/verify-volledig.js"
   },
   "dependencies": {
     "@nestjs/common": "^11.0.1",

--- a/scripts/claims-meten.js
+++ b/scripts/claims-meten.js
@@ -1,0 +1,242 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * Meet welke claims de identity provider werkelijk levert.
+ *
+ * ── Waarom dit script bestaat ────────────────────────────────────────────────
+ *
+ * De code koppelt een gebruiker op de `oid`-claim. Dat is de juiste keuze
+ * volgens de Microsoft-documentatie — `sub` verschilt per applicatie, `email`
+ * verandert — maar het is nooit gemeten. Die aanname staat sinds 2026-07-27 in
+ * de documentatie en is de laatste onbewezen schakel in de identiteitslaag.
+ *
+ * Dit script draait één echte login en toont wat er binnenkomt. Eén keer, met
+ * een mens erbij; daarna is het antwoord bekend en is dit script overbodig.
+ *
+ * ── Waarom niet gewoon in het applicatielog ──────────────────────────────────
+ *
+ * Een ID-token bevat persoonsgegevens: naam, e-mailadres, en identifiers die
+ * naar één persoon herleidbaar zijn. Die horen niet in een log dat blijft
+ * staan, wordt doorgestuurd of in een backup belandt.
+ *
+ * Vandaar dit aparte script: het toont de claims op het scherm, schrijft niets
+ * weg, en maskeert de waarden waar de vórm genoeg is om de vraag te
+ * beantwoorden. Wat je wilt weten is "bestaat oid en is hij stabiel", niet
+ * "welke oid heeft Kees".
+ *
+ * ── Gebruik ──────────────────────────────────────────────────────────────────
+ *
+ *   node scripts/claims-meten.js
+ *
+ * Opent een luisterende server op de redirect-URI, drukt een inloglink af, en
+ * wacht tot de browser terugkomt. Stopt daarna vanzelf.
+ */
+
+require('dotenv/config');
+
+const { createServer } = require('node:http');
+const { createHash, randomBytes } = require('node:crypto');
+
+const VERPLICHT = [
+  'OIDC_ISSUER',
+  'OIDC_TOKEN_ENDPOINT',
+  'OIDC_CLIENT_ID',
+  'OIDC_CLIENT_SECRET',
+  'OIDC_REDIRECT_URI',
+];
+
+/**
+ * Claims waarvan de wáárde niet ter zake doet, alleen of ze bestaan en welke
+ * vorm ze hebben. Bij de rest is de waarde zelf informatief (bijvoorbeeld
+ * `tid`, dat gewoon het tenant-ID is en al bekend).
+ */
+const PERSOONSGEGEVEN = new Set([
+  'oid',
+  'sub',
+  'email',
+  'name',
+  'preferred_username',
+  'given_name',
+  'family_name',
+  'upn',
+]);
+
+/** Toont genoeg om de vraag te beantwoorden, niet meer. */
+function maskeer(naam, waarde) {
+  if (!PERSOONSGEGEVEN.has(naam) || typeof waarde !== 'string') {
+    return JSON.stringify(waarde);
+  }
+
+  if (waarde.length <= 8) {
+    return `"${waarde.slice(0, 2)}…" (${waarde.length} tekens)`;
+  }
+
+  return `"${waarde.slice(0, 4)}…${waarde.slice(-4)}" (${waarde.length} tekens)`;
+}
+
+function main() {
+  const ontbreekt = VERPLICHT.filter((naam) => !process.env[naam]?.trim());
+
+  if (ontbreekt.length > 0) {
+    console.error(`Configuratie onvolledig: ${ontbreekt.join(', ')}`);
+    console.error('Zie .env.example, sectie Identity.');
+    process.exit(1);
+  }
+
+  const redirect = new URL(process.env.OIDC_REDIRECT_URI);
+  const poort = Number(redirect.port || 80);
+
+  const verifier = randomBytes(32).toString('base64url');
+  const challenge = createHash('sha256')
+    .update(verifier, 'utf8')
+    .digest('base64url');
+  const state = randomBytes(16).toString('base64url');
+
+  const autorisatie = process.env.OIDC_TOKEN_ENDPOINT.replace(
+    /\/token(\?|$)/,
+    '/authorize$1',
+  );
+
+  const parameters = new URLSearchParams({
+    client_id: process.env.OIDC_CLIENT_ID,
+    response_type: 'code',
+    redirect_uri: process.env.OIDC_REDIRECT_URI,
+    scope: 'openid profile email',
+    state,
+    code_challenge: challenge,
+    code_challenge_method: 'S256',
+    response_mode: 'query',
+  });
+
+  const server = createServer((verzoek, antwoord) => {
+    const url = new URL(verzoek.url, `http://localhost:${poort}`);
+
+    if (url.pathname !== redirect.pathname) {
+      antwoord.writeHead(404).end('Niet gevonden');
+      return;
+    }
+
+    const fout = url.searchParams.get('error');
+
+    if (fout) {
+      const beschrijving = url.searchParams.get('error_description') ?? '';
+      antwoord
+        .writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' })
+        .end('<h1>Inloggen mislukt</h1><p>Zie de terminal.</p>');
+
+      console.error(`\nEntra weigerde de inlogpoging (${fout}):`);
+      console.error(beschrijving);
+      // De AADSTS-code in de beschrijving benoemt het probleem exact; zonder
+      // die code is een configuratiefout niet te vinden.
+      server.close();
+      process.exitCode = 1;
+      return;
+    }
+
+    if (url.searchParams.get('state') !== state) {
+      antwoord.writeHead(400).end('State komt niet overeen.');
+      console.error('\nState komt niet overeen — inlogpoging afgebroken.');
+      server.close();
+      process.exitCode = 1;
+      return;
+    }
+
+    const code = url.searchParams.get('code');
+
+    antwoord
+      .writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' })
+      .end(
+        '<h1>Gelukt</h1><p>De claims staan in de terminal. Dit venster kan dicht.</p>',
+      );
+
+    void wisselIn(code, verifier).finally(() => server.close());
+  });
+
+  server.listen(poort, () => {
+    console.log('');
+    console.log('Open deze link in je browser en log in:');
+    console.log('');
+    console.log(`${autorisatie}?${parameters.toString()}`);
+    console.log('');
+    console.log(`Wachten op de terugkeer op ${process.env.OIDC_REDIRECT_URI} …`);
+  });
+}
+
+async function wisselIn(code, verifier) {
+  const body = new URLSearchParams({
+    grant_type: 'authorization_code',
+    code,
+    redirect_uri: process.env.OIDC_REDIRECT_URI,
+    client_id: process.env.OIDC_CLIENT_ID,
+    client_secret: process.env.OIDC_CLIENT_SECRET,
+    code_verifier: verifier,
+  });
+
+  const respons = await fetch(process.env.OIDC_TOKEN_ENDPOINT, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+      Accept: 'application/json',
+    },
+    body: body.toString(),
+  });
+
+  const antwoord = await respons.json();
+
+  if (!respons.ok) {
+    console.error(`\nCode inwisselen mislukt (${respons.status}):`);
+    console.error(antwoord.error_description ?? antwoord.error ?? 'onbekend');
+    process.exitCode = 1;
+    return;
+  }
+
+  if (typeof antwoord.id_token !== 'string') {
+    console.error('\nGeen id_token in het antwoord. Ontbreekt de openid-scope?');
+    process.exitCode = 1;
+    return;
+  }
+
+  // Alleen de payload uitlezen, niet verifiëren: dat doet de applicatie zelf
+  // (IdTokenVerificateur). Hier gaat het om de vraag wélke claims er zijn.
+  const payload = JSON.parse(
+    Buffer.from(antwoord.id_token.split('.')[1], 'base64url').toString('utf8'),
+  );
+
+  console.log('\n─────────────────────────────────────────────────────');
+  console.log('Claims uit het ID-token');
+  console.log('─────────────────────────────────────────────────────\n');
+
+  for (const [naam, waarde] of Object.entries(payload).sort()) {
+    console.log(`  ${naam.padEnd(22)} ${maskeer(naam, waarde)}`);
+  }
+
+  console.log('\n─────────────────────────────────────────────────────');
+  console.log('Waar het om ging');
+  console.log('─────────────────────────────────────────────────────\n');
+
+  const oid = payload.oid;
+
+  if (typeof oid === 'string' && oid.trim() !== '') {
+    console.log('  oid aanwezig      JA — de koppeling in de code klopt.');
+    console.log('                    clm.user.external_subject hoort deze');
+    console.log('                    waarde te bevatten.');
+  } else {
+    console.log('  oid aanwezig      NEE — dit breekt de aanname in');
+    console.log('                    id-token-verificatie.ts. De code weigert');
+    console.log('                    het token en niemand kan inloggen.');
+    console.log('                    Alternatief kiezen en vastleggen.');
+  }
+
+  const issuerKlopt = payload.iss === process.env.OIDC_ISSUER;
+
+  console.log(
+    `  issuer klopt      ${issuerKlopt ? 'JA' : 'NEE — OIDC_ISSUER moet worden: ' + payload.iss}`,
+  );
+  console.log(
+    `  audience klopt    ${payload.aud === process.env.OIDC_CLIENT_ID ? 'JA' : 'NEE (aud=' + payload.aud + ')'}`,
+  );
+  console.log('');
+}
+
+main();

--- a/scripts/echte-login.js
+++ b/scripts/echte-login.js
@@ -1,0 +1,298 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * De echte inlogflow, van Entra tot een werkende sessie.
+ *
+ * ── Waarom dit script bestaat ────────────────────────────────────────────────
+ *
+ * `claims-meten.js` bewees welke claims Entra levert. Wat daarna nog open stond
+ * is de vraag of de héle keten sluit: token verifiëren, gebruiker opzoeken,
+ * membership toetsen, sessie maken, cookie zetten, en met dat cookie een
+ * beheerroute aanroepen.
+ *
+ * Dat is niet met een unittest te bewijzen. De verificatie draait tegen een
+ * lokaal sleutelpaar (bewust — zie README), en de e2e-tests maken hun sessies
+ * rechtstreeks via `clm.sessie_aanmaken()`. Beide slaan de provider over.
+ *
+ * Dit script doet dat niet. Het draait één keer, met een mens erbij.
+ *
+ * ── Wat het opzettelijk NIET doet ────────────────────────────────────────────
+ *
+ * De `oid` van de ingelogde gebruiker wordt nergens afgedrukt of weggeschreven
+ * naar een logbestand. Hij gaat rechtstreeks van het ID-token naar de
+ * database — precies zoals in productie. Wat je op het scherm ziet is of het
+ * werkte, niet wie je bent.
+ *
+ * ── Gebruik ──────────────────────────────────────────────────────────────────
+ *
+ *   DATABASE_URL=... node scripts/echte-login.js
+ */
+
+require('dotenv/config');
+
+const { createServer } = require('node:http');
+const { createHash, randomBytes } = require('node:crypto');
+const { Client } = require('pg');
+
+const API_URL = process.env.API_URL ?? 'http://localhost:5001';
+const TENANT_ID = '00000000-0000-0000-0000-00000000e1e1';
+const TENANT_NAAM = 'Echte-login-test';
+
+function melding(regel) {
+  console.log(regel);
+}
+
+async function main() {
+  if (!process.env.DATABASE_URL) {
+    console.error('DATABASE_URL ontbreekt.');
+    process.exit(1);
+  }
+
+  const redirect = new URL(process.env.OIDC_REDIRECT_URI);
+  const verifier = randomBytes(32).toString('base64url');
+  const challenge = createHash('sha256')
+    .update(verifier, 'utf8')
+    .digest('base64url');
+  const state = randomBytes(16).toString('base64url');
+
+  const autorisatie = process.env.OIDC_TOKEN_ENDPOINT.replace(
+    /\/token(\?|$)/,
+    '/authorize$1',
+  );
+
+  const parameters = new URLSearchParams({
+    client_id: process.env.OIDC_CLIENT_ID,
+    response_type: 'code',
+    redirect_uri: process.env.OIDC_REDIRECT_URI,
+    scope: 'openid profile email',
+    state,
+    code_challenge: challenge,
+    code_challenge_method: 'S256',
+    response_mode: 'query',
+  });
+
+  const server = createServer((verzoek, antwoord) => {
+    const url = new URL(verzoek.url, 'http://localhost');
+
+    if (url.pathname !== redirect.pathname) {
+      antwoord.writeHead(404).end();
+      return;
+    }
+
+    // Alleen reageren op een verzoek dat daadwerkelijk een antwoord van de
+    // provider is. Een browser vraagt uit zichzelf van alles op — favicon,
+    // prefetch, een herhaling van een eerdere poging — en zonder deze
+    // controle sloot de server zichzelf af op zo'n verzoek, mét de melding
+    // "state komt niet overeen". Die melding wees dan naar een probleem dat
+    // er niet was; de echte login kwam nooit aan de beurt.
+    if (!url.searchParams.has('code') && !url.searchParams.has('error')) {
+      antwoord.writeHead(204).end();
+      return;
+    }
+
+    const fout = url.searchParams.get('error');
+
+    if (fout) {
+      antwoord
+        .writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' })
+        .end('<h1>Mislukt</h1><p>Zie de terminal.</p>');
+      console.error(
+        `\nEntra weigerde: ${fout} — ${url.searchParams.get('error_description') ?? ''}`,
+      );
+      server.close();
+      process.exitCode = 1;
+      return;
+    }
+
+    if (url.searchParams.get('state') !== state) {
+      // NIET afsluiten. Een oude browsertab die zichzelf herlaadt stuurt de
+      // state van een vórige poging mee; dat is geen aanval maar ruis. Zou de
+      // server hier stoppen, dan is hij weg vóórdat de echte login binnenkomt
+      // — en dat is precies wat er drie keer gebeurde.
+      //
+      // In de applicatiecode is dit terecht wél een harde afwijzing
+      // (auth.controller.ts): daar is elke afwijkende state een CSRF-signaal.
+      // Hier is het een wegwerpscript met één mens ervoor.
+      antwoord
+        .writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' })
+        .end(
+          '<h1>Oude poging</h1><p>Dit is een verouderde tab. Gebruik de nieuwste link uit de terminal.</p>',
+        );
+      console.log('  (verouderd verzoek genegeerd — oude browsertab)');
+      return;
+    }
+
+    antwoord
+      .writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' })
+      .end('<h1>Gelukt</h1><p>Zie de terminal. Dit venster kan dicht.</p>');
+
+    void voltooi(url.searchParams.get('code'), verifier).finally(() =>
+      server.close(),
+    );
+  });
+
+  server.listen(Number(redirect.port), () => {
+    melding('');
+    melding('Open deze link en log in:');
+    melding('');
+    melding(`${autorisatie}?${parameters.toString()}`);
+    melding('');
+  });
+}
+
+async function voltooi(code, verifier) {
+  // ── 1. Code inwisselen ─────────────────────────────────────────────────────
+  const body = new URLSearchParams({
+    grant_type: 'authorization_code',
+    code,
+    redirect_uri: process.env.OIDC_REDIRECT_URI,
+    client_id: process.env.OIDC_CLIENT_ID,
+    client_secret: process.env.OIDC_CLIENT_SECRET,
+    code_verifier: verifier,
+  });
+
+  const respons = await fetch(process.env.OIDC_TOKEN_ENDPOINT, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+      Accept: 'application/json',
+    },
+    body: body.toString(),
+  });
+
+  const tokens = await respons.json();
+
+  if (!respons.ok || typeof tokens.id_token !== 'string') {
+    console.error(`\nCode inwisselen mislukt: ${JSON.stringify(tokens)}`);
+    process.exitCode = 1;
+    return;
+  }
+
+  melding('  1  code ingewisseld            OK');
+
+  // ── 2. Token verifiëren met de échte applicatiecode ────────────────────────
+  //
+  // Niet een eigen controle: dit is IdTokenVerificateur uit dist/, dezelfde
+  // klasse die in productie draait. Zou de verificatie iets afwijzen, dan
+  // gebeurt dat hier op precies dezelfde manier.
+  const { IdTokenVerificateur } = require('../dist/auth/id-token-verificatie');
+  const { leesAuthConfig } = require('../dist/auth/auth.config');
+
+  let identiteit;
+
+  try {
+    identiteit = await new IdTokenVerificateur(leesAuthConfig()).verifieer(
+      tokens.id_token,
+    );
+  } catch (fout) {
+    console.error(`\n  2  token verifiëren          MISLUKT: ${fout.message}`);
+    process.exitCode = 1;
+    return;
+  }
+
+  melding('  2  token geverifieerd         OK (handtekening, iss, aud, exp)');
+
+  // ── 3. Gebruiker en membership klaarzetten ─────────────────────────────────
+  //
+  // In productie doet een beheerder dit; hier doet het script het, zodat de
+  // eerste login niet strandt op "geen membership". De oid gaat rechtstreeks
+  // van het token naar de database en wordt nergens afgedrukt.
+  const client = new Client({ connectionString: process.env.DATABASE_URL });
+  await client.connect();
+
+  try {
+    await client.query('BEGIN');
+    await client.query(`SET LOCAL app.current_tenant_id = '${TENANT_ID}'`);
+    await client.query(
+      'INSERT INTO clm.tenant (tenant_id, name) VALUES ($1, $2) ON CONFLICT DO NOTHING',
+      [TENANT_ID, TENANT_NAAM],
+    );
+
+    const gebruiker = await client.query(
+      `INSERT INTO clm."user" (tenant_id, full_name, external_subject, email)
+       VALUES ($1, $2, $3, $4)
+       ON CONFLICT (external_subject) WHERE external_subject IS NOT NULL
+         DO UPDATE SET full_name = EXCLUDED.full_name
+       RETURNING user_id`,
+      [
+        TENANT_ID,
+        identiteit.naam ?? 'Beheerder',
+        identiteit.externalSubject,
+        identiteit.email ?? null,
+      ],
+    );
+
+    await client.query(
+      `INSERT INTO clm.tenant_membership (user_id, tenant_id, role)
+       VALUES ($1, $2, 'admin') ON CONFLICT DO NOTHING`,
+      [gebruiker.rows[0].user_id, TENANT_ID],
+    );
+    await client.query('COMMIT');
+
+    melding('  3  gebruiker + membership     OK');
+
+    // ── 4. Sessie maken via de échte databasefunctie ─────────────────────────
+    const token = randomBytes(32).toString('base64url');
+    const hash = createHash('sha256').update(token, 'utf8').digest('hex');
+
+    const sessie = await client.query(
+      'SELECT tenant_id, role FROM clm.sessie_aanmaken($1, $2, $3::interval)',
+      [hash, identiteit.externalSubject, '8 hours'],
+    );
+
+    if (sessie.rows.length === 0) {
+      console.error('\n  4  sessie aanmaken           MISLUKT: geen membership');
+      process.exitCode = 1;
+      return;
+    }
+
+    melding(
+      `  4  sessie aangemaakt         OK (rol: ${sessie.rows[0].role})`,
+    );
+
+    // ── 5. De sessie gebruiken op een beheerroute ────────────────────────────
+    //
+    // De cookienaam volgt de configuratie van de backend, niet een vaste
+    // waarde. Zonder SESSIE_COOKIE_INSECURE verwacht hij `__Host-mcm2_sessie`;
+    // mét die schakelaar `mcm2_sessie`. Een verkeerde naam geeft een 401 die
+    // niet verklapt dát het om de naam gaat — kostte bij de eerste echte login
+    // een half uur zoeken.
+    const { cookieInstellingen } = require('../dist/auth/sessie');
+    const cookieNaam = cookieInstellingen().naam;
+
+    const vendors = await fetch(`${API_URL}/vendors`, {
+      headers: { Cookie: `${cookieNaam}=${token}` },
+    });
+
+    if (!vendors.ok) {
+      console.error(
+        `\n  5  /vendors met sessie       MISLUKT: ${vendors.status}`,
+      );
+      console.error('     Draait de backend op poort 5001?');
+      process.exitCode = 1;
+      return;
+    }
+
+    const lijst = await vendors.json();
+
+    melding(
+      `  5  /vendors met sessie       OK (${lijst.vendors.length} leveranciers)`,
+    );
+
+    // ── 6. Zonder sessie hoort dezelfde route dicht te zitten ────────────────
+    const zonder = await fetch(`/vendors`);
+
+    melding(
+      `  6  /vendors zonder sessie    ${zonder.status === 401 ? 'OK (401)' : 'FOUT: ' + zonder.status}`,
+    );
+
+    melding('');
+    melding('De hele keten werkt, van Entra tot de beheerroute.');
+    melding('');
+  } finally {
+    await client.end();
+  }
+}
+
+void main();

--- a/scripts/verify-volledig.js
+++ b/scripts/verify-volledig.js
@@ -1,0 +1,451 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * De volledige doorloop: van code tot browser (`npm run verify:volledig`).
+ *
+ * ── Waarom dit bestaat ───────────────────────────────────────────────────────
+ *
+ * `npm run verify` bewijst dat de code klopt en dat de backend doet wat hij
+ * belooft. Wat het níét bewijst is of de keten áls geheel werkt — of het
+ * scherm de juiste route aanroept, of het sessiecookie meekomt, of een
+ * aangemaakte leverancier daadwerkelijk terugkomt uit de database.
+ *
+ * Dat gat is niet theoretisch. Issue #42 en #43 waren allebei fouten die 155
+ * backend-tests niet zagen en één blik in de browser wél: een ontbrekend
+ * uploadveld en een leesblok met keuzerondjes.
+ *
+ * Dit script sluit dat gat. Eén commando, van opmaakcontrole tot een browser
+ * die een leverancier aanmaakt en hem terugziet.
+ *
+ * ── Wat het doet ─────────────────────────────────────────────────────────────
+ *
+ *   1. npm run verify        code, unittests, e2e tegen een wegwerpdatabase
+ *   2. stack bouwen          beide productie-images via docker compose
+ *   3. migraties + sessie    tenant, gebruiker en een échte sessie
+ *   4. browsertest           Playwright tegen de draaiende stack
+ *   5. opruimen              altijd, ook na een fout
+ *
+ * Stap 4 draait tegen de PRODUCTIE-images, niet tegen `next dev`. Dat verschil
+ * is de hele reden dat de OTAP-doorloop bestaat: een ontwikkelserver had de
+ * EACCES-uploadfout in het productie-image nooit gevonden.
+ */
+
+const { spawnSync } = require('node:child_process');
+const { randomBytes, createHash } = require('node:crypto');
+const { readFileSync } = require('node:fs');
+
+const COMPOSE = ['compose', '-f', 'docker-compose.otap.yml'];
+
+/** Vaste id's voor de doorloop. Buiten de reeksen uit test/test-ids.ts. */
+const TENANT_ID = '00000000-0000-0000-0000-0000000000d0';
+const USER_ID = '00000000-0000-0000-0000-0000000000d1';
+const SUBJECT = 'oid-verify-volledig';
+
+const isWindows = process.platform === 'win32';
+
+function draai(commando, argumenten, opties = {}) {
+  // Een bestand als stdin doorgeven: psql leest het schema dan van de
+  // standaardinvoer, precies zoals het runbook `< bestand.sql` gebruikt.
+  const invoer = opties.invoerBestand
+    ? readFileSync(opties.invoerBestand, 'utf8')
+    : undefined;
+
+  const resultaat = spawnSync(commando, argumenten, {
+    stdio: opties.stil || invoer ? 'pipe' : 'inherit',
+    shell: isWindows,
+    encoding: 'utf8',
+    env: { ...process.env, ...(opties.env ?? {}) },
+    cwd: opties.cwd,
+    input: invoer,
+  });
+
+  return {
+    ok: resultaat.status === 0,
+    uitvoer: (resultaat.stdout ?? '') + (resultaat.stderr ?? ''),
+  };
+}
+
+/** Draait psql in de databasecontainer. */
+function psql(sql, rol = 'postgres') {
+  return draai(
+    'docker',
+    [
+      ...COMPOSE,
+      'exec',
+      '-T',
+      'db',
+      'psql',
+      '-U',
+      rol,
+      // De database expliciet: psql neemt anders de rolnaam als databasenaam
+      // en faalt met `database "clm_migrator" does not exist` — een melding
+      // die naar de verkeerde oorzaak wijst.
+      '-d',
+      'postgres',
+      '-tAc',
+      `"${sql}"`,
+    ],
+    { stil: true },
+  );
+}
+
+function kop(nummer, totaal, tekst) {
+  console.log(`\n${nummer}/${totaal}  ${tekst}`);
+}
+
+function opruimen() {
+  console.log('\nOpruimen…');
+  draai('docker', [...COMPOSE, 'down', '-v'], { stil: true });
+}
+
+/**
+ * Wacht tot de stack antwoordt.
+ *
+ * Bewust pollen op een echte HTTP-reactie en niet op "de container draait":
+ * een Next.js-server met een kapotte build start wél en geeft een 500. Dat
+ * onderscheid is in dit project al eens misgegaan.
+ */
+function wachtOpStack(maxSeconden = 120) {
+  const einde = Date.now() + maxSeconden * 1000;
+  let laatsteFout = '';
+
+  while (Date.now() < einde) {
+    const api = draai(
+      'curl',
+      ['-s', '-o', isWindows ? 'NUL' : '/dev/null', '-w', '%{http_code}', 'http://localhost:5001/health'],
+      { stil: true },
+    );
+    const web = draai(
+      'curl',
+      ['-s', '-o', isWindows ? 'NUL' : '/dev/null', '-w', '%{http_code}', 'http://localhost:3000/'],
+      { stil: true },
+    );
+
+    const apiCode = api.uitvoer.trim();
+    const webCode = web.uitvoer.trim();
+
+    if (apiCode === '200' && webCode === '200') {
+      return { ok: true };
+    }
+
+    laatsteFout = `api=${apiCode || 'geen antwoord'} frontend=${webCode || 'geen antwoord'}`;
+    draai(isWindows ? 'timeout' : 'sleep', isWindows ? ['/t', '2', '/nobreak'] : ['2'], {
+      stil: true,
+    });
+  }
+
+  return { ok: false, reden: laatsteFout };
+}
+
+/** Containernaam voor de wegwerpdatabase van stap 1. */
+const TESTDB = 'mcm2-verify-volledig-db';
+const TESTDB_POORT = 55441;
+
+/**
+ * Start een wegwerpdatabase voor stap 1.
+ *
+ * Los van de doorloopstack (die draait op 55500) en los van de container die
+ * iemand handmatig voor `npm run verify` gebruikt (55440). Drie poorten, drie
+ * doelen — dat voorkomt dat deze doorloop andermans database leegruimt.
+ */
+function startTestDatabase() {
+  draai('docker', ['rm', '-f', TESTDB], { stil: true });
+
+  const gestart = draai(
+    'docker',
+    [
+      'run',
+      '-d',
+      '--name',
+      TESTDB,
+      '-e',
+      'POSTGRES_PASSWORD=pw',
+      '-p',
+      `${TESTDB_POORT}:5432`,
+      'postgres:17.6',
+    ],
+    { stil: true },
+  );
+
+  if (!gestart.ok) {
+    return { ok: false, reden: gestart.uitvoer.trim() };
+  }
+
+  // Wachten tot Postgres verbindingen accepteert.
+  for (let poging = 0; poging < 40; poging += 1) {
+    const gereed = draai(
+      'docker',
+      ['exec', TESTDB, 'pg_isready', '-U', 'postgres'],
+      { stil: true },
+    );
+
+    if (gereed.ok) {
+      const rollen = draai(
+        'docker',
+        ['exec', '-i', TESTDB, 'psql', '-U', 'postgres', '-q'],
+        { stil: true, invoerBestand: 'db/roles/bootstrap-roles.sql' },
+      );
+
+      if (!rollen.ok) {
+        return { ok: false, reden: rollen.uitvoer.trim() };
+      }
+
+      draai(
+        'docker',
+        [
+          'exec',
+          TESTDB,
+          'psql',
+          '-U',
+          'postgres',
+          '-q',
+          '-c',
+          '"ALTER ROLE clm_migrator WITH PASSWORD \'pw\'; ALTER ROLE clm_api_runtime WITH PASSWORD \'pw\';"',
+        ],
+        { stil: true },
+      );
+
+      const migraties = draai('npm', ['run', 'migrate:deploy'], {
+        stil: true,
+        env: {
+          MIGRATION_DATABASE_URL: `postgresql://clm_migrator:pw@localhost:${TESTDB_POORT}/postgres`,
+        },
+      });
+
+      if (!migraties.ok) {
+        return { ok: false, reden: migraties.uitvoer.trim() };
+      }
+
+      return {
+        ok: true,
+        url: `postgresql://clm_api_runtime:pw@localhost:${TESTDB_POORT}/postgres`,
+      };
+    }
+
+    draai(isWindows ? 'timeout' : 'sleep', isWindows ? ['/t', '1', '/nobreak'] : ['1'], {
+      stil: true,
+    });
+  }
+
+  return { ok: false, reden: 'Postgres werd niet op tijd bereikbaar.' };
+}
+
+function stopTestDatabase() {
+  draai('docker', ['rm', '-f', TESTDB], { stil: true });
+}
+
+/**
+ * Bouwt de database vanaf niets op: rollen, wachtwoorden, migraties.
+ *
+ * Dit hoort bij de doorloop en is geen voorbereiding: het bewijst dat een lege
+ * database via de migratieketen tot een werkend schema komt (runbook stap 3).
+ *
+ * De API is al gestart vóórdat de rollen bestonden en kan daardoor niet
+ * verbinden. Herstarten is verplicht — zonder die stap wacht `wachtOpStack()`
+ * tevergeefs op een backend die nooit gezond wordt. Dat kostte bij de eerste
+ * doorloop tijd, en staat daarom in het runbook.
+ */
+function bouwDatabaseOp() {
+  const rollen = draai(
+    'docker',
+    [
+      ...COMPOSE,
+      'exec',
+      '-T',
+      'db',
+      'psql',
+      '-U',
+      'postgres',
+      '-q',
+      '-v',
+      'ON_ERROR_STOP=1',
+      '-f',
+      '-',
+    ],
+    { stil: true, invoerBestand: 'db/roles/bootstrap-roles.sql' },
+  );
+
+  if (!rollen.ok) {
+    return { ok: false, reden: `bootstrap-roles.sql: ${rollen.uitvoer.trim()}` };
+  }
+
+  const wachtwoorden = psql(
+    "ALTER ROLE clm_migrator WITH PASSWORD 'otap_pw'; ALTER ROLE clm_api_runtime WITH PASSWORD 'otap_pw';",
+  );
+
+  if (!wachtwoorden.ok) {
+    return { ok: false, reden: wachtwoorden.uitvoer.trim() };
+  }
+
+  const migraties = draai('npm', ['run', 'migrate:deploy'], {
+    stil: true,
+    env: {
+      MIGRATION_DATABASE_URL:
+        'postgresql://clm_migrator:otap_pw@localhost:55500/postgres',
+    },
+  });
+
+  if (!migraties.ok) {
+    return { ok: false, reden: migraties.uitvoer.trim() };
+  }
+
+  console.log('  Migraties toegepast op een lege database.');
+
+  // Zie de uitleg hierboven: zonder deze herstart blijft de API onbereikbaar.
+  draai('docker', [...COMPOSE, 'restart', 'api'], { stil: true });
+
+  return { ok: true };
+}
+
+/**
+ * Zet een tenant, gebruiker en membership klaar, en maakt een échte sessie.
+ *
+ * Geen nagebootst cookie: `clm.sessie_aanmaken()` doet het werk, inclusief de
+ * membershipcontrole. Wat de browsertest daarna gebruikt is dus precies wat
+ * een geslaagde inlog zou opleveren — alleen het verkrijgen ervan is
+ * overgeslagen, niet de sessie zelf.
+ */
+function maakSessie() {
+  const opzet = [
+    `INSERT INTO clm.tenant (tenant_id, name) VALUES ('${TENANT_ID}', 'Doorloop') ON CONFLICT DO NOTHING;`,
+    `INSERT INTO clm.\\"user\\" (user_id, tenant_id, full_name, external_subject) VALUES ('${USER_ID}', '${TENANT_ID}', 'Doorloop Beheerder', '${SUBJECT}') ON CONFLICT DO NOTHING;`,
+    `INSERT INTO clm.tenant_membership (user_id, tenant_id, role) VALUES ('${USER_ID}', '${TENANT_ID}', 'admin') ON CONFLICT DO NOTHING;`,
+  ];
+
+  for (const sql of opzet) {
+    // Als eigenaar, want deze tabellen staan onder RLS en er is nog geen
+    // tenantcontext. Dit is opzetwerk, geen applicatiecode.
+    const uitkomst = psql(
+      `SET app.current_tenant_id = '${TENANT_ID}'; ${sql}`,
+      'clm_migrator',
+    );
+
+    if (!uitkomst.ok) {
+      return { ok: false, reden: uitkomst.uitvoer.trim() };
+    }
+  }
+
+  const token = randomBytes(32).toString('base64url');
+  const hash = createHash('sha256').update(token, 'utf8').digest('hex');
+
+  const sessie = psql(
+    `SELECT tenant_id FROM clm.sessie_aanmaken('${hash}', '${SUBJECT}', '8 hours'::interval);`,
+    'clm_migrator',
+  );
+
+  if (!sessie.ok || !sessie.uitvoer.includes(TENANT_ID)) {
+    return {
+      ok: false,
+      reden: `sessie_aanmaken() gaf geen sessie terug: ${sessie.uitvoer.trim()}`,
+    };
+  }
+
+  // Zelfde naam als cookieInstellingen() kiest wanneer SESSIE_COOKIE_INSECURE
+  // aanstaat — en dat staat het in docker-compose.otap.yml, want deze doorloop
+  // draait over http.
+  return { ok: true, cookie: `mcm2_sessie=${token}` };
+}
+
+function main() {
+  const stappen = 5;
+  let gestart = false;
+
+  try {
+    kop(1, stappen, 'Code, unittests en backend-e2e (npm run verify)');
+
+    // DATABASE_URL expliciet meegeven, anders slaat verify de e2e-stap over en
+    // meldt hij "GROEN, met overgeslagen stappen" — misleidend in een
+    // commando dat volledigheid belooft. De doorloopstack draait op 55500, dus
+    // dit is een aparte wegwerpdatabase die er niet mee botst.
+    const testDb = startTestDatabase();
+
+    if (!testDb.ok) {
+      console.error(`\nROOD: geen testdatabase kunnen starten.\n${testDb.reden}`);
+      process.exit(1);
+    }
+
+    const verify = draai('npm', ['run', 'verify'], {
+      env: { DATABASE_URL: testDb.url },
+    });
+
+    stopTestDatabase();
+
+    if (!verify.ok) {
+      console.error('\nROOD op stap 1. De rest is niet gedraaid.');
+      process.exit(1);
+    }
+
+    kop(2, stappen, 'Stack bouwen en starten (productie-images)');
+
+    if (!draai('docker', [...COMPOSE, 'up', '--build', '-d']).ok) {
+      console.error('\nROOD: de stack kon niet gestart worden.');
+      process.exit(1);
+    }
+
+    gestart = true;
+
+    kop(3, stappen, 'Migraties, tenant en sessie klaarzetten');
+
+    const opgebouwd = bouwDatabaseOp();
+
+    if (!opgebouwd.ok) {
+      console.error(`\nROOD: de database opbouwen mislukte.\n${opgebouwd.reden}`);
+      process.exit(1);
+    }
+
+    const gereed = wachtOpStack();
+
+    if (!gereed.ok) {
+      console.error(`\nROOD: de stack antwoordt niet (${gereed.reden}).`);
+      console.error('Logs: docker compose -f docker-compose.otap.yml logs');
+      process.exit(1);
+    }
+
+    const sessie = maakSessie();
+
+    if (!sessie.ok) {
+      console.error(`\nROOD: geen sessie kunnen maken.\n${sessie.reden}`);
+      process.exit(1);
+    }
+
+    console.log('  Sessie aangemaakt via clm.sessie_aanmaken().');
+
+    kop(4, stappen, 'Browsertest tegen de draaiende stack');
+
+    const browser = draai('npm', ['run', 'e2e'], {
+      env: {
+        BEHEER_COOKIE: sessie.cookie,
+        PORTAL_URL: 'http://localhost:3000',
+      },
+      cwd: '../MCM2-frontend',
+    });
+
+    if (!browser.ok) {
+      console.error('\nROOD op de browsertest.');
+      console.error(
+        'Playwright bewaart een trace bij een mislukte test:\n' +
+          '  cd ../MCM2-frontend && npx playwright show-trace test-results/**/trace.zip',
+      );
+      process.exit(1);
+    }
+
+    kop(5, stappen, 'Opruimen');
+    console.log('');
+    console.log('GROEN — de hele keten, van code tot browser.');
+    console.log('');
+    console.log('Wat hiermee bewezen is:');
+    console.log('  formulier → API → sessiecookie → guard → RLS → database → lijst');
+    console.log('');
+  } finally {
+    // Ook bij een afgebroken run: een achtergebleven container blokkeert de
+    // volgende doorloop op een poort die al bezet is.
+    stopTestDatabase();
+
+    if (gestart) {
+      opruimen();
+    }
+  }
+}
+
+main();

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -5,9 +5,16 @@ import { AuthModule } from './auth/auth.module';
 import { DatabaseModule } from './db/database.module';
 import { HealthModule } from './health/health.module';
 import { SurveyModule } from './survey/survey.module';
+import { VendorModule } from './vendor/vendor.module';
 
 @Module({
-  imports: [DatabaseModule, HealthModule, SurveyModule, AuthModule],
+  imports: [
+    DatabaseModule,
+    HealthModule,
+    SurveyModule,
+    AuthModule,
+    VendorModule,
+  ],
   controllers: [AppController],
   providers: [AppService],
 })

--- a/src/auth/README.md
+++ b/src/auth/README.md
@@ -39,9 +39,14 @@ OIDC-variabelen ontbreken. Dat raakt twee situaties waarin dat verkeerd is: de
 e2e-testsuite (die de `AppModule` opstart zonder identity) en een lokale run
 waarin alleen aan de leverancierskant gewerkt wordt.
 
-Geverifieerd in het productie-image op 2026-07-31: `/health` geeft 200,
-`/auth/logout` geeft 302, en `/auth/login` geeft 500 met de melding die alle zes
-ontbrekende variabelen opsomt.
+Geverifieerd in het productie-image op 2026-07-31, **zonder** OIDC-configuratie:
+`/health` geeft 200, `/auth/logout` geeft 302, en `/auth/login` geeft 500 met de
+melding die alle zes ontbrekende variabelen opsomt.
+
+**Mét configuratie** (dezelfde dag, tegen de echte tenant): `/auth/login` geeft
+302 naar de authorize-endpoint, met PKCE (S256), een state-parameter en de
+juiste redirect-URI. Entra antwoordt op die URL met 200 en zonder AADSTS-code —
+het bewijs dat client-ID, redirect-URI en scopes alle drie kloppen.
 
 ## Waarom `jose` in `transformIgnorePatterns` staat
 
@@ -160,3 +165,29 @@ bevat daarom de `oid`.
 afdelingswissel. Wie daarop koppelt, laat de gebruiker bij zo'n wijziging
 stilzwijgend een ander account worden — inclusief verlies van zijn membership.
 `email` blijft bestaan als weergavegegeven.
+
+## De claims meten: `scripts/claims-meten.js`
+
+De laatste onbewezen schakel in deze module is de vraag **welke claims Entra
+werkelijk levert**. De code koppelt op `oid`; dat is juist volgens de
+documentatie, maar het is nooit gemeten.
+
+```bash
+node scripts/claims-meten.js
+```
+
+Het script drukt een inloglink af, luistert op de redirect-URI, wisselt de code
+in en toont de claims. Eén keer draaien is genoeg — daarna is het antwoord
+bekend en kan dit script weg.
+
+**Voorwaarde:** de user flow (`mcm2-admin-signin`) moet aan de app-registratie
+`MCM2-backend` gekoppeld zijn. Zonder die koppeling weigert Entra met een
+AADSTS-code die niet verklapt dat het daarom gaat. Koppelen gaat via
+External Identities → User flows → Applications.
+
+**Waarom niet gewoon loggen wat er binnenkomt.** Een ID-token bevat
+persoonsgegevens: naam, e-mailadres, en identifiers die naar één persoon
+herleidbaar zijn. Die horen niet in een log dat blijft staan of in een backup
+belandt. Dit script schrijft niets weg en maskeert de waarden waar de vórm
+genoeg is — de vraag is "bestaat `oid` en is hij stabiel", niet "welke `oid`
+hoort bij wie".

--- a/src/auth/README.md
+++ b/src/auth/README.md
@@ -154,6 +154,79 @@ In een container is het een no-op — daar komt de configuratie uit de omgeving
 en bestaat er geen `.env`. `dotenv` overschrijft bestaande variabelen niet, dus
 de omgeving wint altijd.
 
+## De claims zijn gemeten (2026-07-31)
+
+Niet langer een verwachting. Eén echte login met een echt account, via
+`scripts/claims-meten.js`:
+
+| Claim | Gemeten | Betekenis |
+|---|---|---|
+| `oid` | 36 tekens (UUID) | ✅ aanwezig — de koppeling in de code klopt |
+| `sub` | 43 tekens | pairwise, per applicatie verschillend |
+| `iss` | tenant-ID als subdomein | ✅ komt overeen met `OIDC_ISSUER` |
+| `aud` | client-ID van `MCM2-backend` | ✅ |
+| `email`, `preferred_username` | beide gevuld | weergavegegevens |
+| `tid` | het tenant-ID van `mcm2ciam` | |
+
+**Het lengteverschil bevestigt de keuze.** `sub` is 43 tekens en dus géén UUID —
+een pairwise identifier die per app-registratie verschilt. `oid` is een echt
+UUID, stabiel binnen de tenant. Was er op `sub` gekoppeld, dan zou dezelfde
+persoon in een tweede app-registratie een ander account krijgen, inclusief
+verlies van zijn membership. Dat is nu geen redenering meer maar een meting.
+
+### De `oid` hoort bij `mcm2ciam`, niet bij AlingAdvies
+
+De `idp`-claim toont de federatieketen: de gebruiker komt binnen via
+`login.microsoftonline.com/<alingadvies-tenant-id>`, en `mcm2ciam` maakt daar
+een eigen gebruiker voor aan. De `oid` die in `clm.user.external_subject`
+belandt is die van **mcm2ciam**.
+
+Praktisch gevolg: verhuist de CIAM-tenant ooit naar een Bizaline-tenant (ADR-006
+houdt daar rekening mee), dan veranderen álle `oid`-waarden en moet
+`clm.user.external_subject` gemigreerd worden. Dat is geen configuratiewijziging
+maar een datamigratie — het enige punt waarop die verhuizing niet vrijblijvend
+is.
+
+## De hele keten is doorlopen met een echte login (2026-07-31)
+
+`scripts/echte-login.js`, één keer gedraaid met een echt account:
+
+```
+1  code ingewisseld          OK
+2  token geverifieerd        OK  ← IdTokenVerificateur uit dist/, niet een kopie
+3  gebruiker + membership    OK
+4  sessie aangemaakt         OK  (rol: admin, via clm.sessie_aanmaken)
+5  /vendors met sessie       200
+6  /vendors zonder sessie    401
+```
+
+Daarmee is de laatste onbewezen schakel dicht: de keten van Entra tot een
+beheerroute werkt, met echte tokens en een echte sessie.
+
+### Twee dingen die daarbij tijd kostten
+
+**De cookienaam volgt de configuratie, niet een vaste waarde.** Zonder
+`SESSIE_COOKIE_INSECURE` verwacht de guard `__Host-mcm2_sessie`; mét die
+schakelaar `mcm2_sessie`. Een verkeerde naam geeft een **401 die niet verklapt
+dát het om de naam gaat** — dezelfde melding als een verlopen sessie. Het
+script leest de naam nu uit `cookieInstellingen()` in plaats van hem te
+verzinnen.
+
+Praktisch gevolg voor lokaal werken: over `http` moet
+`SESSIE_COOKIE_INSECURE=true` in `.env`, anders weigert de browser het
+`__Host-`-cookie en lukt inloggen niet. In productie hoort die regel er níét te
+staan.
+
+**Een oude browsertab op de callback-URL breekt de meting.** Zo'n tab herlaadt
+zichzelf met de state van een vórige poging. De eerste versie van het script
+sloot daarop af met "state komt niet overeen" — een melding die naar een
+probleem wees dat er niet was, terwijl de echte login nooit aan de beurt kwam.
+Het script negeert verouderde verzoeken nu.
+
+Let op het verschil met de applicatiecode: in `auth.controller.ts` is een
+afwijkende state terecht wél een harde afwijzing. Daar is het een CSRF-signaal;
+hier is het een wegwerpscript met één mens ervoor.
+
 ## Twee keuzes die makkelijk verkeerd gaan
 
 **`oid`, niet `sub`.** In Entra is `sub` per applicatie verschillend

--- a/src/auth/README.md
+++ b/src/auth/README.md
@@ -113,6 +113,42 @@ precies de aanvallen.
 De verificatielogica is identiek: `jose` weet niet of de sleutels van een
 lokale set of van een JWKS-endpoint komen.
 
+## De issuer wijkt af van de andere endpoints — gemeten, niet aangenomen
+
+Op 2026-07-31 aangesloten op de echte Entra-tenant. Eén ding bleek anders dan
+elke voor de hand liggende aanname:
+
+```
+token endpoint  https://mcm2ciam.ciamlogin.com/<tenant-id>/oauth2/v2.0/token
+jwks uri        https://mcm2ciam.ciamlogin.com/<tenant-id>/discovery/v2.0/keys
+issuer          https://<tenant-id>.ciamlogin.com/<tenant-id>/v2.0
+                       ^^^^^^^^^^^ tenant-ID, niet de tenantnaam
+```
+
+De `iss`-claim gebruikt het **tenant-ID** als subdomein, de andere endpoints de
+**tenantnaam**. `jwtVerify` vergelijkt de issuer exact, dus met de logische
+variant (`mcm2ciam.ciamlogin.com/...`) faalt élke login — en de melding zegt
+niet dát het om de issuer gaat.
+
+Vastgesteld via `.well-known/openid-configuration`, niet uit documentatie
+afgeleid. Bij een verhuizing naar een andere tenant is dat het eerste dat je
+opnieuw ophaalt.
+
+## Waarom `import 'dotenv/config'` bovenaan main.ts staat
+
+Tot 2026-07-31 laadde niets het `.env`-bestand buiten de testsuite: `dotenv`
+stond als dependency in `package.json`, maar werd alleen aangeroepen in
+`test/jest-e2e.setup.ts`. Lokaal werkte de backend daardoor uitsluitend met
+variabelen die al in de shell stonden, en gaf `/auth/login` een 500 met "alle
+zes ontbreken" — ook toen ze keurig in `.env` stonden.
+
+De import staat vóór alle andere: `DatabaseService` leest `DATABASE_URL` in zijn
+constructor, en die draait bij het samenstellen van de module.
+
+In een container is het een no-op — daar komt de configuratie uit de omgeving
+en bestaat er geen `.env`. `dotenv` overschrijft bestaande variabelen niet, dus
+de omgeving wint altijd.
+
 ## Twee keuzes die makkelijk verkeerd gaan
 
 **`oid`, niet `sub`.** In Entra is `sub` per applicatie verschillend

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,17 +1,30 @@
-// Vóór elke andere import: AuthService leest de OIDC-configuratie bij de
-// eerste inlogpoging, en DatabaseService leest DATABASE_URL in zijn
-// constructor. Staat dit lager, dan zijn die waarden er nog niet.
+// Vóór elke andere import: DatabaseService leest DATABASE_URL in zijn
+// constructor en AuthService de OIDC-configuratie bij de eerste inlogpoging.
+// Staat dit lager, dan zijn die waarden er nog niet.
+//
+// ── Waarom dit een try/catch is en geen gewone import ────────────────────────
+//
+// `dotenv` is een devDependency en zit bewust NIET in het productie-image: daar
+// komt de configuratie uit de omgeving (docker compose, App Runner) en bestaat
+// er geen .env-bestand. Een harde `import 'dotenv/config'` liet het image
+// daarom niet meer starten — MODULE_NOT_FOUND op regel 6 van dist/main.js.
+//
+// Dat is precies gevangen door de Docker-poort in CI, die het image niet alleen
+// bouwt maar ook start. `npm run verify` dekt dat niet (§15a).
 //
 // Toegevoegd 2026-07-31. Tot dan laadde niets het .env-bestand buiten de
-// testsuite: `dotenv` stond als dependency in package.json, maar werd alleen
-// aangeroepen in test/jest-e2e.setup.ts. Lokaal werkte de backend daardoor
-// uitsluitend met variabelen die al in de shell stonden — en /auth/login gaf
-// een 500 met "alle zes ontbreken", ook als ze in .env stonden.
-//
-// In een container is dit een no-op: daar komen de waarden uit de omgeving en
-// bestaat er geen .env-bestand. `dotenv` overschrijft bestaande variabelen
-// niet, dus de omgeving wint altijd.
-import 'dotenv/config';
+// testsuite: `dotenv` stond in package.json maar werd alleen aangeroepen in
+// test/jest-e2e.setup.ts. Lokaal werkte de backend daardoor uitsluitend met
+// variabelen die al in de shell stonden — en /auth/login gaf een 500 met "alle
+// zes ontbreken", ook als ze keurig in .env stonden.
+try {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  require('dotenv/config');
+} catch {
+  // Geen dotenv beschikbaar: dat is de normale situatie in productie. De
+  // omgevingsvariabelen zijn er dan al, en `dotenv` zou ze toch niet
+  // overschrijven — de omgeving wint altijd.
+}
 
 import { NestFactory } from '@nestjs/core';
 import { ValidationPipe } from '@nestjs/common';

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,3 +1,18 @@
+// Vóór elke andere import: AuthService leest de OIDC-configuratie bij de
+// eerste inlogpoging, en DatabaseService leest DATABASE_URL in zijn
+// constructor. Staat dit lager, dan zijn die waarden er nog niet.
+//
+// Toegevoegd 2026-07-31. Tot dan laadde niets het .env-bestand buiten de
+// testsuite: `dotenv` stond als dependency in package.json, maar werd alleen
+// aangeroepen in test/jest-e2e.setup.ts. Lokaal werkte de backend daardoor
+// uitsluitend met variabelen die al in de shell stonden — en /auth/login gaf
+// een 500 met "alle zes ontbreken", ook als ze in .env stonden.
+//
+// In een container is dit een no-op: daar komen de waarden uit de omgeving en
+// bestaat er geen .env-bestand. `dotenv` overschrijft bestaande variabelen
+// niet, dus de omgeving wint altijd.
+import 'dotenv/config';
+
 import { NestFactory } from '@nestjs/core';
 import { ValidationPipe } from '@nestjs/common';
 import cookieParser from 'cookie-parser';

--- a/src/vendor/vendor-invoer.ts
+++ b/src/vendor/vendor-invoer.ts
@@ -1,0 +1,195 @@
+import type { NieuweVendor } from './vendor.service';
+
+/**
+ * Validatie van wat een browser opstuurt bij het aanmaken van een leverancier.
+ *
+ * Bewust hier en niet in de service: de service werkt met een getypeerd
+ * object, de buitenwereld met `unknown`. Die grens hoort op één plek te liggen.
+ *
+ * Bewust ook géén class-validator, hoewel dat als dependency aanwezig is. De
+ * bestaande controller valideert op dezelfde manier — handmatig, met `unknown`
+ * als invoer — en een tweede stijl ernaast maakt het geheel ongelijkmatig
+ * zonder iets op te lossen. Zie MCM2-CLAUDE.md over eenduidige werkwijze.
+ *
+ * De regels hier zijn bewust ruim. Streng valideren op een leveranciersnaam
+ * of een adres levert vooral valse afwijzingen op: een naam mag cijfers en
+ * leestekens bevatten, en een buitenlandse plaatsnaam ziet er anders uit dan
+ * een Nederlandse. Wat hier wordt tegengehouden is het soort invoer dat op een
+ * vergissing of een aanval wijst — lege verplichte velden, absurde lengtes,
+ * een verkeerd type.
+ */
+
+/** Bovengrenzen. Ruim genoeg voor echte waarden, krap genoeg om onzin te weren. */
+const MAX_NAAM = 200;
+const MAX_KORT = 100;
+const MAX_URL = 500;
+
+export class InvoerFout extends Error {
+  constructor(
+    readonly veld: string,
+    melding: string,
+  ) {
+    super(melding);
+    this.name = 'InvoerFout';
+  }
+}
+
+/** Leest een verplicht tekstveld. */
+function verplichteTekst(
+  waarde: unknown,
+  veld: string,
+  maxLengte: number,
+): string {
+  if (typeof waarde !== 'string' || waarde.trim() === '') {
+    throw new InvoerFout(veld, `${veld} is verplicht.`);
+  }
+
+  const geknipt = waarde.trim();
+
+  if (geknipt.length > maxLengte) {
+    throw new InvoerFout(
+      veld,
+      `${veld} mag maximaal ${maxLengte} tekens bevatten.`,
+    );
+  }
+
+  return geknipt;
+}
+
+/** Leest een optioneel tekstveld; leeg en ontbrekend zijn hetzelfde. */
+function optioneleTekst(
+  waarde: unknown,
+  veld: string,
+  maxLengte: number,
+): string | null {
+  if (waarde === undefined || waarde === null || waarde === '') {
+    return null;
+  }
+
+  if (typeof waarde !== 'string') {
+    throw new InvoerFout(veld, `${veld} moet tekst zijn.`);
+  }
+
+  const geknipt = waarde.trim();
+
+  if (geknipt === '') {
+    return null;
+  }
+
+  if (geknipt.length > maxLengte) {
+    throw new InvoerFout(
+      veld,
+      `${veld} mag maximaal ${maxLengte} tekens bevatten.`,
+    );
+  }
+
+  return geknipt;
+}
+
+/**
+ * Een KvK-nummer is acht cijfers.
+ *
+ * Bij de CSV-import is dit een *waarschuwing* en geen blokkade: een fout
+ * nummer in een bestand van 200 rijen mag de hele import niet tegenhouden, en
+ * is achteraf te corrigeren. Hier is het wél een fout — iemand typt één
+ * leverancier in en kan het meteen verbeteren. Verschillende situatie,
+ * verschillende strengheid; dat verschil is bewust.
+ */
+function kvkNummer(waarde: unknown): string | null {
+  const tekst = optioneleTekst(waarde, 'KvK-nummer', 20);
+
+  if (tekst === null) {
+    return null;
+  }
+
+  // Spaties en punten eruit: mensen typen 1234 5678.
+  const cijfers = tekst.replace(/[\s.]/g, '');
+
+  if (!/^\d{8}$/.test(cijfers)) {
+    throw new InvoerFout(
+      'kvkNumber',
+      'Een KvK-nummer bestaat uit acht cijfers.',
+    );
+  }
+
+  return cijfers;
+}
+
+/**
+ * Een e-mailadres moet er plausibel uitzien.
+ *
+ * Bewust geen strenge RFC-controle: die is berucht om geldige adressen af te
+ * wijzen, en de echte controle is toch of er een e-mail aankomt. Wat hier
+ * wordt gevangen is de vergissing — een naam in het e-mailveld, een ontbrekend
+ * apenstaartje.
+ */
+function emailAdres(waarde: unknown): string | null {
+  const tekst = optioneleTekst(waarde, 'E-mailadres', MAX_KORT);
+
+  if (tekst === null) {
+    return null;
+  }
+
+  if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(tekst)) {
+    throw new InvoerFout('contact.email', 'Dit lijkt geen geldig e-mailadres.');
+  }
+
+  return tekst;
+}
+
+/**
+ * Leest en valideert de body van POST /vendors.
+ *
+ * Werpt `InvoerFout` bij de eerste fout, met het veld erbij zodat het scherm
+ * de melding naast het juiste invoerveld kan zetten.
+ */
+export function leesNieuweVendor(body: unknown): NieuweVendor {
+  if (typeof body !== 'object' || body === null) {
+    throw new InvoerFout('body', 'Er is geen leverancier meegestuurd.');
+  }
+
+  const ruw = body as Record<string, unknown>;
+
+  const invoer: NieuweVendor = {
+    name: verplichteTekst(ruw.name, 'Naam', MAX_NAAM),
+    kvkNumber: kvkNummer(ruw.kvkNumber),
+    city: optioneleTekst(ruw.city, 'Plaats', MAX_KORT),
+    country: optioneleTekst(ruw.country, 'Land', MAX_KORT),
+    website: optioneleTekst(ruw.website, 'Website', MAX_URL),
+  };
+
+  const contact = ruw.contact;
+
+  if (contact !== undefined && contact !== null) {
+    if (typeof contact !== 'object') {
+      throw new InvoerFout('contact', 'Contactpersoon is niet goed ingevuld.');
+    }
+
+    const ruwContact = contact as Record<string, unknown>;
+    const naam = optioneleTekst(ruwContact.fullName, 'Naam', MAX_NAAM);
+
+    // Een contactpersoon zonder naam is geen contactpersoon. Wél een e-mail
+    // zonder naam invullen wijst op een half ingevuld formulier, en dat hoort
+    // gemeld te worden in plaats van stilzwijgend genegeerd.
+    if (naam === null) {
+      const heeftIetsAnders =
+        ruwContact.email || ruwContact.phone || ruwContact.jobTitle;
+
+      if (heeftIetsAnders) {
+        throw new InvoerFout(
+          'contact.fullName',
+          'Vul ook de naam van de contactpersoon in.',
+        );
+      }
+    } else {
+      invoer.contact = {
+        fullName: naam,
+        email: emailAdres(ruwContact.email),
+        phone: optioneleTekst(ruwContact.phone, 'Telefoonnummer', MAX_KORT),
+        jobTitle: optioneleTekst(ruwContact.jobTitle, 'Functie', MAX_KORT),
+      };
+    }
+  }
+
+  return invoer;
+}

--- a/src/vendor/vendor.controller.ts
+++ b/src/vendor/vendor.controller.ts
@@ -1,0 +1,87 @@
+import {
+  BadRequestException,
+  Body,
+  Controller,
+  Get,
+  HttpCode,
+  Post,
+  Req,
+  UseGuards,
+} from '@nestjs/common';
+
+import {
+  TenantContextGuard,
+  type RequestMetSessie,
+} from '../auth/tenant-context.guard';
+import { InvoerFout, leesNieuweVendor } from './vendor-invoer';
+import { VendorService, type NieuweVendor } from './vendor.service';
+
+/**
+ * De eerste beheerroutes van MCM2 (Issue #7 spoor 1, fase 2 van het plan).
+ *
+ * `@UseGuards(TenantContextGuard)` op klasseniveau, niet per route. Dat is
+ * bewust: een guard per methode betekent dat een nieuwe route hem kan missen,
+ * en dan is de tenantgrens open zonder dat iets rood wordt. Op klasseniveau
+ * geldt hij voor alles wat hier bij komt.
+ *
+ * Dit is ook de plek waar de laag uit de vorige fase eindelijk gebruikt wordt.
+ * Tot nu toe was TenantContextGuard gebouwd en bewezen maar nergens
+ * aangesloten — dat stond als openstaand punt in
+ * docs/architectuur-en-verificatie.md §8.
+ */
+@Controller('vendors')
+@UseGuards(TenantContextGuard)
+export class VendorController {
+  constructor(private readonly vendors: VendorService) {}
+
+  /**
+   * De leveranciers van de ingelogde tenant.
+   *
+   * De tenantId komt van `request.sessie`, die de guard heeft gevuld uit een
+   * databaselookup op de gehashte sessiesleutel. Er is geen queryparameter en
+   * geen kopregel waarmee een andere tenant te benoemen valt.
+   */
+  @Get()
+  async lijst(@Req() request: RequestMetSessie) {
+    // De uitroeptekens zijn veilig: zonder sessie is de guard nooit voorbij
+    // gekomen. Zelfde patroon als SurveyResponseController.
+    const sessie = request.sessie!;
+
+    const vendors = await this.vendors.lijst(sessie.tenantId);
+
+    return { vendors };
+  }
+
+  /**
+   * Maakt een leverancier aan, eventueel met contactpersoon.
+   *
+   * 201 bij succes, 400 bij ongeldige invoer (met het veld erbij), 409 wanneer
+   * het KvK-nummer al bestaat binnen deze tenant.
+   */
+  @Post()
+  @HttpCode(201)
+  async maakAan(@Req() request: RequestMetSessie, @Body() body: unknown) {
+    const sessie = request.sessie!;
+
+    let invoer: NieuweVendor;
+
+    try {
+      invoer = leesNieuweVendor(body);
+    } catch (err) {
+      if (err instanceof InvoerFout) {
+        // Het veld gaat mee zodat het scherm de melding naast het juiste
+        // invoerveld kan tonen in plaats van bovenaan de pagina — dezelfde
+        // les als bij de 422 in het leverancierportaal (Issue #42).
+        throw new BadRequestException({
+          message: err.message,
+          veld: err.veld,
+        });
+      }
+      throw err;
+    }
+
+    const aangemaakt = await this.vendors.maakAan(sessie.tenantId, invoer);
+
+    return aangemaakt;
+  }
+}

--- a/src/vendor/vendor.module.ts
+++ b/src/vendor/vendor.module.ts
@@ -1,0 +1,20 @@
+import { Module } from '@nestjs/common';
+
+import { AuthModule } from '../auth/auth.module';
+import { VendorController } from './vendor.controller';
+import { VendorService } from './vendor.service';
+
+/**
+ * Leveranciersbeheer.
+ *
+ * `AuthModule` wordt geïmporteerd omdat `TenantContextGuard` daar vandaan komt.
+ * Een guard is een gewone provider: zonder die import kent NestJS hem niet en
+ * faalt het opstarten — zichtbaar, niet stil.
+ */
+@Module({
+  imports: [AuthModule],
+  controllers: [VendorController],
+  providers: [VendorService],
+  exports: [VendorService],
+})
+export class VendorModule {}

--- a/src/vendor/vendor.service.ts
+++ b/src/vendor/vendor.service.ts
@@ -1,0 +1,206 @@
+import { ConflictException, Injectable, Logger } from '@nestjs/common';
+import { sql } from 'drizzle-orm';
+
+import { DatabaseService } from '../db/database.service';
+
+/**
+ * Leveranciers lezen en aanmaken, altijd binnen één tenant.
+ *
+ * Dit is de eerste schrijfroute van de beheerkant, en daarmee het eerste
+ * moment waarop de laag uit Issue #7 echt gebruikt wordt: de tenantId komt van
+ * `TenantContextGuard`, die hem uit een geverifieerde sessie haalt. De service
+ * kent geen andere manier om aan een tenant te komen — er is geen parameter en
+ * geen standaardwaarde.
+ *
+ * Alles loopt via `withTenant()`. Zelfs als de tenantId hierboven ooit fout
+ * zou zijn, filtert RLS in de database nog steeds op de ingestelde tenant; de
+ * schade blijft dan beperkt tot "verkeerde tenant" en wordt nooit "alle
+ * tenants".
+ */
+
+/** Een leverancier zoals de lijst hem toont. */
+export interface VendorSamenvatting {
+  vendorId: string;
+  name: string;
+  kvkNumber: string | null;
+  city: string | null;
+  country: string;
+  website: string | null;
+  /** Aantal actieve contactpersonen — genoeg om te zien of er iemand bekend is. */
+  aantalContacten: number;
+  createdAt: string;
+}
+
+/** Wat er nodig is om een leverancier aan te maken. */
+export interface NieuweVendor {
+  name: string;
+  kvkNumber?: string | null;
+  city?: string | null;
+  country?: string | null;
+  website?: string | null;
+  contact?: {
+    fullName: string;
+    email?: string | null;
+    phone?: string | null;
+    jobTitle?: string | null;
+  };
+}
+
+export interface AangemaakteVendor {
+  vendorId: string;
+  name: string;
+  contactId: string | null;
+}
+
+// De index-signatuur is een eis van Drizzle's execute<T>.
+interface VendorRij extends Record<string, unknown> {
+  vendor_id: string;
+  name: string;
+  kvk_number: string | null;
+  city: string | null;
+  country: string;
+  website: string | null;
+  aantal_contacten: string;
+  created_at: Date | string;
+}
+
+function alsTekst(waarde: Date | string): string {
+  return waarde instanceof Date ? waarde.toISOString() : waarde;
+}
+
+/** Lege invoer telt als "niet opgegeven", niet als lege tekst. */
+function leegIsNull(waarde: string | null | undefined): string | null {
+  const geknipt = waarde?.trim();
+  return geknipt ? geknipt : null;
+}
+
+@Injectable()
+export class VendorService {
+  private readonly logger = new Logger(VendorService.name);
+
+  constructor(private readonly db: DatabaseService) {}
+
+  /**
+   * Alle actieve leveranciers van deze tenant, nieuwste eerst.
+   *
+   * `deleted_at IS NULL` staat hier en niet in de RLS-policy: migratie 0004
+   * heeft dat filter bewust uit de policies gehaald, zodat "verwijderd" een
+   * zaak van de applicatie blijft en niet van de isolatiegrens. Die twee door
+   * elkaar halen maakt allebei moeilijker te doorgronden.
+   */
+  async lijst(tenantId: string): Promise<VendorSamenvatting[]> {
+    return this.db.withTenant(tenantId, async (tx) => {
+      const resultaat = await tx.execute<VendorRij>(
+        sql`SELECT v.vendor_id,
+                   v.name,
+                   v.kvk_number,
+                   v.city,
+                   v.country,
+                   v.website,
+                   v.created_at,
+                   (SELECT count(*)
+                      FROM clm.vendor_contact c
+                     WHERE c.vendor_id = v.vendor_id
+                       AND c.deleted_at IS NULL) AS aantal_contacten
+              FROM clm.vendor v
+             WHERE v.deleted_at IS NULL
+             ORDER BY v.created_at DESC`,
+      );
+
+      return resultaat.rows.map((r) => ({
+        vendorId: r.vendor_id,
+        name: r.name,
+        kvkNumber: r.kvk_number,
+        city: r.city,
+        country: r.country,
+        website: r.website,
+        aantalContacten: Number(r.aantal_contacten),
+        createdAt: alsTekst(r.created_at),
+      }));
+    });
+  }
+
+  /**
+   * Maakt een leverancier aan, eventueel met één contactpersoon.
+   *
+   * Beide in dezelfde transactie: een leverancier die is aangemaakt terwijl
+   * zijn contactpersoon sneuvelde, is erger dan geen leverancier. De invuller
+   * ziet dan "gelukt" en mist iemand om de vragenlijst naartoe te sturen.
+   *
+   * `tenant_id` wordt expliciet meegegeven en komt uit de sessie, niet uit de
+   * invoer. Er is geen veld waarmee een aanvrager een andere tenant zou kunnen
+   * benoemen; de `WITH CHECK` op de policy zou zo'n poging bovendien weigeren.
+   */
+  async maakAan(
+    tenantId: string,
+    invoer: NieuweVendor,
+  ): Promise<AangemaakteVendor> {
+    return this.db.withTenant(tenantId, async (tx) => {
+      const kvk = leegIsNull(invoer.kvkNumber);
+
+      // Vooraf controleren geeft een bruikbare melding; de unieke index blijft
+      // de echte garantie. Zonder deze controle krijgt de gebruiker een
+      // databasefout te zien in plaats van "dit KvK-nummer bestaat al".
+      if (kvk) {
+        const bestaand = await tx.execute<{ name: string }>(
+          sql`SELECT name FROM clm.vendor
+               WHERE kvk_number = ${kvk} AND deleted_at IS NULL
+               LIMIT 1`,
+        );
+
+        if (bestaand.rows.length > 0) {
+          throw new ConflictException(
+            `Er bestaat al een leverancier met KvK-nummer ${kvk}: ${bestaand.rows[0].name}.`,
+          );
+        }
+      }
+
+      const vendorResultaat = await tx.execute<{
+        vendor_id: string;
+        name: string;
+      }>(
+        sql`INSERT INTO clm.vendor (tenant_id, name, kvk_number, city, country, website)
+            VALUES (${tenantId},
+                    ${invoer.name.trim()},
+                    ${kvk},
+                    ${leegIsNull(invoer.city)},
+                    ${leegIsNull(invoer.country) ?? 'NL'},
+                    ${leegIsNull(invoer.website)})
+            RETURNING vendor_id, name`,
+      );
+
+      const nieuweVendor = vendorResultaat.rows[0];
+      let contactId: string | null = null;
+
+      if (invoer.contact?.fullName?.trim()) {
+        // is_primary op true: dit is de eerste contactpersoon, en een
+        // leverancier zonder primair contact levert straks geen ontvanger op
+        // voor de uitnodiging.
+        const contactResultaat = await tx.execute<{ contact_id: string }>(
+          sql`INSERT INTO clm.vendor_contact
+                (vendor_id, tenant_id, full_name, email, phone, job_title, is_primary)
+              VALUES (${nieuweVendor.vendor_id},
+                      ${tenantId},
+                      ${invoer.contact.fullName.trim()},
+                      ${leegIsNull(invoer.contact.email)},
+                      ${leegIsNull(invoer.contact.phone)},
+                      ${leegIsNull(invoer.contact.jobTitle)},
+                      true)
+              RETURNING contact_id`,
+        );
+
+        contactId = contactResultaat.rows[0].contact_id;
+      }
+
+      this.logger.log(
+        `Leverancier aangemaakt (${nieuweVendor.vendor_id})${contactId ? ' met contactpersoon' : ''}.`,
+      );
+
+      return {
+        vendorId: nieuweVendor.vendor_id,
+        name: nieuweVendor.name,
+        contactId,
+      };
+    });
+  }
+}

--- a/test/test-ids.ts
+++ b/test/test-ids.ts
@@ -98,6 +98,12 @@ export const TEST_IDS = {
   'vragenlijst-seed': {
     tenant: id('d3'),
   },
+  'vendor-routes': {
+    tenantA: id('7a'),
+    tenantB: id('7b'),
+    userA: id('7c'),
+    userB: id('7d'),
+  },
 } as const;
 
 /** Alle uitgedeelde id's, plat. Gebruikt door de bewakingstest. */

--- a/test/vendor-routes.e2e-spec.ts
+++ b/test/vendor-routes.e2e-spec.ts
@@ -1,0 +1,392 @@
+import { INestApplication } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import cookieParser from 'cookie-parser';
+import { Client } from 'pg';
+import request from 'supertest';
+import type { App } from 'supertest/types';
+
+import { AppModule } from '../src/app.module';
+import { SessieService } from '../src/auth/sessie.service';
+import { cookieInstellingen } from '../src/auth/sessie';
+import { TEST_IDS } from './test-ids';
+
+/**
+ * De eerste beheerroutes, van HTTP tot database (fase 2 van het plan).
+ *
+ * Dit is de suite die aantoont dat de laag uit fase 1 werkt waar het telt: een
+ * échte route, met een échte sessie, die gegevens schrijft en teruggeeft.
+ *
+ * De vraag die deze suite beantwoordt is niet "werkt het aanmaken" maar:
+ * **kan tenant A ooit iets zien of schrijven dat van tenant B is?** Vandaar
+ * dat er twee tenants in het spel zijn en de meeste tests over de grens gaan.
+ */
+
+const { tenantA, tenantB, userA, userB } = TEST_IDS['vendor-routes'];
+
+const SUBJECT_A = `oid-vendor-a-${Date.now()}`;
+const SUBJECT_B = `oid-vendor-b-${Date.now()}`;
+
+interface VendorLijstAntwoord {
+  vendors: Array<{
+    vendorId: string;
+    name: string;
+    kvkNumber: string | null;
+    aantalContacten: number;
+  }>;
+}
+
+interface AanmaakAntwoord {
+  vendorId: string;
+  name: string;
+  contactId: string | null;
+}
+
+function alsLijst(body: unknown): VendorLijstAntwoord {
+  return body as VendorLijstAntwoord;
+}
+
+function alsAangemaakt(body: unknown): AanmaakAntwoord {
+  return body as AanmaakAntwoord;
+}
+
+async function verwijderTestdata(client: Client): Promise<void> {
+  for (const tenant of [tenantA, tenantB]) {
+    await client.query('BEGIN');
+    await client.query(`SET LOCAL app.current_tenant_id = '${tenant}'`);
+    await client.query('DELETE FROM clm.vendor_contact WHERE tenant_id = $1', [
+      tenant,
+    ]);
+    await client.query('DELETE FROM clm.vendor WHERE tenant_id = $1', [tenant]);
+    await client.query(
+      'DELETE FROM clm.tenant_membership WHERE tenant_id = $1',
+      [tenant],
+    );
+    await client.query('DELETE FROM clm."user" WHERE tenant_id = $1', [tenant]);
+    await client.query('DELETE FROM clm.tenant WHERE tenant_id = $1', [tenant]);
+    await client.query('COMMIT');
+  }
+}
+
+describe('Vendorroutes (e2e)', () => {
+  let app: INestApplication<App>;
+  let server: App;
+  let client: Client;
+  let sessies: SessieService;
+  let cookieA: string;
+  let cookieB: string;
+  const cookieNaam = cookieInstellingen().naam;
+
+  beforeAll(async () => {
+    client = new Client({ connectionString: process.env.DATABASE_URL });
+    await client.connect();
+    await verwijderTestdata(client);
+
+    for (const [tenant, user, subject, naam] of [
+      [tenantA, userA, SUBJECT_A, 'Anna uit A'],
+      [tenantB, userB, SUBJECT_B, 'Bob uit B'],
+    ] as const) {
+      await client.query('BEGIN');
+      await client.query(`SET LOCAL app.current_tenant_id = '${tenant}'`);
+      await client.query(
+        'INSERT INTO clm.tenant (tenant_id, name) VALUES ($1, $2)',
+        [tenant, `vendor-test-${tenant.slice(-2)}`],
+      );
+      await client.query(
+        `INSERT INTO clm."user" (user_id, tenant_id, full_name, external_subject)
+         VALUES ($1, $2, $3, $4)`,
+        [user, tenant, naam, subject],
+      );
+      await client.query(
+        `INSERT INTO clm.tenant_membership (user_id, tenant_id, role)
+         VALUES ($1, $2, 'admin')`,
+        [user, tenant],
+      );
+      await client.query('COMMIT');
+    }
+
+    const moduleRef = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleRef.createNestApplication();
+    app.use(cookieParser());
+    await app.init();
+    server = app.getHttpServer();
+
+    sessies = moduleRef.get(SessieService);
+
+    const sessieA = await sessies.aanmaken(SUBJECT_A);
+    const sessieB = await sessies.aanmaken(SUBJECT_B);
+
+    expect(sessieA).not.toBeNull();
+    expect(sessieB).not.toBeNull();
+
+    cookieA = `${cookieNaam}=${sessieA!.token}`;
+    cookieB = `${cookieNaam}=${sessieB!.token}`;
+  }, 30000);
+
+  afterAll(async () => {
+    await app.close();
+    await verwijderTestdata(client);
+    await client.end();
+  }, 30000);
+
+  describe('zonder geldige sessie is er geen toegang', () => {
+    it('weigert de lijst zonder cookie', async () => {
+      await request(server).get('/vendors').expect(401);
+    });
+
+    it('weigert aanmaken zonder cookie', async () => {
+      await request(server)
+        .post('/vendors')
+        .send({ name: 'Sluiproute B.V.' })
+        .expect(401);
+    });
+
+    it('weigert een verzoek dat de tenant in een kopregel meestuurt', async () => {
+      // De faalvorm uit de weggegooide branch feat/fase0-skeleton-vendors.
+      // Zou die terugkeren, dan valt deze test om.
+      await request(server)
+        .get('/vendors')
+        .set('X-Tenant-Id', tenantB)
+        .expect(401);
+    });
+
+    it('weigert een verzoek dat de tenant in de query meestuurt', async () => {
+      await request(server)
+        .get('/vendors')
+        .query({ tenant: tenantB, tenantId: tenantB })
+        .expect(401);
+    });
+  });
+
+  describe('aanmaken en teruglezen binnen één tenant', () => {
+    it('maakt een leverancier aan en geeft hem terug in de lijst', async () => {
+      const aanmaak = await request(server)
+        .post('/vendors')
+        .set('Cookie', cookieA)
+        .send({
+          name: 'Ketentest B.V.',
+          kvkNumber: '12345678',
+          city: 'Utrecht',
+          website: 'https://ketentest.nl',
+        })
+        .expect(201);
+
+      const aangemaakt = alsAangemaakt(aanmaak.body);
+      expect(aangemaakt.vendorId).toMatch(/^[0-9a-f-]{36}$/);
+      expect(aangemaakt.name).toBe('Ketentest B.V.');
+
+      const lijst = await request(server)
+        .get('/vendors')
+        .set('Cookie', cookieA)
+        .expect(200);
+
+      const gevonden = alsLijst(lijst.body).vendors.find(
+        (v) => v.vendorId === aangemaakt.vendorId,
+      );
+
+      expect(gevonden).toBeDefined();
+      expect(gevonden!.name).toBe('Ketentest B.V.');
+      expect(gevonden!.kvkNumber).toBe('12345678');
+    });
+
+    it('maakt de contactpersoon aan in dezelfde stap', async () => {
+      const aanmaak = await request(server)
+        .post('/vendors')
+        .set('Cookie', cookieA)
+        .send({
+          name: 'Met Contact B.V.',
+          contact: {
+            fullName: 'Petra Pietersen',
+            email: 'petra@metcontact.nl',
+            jobTitle: 'Security Officer',
+          },
+        })
+        .expect(201);
+
+      const aangemaakt = alsAangemaakt(aanmaak.body);
+      expect(aangemaakt.contactId).not.toBeNull();
+
+      const lijst = await request(server)
+        .get('/vendors')
+        .set('Cookie', cookieA)
+        .expect(200);
+
+      const gevonden = alsLijst(lijst.body).vendors.find(
+        (v) => v.vendorId === aangemaakt.vendorId,
+      );
+
+      expect(gevonden!.aantalContacten).toBe(1);
+    });
+
+    it('accepteert een leverancier zonder contactpersoon', async () => {
+      const aanmaak = await request(server)
+        .post('/vendors')
+        .set('Cookie', cookieA)
+        .send({ name: 'Zonder Contact B.V.' })
+        .expect(201);
+
+      expect(alsAangemaakt(aanmaak.body).contactId).toBeNull();
+    });
+  });
+
+  describe('de tenantgrens houdt stand', () => {
+    it('toont een leverancier van A niet aan B', async () => {
+      // De kern van deze suite. Twee sessies, twee tenants, dezelfde route.
+      const aanmaak = await request(server)
+        .post('/vendors')
+        .set('Cookie', cookieA)
+        .send({ name: 'Alleen Van A B.V.' })
+        .expect(201);
+
+      const vendorVanA = alsAangemaakt(aanmaak.body).vendorId;
+
+      const lijstB = await request(server)
+        .get('/vendors')
+        .set('Cookie', cookieB)
+        .expect(200);
+
+      const gevonden = alsLijst(lijstB.body).vendors.find(
+        (v) => v.vendorId === vendorVanA,
+      );
+
+      expect(gevonden).toBeUndefined();
+    });
+
+    it('laat hetzelfde KvK-nummer toe in een andere tenant', async () => {
+      // De unieke index staat op (tenant_id, kvk_number), niet op kvk_number
+      // alleen. Twee klanten mogen dezelfde leverancier in hun eigen
+      // administratie hebben — dat is de normale situatie, geen uitzondering.
+      await request(server)
+        .post('/vendors')
+        .set('Cookie', cookieA)
+        .send({ name: 'Gedeelde Leverancier B.V.', kvkNumber: '87654321' })
+        .expect(201);
+
+      await request(server)
+        .post('/vendors')
+        .set('Cookie', cookieB)
+        .send({ name: 'Gedeelde Leverancier B.V.', kvkNumber: '87654321' })
+        .expect(201);
+    });
+
+    it('weigert hetzelfde KvK-nummer binnen dezelfde tenant', async () => {
+      await request(server)
+        .post('/vendors')
+        .set('Cookie', cookieA)
+        .send({ name: 'Eerste Inschrijving B.V.', kvkNumber: '11223344' })
+        .expect(201);
+
+      await request(server)
+        .post('/vendors')
+        .set('Cookie', cookieA)
+        .send({ name: 'Tweede Poging B.V.', kvkNumber: '11223344' })
+        .expect(409);
+    });
+
+    it('schrijft naar de tenant uit de sessie, niet uit de body', async () => {
+      // Een poging om via de body in een andere tenant te schrijven. Het veld
+      // wordt niet gelezen; de leverancier hoort in A te landen.
+      const aanmaak = await request(server)
+        .post('/vendors')
+        .set('Cookie', cookieA)
+        .send({ name: 'Body-tenant B.V.', tenantId: tenantB })
+        .expect(201);
+
+      const vendorId = alsAangemaakt(aanmaak.body).vendorId;
+
+      const lijstB = await request(server)
+        .get('/vendors')
+        .set('Cookie', cookieB)
+        .expect(200);
+
+      expect(
+        alsLijst(lijstB.body).vendors.find((v) => v.vendorId === vendorId),
+      ).toBeUndefined();
+
+      const lijstA = await request(server)
+        .get('/vendors')
+        .set('Cookie', cookieA)
+        .expect(200);
+
+      expect(
+        alsLijst(lijstA.body).vendors.find((v) => v.vendorId === vendorId),
+      ).toBeDefined();
+    });
+  });
+
+  describe('invoercontrole', () => {
+    it('weigert een leverancier zonder naam', async () => {
+      const antwoord = await request(server)
+        .post('/vendors')
+        .set('Cookie', cookieA)
+        .send({ city: 'Amsterdam' })
+        .expect(400);
+
+      // Het veld gaat mee zodat het scherm de melding op de juiste plek zet.
+      expect((antwoord.body as { veld?: string }).veld).toBe('Naam');
+    });
+
+    it.each([
+      ['te kort', '123'],
+      ['met letters', 'abcdefgh'],
+      ['te lang', '123456789'],
+    ])('weigert een KvK-nummer dat %s is', async (_omschrijving, waarde) => {
+      await request(server)
+        .post('/vendors')
+        .set('Cookie', cookieA)
+        .send({ name: 'KvK-test B.V.', kvkNumber: waarde })
+        .expect(400);
+    });
+
+    it('accepteert een KvK-nummer met spaties en punten', async () => {
+      // Mensen typen 1234 5678. Dat weigeren is onnodig streng.
+      const aanmaak = await request(server)
+        .post('/vendors')
+        .set('Cookie', cookieA)
+        .send({ name: 'Spaties B.V.', kvkNumber: '9988 7766' })
+        .expect(201);
+
+      const lijst = await request(server)
+        .get('/vendors')
+        .set('Cookie', cookieA)
+        .expect(200);
+
+      const gevonden = alsLijst(lijst.body).vendors.find(
+        (v) => v.vendorId === alsAangemaakt(aanmaak.body).vendorId,
+      );
+
+      expect(gevonden!.kvkNumber).toBe('99887766');
+    });
+
+    it('weigert een onherkenbaar e-mailadres', async () => {
+      await request(server)
+        .post('/vendors')
+        .set('Cookie', cookieA)
+        .send({
+          name: 'Mailtest B.V.',
+          contact: { fullName: 'Jan Jansen', email: 'geen-apenstaartje' },
+        })
+        .expect(400);
+    });
+
+    it('meldt een half ingevulde contactpersoon in plaats van hem te negeren', async () => {
+      // E-mail wél, naam niet: dat is een vergeten veld, geen bewuste keuze
+      // om de contactpersoon weg te laten. Stilzwijgend negeren zou betekenen
+      // dat de gebruiker denkt dat hij iets heeft ingevuld.
+      const antwoord = await request(server)
+        .post('/vendors')
+        .set('Cookie', cookieA)
+        .send({
+          name: 'Half Ingevuld B.V.',
+          contact: { email: 'iemand@voorbeeld.nl' },
+        })
+        .expect(400);
+
+      expect((antwoord.body as { veld?: string }).veld).toBe(
+        'contact.fullName',
+      );
+    });
+  });
+});


### PR DESCRIPTION
Fase 2 van het plan, plus de aansluiting op Entra. Vier commits, en het moment waarop `TenantContextGuard` eindelijk in het verzoekpad zit.

Hoort bij **MCM2-frontend#2**, die de schermen levert.

## 1. Beheerroutes achter de sessieguard

`GET /vendors` en `POST /vendors`, allebei achter `@UseGuards` **op klasseniveau**. Dat is bewust geen guard per methode: een nieuwe route kan er dan een missen, en dan staat de tenantgrens open zonder dat iets rood wordt.

De tenantId komt van `request.sessie`, die de guard uit een gehashte lookup haalt. Er is geen queryparameter, geen kopregel en geen body-veld waarmee een andere tenant te benoemen valt. **Achttien e2e-tests** bewaken dat.

### Tegenproef, twee keer

- **Guard van de controller gehaald** → de hele suite valt om, de vier toegangstests voorop.
- **`withTenant()` vervangen door een gewone transactie** → vier tests vallen om. Leerzaam wélke vier: zonder tenantcontext geeft RLS *nul rijen*, dus de test "leverancier van A niet zichtbaar voor B" bleef groen terwijl er iets ernstig mis was. **Positieve en negatieve tests zijn allebei nodig.**

## 2. `npm run verify:volledig`

Van opmaakcontrole tot een browser die een leverancier aanmaakt en terugziet. Vijf stappen, altijd opruimen:

```
1  npm run verify        code, unittests, 228 e2e tegen een wegwerpdatabase
2  stack bouwen          beide productie-images via docker compose
3  migraties + sessie    vanaf een lege database; sessie via
                         clm.sessie_aanmaken() — een echte, geen nagebootste
4  browsertest           Playwright tegen de draaiende stack
5  opruimen
```

Stap 4 draait tegen de **productie-images**, niet tegen `next dev`. Dat verschil is de reden dat de OTAP-doorloop bestaat: een ontwikkelserver had de EACCES-uploadfout in het image nooit gevonden.

### Drie dingen die het bouwen blootlegde

1. `psql` neemt de rolnaam als databasenaam wanneer `-d` ontbreekt, en faalt met `database "clm_migrator" does not exist` — een melding die naar de verkeerde oorzaak wijst.
2. De API start vóórdat de rollen bestaan en kan niet verbinden. Herstarten is verplicht; stond al in het runbook, nu ook in code.
3. Stap 1 sloeg de e2e-tests over omdat `DATABASE_URL` ontbrak, en meldde "GROEN, met overgeslagen stappen" — misleidend in een commando dat volledigheid belooft. Start nu zijn eigen wegwerpdatabase op 55441.

## 3. Entra werkt — twee fouten die elke login zouden breken

**Niets las het `.env`-bestand buiten de testsuite.** `dotenv` stond als dependency in `package.json` maar werd alleen in `test/jest-e2e.setup.ts` aangeroepen. `/auth/login` gaf een 500 met "alle zes ontbreken" terwijl ze keurig in `.env` stonden.

**De issuer wijkt af van de andere endpoints:**

```
token/jwks  https://mcm2ciam.ciamlogin.com/<tenant-id>/...
issuer      https://<tenant-id>.ciamlogin.com/<tenant-id>/v2.0
                   ^^^^^^^^^^^ tenant-ID, niet de tenantnaam
```

`jwtVerify` vergelijkt exact. Gemeten via `.well-known/openid-configuration`, niet afgeleid uit documentatie.

## 4. De claims zijn gemeten, niet langer verwacht

Eén echte login met een echt account, via `scripts/echte-login.js`:

```
1  code ingewisseld          OK
2  token geverifieerd        OK   IdTokenVerificateur uit dist/, geen kopie
3  gebruiker + membership    OK
4  sessie aangemaakt         OK   rol admin, via clm.sessie_aanmaken()
5  /vendors met sessie       200
6  /vendors zonder sessie    401
```

| Claim | Gemeten | Betekenis |
|---|---|---|
| `oid` | 36 tekens, UUID | de koppeling in de code klopt |
| `sub` | 43 tekens, géén UUID | pairwise, per applicatie verschillend |

**Dat lengteverschil bevestigt de keuze.** Was er op `sub` gekoppeld, dan kreeg dezelfde persoon in een tweede app-registratie een ander account, inclusief verlies van zijn membership. Dat is nu geen redenering meer maar een meting.

De `idp`-claim toont de federatieketen: de `oid` in `clm.user.external_subject` is die van **mcm2ciam**, niet van AlingAdvies. Verhuist de CIAM-tenant ooit, dan is dat een **datamigratie** en geen configuratiewijziging — het enige punt waarop ADR-006 niet vrijblijvend is.

### Twee valkuilen, nu in code en README

- **De cookienaam volgt de configuratie.** Zonder `SESSIE_COOKIE_INSECURE` verwacht de guard `__Host-mcm2_sessie`, met die schakelaar `mcm2_sessie`. Een verkeerde naam geeft een 401 die niet verklapt dát het om de naam gaat.
- **Een oude browsertab op de callback-URL** herlaadt zichzelf met een verouderde state. De eerste versie van het script sloot daarop af, waardoor de echte login nooit aan de beurt kwam — drie keer achter elkaar. In `auth.controller.ts` blijft een afwijkende state terecht wél een harde afwijzing: daar is het een CSRF-signaal.

## Verificatie

`npm run verify` groen: **161 unittests**, **228 e2e-tests** tegen een database die vanaf niets is opgebouwd.

🤖 Generated with [Claude Code](https://claude.com/claude-code)