### PR TITLE
docs: fase 2 af, Entra gemeten, twee openstaande punten gesloten

### DIFF
--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,7 +1,7 @@
 # MCM2 — actuele status
 
 ## Laatst bijgewerkt
-2026-07-31 (**fase 1 van de beheerkant is af**: de `TenantContextGuard` en de drie auth-routes staan, en daarmee is de tenantgrens dicht — P0 uit Issue #7 is gesloten. Branch `feat/identiteit-en-membership`, zes commits, **gepusht**, nog niet gemerged. Alles hieronder is geverifieerd, niet uit gespreksgeheugen.)
+2026-07-31, avond (**fase 1 én 2 zijn af, en inloggen via Entra werkt aantoonbaar**. Er is een zichtbaar beheerscherm op `/beheer/leveranciers`, één commando dat de hele keten doortest, en de laatste onbewezen aanname — welke claims Entra levert — is gemeten. Alles gemerged, CI groen op `main` in beide repositories. Alles hieronder is geverifieerd, niet uit gespreksgeheugen.)
 
 **Plan voor de komende fases:** `docs/superpowers/plans/2026-07-30-beheerkant-en-demo-tenant.md` — vier fases naar een frontend die eruitziet als MVM_V2, inloggen als tenant, vendors met contactpersonen aanmaken, een demo-tenant met mock data, en een robuuste OTAP-doorloop.
 
@@ -30,13 +30,22 @@ Eigen CI en eigen releasecyclus per repo — bewust, zodat een tekstwijziging in
    - **Issue #59 — `npm audit` meldt 29 kwetsbaarheden.** Niet vergeten, maar ook niet nu oplossen: `npm audit --omit=dev` geeft **0**, dus er zit niets van in het productie-image. De voorgestelde automatische fix zet eslint jaren terug en breekt de lint-configuratie. Hoort bij de eerste major-onderhoudsronde op devDependencies, samen met Dependabot (#22). **Controleer wel bij elke sessie dat `npm audit --omit=dev` nul blijft** — wordt dat meer dan nul, dan is het geen onderhoudspunt meer maar een blocker.
    - **Issue #58 — de backup hangt af van deze laptop.** Draait dagelijks, maar niet als de machine uitstaat. Vóór de pilotstart (rond 1 september) naar iets onafhankelijks.
 
-6. **Eerste concrete vervolgstap: fase 2 — vendorroutes en schermen.** Fase 1 is op 2026-07-31 afgerond; zie het blok "Beheerkant fase 1" hieronder voor wat er staat en wat níét bewezen is.
+6. **Eerste concrete vervolgstap: fase 3 — de demo-tenant met mock data.** Fase 1 en 2 zijn op 2026-07-31 afgerond en gemerged.
 
-   Twee dingen die daarbij horen:
+   **Wat er nu werkt en zichtbaar is:**
 
-   **Bevestig bij de eerste echte login welke claims Entra werkelijk levert.** De code koppelt op `oid` op basis van documentatie, niet op meting. Dit is nu de grootste openstaande onzekerheid in de identiteitslaag: alle tests draaien tegen een lokaal sleutelpaar, niet tegen de echte Entra-tenant.
+   ```
+   /beheer/leveranciers   lijst + aanmaakformulier met contactpersoon
+   npm run verify:volledig   code → 161 unit → 228 e2e → stack → 6 browsertests
+   ```
 
-   **De guard hangt nog nergens op.** Hij is gebouwd en bewezen, maar er is nog geen beheerroute die hem gebruikt — die komen in fase 2. `@UseGuards(TenantContextGuard)` op elke nieuwe beheercontroller is daarmee de eerste regel van fase 2, niet iets om later aan toe te voegen.
+   **Inloggen via Entra werkt aantoonbaar.** Eén echte login doorlopen: code inwisselen, token verifiëren met de échte applicatiecode, gebruiker en membership, sessie via `clm.sessie_aanmaken()`, en met dat cookie `/vendors` → 200. Zonder cookie → 401.
+
+   **De claims zijn gemeten**, niet langer aangenomen: `oid` is 36 tekens (UUID), `sub` 43 en dus géén UUID. Dat lengteverschil bevestigt de keuze voor `oid` — op `sub` koppelen had betekend dat dezelfde persoon in een tweede app-registratie een ander account kreeg.
+
+   **Twee dingen om te onthouden bij lokaal werken:**
+   - `SESSIE_COOKIE_INSECURE=true` moet in `.env` staan, anders weigert de browser het `__Host-`-cookie over http en lukt inloggen niet. In productie hoort die regel er níét te staan.
+   - De `oid` in `clm.user.external_subject` hoort bij **mcm2ciam**, niet bij AlingAdvies. Verhuist de CIAM-tenant ooit, dan is dat een **datamigratie** — zie `docs/architectuur-en-verificatie.md` §11.
 
    **Issue #30 is niet langer de zwaarste blokkade** — de dagelijkse backup draait sinds 2026-07-30 naar OneDrive. Wat rest is het restrisico in #58 (hangt af van de laptop). De drie issues die op backups wachtten (#19, #25, #29) raken de productiedatabase en kunnen nu heroverwogen worden; er wordt intussen tegen wegwerpcontainers gebouwd.
 

--- a/docs/architectuur-en-verificatie.md
+++ b/docs/architectuur-en-verificatie.md
@@ -358,8 +358,9 @@ moeten lezen. Alles hierboven is gemeten; alles hieronder is dat niet.
 
 | Onderwerp | Stand | Wat dat betekent |
 |---|---|---|
-| Claims uit Microsoft Entra | **Aanname** | Alle tests draaien tegen een lokaal sleutelpaar. Welke claims de echte tenant levert (`oid`, `tid`, `email`), is nooit gemeten. Te bevestigen bij de eerste echte login. |
-| De sessieguard in gebruik | **Niet aangesloten** | Gebouwd en bewezen, maar er is nog geen beheerroute die hem gebruikt. `@UseGuards(TenantContextGuard)` is de eerste stap van fase 2. |
+| ~~Claims uit Microsoft Entra~~ | **Gemeten 2026-07-31** | `oid` is 36 tekens (UUID), `sub` 43 en dus géén UUID — het lengteverschil bevestigt de keuze voor `oid`. Zie §11. |
+| ~~De sessieguard in gebruik~~ | **Aangesloten 2026-07-31** | `GET`/`POST /vendors` draaien erachter, met 18 e2e-tests en een tegenproef. |
+| Wachtwoordrotatie `postgres` | **Niet gedaan** | Issue #1. De beheerrol heeft nog het oorspronkelijke wachtwoord. |
 | Gelijktijdige uploads | **Onbewezen** | De `FOR UPDATE`-vergrendeling is er, maar met die vergrendeling verwijderd bleven alle tests groen. De race was niet uit te lokken zonder kunstgrepen in productiecode. |
 | Gezondheid van een uitgerolde omgeving | **Bestaat niet** | De e2e-tests beantwoorden dit nooit — ze zijn destructief van aard. Er is een aparte, alleen-lezende rookproef nodig: **Issue #61**. |
 | Virusscan op bijlagen | **Niet gebouwd** | De klant heeft er niets over gezegd (OV-7); het ontwerp benoemt dit expliciet als openstaand risico. |
@@ -442,6 +443,59 @@ meet, is gevaarlijker dan geen cijfer.**
 op de database steunt. De CSV-parser (58 unittests) en de validatieregels zijn daar al
 kandidaten voor; de vendorlogica uit fase 2 wordt dat ook. Daar meet een mutatiescore wél
 wat hij belooft.
+
+---
+
+## 11. De keten is doorlopen met een echte login (2026-07-31)
+
+De laatste onbewezen schakel uit §8 is dicht. `scripts/echte-login.js`, één keer
+gedraaid met een echt account tegen de echte Entra-tenant:
+
+```
+1  code ingewisseld          OK
+2  token geverifieerd        OK   IdTokenVerificateur uit dist/, geen kopie
+3  gebruiker + membership    OK
+4  sessie aangemaakt         OK   rol admin, via clm.sessie_aanmaken()
+5  /vendors met sessie       200
+6  /vendors zonder sessie    401
+```
+
+### De claims zijn meting geworden
+
+| Claim | Gemeten | Betekenis |
+|---|---|---|
+| `oid` | 36 tekens, UUID | ✅ de koppeling in de code klopt |
+| `sub` | 43 tekens, géén UUID | pairwise, per applicatie verschillend |
+| `iss` | tenant-ID als subdomein | komt overeen met `OIDC_ISSUER` |
+| `aud` | client-ID van `MCM2-backend` | ✅ |
+
+**Het lengteverschil bevestigt de keuze.** Was er op `sub` gekoppeld, dan kreeg dezelfde
+persoon in een tweede app-registratie een ander account, inclusief verlies van zijn
+membership. Dat is nu geen redenering meer.
+
+### Twee dingen die de meting blootlegde
+
+**De issuer wijkt af van de andere endpoints.** Token- en JWKS-endpoint gebruiken de
+tenantnáám, de `iss`-claim het tenant-**ID** als subdomein. `jwtVerify` vergelijkt exact,
+dus de logische variant laat elke login stranden — met een melding die niet zegt dat het
+om de issuer gaat. Opgehaald via `.well-known/openid-configuration`.
+
+**De `oid` hoort bij `mcm2ciam`, niet bij AlingAdvies.** De `idp`-claim toont de
+federatieketen: de gebruiker komt binnen via de AlingAdvies-tenant, en `mcm2ciam` maakt
+daar een eigen gebruiker voor aan. Verhuist de CIAM-tenant ooit (ADR-006 houdt daar
+rekening mee), dan veranderen álle `oid`-waarden en is dat een **datamigratie**, geen
+configuratiewijziging. Het enige punt waarop die verhuizing niet vrijblijvend is.
+
+### Wat de Docker-poort ving dat `verify` niet zag
+
+De eerste versie van deze wijziging bouwde wél maar startte niet: `dotenv` is een
+devDependency en zit niet in het productie-image, dus `import 'dotenv/config'` gaf
+`MODULE_NOT_FOUND`. Dat is precies waarvoor de Docker-job bestaat — hij start het image
+en controleert dat het een pagina serveert.
+
+**Voor de tweede keer bewezen** dat een geslaagde `nest build` niets zegt over het
+artefact; de eerste keer was `jose` in het productie-image. §6 benoemt dit al als grens
+van `verify`.
 
 ---
 

--- a/docs/superpowers/plans/2026-07-30-beheerkant-en-demo-tenant.md
+++ b/docs/superpowers/plans/2026-07-30-beheerkant-en-demo-tenant.md
@@ -19,7 +19,7 @@ Branch `feat/identiteit-en-membership`, vijf commits, nog niet gepusht.
 | **1** | `TenantContextGuard` | ✅ |
 | **1** | Auth-routes `/auth/login`, `/auth/callback`, `/auth/logout` | ✅ |
 | **1** | `X-Tenant-Id` verwijderen | ✅ bleek niets te verwijderen — zie hieronder |
-| 2 | Vendorroutes en schermen | niet gestart |
+| **2** | Vendorroutes en schermen | ✅ gemerged 2026-07-31 (MCM2#67, frontend#2) |
 | 3 | Demo-tenant seed | niet gestart |
 | 4 | OTAP-doorloop uitgebreid | niet gestart |
 


### PR DESCRIPTION
Werkt de documentatie bij naar de stand van 31 juli, avond.

## Twee punten uit §8 zijn nu wél bewezen

| Was | Nu |
|---|---|
| Claims uit Entra: **aanname** | **gemeten** — `oid` 36 tekens (UUID), `sub` 43 en dus géén UUID |
| Sessieguard: **niet aangesloten** | **aangesloten** — `GET`/`POST /vendors`, 18 e2e-tests, tegenproef |

Het lengteverschil bevestigt de keuze voor `oid`: op `sub` koppelen had betekend dat dezelfde persoon in een tweede app-registratie een ander account kreeg, inclusief verlies van zijn membership.

## Nieuw §11 — de keten doorlopen met een echte login

De zes stappen, plus twee dingen die de meting blootlegde:

**De issuer wijkt af van de andere endpoints.** Token en JWKS gebruiken de tenantnáám, de `iss`-claim het tenant-**ID** als subdomein. `jwtVerify` vergelijkt exact.

**De `oid` hoort bij `mcm2ciam`, niet bij AlingAdvies.** Verhuist de CIAM-tenant ooit, dan veranderen álle `oid`-waarden en is dat een **datamigratie** — het enige punt waarop ADR-006 niet vrijblijvend is.

## Wat de Docker-poort ving dat `verify` niet zag

`dotenv` is een devDependency en zit niet in het productie-image, dus een harde `import` liet het image niet meer starten. **Voor de tweede keer bewezen** dat een geslaagde `nest build` niets zegt over het artefact; de eerste keer was `jose`.

## Volgende stap

STATUS.md verzet naar **fase 3** (demo-tenant), met twee dingen die bij lokaal werken horen: `SESSIE_COOKIE_INSECURE` in `.env`, en de herkomst van de `oid`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)