### PR TITLE
De database kent het verschil tussen medewerker en leverancier

### DIFF
--- a/MCM2-CLAUDE.md
+++ b/MCM2-CLAUDE.md
@@ -542,7 +542,7 @@ Daarna herstellen, en controleren dat het bestand weer identiek is
 
 **Waarom dit een harde regel is.** Een test die groen is bij een werkende
 implementatie én groen blijft bij een kapotte, meet niets. Dat klinkt
-theoretisch tot het gebeurt, en in dit project is het **zes keer** gebeurd:
+theoretisch tot het gebeurt, en in dit project is het **negen keer** gebeurd:
 
 | Wanneer | Sabotage | Wat de tests deden |
 |---|---|---|
@@ -552,14 +552,30 @@ theoretisch tot het gebeurt, en in dit project is het **zes keer** gebeurd:
 | 2026-07-30 | `instruction`-tak uit het portaal | 3 controles vielen om, zoals bedoeld |
 | 2026-08-03 | tokenhash vervangen door hex-codering | **alle 8 tests bleven groen** — de test keek naar de vórm van de hash, niet of het de hash ís |
 | 2026-08-03 | `tenantId` toegevoegd aan `/auth/sessie` | **alle 8 browsertests bleven groen** — de sidebar toont dat veld niet, dus het kwam nooit in beeld |
+| 2026-08-03 | `withTenant()` zet de actor altijd op `medewerker` | 2 tests vielen om, zoals bedoeld |
+| 2026-08-03 | standaardactor omgedraaid naar `medewerker` i.p.v. `onbekend` | 3 tests vielen om, zoals bedoeld |
+| 2026-08-03 | leverancierspad kondigt zich aan als `medewerker` | **alle 268 tests bleven groen** — er was nog geen policy die de actor gebruikt, dus niets kon het merken |
 
-Twee van de zes keer bleven de tests volledig groen bij een echt lek. Beide
-keren was de test op de verkeerde plek geschreven.
+Drie van de negen keer bleven de tests volledig groen bij een echt lek. Drie
+keer was de test op de verkeerde plek geschreven — of hij bestond nog niet.
 
-**De les uit die twee.** Test een lek **bij de bron**, niet bij de plek waar je
-hoopt dat het niet opduikt. Een browsertest die controleert wat er in een scherm
-terechtkomt, mist alles wat wél over de lijn gaat maar niet getoond wordt. Het
-antwoord van de route zelf controleren vangt dat wel.
+**De les uit de eerste twee.** Test een lek **bij de bron**, niet bij de plek
+waar je hoopt dat het niet opduikt. Een browsertest die controleert wat er in een
+scherm terechtkomt, mist alles wat wél over de lijn gaat maar niet getoond wordt.
+Het antwoord van de route zelf controleren vangt dat wel.
+
+**De les uit de derde is nieuw en scherper.** Migratie 0013 voegt
+`app.current_actor` toe zonder één policy die hem gebruikt — bewust, zodat hij
+apart groen kan zijn. Gevolg: tussen migratie 0013 en 0014 kan een pad zich als
+de verkeerde actor aankondigen zonder dat íéts dat merkt. Niet omdat de test op
+de verkeerde plek staat, maar omdat er nog geen gedrag is om te meten.
+
+Dat venster is precies wanneer iemand een nieuwe route bouwt en de actor
+overneemt van het verkeerde voorbeeld. **Bouw je een grens in twee stappen, dan
+hoort er in stap één een test die de afspraak zelf bewaakt** — desnoods door de
+broncode te lezen, zoals `actor-context.e2e-spec.ts` doet en `test-ids.spec.ts`
+al deed. Wachten tot stap twee betekent dat de fout er ondertussen in kan
+sluipen.
 
 **Wanneer verplicht:** bij elke wijziging aan RLS-policies, guards, tokens,
 sessies, rolcontroles of iets anders dat bepaalt wie wat mag zien. Niet nodig

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,7 +1,14 @@
 # MCM2 — actuele status
 
 ## Laatst bijgewerkt
-2026-08-03 (**fase 2b, 2c en 3 zijn af**: demo-tenant met één commando, de sidebar en schermindeling van MVM_V2, zoeken, en een detailscherm waarop een leverancier te wijzigen is. Een `reviewer` mag nu aantoonbaar lezen maar niet schrijven. 264 e2e-tests en 25 browsertests groen. Twee dingen die aandacht vragen staan onder "Actieve blokkades": de dagelijkse backup heeft drie dagen stilgelegen, en er staat een productiewachtwoord in de git-historie van `mvm-api-pilot`.)
+2026-08-03, avond (**`app.current_actor` toegevoegd**: de database kan sinds migratie 0013 onderscheid maken tussen een medewerker en een leverancier. Dat kon hij niet — `withTenant()` zette alleen de tenant, en beide paden riepen hem identiek aan. Nodig voor de beoordelingstabel uit het surveybeheerplan, waar "zelfde tenant = mag het zien" voor het eerst níét opgaat. 269 e2e-tests en 25 browsertests groen. Drie tegenproeven gedaan; de derde bleef groen en leverde een nieuwe les op — zie hieronder.)
+
+<details>
+<summary>Vorige stand (2026-08-03, middag)</summary>
+
+**fase 2b, 2c en 3 zijn af**: demo-tenant met één commando, de sidebar en schermindeling van MVM_V2, zoeken, en een detailscherm waarop een leverancier te wijzigen is. Een `reviewer` mag nu aantoonbaar lezen maar niet schrijven. 264 e2e-tests en 25 browsertests groen. Twee dingen die aandacht vragen staan onder "Actieve blokkades": de dagelijkse backup heeft drie dagen stilgelegen, en er staat een productiewachtwoord in de git-historie van `mvm-api-pilot`.
+
+</details>
 
 <details>
 <summary>Vorige stand (2026-07-31, avond)</summary>
@@ -154,6 +161,42 @@ cd ../MCM2-frontend && npm run dev
 # Daarna de browsertest, met een VERSE tokenlink (indienen is eenmalig):
 cd ../MCM2-frontend && SURVEY_TOKEN=<verse-link> npm run e2e
 ```
+
+## De database kent nu het verschil tussen medewerker en leverancier (2026-08-03, migratie 0013)
+
+**Wat er ontbrak.** `DatabaseService.withTenant()` zette precies één sessievariabele: `app.current_tenant_id`. Het leverancierspad (tokenlookup) en het medewerkerspad (sessiecookie) riepen die functie identiek aan, met dezelfde tenantId. Elke policy luidt `USING (tenant_id = clm.current_tenant_id())`.
+
+Gemeten op 2026-08-03: **de database kon geen onderscheid maken tussen een medewerker en een leverancier van dezelfde tenant.** Voor elke bestaande tabel is dat juist — een leverancier hoort zijn eigen respons te kunnen lezen. Het wordt pas een probleem bij de beoordelingstabel uit `docs/superpowers/plans/2026-08-03-surveybeheer.md`: daar mag de leverancier het oordeel over zichzelf níét zien, ook al staat het in zijn tenant.
+
+Zonder deze migratie zou die bescherming volledig bestaan uit de afwezigheid van een route die het oordeel teruggeeft — hetzelfde faalpatroon als tegenproef 6.
+
+**Wat er nu staat.** `app.current_actor` met waarden `medewerker`, `leverancier` en `onbekend`, gelezen via `clm.current_actor()`. Niet gezet betekent `onbekend`, en dat is de striktste stand: een vergeten actor faalt dicht, niet open.
+
+De migratie **verandert bewust geen gedrag** — geen enkele bestaande policy leunt erop. De eerste die dat doet is migratie 0014 (`survey_review`).
+
+**Waarom de parameter optioneel is en toch verplicht.** In de signatuur optioneel, omdat verplicht maken ~70 testregels zou raken die niets met dit onderwerp te maken hebben — ruis in precies de tests die de tenantgrens bewijzen. In de praktijk verplicht, omdat weglaten `onbekend` oplevert en een nieuwe test de leverancierspaden bewaakt.
+
+### Drie tegenproeven, en de derde leverde een nieuwe les
+
+| Sabotage | Uitkomst |
+|---|---|
+| `withTenant()` zet de actor altijd op `medewerker` | 2 tests vielen om, zoals bedoeld |
+| standaard omgedraaid naar `medewerker` i.p.v. `onbekend` | 3 tests vielen om, zoals bedoeld |
+| `vragenlijst-lezen.service.ts` kondigt zich aan als `medewerker` | **alle 268 tests bleven groen** |
+
+Die derde is het ernstigste wat er met dit mechanisme mis kan gaan: een leverancier die zich als medewerker voordoet, krijgt straks toegang tot beoordelingen over zichzelf. Niets merkte het.
+
+**Terecht en tegelijk onacceptabel.** Terecht, want er was nog geen policy die de actor gebruikt — er viel niets te meten. Onacceptabel, want daarmee is de doorgifte tot migratie 0014 volledig onbewaakt, en dat is precies het venster waarin iemand een nieuwe survey-route bouwt en de actor van het verkeerde voorbeeld overneemt.
+
+Opgelost met een test die de broncode zelf leest (`actor-context.e2e-spec.ts`, laatste test) — lelijker dan een gedragstest, maar het verschil tussen een bewaakte afspraak en een goed voornemen. Dezelfde afweging als `test-ids.spec.ts`. Na toevoeging faalt de sabotage wél.
+
+De les staat in MCM2-CLAUDE.md §15b: **bouw je een grens in twee stappen, dan hoort er in stap één een test die de afspraak zelf bewaakt.**
+
+### Bijvangst: een test met een te krappe tijdslimiet
+
+`demo-seed.e2e-spec.ts` viel reproduceerbaar om op een timeout van 5 s. Niet door deze wijziging — het seed-script gebruikt zijn eigen `set_config` en raakt `withTenant()` niet. De test start dat script twee keer als apart Node-proces (~1,6 s per keer, gemeten), wat binnen 5 s alleen past als de machine niets anders doet. In de volledige suite doet hij dat wel.
+
+De foutmelding wees naar hashing terwijl er niets mis was met hashing — dezelfde verwarrende faalvorm als de botsende test-id's van 2026-07-31. Twee tests hebben nu een limiet van 20 s met de reden erbij.
 
 ## Beheerkant — detail, wijzigen en rolcontrole (2026-08-03, fase 2c)
 

--- a/docs/runbooks/otap-doorloop.md
+++ b/docs/runbooks/otap-doorloop.md
@@ -31,9 +31,25 @@ uitrollen werkt".
 - `MCM2-frontend` staat als zustermap naast `MCM2`
 - Poorten 3000, 5001 en 55500 zijn vrij
 
-> **Poort 3000 is de gebruikelijke struikelblok.** Een `npm run dev` die nog
-> draait houdt hem bezet en de stack weigert te starten met "ports are not
-> available". Sluit die eerst af.
+> **Poort 3000 en 5001 zijn de gebruikelijke struikelblokken.** Een `npm run dev`
+> of `npm run start:prod` die nog draait houdt ze bezet, en Docker weigert dan te
+> starten met "ports are not available".
+>
+> **`npm run verify:volledig` controleert dit sinds 2026-08-03 vooraf** en stopt
+> binnen enkele seconden met een melding die vertelt welke poort bezet is en hoe
+> je het proces vindt. Daarvóór strandde de doorloop pas ná stap 1 — enkele
+> minuten aan tests en een wegwerpdatabase voor niets, met een foutmelding van
+> Docker die niet zei wélk proces in de weg zat.
+>
+> Het script sluit die processen bewust **niet** zelf af: dat is meestal een
+> dev-server die iemand zelf heeft gestart.
+>
+> Er zat ook een correctheidsprobleem in. `wachtOpStack()` pollt op
+> `localhost:5001/health` en `:3000`; draaide daar al iets, dan antwoordde dát
+> met 200 en concludeerde het script dat de stack gezond was — waarna de
+> browsertest tegen een dev-server draaide in plaats van tegen de
+> productie-images die deze stap juist moet bewijzen. Een groene doorloop die
+> het verkeerde getest heeft, is erger dan een rode.
 
 ---
 

--- a/docs/superpowers/plans/2026-08-03-surveybeheer.md
+++ b/docs/superpowers/plans/2026-08-03-surveybeheer.md
@@ -1,0 +1,533 @@
+# Implementatieplan — surveybeheer voor de tenant
+
+**Datum:** 2026-08-03 (bijgewerkt 2026-08-03 na vier besluiten van de eigenaar)
+**Status:** TER BEOORDELING — nog niet goedgekeurd, nog geen code
+**Aanleiding:** de beheerkant kan leveranciers beheren maar geen enkele vragenlijst uitzetten
+**Raakt:** ontwerp `2026-07-28-vragenlijst-ontwerp.md` §7 (stap 10 van de bouwvolgorde), Issue #13, #15, #16
+
+> **Let op bij het lezen naast het ontwerp van 28 juli:** §1b daarvan wijst "request
+> revisions" af. Dit plan gaat daar niet tegenin — het legt een oordeel vast zonder de
+> respons te heropenen. Zie §2a.
+
+---
+
+## 0. Waar dit over gaat, in één alinea
+
+MCM2 kan een leverancier een vragenlijst laten invullen — dat werkt end-to-end en is
+bewezen. Wat er niet is: een manier voor de tenant om die vragenlijst **uit te zetten**.
+Er is geen scherm om een vragenlijst te bekijken, geen manier om een ronde te starten,
+geen manier om deelnemers toe te voegen, en geen scherm dat de antwoorden toont. De
+demo-tenant lijkt gevuld, maar dat komt doordat een seed-script rechtstreeks in de
+database schrijft.
+
+Concreet: **`genereerToken()` wordt in geen enkele productieroute aangeroepen.** Alleen
+`seed-demo-tenant.js` en `otap-doorloop.js` maken responses aan. Er bestaat dus geen weg
+waarlangs een echte uitnodiging tot stand komt.
+
+---
+
+## 1. Wat er al ligt — dit is kleiner dan het lijkt
+
+Geverifieerd op 2026-08-03 tegen de code, niet uit gespreksgeheugen.
+
+| Onderdeel | Stand |
+|---|---|
+| Datamodel (`survey_template`, `_category`, `_question`, `_run`, `_response`, `_answer`, `_attachment`) | ✅ compleet, met RLS, CHECK-constraints, bevriezingstrigger |
+| `VragenlijstImportService` — JSON-schema importeren, valideren | ✅ |
+| `VragenlijstLeesService` — vragen ophalen per response | ✅ |
+| `AntwoordIndienService` + validatie | ✅ |
+| `BijlageService` + inhoudscontrole | ✅ |
+| `SurveyAuditService` | ✅ |
+| `SurveyTokenGuard`, `genereerToken()`, `hashToken()` | ✅ maar `genereerToken()` heeft **geen aanroeper** |
+| Lifecycle-kolommen (`status`, `is_test`, `survey_kind`) | ✅ in de database, **nergens gebruikt** |
+| **Beheerroutes** | ❌ geen enkele |
+| **Beheerschermen** | ❌ geen enkele |
+| **Beoordeling van een ingediende respons** | ❌ bestaat nergens — geen tabel, geen route, geen scherm |
+
+De onderlaag is dus af. Wat ontbreekt is de bovenkant: routes, schermen, en de ene
+functie die een token uitgeeft.
+
+**Het ontwerp uit juli beschrijft dit al** (§7 "Beheerderskant", §2b lifecycle, §2c
+deelnemers). Het stond destijds als "nog niet te bouwen — wacht op de Entra-guard". Die
+guard is er sinds 2026-07-31, en sinds vandaag is er ook een `RolGuard`. **Dit plan voert
+stap 10 van die bouwvolgorde uit; het bedenkt geen nieuw ontwerp.**
+
+---
+
+## 2. Wat een tenantbeheerder moet kunnen
+
+In de volgorde waarin hij het doet:
+
+1. **Zien welke vragenlijsten er zijn** en wat erin staat.
+2. **Een ronde starten** op een vragenlijst — echt of als test.
+3. **Deelnemers toevoegen** en daarmee tokenlinks laten uitgeven.
+4. **Volgen wie heeft ingevuld** en wie niet.
+5. **De antwoorden lezen.**
+6. **De ingevulde vragenlijst beoordelen** — Goed, Nadere vragen of Niet goed.
+
+Punt 3 is het hart: daar wordt `genereerToken()` eindelijk aangeroepen, en daar komt de
+regel uit §2c ("onbekend e-mailadres → weigeren en terugmelden") tot leven.
+
+Punt 6 is op 2026-08-03 toegevoegd op verzoek van de eigenaar. Zonder die stap is het
+lezen van antwoorden een leesoefening zonder uitkomst: er staat nergens vast wát de tenant
+ervan vond. Zie §2a — het is bewust iets anders dan UC2.
+
+**Wat er níét bij hoort in deze ronde:** vragenlijsten samenstellen in een scherm.
+Importeren via JSON werkt al, en een vraageditor is een eigen project — acht
+antwoordtypen met elk hun eigen `config`. Dat is een bewuste knip; zie §6.
+
+---
+
+## 2a. Beoordelen is niet UC2 — het onderscheid, en waarom het uitmaakt
+
+Besluit eigenaar 2026-08-03: **UC1 wordt gebouwd, UC2 niet.** Maar een Transdev-collega
+moet de ingevulde vragenlijst wél kunnen beoordelen. Dat lijkt op UC2 en is het niet.
+
+| | UC2 (uitgesteld) | Beoordeling (wél bouwen) |
+|---|---|---|
+| Wat vult de collega in | een eigen vragenlijst met eigen vragen | één oordeel plus toelichting |
+| Waar landt het | `survey_response` met `vendor_id` leeg | eigen tabel `survey_review` |
+| Waarover gaat het | de leverancier in het algemeen | déze ingediende respons |
+| Bestaat los van UC1 | ja | nee — zonder ingediende respons is er niets te beoordelen |
+
+Het verschil dat de bouw bepaalt: UC2 is een **tweede vragenlijst**, beoordelen is een
+**oordeel over een bestaande respons**. UC2 vraagt een tweede schermflow, deelnemersbeheer
+voor collega's en een scoreberekening. Beoordelen vraagt één knop op een scherm dat in fase
+C toch al gebouwd wordt.
+
+**Dat maakt beoordelen een stuk kleiner dan UC2, terwijl het de werkstroom oplevert die de
+eigenaar beschrijft.** UC2 blijft in het datamodel staan en kan later alsnog — er wordt
+hier niets gebouwd dat dat in de weg zit.
+
+### Drie oordelen, en wat "nadere vragen" wel en niet doet
+
+De oordelen zijn `goed`, `nadere_vragen` en `niet_goed`.
+
+`nadere_vragen` **stuurt de vragenlijst niet terug naar de leverancier** (besluit eigenaar
+2026-08-03). Het oordeel en de toelichting worden vastgelegd, de respons blijft dicht, en
+de beheerder neemt zelf contact op. Het scherm laat zien welke leveranciers openstaan.
+
+Dat is een bewuste keuze en geen tekortkoming. Terugsturen zou raken aan vier plekken die
+nu bewezen en groen zijn: de bevriezingstrigger (migratie 0005), de `SurveyTokenGuard`, de
+verlooplogica van het token, en de audittrail. Het ontwerp legt bovendien vast (§1b, besluit
+2026-07-29) dat de tokenlaag bewust eenrichtingsverkeer is: één atomair
+`UPDATE … WHERE status = 'pending'`, daarna een 410.
+
+Er is ook een inhoudelijke vraag die eerst beantwoord moet worden en die dit plan níét kan
+beantwoorden: **mag een leverancier bij heropenen zijn oude antwoorden overschrijven, of
+komt de aanvulling ernaast te staan?** Bij overschrijven is het originele antwoord weg — en
+dat is precies wat je in een compliance-dossier wilt kunnen terughalen. Die vraag is beter
+te beantwoorden ná een maand echte beoordelingen dan nu op een aanname.
+
+**Wat dit besluit openhoudt:** de waarde `nadere_vragen` staat straks in de data. Terugsturen
+toevoegen is later een statusovergang erbij plus een besluit over historie — geen verbouwing
+van wat hier gebouwd wordt.
+
+### Elk oordeel blijft bewaard
+
+Besluit eigenaar 2026-08-03: **oordelen worden nooit overschreven.** Elk oordeel is een
+eigen regel met datum en beoordelaar; het scherm toont ze nieuwste bovenaan.
+
+Reden: een leverancier die vorig jaar `nadere_vragen` kreeg en dit jaar `goed`, is een
+ander verhaal dan een leverancier die altijd goed was. Dat verloop is de kern van wat een
+compliance-instrument moet opleveren, en met overschrijven is het onherstelbaar weg.
+
+Praktisch betekent dit dat "het huidige oordeel" een afgeleide is (de nieuwste regel), geen
+kolom. Dat scheelt later een migratie: een tweede beoordelaar of een vierpuntsschaal past er
+zonder schemawijziging in.
+
+### De toelichting is intern — en dat is de eerste tabel waar "zelfde tenant" niet volstaat
+
+Besluit eigenaar 2026-08-03: **een leverancier komt nooit bij een beoordeling.** Niet het
+oordeel, niet de toelichting, ook niet indirect. Als er iets is, neemt Transdev zelf contact
+op. Blijkt er een aanvulling nodig, dan volgt een volledige tweede ronde — nieuw token,
+nieuwe respons, bestaande mechaniek.
+
+De beoordelaar kan daardoor noteren wat hij denkt zonder het te formuleren alsof de
+leverancier meeleest. En de regel is in één zin uit te spreken, wat hem toetsbaar maakt en
+over een jaar nog steeds naleefbaar.
+
+**Maar dit vereenvoudigt de beveiliging niet — het verplaatst haar.** Dat is de reden dat
+deze paragraaf zo uitvoerig is.
+
+De leverancier staat niet buiten het systeem: hij is de enige die de vragenlijst invult, en
+hij heeft een geldig token voor precies de respons waar het oordeel aan hangt. Op
+2026-08-03 nagelopen in de code:
+
+- `DatabaseService.withTenant()` is de enige plek waar tenantcontext gezet wordt, en zet
+  precies één variabele: `app.current_tenant_id`.
+- Zowel `vragenlijst-lezen.service.ts` (leverancier, tokenpad) als `vendor.service.ts`
+  (medewerker, sessiepad) roepen dezelfde functie met dezelfde parameter aan.
+- Elke bestaande policy luidt `USING (tenant_id = clm.current_tenant_id())`.
+
+**De database kan dus op dit moment geen onderscheid maken tussen jou en de leverancier.**
+Met de standaardpolicy is `survey_review` binnen de tenant leesbaar, punt. Dat de
+leverancier er niet bij kan, komt uitsluitend doordat er geen route bestaat die het
+teruggeeft — bescherming door afwezigheid, die standhoudt tot iemand een route bouwt die
+"de respons met alles eromheen" ophaalt.
+
+Dat is exact het faalpatroon van tegenproef 6 (MCM2-CLAUDE.md §15b): `tenantId` lekte via
+`/auth/sessie` terwijl acht browsertests groen bleven, omdat geen scherm dat veld toonde.
+**De afwezigheid van een lek is niet de aanwezigheid van een grens.**
+
+Overal elders in MCM2 geldt "zelfde tenant = mag het zien". `survey_review` is de eerste
+tabel waar dat níét waar is. Zo'n uitzondering hoort vastgelegd op de plek die niet
+overgeslagen kan worden — de database — en niet in de gewoonte om de juiste route te
+bouwen.
+
+### Hoe de sterke variant werkt
+
+Besluit eigenaar 2026-08-03: **sterk**, niet de goedkopere variant met alleen een tegenproef.
+
+Er komt een tweede sessievariabele naast `app.current_tenant_id`:
+
+```
+app.current_actor  = 'medewerker' | 'leverancier'
+```
+
+- `withTenant()` krijgt die soort als verplicht argument. Verplicht en niet optioneel met
+  een standaardwaarde: een nieuwe aanroeper die het vergeet moet een compilatiefout krijgen,
+  niet stilzwijgend de ruimste variant.
+- `clm.current_actor()` leest hem, met dezelfde vorm als `current_tenant_id()`.
+- De policy op `survey_review` eist beide:
+  ```sql
+  USING (tenant_id = clm.current_tenant_id() AND clm.current_actor() = 'medewerker')
+  ```
+- De tokenpaden (`vragenlijst-lezen`, `antwoord-indienen`, `bijlage`) geven
+  `'leverancier'` door; de sessiepaden `'medewerker'`.
+
+Gevolg: een toekomstige route die `survey_review` aan de leverancierskant meegeeft, krijgt
+**nul rijen** — geen foutmelding, geen lek, gewoon niets. De grens ligt onder de
+applicatielaag en overleeft dus de programmeur die hem niet kent.
+
+**Wat dit kost:** één migratie, een wijziging in `withTenant()` en in ongeveer tien
+aanroepers, plus een tegenproef. Ruwweg een halve dag.
+
+**Wat het oplevert buiten dit plan:** zodra `app.current_actor` bestaat, is elke volgende
+"dit mag de leverancier niet zien" één policyregel in plaats van een ontwerpdiscussie.
+Interne notities bij een leverancier, een risicoscore, een auditlogregel — dat komt er.
+
+**Wat het níét is:** dit vervangt de guards niet. Een leverancier hoort al bij de route te
+stranden. Dit is de tweede grendel voor het geval de eerste ooit ontbreekt — dezelfde
+gedachte als de `WITH CHECK`-clausules die schrijven op een ingediende respons
+tegenhouden terwijl de applicatie dat óók al doet (migratie 0005, §3).
+
+---
+
+## 3. Vier fases
+
+Elke fase eindigt met iets dat aantoonbaar werkt, `verify:volledig` groen en een
+tegenproef op wat er aan beveiliging is toegevoegd (MCM2-CLAUDE.md §15, §15b).
+
+### Fase A — Vragenlijsten en rondes bekijken
+
+**Backend**
+
+```
+GET /admin/survey/templates            lijst met naam, versie, aantal vragen, aantal rondes
+GET /admin/survey/templates/:id        detail: categorieën en vragen, incl. config per type
+GET /admin/survey/runs                 rondes met status, deadline, voortgang
+GET /admin/survey/runs/:id             één ronde met haar responses
+```
+
+Alles achter `TenantContextGuard`. **Lezen mag ook een reviewer** — die moet resultaten
+kunnen inzien, dat is precies zijn rol.
+
+**Frontend**
+
+Sidebar krijgt het menu-item **Vragenlijsten**. Twee schermen: een overzicht van
+vragenlijsten met hun rondes, en een detailscherm dat de vragen toont zoals de
+leverancier ze ziet.
+
+**Klaar wanneer:** je logt in, klikt op Vragenlijsten, en ziet de twee Transdev-lijsten
+met hun 9 en 29 vragen — uit de database, niet uit mock data.
+
+---
+
+### Fase B — Een ronde starten en deelnemers uitnodigen
+
+De kern van dit plan.
+
+**Backend**
+
+```
+POST  /admin/survey/runs                 nieuwe ronde (draft), UC1 of UC2
+PATCH /admin/survey/runs/:id/status      draft → active → finished → archived
+POST  /admin/survey/runs/:id/participants  deelnemers toevoegen; geeft tokens terug
+```
+
+`@VereistRol('admin')` op alle drie: een reviewer mag lezen, niet uitzetten.
+
+**Hier wordt `genereerToken()` voor het eerst in productiecode aangeroepen.** Dat is de
+gevoeligste stap van dit plan, want het raakt de tokenlaag die al groen en bewezen is.
+
+**Drie regels die het ontwerp al vastlegt en die hier gebouwd worden:**
+
+- **Een onbekend e-mailadres wordt geweigerd en teruggemeld** (§2c, besluit opdrachtgever
+  2026-07-29). Niet automatisch een vendor aanmaken: dat levert binnen een jaar dubbele
+  records op, en het vendorbestand is de lijst waar de rapportage op leunt.
+- **Het ruwe token bestaat één keer** — in het antwoord op deze route. Daarna alleen de
+  hash. Dat betekent dat de beheerder de links op dát moment moet kunnen kopiëren of
+  versturen; er is geen "toon nogmaals".
+- **Een gestarte ronde bevriest de vragenlijst** (trigger in migratie 0005, bestaat al).
+  Het scherm moet dat uitleggen vóór de beheerder op "starten" drukt, niet erna met een
+  foutmelding.
+
+**Alleen UC1 in deze ronde** (besluit eigenaar 2026-08-03). De route accepteert
+`survey_kind` en het datamodel kent UC2, maar er komt één scherm: een lijst leveranciers
+die elk over zichzelf invullen. UC2 vraagt een tweede schermflow met een andere
+deelnemerskeuze (één leverancier, daarna de collega's die hem beoordelen), en dat verschil
+achter een keuzerondje verbergen levert een scherm op dat beide dingen half doet.
+
+De behoefte die achter UC2 leek te zitten — een Transdev-collega die iets vindt van een
+leverancier — wordt in dit plan door het beoordelingsscherm ingevuld. Zie §2a.
+
+**Klaar wanneer:** je start een ronde, voegt drie leveranciers toe, en krijgt drie
+werkende tokenlinks die je in een incognitovenster kunt openen.
+
+---
+
+### Fase C — Voortgang, antwoorden lezen en beoordelen
+
+**Twee migraties, bewust gescheiden**
+
+*Migratie 1 — `app.current_actor`.* Raakt geen enkele bestaande policy en verandert geen
+gedrag: hij voegt de variabele, de functie `clm.current_actor()` en de doorgifte in
+`withTenant()` toe. Apart houden omdat hij ~tien aanroepers raakt en dus overal doorwerkt;
+als er iets omvalt, wil je weten dat het hierdóór komt en niet door de nieuwe tabel.
+
+Deze migratie is **eerst groen met alle bestaande tests** voordat de tabel erbij komt. Zie
+de volgorde in §6.
+
+*Migratie 2 — `survey_review`.* Kolommen: `review_id`, `tenant_id`, `response_id`,
+`verdict`, `toelichting`, `reviewer_user_id`, `created_at`, `deleted_at`.
+
+- `CHECK (verdict IN ('goed', 'nadere_vragen', 'niet_goed'))` — dezelfde vorm als de
+  bestaande statuscontroles, zodat een typefout in code een databasefout wordt en niet een
+  rij met onzin.
+- **Geen** unieke sleutel op `response_id`: meerdere oordelen zijn het punt (§2a).
+- `FORCE ROW LEVEL SECURITY` conform migratie 0011, met `USING` én `WITH CHECK`, en in
+  beide de actor-eis erbij:
+  ```sql
+  USING      (tenant_id = clm.current_tenant_id() AND clm.current_actor() = 'medewerker')
+  WITH CHECK (tenant_id = clm.current_tenant_id() AND clm.current_actor() = 'medewerker')
+  ```
+  De eis staat ook in `WITH CHECK`: zonder dat zou een leverancierspad wel kunnen
+  schrijven wat het niet kan lezen — een lek dat pas opvalt als de rij er al staat.
+- Beoordelen mag alleen op een ingediende respons. Dat is een controle in de service, niet
+  in een constraint: de foutmelding moet uitleggen waaróm het niet kan.
+
+**Backend**
+
+```
+GET  /admin/survey/runs/:id/responses      status per deelnemer, wie wel/niet ingediend
+GET  /admin/survey/responses/:id/answers   de antwoorden van één respons, incl. bijlagen
+GET  /admin/survey/responses/:id/reviews   alle oordelen, nieuwste eerst
+POST /admin/survey/responses/:id/reviews   nieuw oordeel vastleggen
+```
+
+**Alle vier mogen door een reviewer** (besluit eigenaar 2026-08-03). Beoordelen ís de rol
+van een reviewer; hem dat ontzeggen maakt de rol betekenisloos en maakt de admin een
+flessenhals. Een reviewer mag nog steeds géén rondes starten, geen deelnemers toevoegen en
+geen leveranciers wijzigen — die houden `@VereistRol('admin')`.
+
+Dat dit verantwoord is, hangt aan één ding uit §2a: **elk oordeel is met naam en datum
+vastgelegd en wordt nooit overschreven.** Een reviewer kan dus niets stilletjes veranderen —
+hij kan alleen iets toevoegen dat zichtbaar van hem is. Zonder die historie zou ik hier
+admin adviseren.
+
+**Frontend**
+
+Een voortgangsscherm per ronde (ingediend / open / verlopen), een leesscherm per respons,
+en onder de antwoorden het beoordeelblok: drie knoppen plus een toelichtingsveld, met
+daaronder de eerdere oordelen op datum.
+
+Twee dingen in dat scherm die geen detail zijn:
+
+- **Het huidige oordeel staat bij de leverancier in de voortgangslijst**, niet alleen op het
+  detailscherm. Anders moet je zeventien schermen openen om te zien wie er nog openstaat —
+  en dan wordt de lijst niet gebruikt.
+- **`nadere_vragen` leest als een openstaande actie, niet als een eindoordeel.** Het scherm
+  moet duidelijk maken dat de leverancier hier niets van merkt en dat de beheerder zelf
+  contact opneemt (§2a). Een knop die suggereert dat er iets verstuurd wordt terwijl dat
+  niet gebeurt, is erger dan geen knop.
+
+**Twee dingen die hier scherp moeten:**
+
+- **Verlopen is `closes_at < now()` bij status `active`** (§2b). Let op de asymmetrie die
+  het ontwerp benoemt: de guard hanteert de striktste van `expires_at` (per token) en
+  `closes_at` (per ronde). Een deadline verlengen op de ronde verlengt de tokens níét —
+  dat moet zichtbaar zijn in het scherm, anders verlengt iemand de deadline en werkt de
+  helft van de links alsnog niet.
+- **De interne score (UC2) is niet zichtbaar voor de leverancier** — dat volgt al uit de
+  architectuur, maar testpunt 39 uit het ontwerp bewaakt het. Dat testpunt hoort hier
+  gebouwd te worden, want dit is de eerste plek waar iemand een route zou kunnen bouwen
+  die op `subject_vendor_id` filtert in plaats van op `response_id`.
+
+**Klaar wanneer:** je ziet per ronde wie heeft ingevuld, kunt een ingediende respons lezen
+inclusief de geüploade certificaten, en kunt hem beoordelen met Goed, Nadere vragen of Niet
+goed — waarna dat oordeel in de voortgangslijst staat en een tweede oordeel het eerste niet
+wist.
+
+---
+
+### Fase D — Uitnodigingen versturen
+
+**Dit is de fase met een externe afhankelijkheid en hoort daarom apart.**
+
+Issue #13 (SMTP via Transdev) en OV-9 uit de klantvragen staan allebei nog open: de
+SMTP-gegevens van `contractmanagement@transdev.nl` zijn er niet.
+
+**Maar dat blokkeert minder dan gedacht.** Op 2026-08-03 nagekeken in
+`C:\dev\Work\jouwcontractmanager`, op aanwijzing van de eigenaar: daar draait een werkende
+uitnodigingsmail met portallink, en die is bruikbaar als voorbeeld.
+
+**Wat daar te halen valt:**
+
+| | Waar | Bruikbaar? |
+|---|---|---|
+| Resend als verzenddienst | `package.json`, `.env.local.example` | ✅ live, testflow bevestigd |
+| Mailsjabloon met portalknop | `src/app/api/uitvragen/[id]/beoordelen/route.ts` r. 113–129 | ✅ als voorbeeld |
+| Afzenderlabel "«klant» via «product»" | idem, r. 107 | ✅ precies wat Transdev nodig heeft |
+| Testadressen via de plus-truc | `docs/OPSTARTEN.md` §5 | ✅ zie hieronder |
+| Mailfout logt maar breekt niet | idem, r. 131 | ✅ juiste keuze, overnemen |
+
+**Testen zonder echte leveranciers:** `cmaling+transdev1@gmail.com` is voor Resend een
+apart adres, maar alles komt in dezelfde inbox aan. Daarmee is een hele ronde met vijf
+"leveranciers" te doorlopen zonder één externe partij te mailen — en zonder een testmodus
+in de code die in productie per ongeluk aan kan staan. Dat is de reden dat dit beter is dan
+een `MAIL_UITGESCHAKELD`-vlag.
+
+**Wat dit betekent voor de planning:** fase D kan gebouwd én getest worden met een eigen
+Resend-account op een eigen domein. De SMTP-gegevens van Transdev zijn dan nog steeds nodig
+— maar alleen om het afzenderadres te wisselen, niet om te kunnen bouwen. OV-9 is daarmee
+een uitrolvraag geworden in plaats van een bouwblokkade.
+
+**Twee dingen die níét zomaar overgenomen worden:**
+
+- **De afwijzingsmail met terugstuurlink.** Dezelfde route stuurt bij afwijzen een nieuw
+  token en een "vul opnieuw in"-link. Dat is precies het heropenen dat hier bewust niet
+  gebouwd wordt (§2a) — én daar worden de oude antwoorden bij verwijderd (`delete()` op
+  `uitvraag_antwoord`, r. 92–95). Voor MCM2 is dat onacceptabel: een compliance-dossier
+  waarin het oorspronkelijke antwoord weg is, bewijst niets meer. Zie §5.
+- **De mail wordt daar vanuit de webapplicatie verstuurd.** In MCM2 hoort dat in de backend,
+  achter dezelfde guard als de rest — de frontend heeft geen tenantcontext.
+
+---
+
+## 4. Wat dit plan expliciet niet doet
+
+- **Geen vraageditor.** Vragenlijsten samenstellen in een scherm is een eigen project:
+  acht antwoordtypen met elk hun eigen `config`, plus de bevriezingsregel en versionering.
+  Importeren via JSON werkt al (§2d) en dekt de behoefte tot de eerste tenant zijn eigen
+  lijst wil opstellen.
+- **Geen UC2.** De interne vragenlijst waarbij een collega een eigen set vragen over een
+  leverancier beantwoordt, blijft in het datamodel staan maar wordt niet gebouwd (besluit
+  eigenaar 2026-08-03). Wat wél gebouwd wordt is beoordelen van een ingediende UC1-respons;
+  het verschil staat in §2a.
+- **Geen terugsturen naar de leverancier.** `nadere_vragen` markeert, heropent niet (§2a).
+  Blijkt een aanvulling nodig, dan volgt een volledige tweede ronde met een nieuw token —
+  bestaande mechaniek, en het levert een dossier op van ronde 1 náást ronde 2 in plaats van
+  een overschreven antwoord.
+- **Geen enkele leveranciersinzage in beoordelingen.** Niet het oordeel, niet de
+  toelichting, niet indirect. Dit is met een policy afgedwongen en niet met de afwezigheid
+  van een route (§2a).
+- **Geen rapportage of scores.** Categoriescores met `min_answers` staan in het datamodel
+  maar zijn een presentatielaag die pas betekenis krijgt zodra er echte antwoorden zijn.
+- **Geen herinneringen.** Issue #16 raakt dit (export- en reminder-acties met expliciete
+  tenantId) maar hangt aan fase D.
+- **Geen export.** OV-4 (exportformaat) is nog open bij de klant.
+
+---
+
+## 5. Risico's en aandachtspunten
+
+**Fase B raakt bestaande, groene code.** De tokenlaag is bewezen en heeft eigen tests. Een
+route die tokens uitgeeft is nieuw gedrag op een oud fundament — daar hoort een tegenproef
+op de tokenuitgifte bij (bijvoorbeeld: het ruwe token per ongeluk opslaan, of een token
+uitgeven voor een andere tenant).
+
+**De statuscontrole in de guard bestaat al** (migratie 0006, "ronde-status in guard"),
+maar er is nog nooit een ronde van status veranderd via een route. Fase B is de eerste
+keer dat die overgang in productiecode gebeurt.
+
+**Twee tenants in elke test.** Elke nieuwe route is een nieuwe kans om de tenantgrens te
+missen. Dat is bij 2c twee keer aangetoond met een tegenproef; dezelfde discipline geldt
+hier.
+
+**Het naburige project laat zien wat er misgaat bij heropenen.** In jouwcontractmanager
+(`src/app/api/uitvragen/[id]/beoordelen/route.ts`) verwijdert de afwijsactie álle antwoorden
+van de leverancier en geeft een nieuw token uit. Voor dat product is dat verdedigbaar: het
+gaat om één certificaat aanleveren, en een half ingevuld formulier heeft daar geen
+bewijswaarde.
+
+Voor MCM2 zou dezelfde keuze het instrument ondermijnen. Wat een leverancier oorspronkelijk
+verklaarde, ís hier het bewijsmateriaal — dat is de reden dat migratie 0005 een
+bevriezingstrigger heeft en dat `survey_answer` na indienen alleen nog leesbaar is.
+
+Dit is geen kritiek op dat project maar een concreet voorbeeld van waarom "nadere vragen"
+hier een tweede ronde wordt en geen heropening (§2a): bij een tweede ronde staat ronde 1
+compleet naast ronde 2, en is achteraf vast te stellen wat er veranderd is en wanneer.
+
+**De beoordeling is een nieuw soort gevoelige data.** Tot nu toe was de vraag steeds "mag
+tenant A bij tenant B?". Bij `survey_review` komt er een tweede grens bij: **mag de
+leverancier bij het oordeel over zichzelf?** Dat is een ander soort lek — de leverancier
+hééft een geldig token voor die respons, dus een route die op `response_id` filtert zonder
+naar de sessie te kijken, geeft hem netjes antwoord.
+
+De tegenproef die daarbij hoort — en die geschreven moet worden vóórdat de route bestaat:
+**voeg `survey_review` toe aan wat `VragenlijstLeesService` teruggeeft** (het leveranciers-
+pad) en controleer dat een test faalt. Faalt er niets, dan test niemand de grens zelf maar
+alleen de plek waar hij toevallig niet zichtbaar is.
+
+Met de sterke variant (§2a) is dat een échte tegenproef en geen formaliteit: het leespad
+draait onder `app.current_actor = 'leverancier'`, dus de policy geeft nul rijen terug. De
+test hoort dan te falen op "het oordeel ontbreekt" — precies het bewijs dat de grens in de
+database ligt en niet in de gewoonte om de juiste route te schrijven.
+
+Dat is exact de les uit §15b van MCM2-CLAUDE.md, tegenproef 6: `tenantId` werd toegevoegd
+aan `/auth/sessie` en alle acht browsertests bleven groen, omdat de sidebar dat veld niet
+toont. **Test een lek bij de bron, niet waar je hoopt dat het niet opduikt.**
+
+**Tweede tegenproef, op de actor zelf.** De eerste bewijst dat de policy werkt zolang de
+actor klopt. Deze bewijst dat de actor niet stilletjes verkeerd kan staan: **zet in één
+tokenpad `'medewerker'` in plaats van `'leverancier'`** en controleer dat een test faalt.
+Zonder deze tweede proef is de hele constructie afhankelijk van tien aanroepers die het
+goed doen, zonder dat iets dat bewaakt.
+
+---
+
+## 6. Voorstel voor de volgorde
+
+Fase A → B → C, dan **fase 4 van het vorige plan** (OTAP-doorloop uitbreiden met álles wat
+er dan staat), dan fase D zodra de SMTP-gegevens er zijn.
+
+**Eén uitzondering op die volgorde: `app.current_actor` mag vooruit.** Die migratie (§ fase
+C, migratie 1) hangt nergens van af — hij voegt alleen een variabele toe en verandert geen
+gedrag. Hem los draaien vóór fase A heeft twee voordelen: hij raakt ~tien aanroepers, en dat
+wil je uitzoeken tegen een codebase die verder stilstaat. En zodra hij er is, kan elke route
+die in A en B gebouwd wordt meteen de juiste actor meegeven — in plaats van dat ze in fase C
+alsnog langsgelopen moeten worden.
+
+Dat is een halve dag die zichzelf terugbetaalt zodra fase B begint.
+
+Reden om de OTAP-doorloop ná C te doen en niet ertussen: die test wat er ís. Elke fase die
+erna komt moet er alsnog in — één keer uitbreiden aan het eind is minder werk dan drie keer
+tussendoor. Voorwaarde is wel dat elke fase blijft eindigen met `verify:volledig` groen
+plus een tegenproef, anders wordt fase 4 een opruimactie in plaats van een uitbreiding.
+
+---
+
+## 7. Vragen voor de eigenaar
+
+**Alles beantwoord op 2026-08-03. Er blokkeert niets meer.**
+
+| Vraag | Antwoord | Waar het landt |
+|---|---|---|
+| UC2 in deze ronde of later? | later — alleen UC1 | fase B, §2a |
+| Stuurt "nadere vragen" de lijst terug? | nee, markeren en zelf contact opnemen | §2a |
+| Wordt een oordeel overschreven? | nee, elk oordeel blijft bewaard | §2a |
+| Ziet de leverancier het oordeel? | nee, en dat wordt met een policy afgedwongen | §2a |
+| Moet Transdev zelf vragen kunnen opstellen? | nee, JSON-import volstaat voorlopig | §4 |
+| Mag een reviewer beoordelen? | ja, lezen én beoordelen | fase C |
+| Hoe komen de tokenlinks bij de leverancier? | kopieerbaar in het scherm; e-mail volgt in fase D | fase B, fase D |

--- a/drizzle/0013_actor_context.sql
+++ b/drizzle/0013_actor_context.sql
@@ -1,0 +1,76 @@
+-- =============================================================================
+-- app.current_actor — de database leert het verschil tussen een medewerker
+-- en een leverancier.
+--
+-- Aanleiding: het plan docs/superpowers/plans/2026-08-03-surveybeheer.md, §2a.
+-- De eigenaar heeft vastgesteld dat een leverancier nooit bij een beoordeling
+-- mag komen. Dat bleek met wat er is niet af te dwingen.
+--
+-- ── Wat er ontbrak ───────────────────────────────────────────────────────────
+--
+-- withTenant() zet precies één sessievariabele: app.current_tenant_id. Zowel
+-- het leverancierspad (vragenlijst-lezen, antwoord-indienen, bijlage) als het
+-- medewerkerspad (vendor, sessie) roept die functie identiek aan, met dezelfde
+-- tenantId. Elke bestaande policy luidt:
+--
+--     USING (tenant_id = clm.current_tenant_id())
+--
+-- Gemeten op 2026-08-03: de database kan op dit moment geen onderscheid maken
+-- tussen een medewerker en een leverancier van dezelfde tenant. Beide zien
+-- exact dezelfde rijen.
+--
+-- Voor elke bestaande tabel is dat juist. Overal in MCM2 geldt "zelfde tenant
+-- = mag het zien" — de leverancier hoort zijn eigen respons te kunnen lezen,
+-- en die staat in zijn tenant.
+--
+-- clm.survey_review (migratie 0014) is de eerste tabel waar dat NIET waar is.
+--
+-- ── Waarom een policy en niet alleen een guard ───────────────────────────────
+--
+-- Zonder deze variabele zou de bescherming van een beoordeling volledig
+-- bestaan uit de afwezigheid van een route die haar teruggeeft. Dat houdt
+-- stand tot iemand een route bouwt die "de respons met alles eromheen"
+-- ophaalt — en die persoon hoeft deze regel niet te kennen.
+--
+-- Dat is exact het faalpatroon van tegenproef 6 (MCM2-CLAUDE.md §15b):
+-- tenantId lekte via /auth/sessie terwijl alle acht browsertests groen bleven,
+-- omdat geen enkel scherm dat veld toonde. De afwezigheid van een lek is niet
+-- de aanwezigheid van een grens.
+--
+-- Vergelijk vragenlijst-lezen.service.ts r. 148: "De query filtert daarom op
+-- response_id en niet op subject_vendor_id. Zodra iemand dat omdraait, ontstaat
+-- het lek dat er nu niet is." Die opmerking beschrijft een discipline. Deze
+-- migratie maakt er een grendel van.
+--
+-- Dit vervangt de guards niet. Een leverancier hoort al bij de route te
+-- stranden; dit is de tweede grendel voor het geval de eerste ooit ontbreekt.
+-- Dezelfde gedachte als de WITH CHECK-clausules in migratie 0005, die schrijven
+-- op een ingediende respons tegenhouden terwijl de applicatie dat óók al doet.
+--
+-- ── Deze migratie verandert geen gedrag ──────────────────────────────────────
+--
+-- Er wordt niets aan bestaande policies gewijzigd. Na deze migratie ziet
+-- iedereen exact dezelfde rijen als ervoor. Dat is opzet: hij raakt ~15
+-- aanroepers in de applicatie en moet groen zijn vóórdat de eerste policy
+-- erop gaat leunen (migratie 0014).
+--
+-- ── Waarom 'onbekend' de standaard is ────────────────────────────────────────
+--
+-- current_setting(..., TRUE) geeft NULL terug als de variabele niet gezet is —
+-- bijvoorbeeld in een migratie, in psql, of in code die deze regel niet kent.
+--
+-- Die NULL wordt hier 'onbekend' en NIET 'medewerker'. Een vergeten actor moet
+-- de striktste uitkomst geven, niet de ruimste: wie de variabele niet zet,
+-- krijgt geen toegang tot wat achter de actor-eis ligt. De omgekeerde keuze
+-- zou betekenen dat elke nieuwe aanroeper die het vergeet stilzwijgend
+-- medewerkersrechten krijgt — precies het soort stille fout dat dit project
+-- probeert uit te sluiten.
+-- =============================================================================
+
+CREATE OR REPLACE FUNCTION clm.current_actor()
+RETURNS TEXT LANGUAGE sql STABLE AS $$
+    SELECT COALESCE(NULLIF(current_setting('app.current_actor', TRUE), ''), 'onbekend')
+$$;--> statement-breakpoint
+
+COMMENT ON FUNCTION clm.current_actor() IS
+    'Leest de soort aanroeper uit de PostgreSQL sessie-variabele app.current_actor, gezet door DatabaseService.withTenant(). Waarden: medewerker, leverancier, onbekend. Niet gezet betekent onbekend, en onbekend krijgt de minste rechten.';--> statement-breakpoint

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -92,6 +92,13 @@
       "when": 1785758400000,
       "tag": "0012_ref_codes_uitbreiden",
       "breakpoints": true
+    },
+    {
+      "idx": 13,
+      "version": "7",
+      "when": 1785844800000,
+      "tag": "0013_actor_context",
+      "breakpoints": true
     }
   ]
 }

--- a/scripts/verify-volledig.js
+++ b/scripts/verify-volledig.js
@@ -138,6 +138,85 @@ function wachtOpStack(maxSeconden = 120) {
   return { ok: false, reden: laatsteFout };
 }
 
+/**
+ * De poorten die de doorloopstack nodig heeft, met wie ze normaal bezet houdt.
+ *
+ * Zie controleerPoortenVrij() hieronder voor waarom dit vooraf gebeurt.
+ */
+const STACK_POORTEN = [
+  { poort: 5001, wat: 'de API', gebruikelijk: 'npm run start:prod of npm run start:dev' },
+  { poort: 3000, wat: 'de frontend', gebruikelijk: 'npm run dev in MCM2-frontend' },
+];
+
+/**
+ * Weigert te starten zolang 5001 of 3000 bezet is.
+ *
+ * ── Waarom dit vóór stap 1 staat en niet bij stap 2 ──────────────────────────
+ *
+ * Aanleiding: op 2026-08-03 liep deze doorloop twee keer achter elkaar vast op
+ * een bezette poort. Beide keren pas ná stap 1 — die duurt enkele minuten,
+ * inclusief het opzetten en weer afbreken van een wegwerpdatabase en 269
+ * e2e-tests. De foutmelding kwam van Docker en luidde "ports are not
+ * available", zonder te zeggen wélk proces de poort vasthield.
+ *
+ * De poorten waren bezet door een handmatig gestarte backend en frontend uit
+ * een eerdere sessie — de normaalste zaak van de wereld tijdens ontwikkelen.
+ *
+ * Vooraf controleren kost een fractie van een seconde en bespaart die hele
+ * ronde. Dat is de hele reden dat dit hier staat.
+ *
+ * ── Waarom weigeren en niet zelf afsluiten ───────────────────────────────────
+ *
+ * Een proces doodschieten dat iemand bewust heeft gestart, is een
+ * onomkeerbare actie op andermans werk: een dev-server met ongesaveerde staat,
+ * een debugsessie, een demo die live staat. Het script meldt wat er in de weg
+ * staat en laat de keuze aan de gebruiker.
+ *
+ * ── Waarom dit óók een correctheidsprobleem is ───────────────────────────────
+ *
+ * wachtOpStack() pollt op http://localhost:5001/health en :3000. Draait daar al
+ * iets, dan antwoordt dát met 200 en concludeert het script dat de stack
+ * gezond is — terwijl de browsertest vervolgens tegen een dev-server draait in
+ * plaats van tegen de productie-images die deze stap juist moet bewijzen.
+ *
+ * Vandaar dat het bezet zijn van een poort hier hard faalt en niet alleen een
+ * waarschuwing geeft: een groene doorloop die het verkeerde getest heeft, is
+ * erger dan een rode.
+ */
+function controleerPoortenVrij() {
+  const bezet = [];
+
+  for (const { poort, wat, gebruikelijk } of STACK_POORTEN) {
+    // Bewust curl en geen netstat: netstat verschilt per platform en vraagt op
+    // Windows om parsing van een tabel. Een HTTP-antwoord bewijst bovendien
+    // méér — een luisterende poort zonder antwoord blokkeert Docker niet.
+    const antwoord = draai(
+      'curl',
+      [
+        '-s',
+        '-o',
+        isWindows ? 'NUL' : '/dev/null',
+        '-w',
+        '%{http_code}',
+        '--max-time',
+        '2',
+        `http://localhost:${poort}/`,
+      ],
+      { stil: true },
+    );
+
+    const code = antwoord.uitvoer.trim();
+
+    // Elk HTTP-antwoord betekent dat er iets luistert. Ook een 404 of 500:
+    // Docker kan de poort dan evengoed niet binden.
+    if (code && code !== '000') {
+      bezet.push({ poort, wat, gebruikelijk, code });
+    }
+  }
+
+  return bezet;
+}
+
 /** Containernaam voor de wegwerpdatabase van stap 1. */
 const TESTDB = 'mcm2-verify-volledig-db';
 const TESTDB_POORT = 55441;
@@ -373,6 +452,37 @@ function maakSessie() {
 function main() {
   const stappen = 5;
   let gestart = false;
+
+  // Vóór alles: stap 1 duurt minuten, en die zijn weggegooid als stap 2 op een
+  // bezette poort strandt. Zie controleerPoortenVrij().
+  const bezet = controleerPoortenVrij();
+
+  if (bezet.length > 0) {
+    console.error('\nROOD: de doorloop kan niet starten — poorten zijn bezet.\n');
+
+    for (const { poort, wat, gebruikelijk, code } of bezet) {
+      console.error(
+        `  poort ${poort} (${wat}) — er antwoordt al iets (HTTP ${code})`,
+      );
+      console.error(`     meestal: ${gebruikelijk}`);
+    }
+
+    console.error(
+      '\nDeze doorloop start de volledige stack op dezelfde poorten. Sluit af wat\n' +
+        'daar draait en probeer opnieuw. Zoeken welk proces het is:\n',
+    );
+    console.error(
+      isWindows
+        ? `  netstat -ano | findstr ":${bezet[0].poort} "     (laatste kolom is de PID)\n` +
+            '  taskkill /PID <pid> /F'
+        : `  lsof -i :${bezet[0].poort}\n  kill <pid>`,
+    );
+    console.error(
+      '\nBewust niet automatisch afgesloten: dat is meestal een dev-server die\n' +
+        'iemand zelf heeft gestart.',
+    );
+    process.exit(1);
+  }
 
   try {
     kop(1, stappen, 'Code, unittests en backend-e2e (npm run verify)');

--- a/src/auth/sessie.service.ts
+++ b/src/auth/sessie.service.ts
@@ -144,26 +144,30 @@ export class SessieService {
   async profiel(
     context: SessieContext,
   ): Promise<{ naam: string; tenantNaam: string } | null> {
-    return this.db.withTenant(context.tenantId, async (tx) => {
-      const resultaat = await tx.execute<{
-        naam: string;
-        tenant_naam: string;
-      }>(
-        sql`SELECT u.full_name AS naam, t.name AS tenant_naam
+    return this.db.withTenant(
+      context.tenantId,
+      async (tx) => {
+        const resultaat = await tx.execute<{
+          naam: string;
+          tenant_naam: string;
+        }>(
+          sql`SELECT u.full_name AS naam, t.name AS tenant_naam
               FROM clm."user" u
               JOIN clm.tenant t ON t.tenant_id = u.tenant_id
              WHERE u.user_id = ${context.userId}
                AND u.deleted_at IS NULL`,
-      );
+        );
 
-      const rij = resultaat.rows[0];
+        const rij = resultaat.rows[0];
 
-      if (!rij) {
-        return null;
-      }
+        if (!rij) {
+          return null;
+        }
 
-      return { naam: rij.naam, tenantNaam: rij.tenant_naam };
-    });
+        return { naam: rij.naam, tenantNaam: rij.tenant_naam };
+      },
+      'medewerker',
+    );
   }
 
   /**

--- a/src/db/database.service.ts
+++ b/src/db/database.service.ts
@@ -8,7 +8,7 @@ import { NodePgDatabase, drizzle } from 'drizzle-orm/node-postgres';
 import { Pool } from 'pg';
 
 import * as schema from './schema';
-import { setTenantContext } from './schema';
+import { setActorContext, setTenantContext, type Actor } from './schema';
 
 const UUID_REGEX =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
@@ -94,10 +94,29 @@ export class DatabaseService implements OnModuleInit, OnModuleDestroy {
    *
    * De tenantId hoort uit geverifieerde identiteit te komen — een ID-token of
    * een tokenlookup — nooit uit een header of query-parameter (Issue #7).
+   *
+   * ── De actor ─────────────────────────────────────────────────────────────
+   * Naast de tenant legt elke transactie vast wélke soort aanroeper hem opent:
+   * een `medewerker` (sessiepad) of een `leverancier` (tokenpad). Zie
+   * drizzle/0013_actor_context.sql.
+   *
+   * De parameter is bewust optioneel in de signatuur en tegelijk verplicht in
+   * de praktijk. Dat lijkt tegenstrijdig en is het niet:
+   *
+   * - Weglaten levert actor `onbekend` op. Dat is de striktste stand — geen
+   *   toegang tot wat achter een actor-eis ligt. Een vergeten actor faalt dus
+   *   dicht, niet open.
+   * - Een verplichte parameter zou ~70 testregels raken die niets met dit
+   *   onderwerp te maken hebben. Die aanpassen levert ruis op in precies de
+   *   tests die de tenantgrens bewijzen, en dat is een slechte ruil.
+   *
+   * Voor productiecode geldt: altijd meegeven. De tegenproef in
+   * survey-review.e2e-spec bewaakt dat het tokenpad `leverancier` doorgeeft.
    */
   async withTenant<T>(
     tenantId: string,
     fn: (tx: TenantTransaction) => Promise<T>,
+    actor?: Actor,
   ): Promise<T> {
     if (!UUID_REGEX.test(tenantId)) {
       throw new Error(`Ongeldige tenant-id: '${tenantId}'`);
@@ -105,6 +124,15 @@ export class DatabaseService implements OnModuleInit, OnModuleDestroy {
 
     return this.db.transaction(async (tx) => {
       await tx.execute(setTenantContext(tenantId));
+
+      // Alleen zetten als hij meegegeven is. Niet zetten laat de variabele
+      // leeg, en clm.current_actor() maakt daar 'onbekend' van — de striktste
+      // uitkomst. Hier expliciet 'onbekend' schrijven zou hetzelfde doen maar
+      // suggereren dat het een bewuste keuze van de aanroeper was.
+      if (actor) {
+        await tx.execute(setActorContext(actor));
+      }
+
       return fn(tx);
     });
   }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -819,3 +819,20 @@ export const surveyResponseRelations = relations(
 // feat/fase0-skeleton-vendors.
 export const setTenantContext = (tenantId: string) =>
   sql`SELECT set_config('app.current_tenant_id', ${tenantId}, true)`;
+
+// ─── Actor-context ─────────────────────────────────────────────────────────
+// Naast de tenant legt elke transactie vast wélke soort aanroeper hem opent.
+// De database kon dat verschil tot migratie 0013 niet zien: het tokenpad van
+// een leverancier en het sessiepad van een medewerker riepen withTenant()
+// identiek aan, met dezelfde tenantId.
+//
+// Voor alle bestaande tabellen is dat juist — "zelfde tenant = mag het zien"
+// geldt daar. clm.survey_review is de eerste tabel waar dat niet opgaat: een
+// leverancier mag het oordeel over zichzelf niet lezen, ook al staat het in
+// zijn eigen tenant.
+//
+// Zie drizzle/0013_actor_context.sql voor de volledige onderbouwing.
+export type Actor = 'medewerker' | 'leverancier';
+
+export const setActorContext = (actor: Actor) =>
+  sql`SELECT set_config('app.current_actor', ${actor}, true)`;

--- a/src/survey/antwoord-indienen.service.ts
+++ b/src/survey/antwoord-indienen.service.ts
@@ -56,49 +56,51 @@ export class AntwoordIndienService {
     invoer: unknown,
   ): Promise<IndienUitkomst> {
     return this.db
-      .withTenant<IndienUitkomst>(tenantId, async (tx) => {
-        const vragen = await this.haalVragen(tx, responseId);
+      .withTenant<IndienUitkomst>(
+        tenantId,
+        async (tx) => {
+          const vragen = await this.haalVragen(tx, responseId);
 
-        // Geen vragen betekent: er valt niets in te dienen. Behandeld als
-        // "niet meer open" in plaats van als lege geldige indiening — anders
-        // zou een lege template een response kunnen afsluiten zonder inhoud.
-        if (vragen.length === 0) {
-          return { status: 'niet-meer-open' };
-        }
+          // Geen vragen betekent: er valt niets in te dienen. Behandeld als
+          // "niet meer open" in plaats van als lege geldige indiening — anders
+          // zou een lege template een response kunnen afsluiten zonder inhoud.
+          if (vragen.length === 0) {
+            return { status: 'niet-meer-open' };
+          }
 
-        const bestanden = await this.telBestanden(tx, responseId);
+          const bestanden = await this.telBestanden(tx, responseId);
 
-        const uitkomst = valideerAntwoorden(
-          vragen.map(naarValidatievraag),
-          invoer,
-          bestanden,
-        );
+          const uitkomst = valideerAntwoorden(
+            vragen.map(naarValidatievraag),
+            invoer,
+            bestanden,
+          );
 
-        if (!uitkomst.geldig) {
-          // Bewust vóór elke schrijfactie. De transactie heeft nog niets
-          // gewijzigd, dus er valt niets terug te draaien en de link blijft
-          // bruikbaar (testpunt 25).
-          return { status: 'ongeldig', fouten: uitkomst.fouten };
-        }
+          if (!uitkomst.geldig) {
+            // Bewust vóór elke schrijfactie. De transactie heeft nog niets
+            // gewijzigd, dus er valt niets terug te draaien en de link blijft
+            // bruikbaar (testpunt 25).
+            return { status: 'ongeldig', fouten: uitkomst.fouten };
+          }
 
-        const idPerSleutel = new Map(
-          vragen.map((v) => [v.question_key, v.question_id]),
-        );
+          const idPerSleutel = new Map(
+            vragen.map((v) => [v.question_key, v.question_id]),
+          );
 
-        await this.schrijfAntwoorden(
-          tx,
-          tenantId,
-          responseId,
-          uitkomst.antwoorden,
-          idPerSleutel,
-        );
+          await this.schrijfAntwoorden(
+            tx,
+            tenantId,
+            responseId,
+            uitkomst.antwoorden,
+            idPerSleutel,
+          );
 
-        // Pas hierna afsluiten. Eén atomair statement met de status als
-        // voorwaarde, net als in SurveyTokenService.dienIn(): de database
-        // beslist wie wint bij gelijktijdige verzoeken, niet de volgorde waarin
-        // ze toevallig aankomen.
-        const afgesloten = await tx.execute<{ response_id: string }>(
-          sql`UPDATE clm.survey_response AS r
+          // Pas hierna afsluiten. Eén atomair statement met de status als
+          // voorwaarde, net als in SurveyTokenService.dienIn(): de database
+          // beslist wie wint bij gelijktijdige verzoeken, niet de volgorde waarin
+          // ze toevallig aankomen.
+          const afgesloten = await tx.execute<{ response_id: string }>(
+            sql`UPDATE clm.survey_response AS r
                SET status = 'submitted', submitted_at = now()
              WHERE r.response_id = ${responseId}
                AND r.status = 'pending'
@@ -109,28 +111,30 @@ export class AntwoordIndienService {
                         AND run.status = 'active'
                    )
          RETURNING r.response_id`,
-        );
+          );
 
-        if (afgesloten.rows.length !== 1) {
-          // Iemand was eerder, of de ronde is inmiddels dicht. De transactie
-          // rolt terug door de fout hieronder niet te gooien maar de uitkomst
-          // te melden — Drizzle commit anders de zojuist geschreven antwoorden.
-          throw new NietMeerOpenError();
-        }
+          if (afgesloten.rows.length !== 1) {
+            // Iemand was eerder, of de ronde is inmiddels dicht. De transactie
+            // rolt terug door de fout hieronder niet te gooien maar de uitkomst
+            // te melden — Drizzle commit anders de zojuist geschreven antwoorden.
+            throw new NietMeerOpenError();
+          }
 
-        await this.audit.leg(tx, {
-          tenantId,
-          actie: 'survey_response_ingediend',
-          responseId,
-          details: { aantalAntwoorden: uitkomst.antwoorden.length },
-        });
+          await this.audit.leg(tx, {
+            tenantId,
+            actie: 'survey_response_ingediend',
+            responseId,
+            details: { aantalAntwoorden: uitkomst.antwoorden.length },
+          });
 
-        this.logger.log(
-          `Response ${responseId} ingediend met ${uitkomst.antwoorden.length} antwoorden.`,
-        );
+          this.logger.log(
+            `Response ${responseId} ingediend met ${uitkomst.antwoorden.length} antwoorden.`,
+          );
 
-        return { status: 'ingediend' };
-      })
+          return { status: 'ingediend' };
+        },
+        'leverancier',
+      )
       .catch((fout: unknown) => {
         // NietMeerOpenError is geen storing maar het verwachte gedrag bij een
         // tweede poging. Door hem als fout te gooien rolt de transactie terug;

--- a/src/survey/bijlage.service.ts
+++ b/src/survey/bijlage.service.ts
@@ -65,68 +65,70 @@ export class BijlageService {
     await this.opslag.bewaar(storageKey, bestand.buffer);
 
     try {
-      return await this.db.withTenant<BijlageUitkomst>(tenantId, async (tx) => {
-        // FOR UPDATE op de responserij, zodat twee overlappende uploads niet
-        // allebei hetzelfde aantal tellen en samen over max_files heen gaan.
-        // Een CHECK kan dit niet afvangen: die kan noch over meerdere rijen
-        // tellen noch survey_question raadplegen.
-        //
-        // EERLIJK OVER WAT BEWEZEN IS: de tests tonen dat het maximum
-        // standhoudt, niet dat déze vergrendeling daarvoor nodig is. Met de
-        // FOR UPDATE verwijderd bleven ze groen — gemeten, niet aangenomen.
-        // Twee transacties via dezelfde pg-Pool komen in de praktijk achter
-        // elkaar aan de beurt, dus de race was niet uit te lokken zonder een
-        // wachtpunt in deze code te bouwen. Dat is de prijs niet waard voor
-        // een vergrendeling die goedkoop en correct is; hij blijft staan voor
-        // het geval de transacties wél overlappen (meerdere processen).
-        const response = await tx.execute<{ status: string }>(
-          sql`SELECT status FROM clm.survey_response
+      return await this.db.withTenant<BijlageUitkomst>(
+        tenantId,
+        async (tx) => {
+          // FOR UPDATE op de responserij, zodat twee overlappende uploads niet
+          // allebei hetzelfde aantal tellen en samen over max_files heen gaan.
+          // Een CHECK kan dit niet afvangen: die kan noch over meerdere rijen
+          // tellen noch survey_question raadplegen.
+          //
+          // EERLIJK OVER WAT BEWEZEN IS: de tests tonen dat het maximum
+          // standhoudt, niet dat déze vergrendeling daarvoor nodig is. Met de
+          // FOR UPDATE verwijderd bleven ze groen — gemeten, niet aangenomen.
+          // Twee transacties via dezelfde pg-Pool komen in de praktijk achter
+          // elkaar aan de beurt, dus de race was niet uit te lokken zonder een
+          // wachtpunt in deze code te bouwen. Dat is de prijs niet waard voor
+          // een vergrendeling die goedkoop en correct is; hij blijft staan voor
+          // het geval de transacties wél overlappen (meerdere processen).
+          const response = await tx.execute<{ status: string }>(
+            sql`SELECT status FROM clm.survey_response
                  WHERE response_id = ${responseId}
                  FOR UPDATE`,
-        );
+          );
 
-        const status = response.rows[0]?.status;
+          const status = response.rows[0]?.status;
 
-        // Na indienen geen uploads meer. De RLS-policy weigert dit ook, maar
-        // dan als databasefout; hier wordt het een nette 410.
-        if (status !== 'pending') {
-          return { status: 'niet-meer-open' };
-        }
+          // Na indienen geen uploads meer. De RLS-policy weigert dit ook, maar
+          // dan als databasefout; hier wordt het een nette 410.
+          if (status !== 'pending') {
+            return { status: 'niet-meer-open' };
+          }
 
-        const vraag = await tx.execute<VraagRij>(
-          sql`SELECT q.question_id, q.allows_upload, q.max_files
+          const vraag = await tx.execute<VraagRij>(
+            sql`SELECT q.question_id, q.allows_upload, q.max_files
                   FROM clm.survey_response r
                   JOIN clm.survey_run      run ON run.run_id    = r.run_id
                   JOIN clm.survey_question q   ON q.template_id = run.template_id
                  WHERE r.response_id = ${responseId}
                    AND q.question_key = ${questionKey}`,
-        );
+          );
 
-        const rij = vraag.rows[0];
+          const rij = vraag.rows[0];
 
-        // Geen rij betekent: deze vraag hoort niet bij de vragenlijst van
-        // déze run. Dezelfde regel als bij het indienen — RLS beschermt
-        // tegen een andere tenant, deze join tegen een andere template.
-        if (!rij) {
-          return { status: 'onbekende-vraag' };
-        }
+          // Geen rij betekent: deze vraag hoort niet bij de vragenlijst van
+          // déze run. Dezelfde regel als bij het indienen — RLS beschermt
+          // tegen een andere tenant, deze join tegen een andere template.
+          if (!rij) {
+            return { status: 'onbekende-vraag' };
+          }
 
-        if (!rij.allows_upload || rij.max_files < 1) {
-          return { status: 'geen-upload-vraag' };
-        }
+          if (!rij.allows_upload || rij.max_files < 1) {
+            return { status: 'geen-upload-vraag' };
+          }
 
-        const aantal = await tx.execute<{ n: string }>(
-          sql`SELECT count(*)::text AS n FROM clm.survey_attachment
+          const aantal = await tx.execute<{ n: string }>(
+            sql`SELECT count(*)::text AS n FROM clm.survey_attachment
                  WHERE response_id = ${responseId}
                    AND question_id = ${rij.question_id}`,
-        );
+          );
 
-        if (Number(aantal.rows[0].n) >= rij.max_files) {
-          return { status: 'te-veel-bestanden', maximum: rij.max_files };
-        }
+          if (Number(aantal.rows[0].n) >= rij.max_files) {
+            return { status: 'te-veel-bestanden', maximum: rij.max_files };
+          }
 
-        const bijlage = await tx.execute<{ attachment_id: string }>(
-          sql`INSERT INTO clm.survey_attachment
+          const bijlage = await tx.execute<{ attachment_id: string }>(
+            sql`INSERT INTO clm.survey_attachment
                     (tenant_id, response_id, question_id, original_name,
                      storage_key, content_type, byte_size, sha256)
                 VALUES (${tenantId}, ${responseId}, ${rij.question_id},
@@ -134,18 +136,20 @@ export class BijlageService {
                         ${storageKey}, ${gecontroleerd.contentType},
                         ${bestand.buffer.length}, ${gecontroleerd.sha256})
                 RETURNING attachment_id`,
-        );
+          );
 
-        this.logger.log(
-          `Bijlage toegevoegd aan response ${responseId} (${gecontroleerd.contentType}, ${bestand.buffer.length} bytes).`,
-        );
+          this.logger.log(
+            `Bijlage toegevoegd aan response ${responseId} (${gecontroleerd.contentType}, ${bestand.buffer.length} bytes).`,
+          );
 
-        return {
-          status: 'opgeslagen',
-          attachmentId: bijlage.rows[0].attachment_id,
-          contentType: gecontroleerd.contentType,
-        };
-      });
+          return {
+            status: 'opgeslagen',
+            attachmentId: bijlage.rows[0].attachment_id,
+            contentType: gecontroleerd.contentType,
+          };
+        },
+        'leverancier',
+      );
     } finally {
       // Elke uitkomst behalve 'opgeslagen' laat een bestand achter zonder rij.
       // Dat opruimen gebeurt hier, ook wanneer de transactie een fout gooide.
@@ -166,11 +170,14 @@ export class BijlageService {
     storageKey: string,
   ): Promise<void> {
     try {
-      const bestaat = await this.db.withTenant(tenantId, (tx) =>
-        tx.execute<{ n: string }>(
-          sql`SELECT count(*)::text AS n FROM clm.survey_attachment
+      const bestaat = await this.db.withTenant(
+        tenantId,
+        (tx) =>
+          tx.execute<{ n: string }>(
+            sql`SELECT count(*)::text AS n FROM clm.survey_attachment
                WHERE storage_key = ${storageKey}`,
-        ),
+          ),
+        'leverancier',
       );
 
       if (Number(bestaat.rows[0].n) === 0) {

--- a/src/survey/survey-token.service.ts
+++ b/src/survey/survey-token.service.ts
@@ -200,13 +200,15 @@ export class SurveyTokenService {
    * Geen rij terug betekent: iemand was eerder, of hij is inmiddels verlopen.
    */
   async dienIn(tenantId: string, responseId: string): Promise<boolean> {
-    return this.db.withTenant(tenantId, async (tx) => {
-      const resultaat = await tx.execute<{ response_id: string }>(
-        // De ronde-status staat óók in dit statement, niet alleen in de guard.
-        // De guard beschermt het HTTP-pad; deze voorwaarde beschermt de
-        // methode zelf, zodat een toekomstige aanroeper die de guard niet
-        // passeert geen indiening kan forceren op een ronde die dicht staat.
-        sql`UPDATE clm.survey_response AS r
+    return this.db.withTenant(
+      tenantId,
+      async (tx) => {
+        const resultaat = await tx.execute<{ response_id: string }>(
+          // De ronde-status staat óók in dit statement, niet alleen in de guard.
+          // De guard beschermt het HTTP-pad; deze voorwaarde beschermt de
+          // methode zelf, zodat een toekomstige aanroeper die de guard niet
+          // passeert geen indiening kan forceren op een ronde die dicht staat.
+          sql`UPDATE clm.survey_response AS r
                SET status = 'submitted', submitted_at = now()
              WHERE r.response_id = ${responseId}
                AND r.status = 'pending'
@@ -217,28 +219,30 @@ export class SurveyTokenService {
                         AND run.status = 'active'
                    )
          RETURNING r.response_id`,
-      );
-
-      const gelukt = resultaat.rows.length === 1;
-
-      if (!gelukt) {
-        // Geen fout: dit is het verwachte gedrag bij een tweede poging.
-        this.logger.warn(
-          `Indienen geweigerd voor response ${responseId}: al ingediend of verlopen.`,
         );
-        return false;
-      }
 
-      // Binnen dezelfde transactie (AC8): rolt de indiening terug, dan
-      // verdwijnt de auditregel mee. Een auditregel voor iets dat niet
-      // gebeurd is, is erger dan geen auditregel.
-      await this.audit.leg(tx, {
-        tenantId,
-        actie: 'survey_response_ingediend',
-        responseId,
-      });
+        const gelukt = resultaat.rows.length === 1;
 
-      return true;
-    });
+        if (!gelukt) {
+          // Geen fout: dit is het verwachte gedrag bij een tweede poging.
+          this.logger.warn(
+            `Indienen geweigerd voor response ${responseId}: al ingediend of verlopen.`,
+          );
+          return false;
+        }
+
+        // Binnen dezelfde transactie (AC8): rolt de indiening terug, dan
+        // verdwijnt de auditregel mee. Een auditregel voor iets dat niet
+        // gebeurd is, is erger dan geen auditregel.
+        await this.audit.leg(tx, {
+          tenantId,
+          actie: 'survey_response_ingediend',
+          responseId,
+        });
+
+        return true;
+      },
+      'leverancier',
+    );
   }
 }

--- a/src/survey/vragenlijst-import.service.ts
+++ b/src/survey/vragenlijst-import.service.ts
@@ -104,40 +104,44 @@ export class VragenlijstImportService {
   ): Promise<ImportResultaat> {
     const lijst = valideerVragenlijst(document);
 
-    return this.db.withTenant(tenantId, async (tx) => {
-      const templateId = await this.maakTemplate(tx, tenantId, lijst);
+    return this.db.withTenant(
+      tenantId,
+      async (tx) => {
+        const templateId = await this.maakTemplate(tx, tenantId, lijst);
 
-      // De koppeling vraag → categorie loopt via category_key uit het bestand.
-      // Deze map vertaalt die sleutel naar de UUID die we zojuist zelf hebben
-      // gegenereerd; een UUID uit het bestand komt er niet aan te pas.
-      const categorieIds = await this.maakCategorieen(
-        tx,
-        tenantId,
-        templateId,
-        lijst.categories ?? [],
-      );
+        // De koppeling vraag → categorie loopt via category_key uit het bestand.
+        // Deze map vertaalt die sleutel naar de UUID die we zojuist zelf hebben
+        // gegenereerd; een UUID uit het bestand komt er niet aan te pas.
+        const categorieIds = await this.maakCategorieen(
+          tx,
+          tenantId,
+          templateId,
+          lijst.categories ?? [],
+        );
 
-      await this.maakVragen(
-        tx,
-        tenantId,
-        templateId,
-        lijst.questions,
-        categorieIds,
-      );
+        await this.maakVragen(
+          tx,
+          tenantId,
+          templateId,
+          lijst.questions,
+          categorieIds,
+        );
 
-      this.logger.log(
-        `Vragenlijst '${lijst.name}' v${lijst.version} geïmporteerd: ` +
-          `${lijst.questions.length} vragen, ${categorieIds.size} categorieën.`,
-      );
+        this.logger.log(
+          `Vragenlijst '${lijst.name}' v${lijst.version} geïmporteerd: ` +
+            `${lijst.questions.length} vragen, ${categorieIds.size} categorieën.`,
+        );
 
-      return {
-        templateId,
-        naam: lijst.name,
-        versie: lijst.version,
-        aantalCategorieen: categorieIds.size,
-        aantalVragen: lijst.questions.length,
-      };
-    });
+        return {
+          templateId,
+          naam: lijst.name,
+          versie: lijst.version,
+          aantalCategorieen: categorieIds.size,
+          aantalVragen: lijst.questions.length,
+        };
+      },
+      'medewerker',
+    );
   }
 
   private async maakTemplate(
@@ -260,77 +264,81 @@ export class VragenlijstImportService {
     tenantId: string,
     templateId: string,
   ): Promise<VragenlijstInvoer> {
-    return this.db.withTenant(tenantId, async (tx) => {
-      const template = await tx.execute<{ name: string; version: number }>(
-        sql`SELECT name, version FROM clm.survey_template
+    return this.db.withTenant(
+      tenantId,
+      async (tx) => {
+        const template = await tx.execute<{ name: string; version: number }>(
+          sql`SELECT name, version FROM clm.survey_template
              WHERE template_id = ${templateId}`,
-      );
+        );
 
-      const kop = template.rows[0];
+        const kop = template.rows[0];
 
-      // Geen rij betekent hier "bestaat niet of hoort bij een andere tenant" —
-      // RLS maakt dat onderscheid onzichtbaar, en dat is precies de bedoeling.
-      if (!kop) {
-        throw new TemplateOnbekendError(templateId);
-      }
+        // Geen rij betekent hier "bestaat niet of hoort bij een andere tenant" —
+        // RLS maakt dat onderscheid onzichtbaar, en dat is precies de bedoeling.
+        if (!kop) {
+          throw new TemplateOnbekendError(templateId);
+        }
 
-      const categorieen = await tx.execute<CategorieRij>(
-        sql`SELECT category_id, position, name, min_answers
+        const categorieen = await tx.execute<CategorieRij>(
+          sql`SELECT category_id, position, name, min_answers
               FROM clm.survey_category
              WHERE template_id = ${templateId}
              ORDER BY position`,
-      );
+        );
 
-      // De sleutel in het exportbestand wordt afgeleid van de naam, niet van de
-      // UUID: een export moet leesbaar en herimporteerbaar zijn zonder iets
-      // over de interne identiteiten te verklappen.
-      const sleutels = new Map<string, string>();
-      const gebruikt = new Set<string>();
+        // De sleutel in het exportbestand wordt afgeleid van de naam, niet van de
+        // UUID: een export moet leesbaar en herimporteerbaar zijn zonder iets
+        // over de interne identiteiten te verklappen.
+        const sleutels = new Map<string, string>();
+        const gebruikt = new Set<string>();
 
-      for (const categorie of categorieen.rows) {
-        let sleutel = maakSleutel(categorie.name);
-        let volgnummer = 2;
-        while (gebruikt.has(sleutel)) {
-          sleutel = `${maakSleutel(categorie.name)}-${volgnummer++}`;
+        for (const categorie of categorieen.rows) {
+          let sleutel = maakSleutel(categorie.name);
+          let volgnummer = 2;
+          while (gebruikt.has(sleutel)) {
+            sleutel = `${maakSleutel(categorie.name)}-${volgnummer++}`;
+          }
+          gebruikt.add(sleutel);
+          sleutels.set(categorie.category_id, sleutel);
         }
-        gebruikt.add(sleutel);
-        sleutels.set(categorie.category_id, sleutel);
-      }
 
-      const vragen = await tx.execute<VraagRij>(
-        sql`SELECT question_key, category_id, position, title, body,
+        const vragen = await tx.execute<VraagRij>(
+          sql`SELECT question_key, category_id, position, title, body,
                    answer_type, is_required, allows_upload, max_files, config
               FROM clm.survey_question
              WHERE template_id = ${templateId}
              ORDER BY position`,
-      );
+        );
 
-      return {
-        schema_version: SCHEMA_VERSIE,
-        name: kop.name,
-        version: kop.version,
-        categories: categorieen.rows.map((categorie) => ({
-          key: sleutels.get(categorie.category_id) as string,
-          position: categorie.position,
-          name: categorie.name,
-          min_answers: categorie.min_answers,
-        })),
-        questions: vragen.rows.map((vraag) => ({
-          question_key: vraag.question_key,
-          category_key: vraag.category_id
-            ? (sleutels.get(vraag.category_id) ?? null)
-            : null,
-          position: vraag.position,
-          title: vraag.title,
-          body: vraag.body,
-          answer_type: vraag.answer_type as AntwoordType,
-          is_required: vraag.is_required,
-          allows_upload: vraag.allows_upload,
-          max_files: vraag.max_files,
-          config: vraag.config ?? {},
-        })),
-      };
-    });
+        return {
+          schema_version: SCHEMA_VERSIE,
+          name: kop.name,
+          version: kop.version,
+          categories: categorieen.rows.map((categorie) => ({
+            key: sleutels.get(categorie.category_id) as string,
+            position: categorie.position,
+            name: categorie.name,
+            min_answers: categorie.min_answers,
+          })),
+          questions: vragen.rows.map((vraag) => ({
+            question_key: vraag.question_key,
+            category_key: vraag.category_id
+              ? (sleutels.get(vraag.category_id) ?? null)
+              : null,
+            position: vraag.position,
+            title: vraag.title,
+            body: vraag.body,
+            answer_type: vraag.answer_type as AntwoordType,
+            is_required: vraag.is_required,
+            allows_upload: vraag.allows_upload,
+            max_files: vraag.max_files,
+            config: vraag.config ?? {},
+          })),
+        };
+      },
+      'medewerker',
+    );
   }
 }
 

--- a/src/survey/vragenlijst-lezen.service.ts
+++ b/src/survey/vragenlijst-lezen.service.ts
@@ -163,13 +163,15 @@ export class VragenlijstLeesService {
     tenantId: string,
     responseId: string,
   ): Promise<Vragenlijst | null> {
-    return this.db.withTenant(tenantId, async (tx) => {
-      const resultaat = await tx.execute<VraagRij>(
-        // De keten response → run → template → vragen. Elke stap zit binnen de
-        // tenantcontext, dus RLS beschermt tegen een andere tenant; de
-        // response_id-voorwaarde beschermt tegen een andere respons binnen
-        // dezelfde tenant.
-        sql`SELECT q.question_key,
+    return this.db.withTenant(
+      tenantId,
+      async (tx) => {
+        const resultaat = await tx.execute<VraagRij>(
+          // De keten response → run → template → vragen. Elke stap zit binnen de
+          // tenantcontext, dus RLS beschermt tegen een andere tenant; de
+          // response_id-voorwaarde beschermt tegen een andere respons binnen
+          // dezelfde tenant.
+          sql`SELECT q.question_key,
                    q.title,
                    q.body,
                    q.answer_type,
@@ -190,69 +192,71 @@ export class VragenlijstLeesService {
               LEFT JOIN clm.survey_category c ON c.category_id = q.category_id
              WHERE r.response_id = ${responseId}
              ORDER BY c.position NULLS FIRST, q.position`,
-      );
+        );
 
-      const rijen = resultaat.rows;
+        const rijen = resultaat.rows;
 
-      // Geen rijen betekent: de respons bestaat niet in deze tenant, of de
-      // template heeft nog geen vragen. Voor de aanroeper is dat hetzelfde —
-      // er valt niets te tonen.
-      if (rijen.length === 0) {
-        return null;
-      }
-
-      const categorieen = new Map<string, Categorie>();
-      const losseVragen: Vraag[] = [];
-
-      for (const rij of rijen) {
-        const vraag: Vraag = {
-          questionKey: rij.question_key,
-          title: rij.title,
-          body: rij.body,
-          answerType: rij.answer_type as AntwoordType,
-          isRequired: rij.is_required,
-          allowsUpload: rij.allows_upload,
-          maxFiles: rij.max_files,
-          config: vertaalConfig(rij.config),
-        };
-
-        if (rij.category_id === null || rij.category_name === null) {
-          losseVragen.push(vraag);
-          continue;
+        // Geen rijen betekent: de respons bestaat niet in deze tenant, of de
+        // template heeft nog geen vragen. Voor de aanroeper is dat hetzelfde —
+        // er valt niets te tonen.
+        if (rijen.length === 0) {
+          return null;
         }
 
-        let categorie = categorieen.get(rij.category_id);
+        const categorieen = new Map<string, Categorie>();
+        const losseVragen: Vraag[] = [];
 
-        if (!categorie) {
-          categorie = {
-            key: maakSleutel(rij.category_name),
-            name: rij.category_name,
-            minAnswers: rij.category_min_answers ?? 0,
-            questions: [],
+        for (const rij of rijen) {
+          const vraag: Vraag = {
+            questionKey: rij.question_key,
+            title: rij.title,
+            body: rij.body,
+            answerType: rij.answer_type as AntwoordType,
+            isRequired: rij.is_required,
+            allowsUpload: rij.allows_upload,
+            maxFiles: rij.max_files,
+            config: vertaalConfig(rij.config),
           };
-          categorieen.set(rij.category_id, categorie);
+
+          if (rij.category_id === null || rij.category_name === null) {
+            losseVragen.push(vraag);
+            continue;
+          }
+
+          let categorie = categorieen.get(rij.category_id);
+
+          if (!categorie) {
+            categorie = {
+              key: maakSleutel(rij.category_name),
+              name: rij.category_name,
+              minAnswers: rij.category_min_answers ?? 0,
+              questions: [],
+            };
+            categorieen.set(rij.category_id, categorie);
+          }
+
+          categorie.questions.push(vraag);
         }
 
-        categorie.questions.push(vraag);
-      }
+        const eerste = rijen[0];
+        const sluit = eerste.closes_at;
 
-      const eerste = rijen[0];
-      const sluit = eerste.closes_at;
-
-      return {
-        name: eerste.template_name,
-        categories: [...categorieen.values()],
-        questions: losseVragen,
-        // Tijdstippen komen bij ruwe SQL als string terug wanneer ze uit een
-        // JOIN komen; vandaar de dubbele behandeling. Zelfde patroon als
-        // alsDatum() in survey-token.service.ts.
-        closesAt:
-          sluit === null
-            ? null
-            : sluit instanceof Date
-              ? sluit.toISOString()
-              : new Date(sluit).toISOString(),
-      };
-    });
+        return {
+          name: eerste.template_name,
+          categories: [...categorieen.values()],
+          questions: losseVragen,
+          // Tijdstippen komen bij ruwe SQL als string terug wanneer ze uit een
+          // JOIN komen; vandaar de dubbele behandeling. Zelfde patroon als
+          // alsDatum() in survey-token.service.ts.
+          closesAt:
+            sluit === null
+              ? null
+              : sluit instanceof Date
+                ? sluit.toISOString()
+                : new Date(sluit).toISOString(),
+        };
+      },
+      'leverancier',
+    );
   }
 }

--- a/src/vendor/vendor.service.ts
+++ b/src/vendor/vendor.service.ts
@@ -187,9 +187,11 @@ export class VendorService {
    * elkaar halen maakt allebei moeilijker te doorgronden.
    */
   async lijst(tenantId: string): Promise<VendorSamenvatting[]> {
-    return this.db.withTenant(tenantId, async (tx) => {
-      const resultaat = await tx.execute<VendorRij>(
-        sql`SELECT v.vendor_id,
+    return this.db.withTenant(
+      tenantId,
+      async (tx) => {
+        const resultaat = await tx.execute<VendorRij>(
+          sql`SELECT v.vendor_id,
                    v.name,
                    v.kvk_number,
                    v.city,
@@ -203,19 +205,21 @@ export class VendorService {
               FROM clm.vendor v
              WHERE v.deleted_at IS NULL
              ORDER BY v.created_at DESC`,
-      );
+        );
 
-      return resultaat.rows.map((r) => ({
-        vendorId: r.vendor_id,
-        name: r.name,
-        kvkNumber: r.kvk_number,
-        city: r.city,
-        country: r.country,
-        website: r.website,
-        aantalContacten: Number(r.aantal_contacten),
-        createdAt: alsTekst(r.created_at),
-      }));
-    });
+        return resultaat.rows.map((r) => ({
+          vendorId: r.vendor_id,
+          name: r.name,
+          kvkNumber: r.kvk_number,
+          city: r.city,
+          country: r.country,
+          website: r.website,
+          aantalContacten: Number(r.aantal_contacten),
+          createdAt: alsTekst(r.created_at),
+        }));
+      },
+      'medewerker',
+    );
   }
 
   /**
@@ -233,31 +237,33 @@ export class VendorService {
     tenantId: string,
     invoer: NieuweVendor,
   ): Promise<AangemaakteVendor> {
-    return this.db.withTenant(tenantId, async (tx) => {
-      const kvk = leegIsNull(invoer.kvkNumber);
+    return this.db.withTenant(
+      tenantId,
+      async (tx) => {
+        const kvk = leegIsNull(invoer.kvkNumber);
 
-      // Vooraf controleren geeft een bruikbare melding; de unieke index blijft
-      // de echte garantie. Zonder deze controle krijgt de gebruiker een
-      // databasefout te zien in plaats van "dit KvK-nummer bestaat al".
-      if (kvk) {
-        const bestaand = await tx.execute<{ name: string }>(
-          sql`SELECT name FROM clm.vendor
+        // Vooraf controleren geeft een bruikbare melding; de unieke index blijft
+        // de echte garantie. Zonder deze controle krijgt de gebruiker een
+        // databasefout te zien in plaats van "dit KvK-nummer bestaat al".
+        if (kvk) {
+          const bestaand = await tx.execute<{ name: string }>(
+            sql`SELECT name FROM clm.vendor
                WHERE kvk_number = ${kvk} AND deleted_at IS NULL
                LIMIT 1`,
-        );
-
-        if (bestaand.rows.length > 0) {
-          throw new ConflictException(
-            `Er bestaat al een leverancier met KvK-nummer ${kvk}: ${bestaand.rows[0].name}.`,
           );
-        }
-      }
 
-      const vendorResultaat = await tx.execute<{
-        vendor_id: string;
-        name: string;
-      }>(
-        sql`INSERT INTO clm.vendor (tenant_id, name, kvk_number, city, country, website)
+          if (bestaand.rows.length > 0) {
+            throw new ConflictException(
+              `Er bestaat al een leverancier met KvK-nummer ${kvk}: ${bestaand.rows[0].name}.`,
+            );
+          }
+        }
+
+        const vendorResultaat = await tx.execute<{
+          vendor_id: string;
+          name: string;
+        }>(
+          sql`INSERT INTO clm.vendor (tenant_id, name, kvk_number, city, country, website)
             VALUES (${tenantId},
                     ${invoer.name.trim()},
                     ${kvk},
@@ -265,17 +271,17 @@ export class VendorService {
                     ${leegIsNull(invoer.country) ?? 'NL'},
                     ${leegIsNull(invoer.website)})
             RETURNING vendor_id, name`,
-      );
+        );
 
-      const nieuweVendor = vendorResultaat.rows[0];
-      let contactId: string | null = null;
+        const nieuweVendor = vendorResultaat.rows[0];
+        let contactId: string | null = null;
 
-      if (invoer.contact?.fullName?.trim()) {
-        // is_primary op true: dit is de eerste contactpersoon, en een
-        // leverancier zonder primair contact levert straks geen ontvanger op
-        // voor de uitnodiging.
-        const contactResultaat = await tx.execute<{ contact_id: string }>(
-          sql`INSERT INTO clm.vendor_contact
+        if (invoer.contact?.fullName?.trim()) {
+          // is_primary op true: dit is de eerste contactpersoon, en een
+          // leverancier zonder primair contact levert straks geen ontvanger op
+          // voor de uitnodiging.
+          const contactResultaat = await tx.execute<{ contact_id: string }>(
+            sql`INSERT INTO clm.vendor_contact
                 (vendor_id, tenant_id, full_name, email, phone, job_title, is_primary)
               VALUES (${nieuweVendor.vendor_id},
                       ${tenantId},
@@ -285,21 +291,23 @@ export class VendorService {
                       ${leegIsNull(invoer.contact.jobTitle)},
                       true)
               RETURNING contact_id`,
+          );
+
+          contactId = contactResultaat.rows[0].contact_id;
+        }
+
+        this.logger.log(
+          `Leverancier aangemaakt (${nieuweVendor.vendor_id})${contactId ? ' met contactpersoon' : ''}.`,
         );
 
-        contactId = contactResultaat.rows[0].contact_id;
-      }
-
-      this.logger.log(
-        `Leverancier aangemaakt (${nieuweVendor.vendor_id})${contactId ? ' met contactpersoon' : ''}.`,
-      );
-
-      return {
-        vendorId: nieuweVendor.vendor_id,
-        name: nieuweVendor.name,
-        contactId,
-      };
-    });
+        return {
+          vendorId: nieuweVendor.vendor_id,
+          name: nieuweVendor.name,
+          contactId,
+        };
+      },
+      'medewerker',
+    );
   }
 
   /**
@@ -315,8 +323,10 @@ export class VendorService {
     tenantId: string,
     vendorId: string,
   ): Promise<VendorDetail | null> {
-    return this.db.withTenant(tenantId, (tx) =>
-      this.detailBinnenTransactie(tx, vendorId),
+    return this.db.withTenant(
+      tenantId,
+      (tx) => this.detailBinnenTransactie(tx, vendorId),
+      'medewerker',
     );
   }
 
@@ -341,92 +351,98 @@ export class VendorService {
         ? undefined
         : leegIsNull(wijziging.kvkNumber);
 
-    return this.db.withTenant(tenantId, async (tx) => {
-      const bestaat = await tx.execute<{ vendor_id: string }>(
-        sql`SELECT vendor_id FROM clm.vendor
+    return this.db.withTenant(
+      tenantId,
+      async (tx) => {
+        const bestaat = await tx.execute<{ vendor_id: string }>(
+          sql`SELECT vendor_id FROM clm.vendor
              WHERE vendor_id = ${vendorId} AND deleted_at IS NULL`,
-      );
+        );
 
-      if (bestaat.rows.length === 0) {
-        return null;
-      }
+        if (bestaat.rows.length === 0) {
+          return null;
+        }
 
-      // Zelfde controle als bij aanmaken, plus "en niet ikzelf": zonder die
-      // uitzondering kan een leverancier zijn eigen KvK-nummer niet opnieuw
-      // opslaan.
-      if (kvk) {
-        const botsing = await tx.execute<{ name: string }>(
-          sql`SELECT name FROM clm.vendor
+        // Zelfde controle als bij aanmaken, plus "en niet ikzelf": zonder die
+        // uitzondering kan een leverancier zijn eigen KvK-nummer niet opnieuw
+        // opslaan.
+        if (kvk) {
+          const botsing = await tx.execute<{ name: string }>(
+            sql`SELECT name FROM clm.vendor
                WHERE kvk_number = ${kvk}
                  AND vendor_id <> ${vendorId}
                  AND deleted_at IS NULL
                LIMIT 1`,
-        );
+          );
 
-        if (botsing.rows.length > 0) {
-          throw new ConflictException(
-            `Er bestaat al een leverancier met KvK-nummer ${kvk}: ${botsing.rows[0].name}.`,
+          if (botsing.rows.length > 0) {
+            throw new ConflictException(
+              `Er bestaat al een leverancier met KvK-nummer ${kvk}: ${botsing.rows[0].name}.`,
+            );
+          }
+        }
+
+        const zetten: SQL[] = [];
+
+        if (wijziging.name !== undefined) {
+          zetten.push(sql`name = ${wijziging.name.trim()}`);
+        }
+        if (kvk !== undefined) {
+          zetten.push(sql`kvk_number = ${kvk}`);
+        }
+        if (wijziging.vestigingsnummer !== undefined) {
+          zetten.push(
+            sql`vestigingsnummer = ${leegIsNull(wijziging.vestigingsnummer)}`,
           );
         }
-      }
+        if (wijziging.statutoryName !== undefined) {
+          zetten.push(
+            sql`statutory_name = ${leegIsNull(wijziging.statutoryName)}`,
+          );
+        }
+        if (wijziging.city !== undefined) {
+          zetten.push(sql`city = ${leegIsNull(wijziging.city)}`);
+        }
+        if (wijziging.country !== undefined) {
+          zetten.push(sql`country = ${leegIsNull(wijziging.country) ?? 'NL'}`);
+        }
+        if (wijziging.website !== undefined) {
+          zetten.push(sql`website = ${leegIsNull(wijziging.website)}`);
+        }
+        if (wijziging.categoryCode !== undefined) {
+          zetten.push(
+            sql`category_code = ${leegIsNull(wijziging.categoryCode)}`,
+          );
+        }
+        if (wijziging.businessCriticalityCode !== undefined) {
+          zetten.push(
+            sql`business_criticality_code = ${leegIsNull(wijziging.businessCriticalityCode)}`,
+          );
+        }
+        if (wijziging.complianceStatusCode !== undefined) {
+          zetten.push(
+            sql`compliance_status_code = ${leegIsNull(wijziging.complianceStatusCode)}`,
+          );
+        }
 
-      const zetten: SQL[] = [];
+        // Niets meegestuurd: geen UPDATE draaien, maar wel het detail teruggeven.
+        // Een lege PATCH is geen fout — hij verandert alleen niets.
+        if (zetten.length > 0) {
+          zetten.push(sql`updated_at = now()`);
 
-      if (wijziging.name !== undefined) {
-        zetten.push(sql`name = ${wijziging.name.trim()}`);
-      }
-      if (kvk !== undefined) {
-        zetten.push(sql`kvk_number = ${kvk}`);
-      }
-      if (wijziging.vestigingsnummer !== undefined) {
-        zetten.push(
-          sql`vestigingsnummer = ${leegIsNull(wijziging.vestigingsnummer)}`,
-        );
-      }
-      if (wijziging.statutoryName !== undefined) {
-        zetten.push(
-          sql`statutory_name = ${leegIsNull(wijziging.statutoryName)}`,
-        );
-      }
-      if (wijziging.city !== undefined) {
-        zetten.push(sql`city = ${leegIsNull(wijziging.city)}`);
-      }
-      if (wijziging.country !== undefined) {
-        zetten.push(sql`country = ${leegIsNull(wijziging.country) ?? 'NL'}`);
-      }
-      if (wijziging.website !== undefined) {
-        zetten.push(sql`website = ${leegIsNull(wijziging.website)}`);
-      }
-      if (wijziging.categoryCode !== undefined) {
-        zetten.push(sql`category_code = ${leegIsNull(wijziging.categoryCode)}`);
-      }
-      if (wijziging.businessCriticalityCode !== undefined) {
-        zetten.push(
-          sql`business_criticality_code = ${leegIsNull(wijziging.businessCriticalityCode)}`,
-        );
-      }
-      if (wijziging.complianceStatusCode !== undefined) {
-        zetten.push(
-          sql`compliance_status_code = ${leegIsNull(wijziging.complianceStatusCode)}`,
-        );
-      }
-
-      // Niets meegestuurd: geen UPDATE draaien, maar wel het detail teruggeven.
-      // Een lege PATCH is geen fout — hij verandert alleen niets.
-      if (zetten.length > 0) {
-        zetten.push(sql`updated_at = now()`);
-
-        await tx.execute(
-          sql`UPDATE clm.vendor
+          await tx.execute(
+            sql`UPDATE clm.vendor
                  SET ${sql.join(zetten, sql`, `)}
                WHERE vendor_id = ${vendorId}`,
-        );
+          );
 
-        this.logger.log(`Leverancier gewijzigd (${vendorId}).`);
-      }
+          this.logger.log(`Leverancier gewijzigd (${vendorId}).`);
+        }
 
-      return this.detailBinnenTransactie(tx, vendorId);
-    });
+        return this.detailBinnenTransactie(tx, vendorId);
+      },
+      'medewerker',
+    );
   }
 
   /**
@@ -437,29 +453,33 @@ export class VendorService {
    * in een surveyronde voorkomen en die respons is bewijsmateriaal.
    */
   async verwijder(tenantId: string, vendorId: string): Promise<boolean> {
-    return this.db.withTenant(tenantId, async (tx) => {
-      const resultaat = await tx.execute<{ vendor_id: string }>(
-        sql`UPDATE clm.vendor
+    return this.db.withTenant(
+      tenantId,
+      async (tx) => {
+        const resultaat = await tx.execute<{ vendor_id: string }>(
+          sql`UPDATE clm.vendor
                SET deleted_at = now()
              WHERE vendor_id = ${vendorId}
                AND deleted_at IS NULL
              RETURNING vendor_id`,
-      );
+        );
 
-      if (resultaat.rows.length === 0) {
-        return false;
-      }
+        if (resultaat.rows.length === 0) {
+          return false;
+        }
 
-      await tx.execute(
-        sql`UPDATE clm.vendor_contact
+        await tx.execute(
+          sql`UPDATE clm.vendor_contact
                SET deleted_at = now()
              WHERE vendor_id = ${vendorId}
                AND deleted_at IS NULL`,
-      );
+        );
 
-      this.logger.log(`Leverancier verwijderd (${vendorId}).`);
-      return true;
-    });
+        this.logger.log(`Leverancier verwijderd (${vendorId}).`);
+        return true;
+      },
+      'medewerker',
+    );
   }
 
   // ── Contactpersonen ──────────────────────────────────────────────────────
@@ -477,36 +497,38 @@ export class VendorService {
     vendorId: string,
     invoer: ContactInvoer,
   ): Promise<Contactpersoon | null> {
-    return this.db.withTenant(tenantId, async (tx) => {
-      const bestaat = await tx.execute<{ vendor_id: string }>(
-        sql`SELECT vendor_id FROM clm.vendor
+    return this.db.withTenant(
+      tenantId,
+      async (tx) => {
+        const bestaat = await tx.execute<{ vendor_id: string }>(
+          sql`SELECT vendor_id FROM clm.vendor
              WHERE vendor_id = ${vendorId} AND deleted_at IS NULL`,
-      );
+        );
 
-      if (bestaat.rows.length === 0) {
-        return null;
-      }
+        if (bestaat.rows.length === 0) {
+          return null;
+        }
 
-      // Eerste contactpersoon wordt vanzelf primair: anders heeft een
-      // leverancier contacten maar geen aanspreekpunt.
-      const aantal = await tx.execute<{ n: string }>(
-        sql`SELECT count(*) AS n FROM clm.vendor_contact
+        // Eerste contactpersoon wordt vanzelf primair: anders heeft een
+        // leverancier contacten maar geen aanspreekpunt.
+        const aantal = await tx.execute<{ n: string }>(
+          sql`SELECT count(*) AS n FROM clm.vendor_contact
              WHERE vendor_id = ${vendorId} AND deleted_at IS NULL`,
-      );
+        );
 
-      const wordtPrimair =
-        invoer.isPrimary === true || Number(aantal.rows[0].n) === 0;
+        const wordtPrimair =
+          invoer.isPrimary === true || Number(aantal.rows[0].n) === 0;
 
-      if (wordtPrimair) {
-        await tx.execute(
-          sql`UPDATE clm.vendor_contact
+        if (wordtPrimair) {
+          await tx.execute(
+            sql`UPDATE clm.vendor_contact
                  SET is_primary = false, updated_at = now()
                WHERE vendor_id = ${vendorId} AND is_primary = true`,
-        );
-      }
+          );
+        }
 
-      const resultaat = await tx.execute<ContactRij>(
-        sql`INSERT INTO clm.vendor_contact
+        const resultaat = await tx.execute<ContactRij>(
+          sql`INSERT INTO clm.vendor_contact
                 (vendor_id, tenant_id, full_name, email, phone, job_title,
                  is_primary)
             VALUES (${vendorId}, ${tenantId},
@@ -516,20 +538,22 @@ export class VendorService {
                     ${leegIsNull(invoer.jobTitle)},
                     ${wordtPrimair})
             RETURNING contact_id, full_name, email, phone, job_title, is_primary`,
-      );
+        );
 
-      const c = resultaat.rows[0];
-      this.logger.log(`Contactpersoon toegevoegd (${c.contact_id}).`);
+        const c = resultaat.rows[0];
+        this.logger.log(`Contactpersoon toegevoegd (${c.contact_id}).`);
 
-      return {
-        contactId: c.contact_id,
-        fullName: c.full_name,
-        email: c.email,
-        phone: c.phone,
-        jobTitle: c.job_title,
-        isPrimary: c.is_primary,
-      };
-    });
+        return {
+          contactId: c.contact_id,
+          fullName: c.full_name,
+          email: c.email,
+          phone: c.phone,
+          jobTitle: c.job_title,
+          isPrimary: c.is_primary,
+        };
+      },
+      'medewerker',
+    );
   }
 
   /** Wijzigt een contactpersoon. Alleen de meegestuurde velden. */
@@ -539,73 +563,77 @@ export class VendorService {
     contactId: string,
     invoer: ContactInvoer,
   ): Promise<Contactpersoon | null> {
-    return this.db.withTenant(tenantId, async (tx) => {
-      const bestaat = await tx.execute<{ contact_id: string }>(
-        sql`SELECT contact_id FROM clm.vendor_contact
+    return this.db.withTenant(
+      tenantId,
+      async (tx) => {
+        const bestaat = await tx.execute<{ contact_id: string }>(
+          sql`SELECT contact_id FROM clm.vendor_contact
              WHERE contact_id = ${contactId}
                AND vendor_id = ${vendorId}
                AND deleted_at IS NULL`,
-      );
+        );
 
-      if (bestaat.rows.length === 0) {
-        return null;
-      }
+        if (bestaat.rows.length === 0) {
+          return null;
+        }
 
-      if (invoer.isPrimary === true) {
-        await tx.execute(
-          sql`UPDATE clm.vendor_contact
+        if (invoer.isPrimary === true) {
+          await tx.execute(
+            sql`UPDATE clm.vendor_contact
                  SET is_primary = false, updated_at = now()
                WHERE vendor_id = ${vendorId}
                  AND contact_id <> ${contactId}
                  AND is_primary = true`,
-        );
-      }
+          );
+        }
 
-      const zetten: SQL[] = [];
+        const zetten: SQL[] = [];
 
-      if (invoer.fullName !== undefined) {
-        zetten.push(sql`full_name = ${invoer.fullName.trim()}`);
-      }
-      if (invoer.email !== undefined) {
-        zetten.push(sql`email = ${leegIsNull(invoer.email)}`);
-      }
-      if (invoer.phone !== undefined) {
-        zetten.push(sql`phone = ${leegIsNull(invoer.phone)}`);
-      }
-      if (invoer.jobTitle !== undefined) {
-        zetten.push(sql`job_title = ${leegIsNull(invoer.jobTitle)}`);
-      }
-      if (invoer.isPrimary !== undefined) {
-        zetten.push(sql`is_primary = ${invoer.isPrimary}`);
-      }
+        if (invoer.fullName !== undefined) {
+          zetten.push(sql`full_name = ${invoer.fullName.trim()}`);
+        }
+        if (invoer.email !== undefined) {
+          zetten.push(sql`email = ${leegIsNull(invoer.email)}`);
+        }
+        if (invoer.phone !== undefined) {
+          zetten.push(sql`phone = ${leegIsNull(invoer.phone)}`);
+        }
+        if (invoer.jobTitle !== undefined) {
+          zetten.push(sql`job_title = ${leegIsNull(invoer.jobTitle)}`);
+        }
+        if (invoer.isPrimary !== undefined) {
+          zetten.push(sql`is_primary = ${invoer.isPrimary}`);
+        }
 
-      if (zetten.length > 0) {
-        zetten.push(sql`updated_at = now()`);
+        if (zetten.length > 0) {
+          zetten.push(sql`updated_at = now()`);
 
-        await tx.execute(
-          sql`UPDATE clm.vendor_contact
+          await tx.execute(
+            sql`UPDATE clm.vendor_contact
                  SET ${sql.join(zetten, sql`, `)}
                WHERE contact_id = ${contactId}`,
-        );
-      }
+          );
+        }
 
-      const resultaat = await tx.execute<ContactRij>(
-        sql`SELECT contact_id, full_name, email, phone, job_title, is_primary
+        const resultaat = await tx.execute<ContactRij>(
+          sql`SELECT contact_id, full_name, email, phone, job_title, is_primary
               FROM clm.vendor_contact
              WHERE contact_id = ${contactId}`,
-      );
+        );
 
-      const c = resultaat.rows[0];
+        const c = resultaat.rows[0];
 
-      return {
-        contactId: c.contact_id,
-        fullName: c.full_name,
-        email: c.email,
-        phone: c.phone,
-        jobTitle: c.job_title,
-        isPrimary: c.is_primary,
-      };
-    });
+        return {
+          contactId: c.contact_id,
+          fullName: c.full_name,
+          email: c.email,
+          phone: c.phone,
+          jobTitle: c.job_title,
+          isPrimary: c.is_primary,
+        };
+      },
+      'medewerker',
+    );
   }
 
   /**
@@ -620,23 +648,25 @@ export class VendorService {
     vendorId: string,
     contactId: string,
   ): Promise<boolean> {
-    return this.db.withTenant(tenantId, async (tx) => {
-      const resultaat = await tx.execute<{ is_primary: boolean }>(
-        sql`UPDATE clm.vendor_contact
+    return this.db.withTenant(
+      tenantId,
+      async (tx) => {
+        const resultaat = await tx.execute<{ is_primary: boolean }>(
+          sql`UPDATE clm.vendor_contact
                SET deleted_at = now()
              WHERE contact_id = ${contactId}
                AND vendor_id = ${vendorId}
                AND deleted_at IS NULL
              RETURNING is_primary`,
-      );
+        );
 
-      if (resultaat.rows.length === 0) {
-        return false;
-      }
+        if (resultaat.rows.length === 0) {
+          return false;
+        }
 
-      if (resultaat.rows[0].is_primary) {
-        await tx.execute(
-          sql`UPDATE clm.vendor_contact
+        if (resultaat.rows[0].is_primary) {
+          await tx.execute(
+            sql`UPDATE clm.vendor_contact
                  SET is_primary = true, updated_at = now()
                WHERE contact_id = (
                  SELECT contact_id FROM clm.vendor_contact
@@ -644,12 +674,14 @@ export class VendorService {
                   ORDER BY created_at
                   LIMIT 1
                )`,
-        );
-      }
+          );
+        }
 
-      this.logger.log(`Contactpersoon verwijderd (${contactId}).`);
-      return true;
-    });
+        this.logger.log(`Contactpersoon verwijderd (${contactId}).`);
+        return true;
+      },
+      'medewerker',
+    );
   }
 
   /**

--- a/test/actor-context.e2e-spec.ts
+++ b/test/actor-context.e2e-spec.ts
@@ -1,0 +1,164 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { Test, TestingModule } from '@nestjs/testing';
+import { sql } from 'drizzle-orm';
+
+import { DatabaseService } from '../src/db/database.service';
+import { TEST_IDS } from './test-ids';
+
+const TENANT = TEST_IDS['actor-context'].tenant;
+
+/**
+ * Bewijst dat `app.current_actor` daadwerkelijk in de database aankomt.
+ *
+ * ── Waarom deze test bestaat vóór de eerste policy ───────────────────────────
+ *
+ * Migratie 0013 verandert bewust geen gedrag: geen enkele bestaande policy
+ * leunt op de actor. Dat maakt hem veilig om uit te rollen, maar het betekent
+ * ook dat een fout erin volledig onzichtbaar is — alles blijft groen, ook als
+ * de variabele nooit gezet wordt.
+ *
+ * Migratie 0014 gaat er wél op leunen. Als de doorgifte dan stuk blijkt, is de
+ * uitkomst niet een foutmelding maar nul rijen op een plek waar een medewerker
+ * iets hoort te zien. Dat is precies de faalvorm die dit project probeert uit
+ * te sluiten: stil, en pas zichtbaar wanneer iemand er last van heeft.
+ *
+ * Vandaar deze test nu, en niet samen met survey_review.
+ */
+describe('Actor-context (e2e)', () => {
+  let moduleRef: TestingModule;
+  let db: DatabaseService;
+
+  const leesActor = (actor?: 'medewerker' | 'leverancier') =>
+    db.withTenant(
+      TENANT,
+      async (tx) => {
+        const r = await tx.execute<{ actor: string }>(
+          sql`SELECT clm.current_actor() AS actor`,
+        );
+        return r.rows[0].actor;
+      },
+      actor,
+    );
+
+  beforeAll(async () => {
+    moduleRef = await Test.createTestingModule({
+      providers: [DatabaseService],
+    }).compile();
+
+    db = moduleRef.get(DatabaseService);
+    await db.onModuleInit();
+  });
+
+  afterAll(async () => {
+    await moduleRef.close();
+  });
+
+  it('geeft de actor door aan de database', async () => {
+    await expect(leesActor('medewerker')).resolves.toBe('medewerker');
+    await expect(leesActor('leverancier')).resolves.toBe('leverancier');
+  });
+
+  /**
+   * De kern van het ontwerp: niet zetten faalt dicht, niet open.
+   *
+   * Was de standaard 'medewerker' geweest, dan zou elke aanroeper die de actor
+   * vergeet stilzwijgend de ruimste rechten krijgen — en dat is nooit op te
+   * merken, want het werkt gewoon.
+   */
+  it('levert onbekend op wanneer de actor niet is meegegeven', async () => {
+    await expect(leesActor()).resolves.toBe('onbekend');
+  });
+
+  /**
+   * De actor mag niet overleven buiten zijn transactie.
+   *
+   * set_config(..., true) is transactielokaal, maar de verbindingenpool geeft
+   * dezelfde connectie aan een volgend verzoek. Lekte de waarde, dan zou een
+   * leveranciersverzoek de actor van een eerdere medewerker kunnen erven — een
+   * rechtenlek dat alleen onder belasting optreedt en dus vrijwel niet te
+   * reproduceren is.
+   *
+   * Deze test dwingt hergebruik af door de pool op één verbinding te zetten
+   * (DATABASE_POOL_MAX) is hier niet nodig: de aanroepen zijn sequentieel, dus
+   * de tweede pakt per definitie een vrijgekomen connectie.
+   */
+  it('laat de actor niet lekken naar een volgende transactie', async () => {
+    await leesActor('medewerker');
+    await expect(leesActor()).resolves.toBe('onbekend');
+
+    await leesActor('leverancier');
+    await expect(leesActor()).resolves.toBe('onbekend');
+  });
+
+  /**
+   * Tegenproef-ondersteuning: de actor is per transactie, niet per proces.
+   *
+   * Twee gelijktijdige transacties met verschillende actors mogen elkaar niet
+   * beïnvloeden. Zonder deze garantie zou de policy op survey_review afhangen
+   * van timing.
+   */
+  it('houdt gelijktijdige transacties uit elkaar', async () => {
+    const [a, b, c] = await Promise.all([
+      leesActor('medewerker'),
+      leesActor('leverancier'),
+      leesActor(),
+    ]);
+
+    expect(a).toBe('medewerker');
+    expect(b).toBe('leverancier');
+    expect(c).toBe('onbekend');
+  });
+
+  /**
+   * Bewaakt dat de drie leverancierspaden zichzelf niet als medewerker
+   * aankondigen.
+   *
+   * ── Waarom deze test de broncode leest en niet het gedrag ────────────────
+   *
+   * Deze controle is er gekomen door een tegenproef die groen bleef. Op
+   * 2026-08-03 is `vragenlijst-lezen.service.ts` van 'leverancier' naar
+   * 'medewerker' gezet — het ernstigste wat er met dit mechanisme mis kan gaan,
+   * want daarmee krijgt een leverancier straks toegang tot beoordelingen over
+   * zichzelf. Alle 268 tests bleven groen.
+   *
+   * Dat is terecht en tegelijk onacceptabel. Terecht, omdat er nog geen policy
+   * bestaat die de actor gebruikt: migratie 0013 verandert bewust geen gedrag,
+   * en tot migratie 0014 is er niets dat een verkeerde actor kan merken.
+   * Onacceptabel, omdat de doorgifte daarmee tot dat moment volledig onbewaakt
+   * is — en dit is precies het venster waarin iemand een nieuwe survey-route
+   * bouwt en de actor vergeet of overneemt van het verkeerde voorbeeld.
+   *
+   * Een gedragstest is hier dus niet mogelijk. De broncode lezen is lelijker,
+   * maar het is het verschil tussen een bewaakte afspraak en een goed
+   * voornemen — dezelfde afweging als in test-ids.spec.ts.
+   *
+   * Zodra migratie 0014 er is, blijft deze test staan: hij vangt de fout bij de
+   * bron, terwijl een policytest hem pas vangt op de ene plek waar hij toevallig
+   * zichtbaar wordt (MCM2-CLAUDE.md §15b, tegenproef 6).
+   */
+  it('kondigt elk leverancierspad aan als leverancier', () => {
+    // De drie paden die een leverancier met zijn token bereikt. vragenlijst-
+    // import staat er bewust niet bij: dat is beheerwerk achter een sessie.
+    const leverancierspaden = [
+      'src/survey/vragenlijst-lezen.service.ts',
+      'src/survey/antwoord-indienen.service.ts',
+      'src/survey/bijlage.service.ts',
+      'src/survey/survey-token.service.ts',
+    ];
+
+    for (const pad of leverancierspaden) {
+      const bron = readFileSync(join(__dirname, '..', pad), 'utf8');
+
+      expect({ pad, medewerker: bron.includes("'medewerker'") }).toEqual({
+        pad,
+        medewerker: false,
+      });
+      expect({ pad, leverancier: bron.includes("'leverancier'") }).toEqual({
+        pad,
+        leverancier: true,
+      });
+    }
+  });
+});

--- a/test/demo-seed.e2e-spec.ts
+++ b/test/demo-seed.e2e-spec.ts
@@ -245,7 +245,24 @@ describe('Demo-seed (e2e)', () => {
       const alsTekst = Buffer.from(rij.token_hash, 'hex').toString('utf8');
       expect(alsTekst).not.toContain('demo-');
     }
-  });
+    // Twintig seconden en niet de standaard vijf.
+    //
+    // Deze test start het seed-script twee keer als apart Node-proces. Eén
+    // aanroep duurt ~1,6 s tegen een rustige database: een Node-start, de
+    // migratiecontrole en ruim honderd inserts. Twee aanroepen zitten daarmee
+    // al op ~3,2 s, en dat is binnen de standaardlimiet van 5 s alleen genoeg
+    // zolang de machine niets anders doet.
+    //
+    // In de volledige suite doet hij dat wel: twintig suites draaien parallel
+    // tegen dezelfde database en delen een pool van vier verbindingen per
+    // applicatie. Dan valt deze test om op een timeout — met een foutmelding
+    // die naar hashing wijst terwijl er niets mis is met hashing.
+    //
+    // Dat is dezelfde faalvorm als de botsende test-id's van 2026-07-31: de
+    // melding wijst naar het gevolg, niet naar de oorzaak, en "even opnieuw
+    // draaien" wordt een gewoonte. Vandaar een limiet die past bij wat de test
+    // daadwerkelijk doet.
+  }, 20_000);
 
   it('gebruikt tokens met de vorm die de guard accepteert', () => {
     // Deze test bestaat door schade: de eerste versie van het script gebruikte
@@ -268,7 +285,8 @@ describe('Demo-seed (e2e)', () => {
     for (const token of links) {
       expect(token).toMatch(TOKEN_PATROON);
     }
-  });
+    // Ook twee scriptaanroepen, dus dezelfde limiet als de test hierboven.
+  }, 20_000);
 
   // ── Tenantgrens ───────────────────────────────────────────────────────────
 

--- a/test/test-ids.ts
+++ b/test/test-ids.ts
@@ -44,6 +44,9 @@ function id(merk: string): string {
  * de herkomst van een id te vinden is zonder te zoeken.
  */
 export const TEST_IDS = {
+  'actor-context': {
+    tenant: id('ac'),
+  },
   'antwoord-indienen': {
     tenant: id('b1'),
   },


### PR DESCRIPTION
Nieuw op GitHub — drie commits, `verify:volledig` groen (269 e2e-tests, 25 browsertests).

## Waar dit over gaat

De eigenaar heeft vastgesteld dat een leverancier nooit bij een beoordeling van zichzelf mag komen. Bij het uitwerken bleek dat niet af te dwingen met wat er lag.

`DatabaseService.withTenant()` zette precies één sessievariabele: `app.current_tenant_id`. Het leverancierspad (tokenlookup) en het medewerkerspad (sessiecookie) riepen die functie identiek aan, met dezelfde tenantId. Elke policy luidt `USING (tenant_id = clm.current_tenant_id())`.

Gemeten op 2026-08-03: **de database kon geen onderscheid maken tussen een medewerker en een leverancier van dezelfde tenant.**

Voor elke bestaande tabel is dat juist — een leverancier hoort zijn eigen respons te lezen. Het wordt pas een probleem bij `survey_review` (migratie 0014), waar het oordeel over een leverancier voor die leverancier onzichtbaar moet blijven. Zonder deze migratie zou die bescherming volledig bestaan uit de afwezigheid van een route die het teruggeeft — hetzelfde faalpatroon als tegenproef 6.

## Wat er nu staat

`app.current_actor` met waarden `medewerker`, `leverancier` en `onbekend`, gelezen via `clm.current_actor()`. Niet gezet betekent `onbekend`: een vergeten actor faalt dicht, niet open.

De migratie **verandert bewust geen gedrag** — geen enkele bestaande policy leunt erop. Apart gehouden zodat hij groen kan zijn vóórdat migratie 0014 er op gaat leunen.

## Drie tegenproeven, en de derde leverde een nieuwe les

| Sabotage | Uitkomst |
|---|---|
| `withTenant()` zet de actor altijd op `medewerker` | 2 tests vielen om, zoals bedoeld |
| standaard omgedraaid naar `medewerker` i.p.v. `onbekend` | 3 tests vielen om, zoals bedoeld |
| leverancierspad kondigt zich aan als `medewerker` | **alle 268 tests bleven groen** |

Die derde is het ernstigste wat er met dit mechanisme mis kan gaan. Niets merkte het.

Terecht — er was nog geen policy die de actor gebruikt, dus viel er niets te meten. En tegelijk onacceptabel: daarmee is de doorgifte tot migratie 0014 volledig onbewaakt, en dat is precies het venster waarin iemand een nieuwe route bouwt en de actor van het verkeerde voorbeeld overneemt.

Opgelost met een test die de broncode zelf leest (`actor-context.e2e-spec.ts`) — lelijker dan een gedragstest, maar het verschil tussen een bewaakte afspraak en een goed voornemen. Dezelfde afweging als `test-ids.spec.ts`. Na toevoeging faalt de sabotage wél.

De les staat in MCM2-CLAUDE.md §15b: **bouw je een grens in twee stappen, dan hoort er in stap één een test die de afspraak zelf bewaakt.**

## Twee dingen die onderweg naar boven kwamen

**`verify:volledig` strandde twee keer op een bezette poort** — beide keren pas ná stap 1, die minuten duurt. De controle staat nu vooraan en stopt binnen ~2,5 seconde met een melding die zegt welke poort bezet is en hoe je het proces vindt.

Dat was ook een correctheidsprobleem: `wachtOpStack()` pollt op `localhost:5001/health` en `:3000`, dus een draaiende dev-server antwoordde met 200 en het script concludeerde dat de stack gezond was — waarna de browsertest tegen die dev-server draaide in plaats van tegen de productie-images. Vandaar hard falen en niet alleen waarschuwen.

**`demo-seed.e2e-spec` viel reproduceerbaar om op een timeout van 5 s.** Niet door deze wijziging: het seed-script gebruikt zijn eigen `set_config` en raakt `withTenant()` niet. De test start dat script twee keer als apart proces (~1,6 s per keer, gemeten). Twee tests staan nu op 20 s met de reden erbij.

## Ook in deze PR

Het plan `docs/superpowers/plans/2026-08-03-surveybeheer.md`, met vier besluiten van de eigenaar: alleen UC1, beoordelen met goed/nadere_vragen/niet_goed, "nadere vragen" markeert en heropent niet (een aanvulling wordt een tweede ronde zodat ronde 1 bewijsmateriaal blijft), en elk oordeel blijft bewaard met naam en datum.

## Volgende stap

Migratie 0014 (`survey_review`) met de actor-eis in de policy, plus de tegenproef die het oordeel bewust aan het leverancierspad toevoegt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
