### PR TITLE
feat(auth): sessieroute voor de schermen, plus tegenproef en verify:volledig vastgelegd

### DIFF
--- a/MCM2-CLAUDE.md
+++ b/MCM2-CLAUDE.md
@@ -463,7 +463,8 @@ Een wijziging is pas “klaar” wanneer:
 [ ] Relevante architectuur- en securityregels toegepast
 [ ] Geen secrets hardcoded of zichtbaar gemaakt
 [ ] Lokaal getest in de Docker-werkwijze, waar van toepassing
-[ ] `npm run verify` groen — NIET losse commando's, zie §15a
+[ ] `npm run verify:volledig` groen — NIET losse commando's, zie §15a
+[ ] Tegenproef gedaan op wat er aan beveiliging is toegevoegd, zie §15b
 [ ] RLS read/write-isolatietest toegevoegd bij tenantdata
 [ ] Migratie getest op lege database, indien schema gewijzigd
 [ ] Docker production build geslaagd
@@ -473,12 +474,25 @@ Een wijziging is pas “klaar” wanneer:
 [ ] OTAP-route gevolgd vóór productie wordt voorgesteld
 ```
 
-### 15a. "Groen" wordt vastgesteld met `npm run verify` — nooit met losse commando's
+### 15a. "Groen" wordt vastgesteld met één commando — nooit met losse commando's
 
 ```bash
-npm run verify        # alle vijf poorten, vraagt DATABASE_URL
-npm run verify:snel   # zonder e2e — meldt zelf dat het onvolledig is
+npm run verify:volledig   # de hele keten: code → unit → e2e → images → browser
+npm run verify            # alleen de code-poorten, vraagt DATABASE_URL
+npm run verify:snel       # zonder e2e — meldt zelf dat het onvolledig is
 ```
+
+**`verify:volledig` is de norm** (sinds 2026-07-31). Die zet zelf een
+wegwerpdatabase op, draait de migratieketen vanaf niets, bouwt **beide**
+productie-images, start de stack en klikt door de browser. Stopt bij de eerste
+rode stap en noemt welke CI-job dat is.
+
+`npm run verify` blijft bruikbaar tijdens het werk — sneller, en genoeg om te
+zien of de code-poorten dichtblijven. Maar een fase of PR afsluiten op `verify`
+alleen laat twee dingen ongetest die in dit project al eens zijn misgegaan: het
+productie-image (dat startte niet door een ontbrekende `dotenv`) en de schermen
+(Issue #42 en #43 zijn door de browser gevonden en door 155 backendtests
+gemist).
 
 **Waarom dit een harde regel is en geen aanbeveling.** Op 2026-07-31 faalde CI
 op de lintstap terwijl lokaal alles groen leek. De oorzaak was geen typefout
@@ -496,10 +510,17 @@ en dan is "groen" een mening in plaats van een meting. `scripts/verify.js`
 draait ze in dezelfde volgorde als de workflow en stopt bij de eerste rode
 stap. Elke stap noemt bij een fout de bijbehorende CI-job.
 
-**Wat `verify` bewust niet dekt:** de Docker-productiebuild. Die draait alleen
-in CI (job `docker-build`). Bij een wijziging aan de `Dockerfile` of aan
-runtime-dependencies hoort een lokale `docker build` — een geslaagde
-`nest build` bewijst niet dat het artefact werkt (zie `src/auth/README.md`).
+**Wat `verify` bewust niet dekt:** de Docker-productiebuild en de schermen.
+Daarvoor is `verify:volledig` er — die bouwt beide images en start ze, want een
+geslaagde `nest build` bewijst niet dat het artefact werkt (zie
+`src/auth/README.md`), en een Next.js-server met een kapotte build start wél en
+geeft een 500.
+
+**Let op de poorten bij handmatig testen.** `verify:volledig` claimt **55441**
+voor zijn wegwerpdatabase; de doorloopstack gebruikt 55500 en een handmatige
+`verify` 55440. Draait er nog een container van een afgebroken run, dan faalt
+stap 1 met "geen testdatabase kunnen starten" — een melding die naar de
+verkeerde oorzaak wijst. Opruimen met `docker rm -f <naam>`.
 
 **De veiligheidsklep.** `verify` weigert te draaien wanneer `DATABASE_URL` niet
 naar een lokale wegwerpdatabase wijst. De e2e-suite maakt tenants aan en
@@ -511,6 +532,42 @@ te vangen is.
 destructief van aard. De vraag "draait de uitgerolde omgeving en klopt hij" is
 een andere controle — een leesbare rookproef, Issue #61 — die bij de
 OTAP-doorloop hoort (#18), niet hier.
+
+### 15b. Groene tests zonder tegenproef bewijzen niets
+
+**De regel.** Wie een beveiligingsgarantie toevoegt of wijzigt, breekt hem
+daarna opzettelijk en stelt vast dat **precies de bedoelde tests omvallen**.
+Daarna herstellen, en controleren dat het bestand weer identiek is
+(`diff` tegen een kopie — niet op het oog).
+
+**Waarom dit een harde regel is.** Een test die groen is bij een werkende
+implementatie én groen blijft bij een kapotte, meet niets. Dat klinkt
+theoretisch tot het gebeurt, en in dit project is het **zes keer** gebeurd:
+
+| Wanneer | Sabotage | Wat de tests deden |
+|---|---|---|
+| 2026-07-31 | terugval op `X-Tenant-Id` in de guard | 18 guard-tests bleven groen — de test die een header hoorde te negeren stuurde zelf een gèldig cookie mee |
+| 2026-07-31 | verloopcontrole van de sessie eruit | 9 tests vielen om, zoals bedoeld |
+| 2026-07-31 | rechten op `clm.sessie` toegekend | 2 deur-tests vielen om, zoals bedoeld |
+| 2026-07-30 | `instruction`-tak uit het portaal | 3 controles vielen om, zoals bedoeld |
+| 2026-08-03 | tokenhash vervangen door hex-codering | **alle 8 tests bleven groen** — de test keek naar de vórm van de hash, niet of het de hash ís |
+| 2026-08-03 | `tenantId` toegevoegd aan `/auth/sessie` | **alle 8 browsertests bleven groen** — de sidebar toont dat veld niet, dus het kwam nooit in beeld |
+
+Twee van de zes keer bleven de tests volledig groen bij een echt lek. Beide
+keren was de test op de verkeerde plek geschreven.
+
+**De les uit die twee.** Test een lek **bij de bron**, niet bij de plek waar je
+hoopt dat het niet opduikt. Een browsertest die controleert wat er in een scherm
+terechtkomt, mist alles wat wél over de lijn gaat maar niet getoond wordt. Het
+antwoord van de route zelf controleren vangt dat wel.
+
+**Wanneer verplicht:** bij elke wijziging aan RLS-policies, guards, tokens,
+sessies, rolcontroles of iets anders dat bepaalt wie wat mag zien. Niet nodig
+bij tekstwijzigingen, opmaak of documentatie.
+
+**Vastleggen waar het thuishoort.** De uitkomst hoort in de commit-boodschap en
+in `docs/STATUS.md`, niet alleen in het gesprek waarin het gebeurde — anders is
+de kennis weg zodra de sessie afloopt.
 
 ---
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,7 +1,7 @@
 # MCM2 — actuele status
 
 ## Laatst bijgewerkt
-2026-08-03 (**fase 3 is af**: `npm run seed:demo` vult in één commando een demo-tenant met 21 leveranciers, drie gebruikers, beide vragenlijsten en een lopende ronde. 236 e2e-tests groen — acht nieuwe. Twee dingen die aandacht vragen staan onder "Actieve blokkades": de dagelijkse backup heeft drie dagen stilgelegen, en er staat een productiewachtwoord in de git-historie van `mvm-api-pilot`.)
+2026-08-03 (**fase 3 en 2b zijn af**: `npm run seed:demo` vult in één commando een demo-tenant, en de beheerkant heeft nu de sidebar en schermindeling van MVM_V2 plus zoeken. 241 e2e-tests en 14 browsertests groen. Twee dingen die aandacht vragen staan onder "Actieve blokkades": de dagelijkse backup heeft drie dagen stilgelegen, en er staat een productiewachtwoord in de git-historie van `mvm-api-pilot`.)
 
 <details>
 <summary>Vorige stand (2026-07-31, avond)</summary>
@@ -39,14 +39,14 @@ Eigen CI en eigen releasecyclus per repo — bewust, zodat een tekstwijziging in
    - **Issue #59 — `npm audit` meldt 29 kwetsbaarheden.** Niet vergeten, maar ook niet nu oplossen: `npm audit --omit=dev` geeft **0**, dus er zit niets van in het productie-image. De voorgestelde automatische fix zet eslint jaren terug en breekt de lint-configuratie. Hoort bij de eerste major-onderhoudsronde op devDependencies, samen met Dependabot (#22). **Controleer wel bij elke sessie dat `npm audit --omit=dev` nul blijft** — wordt dat meer dan nul, dan is het geen onderhoudspunt meer maar een blocker.
    - **Issue #58 — de backup hangt af van deze laptop.** Draait dagelijks, maar niet als de machine uitstaat. Vóór de pilotstart (rond 1 september) naar iets onafhankelijks.
 
-6. **Eerste concrete vervolgstap: fase 4 — de OTAP-doorloop uitbreiden.** Fase 1 en 2 zijn op 2026-07-31 afgerond, fase 3 op 2026-08-03.
+6. **Eerste concrete vervolgstap: fase 4 — de OTAP-doorloop uitbreiden.** Fase 1 en 2 zijn op 2026-07-31 afgerond, fase 3 en 2b op 2026-08-03.
 
    **Wat er nu werkt en zichtbaar is:**
 
    ```
-   /beheer/leveranciers   lijst + aanmaakformulier met contactpersoon
+   /beheer/leveranciers   sidebar + lijst met zoeken + aanmaakformulier
    npm run seed:demo      demo-tenant: 21 leveranciers, 3 gebruikers, 3 responses
-   npm run verify:volledig   code → 161 unit → 236 e2e → stack → 6 browsertests
+   npm run verify:volledig   code → 161 unit → 241 e2e → stack → 14 browsertests
    ```
 
    **Inloggen via Entra werkt aantoonbaar.** Eén echte login doorlopen: code inwisselen, token verifiëren met de échte applicatiecode, gebruiker en membership, sessie via `clm.sessie_aanmaken()`, en met dat cookie `/vendors` → 200. Zonder cookie → 401.
@@ -85,8 +85,8 @@ Blijken ze over een half jaar nog steeds ongebruikt, dan kunnen ze weg — de ke
 npm run verify:volledig
 ```
 
-Vijf stappen: code, 161 unittests, 236 e2e tegen een wegwerpdatabase, beide
-productie-images bouwen, zes browsertests, en altijd opruimen. Stopt bij de
+Vijf stappen: code, 161 unittests, 241 e2e tegen een wegwerpdatabase, beide
+productie-images bouwen, veertien browsertests, en altijd opruimen. Stopt bij de
 eerste rode stap en noemt welke CI-job dat is.
 
 **Let op bij handmatig een testcontainer draaien:** `verify:volledig` claimt poort
@@ -149,6 +149,32 @@ cd ../MCM2-frontend && npm run dev
 # Daarna de browsertest, met een VERSE tokenlink (indienen is eenmalig):
 cd ../MCM2-frontend && SURVEY_TOKEN=<verse-link> npm run e2e
 ```
+
+## Beheerkant — sidebar, schermindeling en zoeken (2026-08-03, fase 2b)
+
+De beheerkant lijkt nu op MVM_V2: navigatiekolom links, titelbalk boven, de huisstijlkleuren. Aanleiding was de vraag van de eigenaar waarom het er zo anders uitzag — en het antwoord was dat fase 2 als "af" was afgevinkt terwijl alleen de kleuren waren overgenomen, niet de layout. Het plan vroeg letterlijk om "sidebar, kleuren, typografie, schermindeling".
+
+**Nieuw in de backend: `GET /auth/sessie`.** De frontend wist niet wie er was ingelogd — het sessiecookie is `httpOnly` en dus onleesbaar voor JavaScript. Deze route geeft naam, tenantnaam en rol; **geen tenantId, userId of sessieId**, want wat er niet in staat kan ook niet in een URL belanden (§6).
+
+**Nieuw in de frontend:** `Sidebar.tsx`, `AppLayout.tsx` (beide uit MVM_V2, met bronvermelding), zoeken op naam/KvK/plaats, en `magZien()` — de ene plek die bepaalt of iemand een menu-item ziet.
+
+**Drie dingen bewust anders dan MVM_V2:**
+
+- **Alleen menu-items die werken.** MVM_V2 heeft er zes; hier bestaat alleen Leveranciers.
+- **Geen gebruikersschakelaar.** Die zou een tweede pad naar identiteit zijn naast het sessiecookie.
+- **Geen verborgen knoppen bij open routes.** `POST /vendors` staat open voor elke geldige sessie, ook voor een `reviewer`. De knop verbergen zou de indruk wekken dat er een rechtenmodel is dat er niet is.
+
+**De tegenproef vond een echt gat, de zesde keer in dit project.** Met een `tenantId` toegevoegd aan `/auth/sessie` bleven **alle acht browsertests groen** — de sidebar toont dat veld niet, dus het kwam nooit in beeld terwijl het wél over de lijn ging. Een lek hoort bij de bron getest te worden; `test/sessie-route.e2e-spec.ts` controleert nu het antwoord zelf, en daar vallen met de sabotage twee tests om.
+
+**Feature flags: ontworpen, niet gebouwd.** De eigenaar wees op twee lagen — betaalde features per tenant én verschillen per gebruiker binnen een tenant. Uitgewerkt in `docs/superpowers/specs/2026-08-03-feature-flags-en-rechten.md`, inclusief drie manieren om laag 1 vast te leggen en een advies. **Besluit ligt bij de eigenaar.** Vier openstaande vragen staan in §7 van dat document; geen daarvan blokkeert fase 4.
+
+### Onregelmatig falende doorloop opgelost
+
+`verify:volledig` faalde wisselend op `psql: connection to server on socket … failed: No such file or directory` — een melding die naar de verkeerde oorzaak wijst, want de container was gezond.
+
+Oorzaak: het `postgres`-image start tijdens de **eerste initialisatie** een tijdelijke server die alleen op de Unix-socket luistert. `pg_isready` meldt die als "accepting connections", waarna het image hem stopt en de echte server start. Een `psql` die precies daartussen valt, faalt.
+
+De wachtlus eist nu **twee opeenvolgende geslaagde queries** in plaats van één `pg_isready`. Daarna vijf runs achter elkaar groen.
 
 ## Demo-tenant — één commando, geen klantdata (2026-08-03, fase 3)
 

--- a/docs/superpowers/plans/2026-07-30-beheerkant-en-demo-tenant.md
+++ b/docs/superpowers/plans/2026-07-30-beheerkant-en-demo-tenant.md
@@ -20,6 +20,7 @@ Branch `feat/identiteit-en-membership`, vijf commits, nog niet gepusht.
 | **1** | Auth-routes `/auth/login`, `/auth/callback`, `/auth/logout` | ✅ |
 | **1** | `X-Tenant-Id` verwijderen | ✅ bleek niets te verwijderen — zie hieronder |
 | **2** | Vendorroutes en schermen | ✅ gemerged 2026-07-31 (MCM2#67, frontend#2) |
+| **2b** | Sidebar, schermindeling en zoeken | ✅ 2026-08-03 — het deel van fase 2 dat was blijven liggen |
 | **3** | Demo-tenant seed | ✅ 2026-08-03 — `npm run seed:demo`, 8 e2e-tests, tegenproef vond een echt gat |
 | 4 | OTAP-doorloop uitgebreid | niet gestart |
 
@@ -216,6 +217,52 @@ zou tegenhouden.
 
 **Klaar wanneer:** je logt in als tenant, maakt een vendor aan met contactpersoon en
 e-mailadres, en ziet die terug in de lijst — in de browser, tegen de echte backend.
+
+#### Fase 2b — wat er van 2b was blijven liggen (uitgevoerd 2026-08-03)
+
+Fase 2 is op 2026-07-31 afgevinkt terwijl de frontend-helft maar deels gedaan was.
+Van "sidebar, kleuren, typografie, schermindeling" hierboven waren alleen de
+kleuren en typografie overgenomen; de sidebar en de schermindeling niet. Dat viel
+op toen de eigenaar vroeg waarom het er anders uitzag dan MVM_V2.
+
+**Gebouwd:**
+
+- `Sidebar.tsx` en `AppLayout.tsx`, overgenomen uit MVM_V2 met bronvermelding.
+- Zoeken op de leverancierslijst (naam, KvK, plaats; losse woorden).
+- `GET /auth/sessie` in de backend — de frontend wist niet wie er was ingelogd.
+
+**Drie dingen bewust anders dan MVM_V2:**
+
+- **Alleen menu-items die werken.** MVM_V2 toont er zes; hiervan bestaat alleen
+  Leveranciers. Een menu-item naar een lege pagina belooft iets dat er niet is.
+- **Geen gebruikersschakelaar.** MVM_V2 heeft er een voor demo's op mock data;
+  hier zou dat een tweede pad naar identiteit zijn naast het sessiecookie —
+  precies wat Issue #7 uitsluit.
+- **Geen verborgen knoppen bij open routes.** `POST /vendors` staat open voor elke
+  geldige sessie, dus ook voor een `reviewer`. De knop verbergen zou de indruk
+  wekken dat er een rechtenmodel is. Zie het rechten-ontwerp §6.
+
+**De tegenproef vond opnieuw een echt gat.** Met een `tenantId` toegevoegd aan het
+antwoord van `/auth/sessie` bleven **alle acht browsertests groen**: de sidebar
+toont dat veld niet, dus het kwam nooit in beeld terwijl het wél over de lijn
+ging. Een lek test je bij de bron, niet bij de plek waar je hoopt dat het niet
+opduikt — vandaar `test/sessie-route.e2e-spec.ts`, die het antwoord zelf
+controleert. Met de sabotage erin vallen daar twee tests om.
+
+**Bijvangst: een onregelmatig falende doorloop opgelost.** `verify:volledig` faalde
+wisselend op `psql: connection to server on socket … failed`. Oorzaak: het
+postgres-image start tijdens de eerste initialisatie een *tijdelijke* server die
+alleen op de Unix-socket luistert; `pg_isready` meldt die als gereed, waarna het
+image herstart. Een `psql` die daartussen valt, faalt met een melding die naar de
+verkeerde oorzaak wijst. De wachtlus eist nu twee opeenvolgende geslaagde
+queries. Daarna vijf runs achter elkaar groen.
+
+**Feature flags zijn níét gebouwd.** De eigenaar wees erop dat die twee lagen
+kennen — betaalde features per tenant, én verschillen per gebruiker binnen een
+tenant. Dat is uitgewerkt in
+`docs/superpowers/specs/2026-08-03-feature-flags-en-rechten.md`, met drie manieren
+om laag 1 vast te leggen en een advies. Besluit ligt bij de eigenaar; 2b bouwt
+alleen `magZien()`, de plek waar beide lagen straks samenkomen.
 
 ---
 

--- a/docs/superpowers/specs/2026-08-03-feature-flags-en-rechten.md
+++ b/docs/superpowers/specs/2026-08-03-feature-flags-en-rechten.md
@@ -1,0 +1,230 @@
+# Ontwerp — feature flags en rechten: twee lagen, één poort
+
+**Datum:** 2026-08-03
+**Status:** ONTWERP — niet gebouwd, geen migratie, geen besluit gevraagd op de invulling
+**Aanleiding:** bij fase 2b (sidebar) bleek dat de vraag "wie mag dit menu-item zien"
+twee verschillende antwoorden nodig heeft die vandaag geen van beide bestaan.
+**Raakt:** fase 2b, Issue #57 (platformbeheer), ADR-006
+
+---
+
+## 0. Waarom dit document er is
+
+De sidebar van MVM_V2 verbergt menu-items op twee gronden tegelijk. Dat is te zien
+in `MVM_V2/src/shared/components/layout/Sidebar.tsx`:
+
+```ts
+const itCompliancyEnabled = useFeatureFlag(transdevConfig, 'itCompliancyCockpit')
+const isAdmin            = canDo(currentUser.role, 'user.manage')
+```
+
+Twee aanroepen, twee bronnen, twee betekenissen. Bij het overnemen van die sidebar
+naar MCM2 moet duidelijk zijn wélke van de twee je aan het bouwen bent — anders
+ontstaat er één vage `magDitZien()` waarin een ingekochte module en een
+persoonlijke bevoegdheid door elkaar lopen. Dat is precies het soort verwarring
+dat later een beveiligingsfout wordt.
+
+De eigenaar formuleerde het onderscheid op 2026-08-03 zo:
+
+> feature flags hebben 2 soorten gebruik: sommige tenants hebben meer features
+> (betaald) dan anderen en binnen een tenant hebben sommige gebruikers meer
+> features tot hun beschikking dan anderen
+
+Dit document werkt dat uit. **Er wordt niets gebouwd op basis hiervan** tot de
+eigenaar de invulling heeft gekozen; fase 2b bouwt alleen de plek waar de twee
+lagen samenkomen.
+
+---
+
+## 1. De twee lagen
+
+| | Laag 1 — **tenantrecht** | Laag 2 — **gebruikersrecht** |
+|---|---|---|
+| Vraag | Heeft deze klant deze functie? | Mag deze persoon deze functie? |
+| Verandert bij | een contract, een upgrade | een functiewissel, een nieuwe collega |
+| Wie beheert | Bizaline (leverancier) | de beheerder van de klant |
+| Voorbeeld | "Transdev heeft de IT-compliancemodule" | "Sophie mag leveranciers aanmaken, Mark alleen lezen" |
+| Bestaat in MCM2 | **nee** | **deels** — `tenant_membership.role` |
+
+**Ze vermenigvuldigen, ze vervangen elkaar niet.** Een menu-item is zichtbaar als
+de tenant de feature heeft **én** de gebruiker het recht. De volgorde van
+controleren doet er niet toe voor de uitkomst, wél voor de foutmelding: "uw
+organisatie heeft deze module niet" is iets anders dan "u heeft hier geen
+toegang toe", en een gebruiker die het verschil niet krijgt te horen belt de
+verkeerde persoon.
+
+### Waarom niet één lijst rechten
+
+De verleiding is om laag 1 op te lossen door de tenantbeheerder simpelweg geen
+rechten uit te delen voor wat niet is ingekocht. Dat werkt niet:
+
+- **Het is omkeerbaar door de verkeerde partij.** Een tenantbeheerder die alle
+  rechten mag uitdelen, kan zichzelf een niet-betaalde module toekennen.
+- **Het overleeft geen upgrade.** Koopt de klant de module alsnog, dan moet
+  iemand handmatig bij alle bestaande gebruikers het recht bijzetten.
+- **Het maakt facturatie onbewijsbaar.** "Welke klanten gebruiken module X" is
+  dan een vraag over rechtenrijen in plaats van over één veld per tenant.
+
+---
+
+## 2. Wat er vandaag is
+
+**Laag 2, gedeeltelijk.** `clm.tenant_membership.role` is `admin` of `reviewer`,
+met een CHECK-constraint op die twee waarden (migratie 0009). De rol reist mee tot
+in de sessie: `clm.sessie_oplossen()` geeft hem terug
+(`RETURNS TABLE (sessie_id, user_id, tenant_id, role)`, migratie 0010) en
+`SessieService` leest hem uit.
+
+**De frontend kan er niet bij.** Er is geen route die de huidige sessie
+teruggeeft: `/auth/login`, `/auth/callback` en `/auth/logout`, meer niet. Een
+sidebar die de naam van de ingelogde gebruiker toont of een knop verbergt voor
+een reviewer, heeft die route nodig. Dat is het enige echte gat dat fase 2b moet
+dichten.
+
+**Laag 1 bestaat nergens.** Niet op `clm.tenant`, niet in de frontend, niet in de
+configuratie.
+
+---
+
+## 3. Twee rollen zijn te grof, en dat is nu geen probleem
+
+`admin` en `reviewer` dekken de huidige twee handelingen (beheren, beoordelen).
+Zodra er een derde soort gebruiker komt — iemand die alleen rapportages leest,
+of iemand die wél vragenlijsten opstelt maar geen leveranciers beheert — is de
+tweedeling op. Dat is te voorzien maar nog niet aan de orde.
+
+**Het advies is om nu níét naar losse permissies te gaan.** MVM_V2 doet dat wel
+(`canDo(role, 'user.manage')`), en dat is de juiste eindvorm. Maar een
+permissiemodel ontwerpen tegen twee bestaande rollen levert een abstractie op
+voor een probleem dat je nog niet kent. De goedkope voorbereiding is de aanroep
+zó te schrijven dat de vervanging later lokaal blijft:
+
+```ts
+// Nu: één regel, leest de rol.
+// Straks: dezelfde aanroep, andere inhoud.
+magBeheren(sessie)   in plaats van   sessie.role === 'admin'
+```
+
+Wie overal `role === 'admin'` schrijft, moet later elke plek vinden. Wie één
+functie aanroept, vervangt de inhoud daarvan.
+
+---
+
+## 4. Drie manieren om laag 1 vast te leggen
+
+Niet gekozen — dit is de afweging die de eigenaar te zien krijgt.
+
+### A. Kolom op `clm.tenant`
+
+```sql
+ALTER TABLE clm.tenant ADD COLUMN feature_flags jsonb NOT NULL DEFAULT '{}';
+```
+
+**Voor:** één migratie, één plek, meteen bevraagbaar per tenant. De sessieroute
+kan de flags meteen meesturen, dus de frontend hoeft geen tweede verzoek.
+
+**Tegen:** `jsonb` betekent geen enkele controle op wat erin staat. Een typefout
+in een flagnaam (`itCompliancy` versus `itCompliancyCockpit`) levert stilzwijgend
+`false` op — precies de faalvorm die dit project elders juist vermijdt met
+CHECK-constraints. Te ondervangen met een `ref.feature`-tabel en een
+koppeltabel, maar dan is optie B eerlijker.
+
+### B. Referentietabel plus koppeltabel
+
+```sql
+ref.feature (code, label, omschrijving)
+clm.tenant_feature (tenant_id, feature_code, actief_vanaf, actief_tot)
+```
+
+**Voor:** een onbekende flagnaam is een foreign-key-fout, geen stille `false`.
+Sluit aan op hoe MCM2 `vendor_category` en `compliance_status` al doet. Met
+`actief_vanaf`/`actief_tot` is een proefperiode of een opgezegde module
+vastlegbaar, en is achteraf te zien wat wanneer aanstond — dat is een
+facturatievraag, niet alleen een technische.
+
+**Tegen:** twee tabellen en een migratie voor iets waarvan de eerste echte
+toepassing nog niet bestaat. Meer werk vooraf.
+
+### C. Configuratiebestand per tenant, zoals MVM_V2
+
+`tenant.config.ts` met een `featureFlags`-object, in de code.
+
+**Voor:** geen migratie, geen database, direct te lezen in de frontend. Werkt
+goed zolang er één klant is.
+
+**Tegen:** een feature aan- of uitzetten wordt een deploy. Bij MVM_V2 kan dat,
+want daar is de tenantmap onderdeel van de drielaagse klantaanpassing
+(`C:\dev\CLAUDE.md`). Voor MCM2 is het strijdig met de opzet: klantspecificiteit
+hoort in configuratie en data, en een betaalde module is data — hij verandert
+door een handtekening, niet door een release.
+
+**Neiging van de schrijver, geen besluit:** **B**, en pas bouwen wanneer de
+eerste echte betaalde feature bestaat. Tot dan is elke keuze een gok op de vorm.
+
+---
+
+## 5. Wat fase 2b hiervan bouwt
+
+Alleen dit, en bewust niet meer:
+
+1. **Een sessieroute** — `GET /auth/sessie` geeft terug wie is ingelogd
+   (naam, rol, tenantnaam). Zonder geldig cookie een 401. Dit is geen
+   voorbereiding op iets toekomstigs maar een gat van vandaag: de sidebar kan
+   anders geen naam tonen.
+
+2. **Eén functie in de frontend** waar de zichtbaarheid van een menu-item wordt
+   bepaald. Die leest nu uitsluitend de rol. De tenantlaag is er later één
+   controle bij, op één plek:
+
+   ```ts
+   // src/core/auth/rechten.ts — fase 2b
+   export function magZien(item: MenuItem, sessie: Sessie): boolean {
+     return item.vereistRol ? sessie.role === item.vereistRol : true;
+   }
+   // Later, wanneer laag 1 bestaat:
+   //   && (!item.vereistFeature || sessie.features.includes(item.vereistFeature))
+   ```
+
+**Uitdrukkelijk niet in 2b:** geen migratie, geen `featureFlags`-kolom, geen
+permissiemodel, geen tenantconfiguratie in de frontend.
+
+---
+
+## 6. De valkuil die dit document eigenlijk moet voorkomen
+
+**Een verborgen menu-item is geen beveiliging.** De sidebar bepaalt wat iemand
+*ziet*, niet wat iemand *kan*. Wie het adres kent, roept de route rechtstreeks
+aan.
+
+Dat is vandaag geen gat, want de backend controleert zelf: `TenantContextGuard`
+weigert zonder geldige sessie, RLS weigert data van een andere tenant. Maar
+zodra de eerste route "alleen voor admin" wordt, moet die controle in de
+**backend** staan — de sidebar mag hem hooguit weerspiegelen.
+
+Concreet: `POST /vendors` staat nu open voor elke geldige sessie, dus ook voor
+een `reviewer`. Verbergt 2b de knop "Leverancier toevoegen" voor reviewers, dan
+lijkt dat een rechtenmodel terwijl het een gordijn is. **Ofwel de route krijgt
+de controle erbij, ofwel de knop blijft zichtbaar** — de tussenvorm is de
+gevaarlijkste, want die wekt de indruk dat er iets geregeld is.
+
+Aanbeveling: in 2b de knop zichtbaar houden voor iedereen, en de rolcontrole op
+`POST /vendors` als eigen stap oppakken zodra duidelijk is wat een `reviewer`
+precies wel en niet mag. Dat is een productvraag, geen implementatiedetail.
+
+---
+
+## 7. Openstaande vragen voor de eigenaar
+
+Geen daarvan blokkeert fase 2b.
+
+1. **Welke features worden ooit apart verkocht?** Zonder één concreet voorbeeld
+   is de vorm van laag 1 niet te kiezen. De IT-compliancemodule van MVM_V2 is
+   de enige kandidaat die nu bekend is.
+2. **Mag een `reviewer` leveranciers aanmaken?** Nu wel (de route controleert
+   niets). Zo niet, dan is dat backendwerk — zie §6.
+3. **Komt er een derde rol?** Zo ja, dan is het permissiemodel uit §3 eerder aan
+   de orde dan gedacht.
+4. **Hoe verhoudt dit zich tot Issue #57** (platformbeheer-toegang tot
+   klant-tenants)? Een Bizaline-medewerker die meekijkt bij een klant is een
+   derde soort recht, buiten beide lagen. Dat issue staat al open en hoort hier
+   niet opgelost te worden.

--- a/scripts/verify-volledig.js
+++ b/scripts/verify-volledig.js
@@ -173,14 +173,34 @@ function startTestDatabase() {
   }
 
   // Wachten tot Postgres verbindingen accepteert.
-  for (let poging = 0; poging < 40; poging += 1) {
+  //
+  // `pg_isready` alleen is niet genoeg, en dat leverde een onregelmatig
+  // falende doorloop op (2026-08-03): het officiële postgres-image start
+  // tijdens de eerste initialisatie een *tijdelijke* server die alleen op de
+  // Unix-socket luistert. pg_isready meldt die als "accepting connections",
+  // waarna het image de server stopt en opnieuw start voor de echte. Een psql
+  // die precies daartussen valt, faalt met:
+  //
+  //   connection to server on socket "/var/run/postgresql/.s.PGSQL.5432"
+  //   failed: No such file or directory
+  //
+  // Een melding die naar de verkeerde oorzaak wijst — hij suggereert dat er
+  // geen server draait, terwijl de container gezond is.
+  //
+  // Daarom een echte query als bewijs van gereedheid, en pas doorgaan als die
+  // twee keer achter elkaar slaagt: één keer kan nog de tijdelijke server zijn.
+  let opeenvolgendGoed = 0;
+
+  for (let poging = 0; poging < 60; poging += 1) {
     const gereed = draai(
       'docker',
-      ['exec', TESTDB, 'pg_isready', '-U', 'postgres'],
+      ['exec', TESTDB, 'psql', '-U', 'postgres', '-tAc', '"SELECT 1"'],
       { stil: true },
     );
 
-    if (gereed.ok) {
+    opeenvolgendGoed = gereed.ok ? opeenvolgendGoed + 1 : 0;
+
+    if (opeenvolgendGoed >= 2) {
       const rollen = draai(
         'docker',
         ['exec', '-i', TESTDB, 'psql', '-U', 'postgres', '-q'],
@@ -228,7 +248,10 @@ function startTestDatabase() {
     });
   }
 
-  return { ok: false, reden: 'Postgres werd niet op tijd bereikbaar.' };
+  return {
+    ok: false,
+    reden: `Postgres in ${TESTDB} accepteerde binnen 60 seconden geen twee opeenvolgende queries. Bekijk 'docker logs ${TESTDB}'.`,
+  };
 }
 
 function stopTestDatabase() {

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -6,6 +6,7 @@ import {
   Req,
   Res,
   UnauthorizedException,
+  UseGuards,
 } from '@nestjs/common';
 import type { Request, Response } from 'express';
 
@@ -19,7 +20,11 @@ import {
   stateKlopt,
 } from './inlogpoging';
 import { cookieInstellingen } from './sessie';
-import { leesCookies, type RequestMetSessie } from './tenant-context.guard';
+import {
+  TenantContextGuard,
+  leesCookies,
+  type RequestMetSessie,
+} from './tenant-context.guard';
 
 /**
  * De drie routes van de inlogflow (Issue #7, spoor 1).
@@ -141,6 +146,47 @@ export class AuthController {
     });
 
     response.redirect(this.auth.naLoginBestemming());
+  }
+
+  /**
+   * Wie is er ingelogd, en met welke rol.
+   *
+   * De enige route in deze controller mét de guard. De andere drie bestaan om
+   * een sessie te krijgen of kwijt te raken; deze vereist er juist één en geeft
+   * 401 zonder.
+   *
+   * Bestaat omdat de frontend anders niets over de ingelogde gebruiker weet:
+   * het sessiecookie is httpOnly en dus onleesbaar voor JavaScript, en dat is
+   * met opzet — een token binnen JavaScript-bereik is een XSS-doelwit. De
+   * schermen hebben de naam nodig om te tonen wie er is, en de rol om te
+   * bepalen wat er zichtbaar hoort te zijn.
+   *
+   * **Geeft geen userId, sessieId of tenantId terug.** Een scherm heeft ze niet
+   * nodig — elke route leidt de tenant zelf af uit het cookie — en een tenantId
+   * in een antwoord is precies wat de CI-poort van de frontend verbiedt
+   * (MCM2-CLAUDE.md §6). Wat er niet in staat, kan ook niet per ongeluk in een
+   * URL belanden.
+   */
+  @Get('sessie')
+  @UseGuards(TenantContextGuard)
+  async huidigeSessie(@Req() request: RequestMetSessie) {
+    // Veilig: zonder sessie is de guard nooit voorbijgekomen.
+    const sessie = request.sessie!;
+
+    const profiel = await this.auth.profiel(sessie);
+
+    if (!profiel) {
+      // Geldige sessie, maar de gebruiker bestaat niet meer of is verwijderd.
+      // Zeldzaam — het membership zou dan ook weg moeten zijn — maar een lege
+      // naam in de sidebar is een raadsel voor wie hem ziet.
+      throw new UnauthorizedException('De gebruiker bestaat niet meer.');
+    }
+
+    return {
+      naam: profiel.naam,
+      tenantNaam: profiel.tenantNaam,
+      rol: sessie.role,
+    };
   }
 
   /**

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -8,7 +8,11 @@ import {
   type GeverifieerdeIdentiteit,
 } from './id-token-verificatie';
 import { Inlogpoging, codeChallenge, nieuweInlogpoging } from './inlogpoging';
-import { SessieService, type NieuweSessie } from './sessie.service';
+import {
+  SessieService,
+  type NieuweSessie,
+  type SessieContext,
+} from './sessie.service';
 
 /**
  * Bindt de vier bestaande bouwstenen aan elkaar tot één inlogflow:
@@ -146,6 +150,13 @@ export class AuthService {
   /** Beëindigt de sessie bij het ruwe token uit het cookie. */
   async uitloggen(ruwToken: unknown): Promise<void> {
     await this.sessies.beeindigen(ruwToken);
+  }
+
+  /** Naam en tenantnaam van de ingelogde gebruiker, voor de schermen. */
+  async profiel(
+    context: SessieContext,
+  ): Promise<{ naam: string; tenantNaam: string } | null> {
+    return this.sessies.profiel(context);
   }
 
   naLoginBestemming(): string {

--- a/src/auth/sessie.service.ts
+++ b/src/auth/sessie.service.ts
@@ -131,6 +131,42 @@ export class SessieService {
   }
 
   /**
+   * De gegevens die een scherm nodig heeft om te tonen wie er is ingelogd.
+   *
+   * Apart van oplossen(): die draait bij élk verzoek en moet zo klein mogelijk
+   * blijven. Dit is één extra query die alleen loopt wanneer een scherm er om
+   * vraagt — de sidebar, één keer per paginalading.
+   *
+   * Gaat door withTenant(), dus RLS geldt: de query kan per constructie geen
+   * gebruiker of tenant van iemand anders opleveren, ook niet bij een fout in
+   * de WHERE-clausule.
+   */
+  async profiel(
+    context: SessieContext,
+  ): Promise<{ naam: string; tenantNaam: string } | null> {
+    return this.db.withTenant(context.tenantId, async (tx) => {
+      const resultaat = await tx.execute<{
+        naam: string;
+        tenant_naam: string;
+      }>(
+        sql`SELECT u.full_name AS naam, t.name AS tenant_naam
+              FROM clm."user" u
+              JOIN clm.tenant t ON t.tenant_id = u.tenant_id
+             WHERE u.user_id = ${context.userId}
+               AND u.deleted_at IS NULL`,
+      );
+
+      const rij = resultaat.rows[0];
+
+      if (!rij) {
+        return null;
+      }
+
+      return { naam: rij.naam, tenantNaam: rij.tenant_naam };
+    });
+  }
+
+  /**
    * Beëindigt de sessie. Verwijdert de rij en ruimt meteen verlopen sessies op.
    *
    * Werpt niet bij een onbekend token: uitloggen moet altijd slagen. Wie op

--- a/test/sessie-route.e2e-spec.ts
+++ b/test/sessie-route.e2e-spec.ts
@@ -1,0 +1,175 @@
+import { INestApplication } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import cookieParser from 'cookie-parser';
+import { Client } from 'pg';
+import request from 'supertest';
+import type { App } from 'supertest/types';
+
+import { AppModule } from '../src/app.module';
+import { SessieService } from '../src/auth/sessie.service';
+import { cookieInstellingen } from '../src/auth/sessie';
+import { TEST_IDS } from './test-ids';
+
+/**
+ * GET /auth/sessie — wie is er ingelogd (fase 2b).
+ *
+ * ── Waarom deze suite bestaat ──────────────────────────────────────────────
+ * De browsertests in de frontend controleren wat er in de sidebar *terechtkomt*.
+ * Dat bleek niet genoeg: bij een tegenproef waarin de route een `tenantId`
+ * meestuurde, bleven alle acht browsertests groen — de sidebar toont dat veld
+ * namelijk niet, dus het kwam nooit in beeld terwijl het wél over de lijn ging.
+ *
+ * Een lek test je bij de bron, niet bij de plek waar je hoopt dat het niet
+ * opduikt. Vandaar deze suite, op het antwoord van de route zelf.
+ *
+ * ── Wat er niet in het antwoord hoort ──────────────────────────────────────
+ * Geen tenantId, userId of sessieId. MCM2-CLAUDE.md §6 verbiedt een tenant in
+ * de client, en er staat een CI-poort op de frontend die op datzelfde patroon
+ * afgaat. Wat de backend niet verstuurt, kan de frontend niet lekken.
+ */
+
+const TENANT = TEST_IDS['sessie-route'].tenant;
+const USER = TEST_IDS['sessie-route'].user;
+
+// Uniek per run: external_subject heeft een globale unieke index, dus een vaste
+// waarde laat een tweede run falen op een rij van de vorige.
+const SUBJECT = `oid-sessieroute-${Date.now()}`;
+
+const TENANT_NAAM = 'Sessieroute-test';
+const VOLLEDIGE_NAAM = 'Sanne Sessie';
+
+/** Wat de route hoort terug te geven — en niets anders. */
+interface SessieBody {
+  naam: string;
+  tenantNaam: string;
+  rol: string;
+}
+
+async function verwijderTestdata(client: Client): Promise<void> {
+  await client.query('BEGIN');
+  await client.query(`SET LOCAL app.current_tenant_id = '${TENANT}'`);
+  await client.query('DELETE FROM clm.tenant_membership WHERE tenant_id = $1', [
+    TENANT,
+  ]);
+  await client.query('DELETE FROM clm."user" WHERE tenant_id = $1', [TENANT]);
+  await client.query('DELETE FROM clm.tenant WHERE tenant_id = $1', [TENANT]);
+  await client.query('COMMIT');
+}
+
+describe('GET /auth/sessie (e2e)', () => {
+  let app: INestApplication<App>;
+  let server: App;
+  let client: Client;
+  let sessies: SessieService;
+  let token: string;
+
+  const cookieNaam = cookieInstellingen().naam;
+
+  beforeAll(async () => {
+    client = new Client({ connectionString: process.env.DATABASE_URL });
+    await client.connect();
+    await verwijderTestdata(client);
+
+    await client.query('BEGIN');
+    await client.query(`SET LOCAL app.current_tenant_id = '${TENANT}'`);
+    await client.query(
+      'INSERT INTO clm.tenant (tenant_id, name) VALUES ($1, $2)',
+      [TENANT, TENANT_NAAM],
+    );
+    await client.query(
+      `INSERT INTO clm."user" (user_id, tenant_id, full_name, external_subject)
+       VALUES ($1, $2, $3, $4)`,
+      [USER, TENANT, VOLLEDIGE_NAAM, SUBJECT],
+    );
+    await client.query(
+      `INSERT INTO clm.tenant_membership (user_id, tenant_id, role)
+       VALUES ($1, $2, 'admin')`,
+      [USER, TENANT],
+    );
+    await client.query('COMMIT');
+
+    const moduleRef = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleRef.createNestApplication();
+    app.use(cookieParser());
+    await app.init();
+
+    server = app.getHttpServer();
+    sessies = app.get(SessieService);
+
+    // Een échte sessie via sessie_aanmaken(), inclusief membershipcontrole.
+    const sessie = await sessies.aanmaken(SUBJECT);
+    token = sessie!.token;
+  });
+
+  afterAll(async () => {
+    await sessies.beeindigen(token);
+    await app.close();
+    await verwijderTestdata(client);
+    await client.end();
+  });
+
+  // ── Toegang ──────────────────────────────────────────────────────────────
+
+  it('geeft 401 zonder cookie', async () => {
+    await request(server).get('/auth/sessie').expect(401);
+  });
+
+  it('geeft 401 bij een onbekend token', async () => {
+    await request(server)
+      .get('/auth/sessie')
+      .set('Cookie', `${cookieNaam}=${'z'.repeat(43)}`)
+      .expect(401);
+  });
+
+  it('geeft de naam, tenantnaam en rol bij een geldige sessie', async () => {
+    const antwoord = await request(server)
+      .get('/auth/sessie')
+      .set('Cookie', `${cookieNaam}=${token}`)
+      .expect(200);
+
+    expect(antwoord.body).toEqual({
+      naam: VOLLEDIGE_NAAM,
+      tenantNaam: TENANT_NAAM,
+      rol: 'admin',
+    });
+  });
+
+  // ── Wat er níét in mag ───────────────────────────────────────────────────
+
+  it('stuurt geen tenantId, userId of sessieId mee', async () => {
+    const antwoord = await request(server)
+      .get('/auth/sessie')
+      .set('Cookie', `${cookieNaam}=${token}`)
+      .expect(200);
+
+    // toEqual hierboven dekt dit al, maar deze test benoemt wát er niet mag en
+    // waarom. Zonder hem leest de volgende ontwikkelaar `toEqual` als "dit is
+    // wat er nu in zit" in plaats van "dit is de volledige toegestane lijst",
+    // en dan is een veld erbij zetten een kleine wijziging in plaats van een
+    // besluit.
+    const body = antwoord.body as SessieBody;
+    const ruw = JSON.stringify(body);
+
+    expect(ruw).not.toContain(TENANT);
+    expect(ruw).not.toContain(USER);
+    expect(Object.keys(body).sort()).toEqual(['naam', 'rol', 'tenantNaam']);
+
+    // Geen enkel veld dat op een UUID lijkt. Vangt ook een id dat onder een
+    // andere naam meelift.
+    expect(ruw).not.toMatch(/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}/i);
+  });
+
+  it('stuurt het ruwe sessietoken niet terug', async () => {
+    const antwoord = await request(server)
+      .get('/auth/sessie')
+      .set('Cookie', `${cookieNaam}=${token}`)
+      .expect(200);
+
+    // Het cookie is httpOnly zodat JavaScript er niet bij kan. Het token in het
+    // antwoord zetten zou die bescherming ongedaan maken langs de achterdeur.
+    expect(JSON.stringify(antwoord.body)).not.toContain(token);
+  });
+});

--- a/test/test-ids.ts
+++ b/test/test-ids.ts
@@ -81,6 +81,10 @@ export const TEST_IDS = {
     tenantA: id('a2'),
     tenantB: id('a3'),
   },
+  'sessie-route': {
+    tenant: id('8a'),
+    user: id('8b'),
+  },
   'tenant-context-guard': {
     tenantA: id('9a'),
     tenantB: id('9b'),


### PR DESCRIPTION
Backendhelft van fase 2b, plus twee regels die alleen als gewoonte bestonden.

Hoort bij **MCM2-frontend#3** — beide zijn nodig; los gemerged toont de sidebar geen gebruikersnaam.

## `GET /auth/sessie`

De frontend wist niet wie er was ingelogd: het sessiecookie is `httpOnly` en dus onleesbaar voor JavaScript — met opzet, want een token binnen JavaScript-bereik is een XSS-doelwit. Zonder route hierheen kan geen enkel scherm een naam tonen.

Geeft naam, tenantnaam en rol. De enige route in `AuthController` **mét** de guard; de andere drie bestaan juist om een sessie te krijgen of kwijt te raken.

**Geen tenantId, userId of sessieId.** Een scherm heeft ze niet nodig — elke route leidt de tenant zelf af uit het cookie — en wat er niet in staat, kan ook niet per ongeluk in een URL belanden (§6).

## De tegenproef vond een echt gat

Met een `tenantId` toegevoegd aan het antwoord bleven **alle acht browsertests in de frontend groen**: de sidebar toont dat veld niet, dus het kwam nooit in beeld terwijl het wél over de lijn ging.

Een lek hoort bij de bron getest te worden, niet bij de plek waar je hoopt dat het niet opduikt. Vandaar `test/sessie-route.e2e-spec.ts`, dat het antwoord zelf controleert — met de sabotage erin vallen daar twee tests om.

## Feature flags: ontworpen, niet gebouwd

De eigenaar wees erop dat die twee lagen kennen, en dat ze vermenigvuldigen:

| Laag | Vraag | Bestaat in MCM2 |
|---|---|---|
| 1 — tenantrecht | heeft deze klant deze functie (betaald)? | **nee** |
| 2 — gebruikersrecht | mag deze persoon deze functie? | deels (`tenant_membership.role`) |

`docs/superpowers/specs/2026-08-03-feature-flags-en-rechten.md` beschrijft drie manieren om laag 1 vast te leggen, met een advies (referentietabel plus koppeltabel, en pas bouwen bij de eerste echte betaalde feature). **Besluit ligt bij de eigenaar**; vier openstaande vragen in §7, geen daarvan blokkeert fase 4.

## Bijvangst: onregelmatig falende doorloop opgelost

`verify:volledig` faalde wisselend op `psql: connection to server on socket … failed` — een melding die naar de verkeerde oorzaak wijst, want de container was gezond.

Het `postgres`-image start tijdens de eerste initialisatie een **tijdelijke** server die alleen op de Unix-socket luistert. `pg_isready` meldt die als gereed, waarna het image hem stopt en de echte start. Een `psql` die daartussen valt, faalt. De wachtlus eist nu twee opeenvolgende geslaagde queries; daarna vijf runs achter elkaar groen.

## §15a en §15b

Beide regels bestonden alleen als gewoonte, of in een plan dat straks af is — en dan verdwijnt de kennis met het document.

- **§15a** — `verify:volledig` is de norm voor "groen". `verify` dekt het productie-image en de schermen niet, en juist daar ging het twee keer mis (een image dat niet startte, en Issue #42/#43 die door de browser zijn gevonden en door 155 backendtests gemist). Plus de poortenval: 55441 versus 55500 versus 55440.
- **§15b, nieuw** — groene tests zonder tegenproef bewijzen niets, met alle zes gevallen uit dit project in een tabel. Twee daarvan bleven volledig groen bij een echt lek.

## Geverifieerd

`npm run verify:volledig`: 161 unittests, **241 e2e** (5 nieuw), **14 browsertests** (was 6) — groen, twee runs achter elkaar. `npm audit --omit=dev` blijft 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)