### PR TITLE
Documentatie bijgewerkt: actorgrens en gemeten testaantallen

### DIFF
--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,7 +1,9 @@
 # MCM2 — actuele status
 
 ## Laatst bijgewerkt
-2026-08-03, avond (**`app.current_actor` toegevoegd**: de database kan sinds migratie 0013 onderscheid maken tussen een medewerker en een leverancier. Dat kon hij niet — `withTenant()` zette alleen de tenant, en beide paden riepen hem identiek aan. Nodig voor de beoordelingstabel uit het surveybeheerplan, waar "zelfde tenant = mag het zien" voor het eerst níét opgaat. 269 e2e-tests en 25 browsertests groen. Drie tegenproeven gedaan; de derde bleef groen en leverde een nieuwe les op — zie hieronder.)
+2026-08-03, avond (**`app.current_actor` toegevoegd en gemerged**, PR #73: de database kan sinds migratie 0013 onderscheid maken tussen een medewerker en een leverancier. Dat kon hij niet — `withTenant()` zette alleen de tenant, en beide paden riepen hem identiek aan. Nodig voor de beoordelingstabel uit het surveybeheerplan, waar "zelfde tenant = mag het zien" voor het eerst níét opgaat. 269 e2e-tests en 25 browsertests groen, CI groen op `main`, geen open branches. Drie tegenproeven gedaan; de derde bleef groen en leverde een nieuwe les op — zie hieronder.)
+
+**Volgende stap:** fase A uit `docs/superpowers/plans/2026-08-03-surveybeheer.md` — het menu-item **Vragenlijsten** met de twee Transdev-lijsten uit de database.
 
 <details>
 <summary>Vorige stand (2026-08-03, middag)</summary>
@@ -19,7 +21,16 @@
 
 Alles hieronder is geverifieerd, niet uit gespreksgeheugen.
 
-**Plan voor de komende fases:** `docs/superpowers/plans/2026-07-30-beheerkant-en-demo-tenant.md` — vier fases naar een frontend die eruitziet als MVM_V2, inloggen als tenant, vendors met contactpersonen aanmaken, een demo-tenant met mock data, en een robuuste OTAP-doorloop.
+**Plan voor de komende fases:** `docs/superpowers/plans/2026-08-03-surveybeheer.md` — vier fases naar een tenant die zelf een vragenlijst kan uitzetten: rondes bekijken (A), een ronde starten en deelnemers uitnodigen (B), voortgang volgen, antwoorden lezen en beoordelen (C), en uitnodigingen mailen (D). Alle openstaande vragen daarin zijn op 2026-08-03 beantwoord.
+
+Dat plan begint met een bevinding die het waard is om te onthouden: **`genereerToken()` heeft geen enkele productieaanroeper.** Alleen `seed-demo-tenant.js` en `otap-doorloop.js` maken responses aan. Er bestaat dus nog geen weg waarlangs een echte uitnodiging tot stand komt — de beheerkant kan leveranciers beheren, maar geen vragenlijst uitzetten.
+
+<details>
+<summary>Vorig plan (2026-07-30, alle vier de fases af)</summary>
+
+`docs/superpowers/plans/2026-07-30-beheerkant-en-demo-tenant.md` — een frontend die eruitziet als MVM_V2, inloggen als tenant, vendors met contactpersonen aanmaken, een demo-tenant met mock data, en een robuuste OTAP-doorloop.
+
+</details>
 
 ## Het project bestaat uit twee repositories
 
@@ -58,7 +69,7 @@ Eigen CI en eigen releasecyclus per repo — bewust, zodat een tekstwijziging in
    /beheer/leveranciers        sidebar + lijst met zoeken + aanmaakformulier
    /beheer/leveranciers/[id]   detail: stamgegevens wijzigen, contactpersonen beheren
    npm run seed:demo           demo-tenant: 21 leveranciers, 3 gebruikers, 3 responses
-   npm run verify:volledig     code → 161 unit → 264 e2e → stack → 25 browsertests
+   npm run verify:volledig     code → 161 unit → 269 e2e → stack → 25 browsertests
    ```
 
    **Inloggen via Entra werkt aantoonbaar.** Eén echte login doorlopen: code inwisselen, token verifiëren met de échte applicatiecode, gebruiker en membership, sessie via `clm.sessie_aanmaken()`, en met dat cookie `/vendors` → 200. Zonder cookie → 401.
@@ -97,9 +108,21 @@ Blijken ze over een half jaar nog steeds ongebruikt, dan kunnen ze weg — de ke
 npm run verify:volledig
 ```
 
-Vijf stappen: code, 161 unittests, 264 e2e tegen een wegwerpdatabase, beide
+Vijf stappen: code, 161 unittests, 269 e2e tegen een wegwerpdatabase, beide
 productie-images bouwen, 25 browsertests, en altijd opruimen. Stopt bij de
 eerste rode stap en noemt welke CI-job dat is.
+
+**Sinds 2026-08-03 controleert hij eerst of poort 5001 en 3000 vrij zijn.** Draait
+daar een dev-server, dan stopt hij binnen ~2,5 seconde met een melding die zegt
+welke poort bezet is en hoe je het proces vindt. Daarvóór strandde de doorloop
+pas ná stap 1 — minuten aan tests voor niets, met een Docker-melding die niet zei
+wélk proces in de weg zat.
+
+Dat was ook een correctheidsprobleem: `wachtOpStack()` pollt op die twee poorten,
+dus een draaiende dev-server antwoordde met 200 en het script dacht dat de stack
+gezond was — waarna de browsertest tegen die dev-server draaide in plaats van
+tegen de productie-images. Vandaar hard falen en niet alleen waarschuwen. Het
+script sluit bewust niets zelf af.
 
 **Let op bij handmatig een testcontainer draaien:** `verify:volledig` claimt poort
 **55441**. Draait daar nog iets van een vorige sessie, dan faalt stap 1 met
@@ -124,7 +147,7 @@ docker exec -i mcm2test psql -U postgres -q < db/roles/bootstrap-roles.sql
 docker exec mcm2test psql -U postgres -d postgres -c "ALTER ROLE clm_migrator WITH PASSWORD 'pw'; ALTER ROLE clm_api_runtime WITH PASSWORD 'pw';"
 MIGRATION_DATABASE_URL="postgresql://clm_migrator:pw@localhost:55440/postgres" npm run migrate:deploy
 DATABASE_URL="postgresql://clm_api_runtime:pw@localhost:55440/postgres" \
-  npx jest --config test/jest-e2e.json --forceExit    # 228 tests, 16 suites
+  npx jest --config test/jest-e2e.json --forceExit    # 269 tests, 20 suites
 # --forceExit is nodig sinds de sessiesuite: die houdt een pg-verbinding open
 # waardoor Jest anders blijft hangen zonder foutmelding.
 # `-d postgres` is niet optioneel: psql neemt anders de rolnaam als
@@ -456,6 +479,14 @@ Transdev Vendor IT Compliance Survey als eerste verticale MVP-slice.
 
 ## Aantoonbaar werkend
 
+- **De actor-grens (2026-08-03, migratie 0013, PR #73).** De database kan onderscheid maken tussen een medewerker en een leverancier van dezelfde tenant. `withTenant()` zet naast de tenant nu ook `app.current_actor`, gelezen via `clm.current_actor()`; niet gezet betekent `onbekend`, de striktste stand.
+
+  **269 e2e-tests groen in 20 suites** plus **161 unittests**, tegen een database die vanaf niets is opgebouwd met migraties 0000 t/m 0013. Vier leverancierspaden geven `leverancier` door, twaalf medewerkerspaden `medewerker` — geverifieerd na afloop, niet aangenomen.
+
+  **Eerlijk over wat níét bewezen is:** er is nog geen policy die de actor gebruikt. Deze migratie verandert bewust geen gedrag; wat hier bewezen is, is uitsluitend dat de waarde correct in de database aankomt en per transactie geïsoleerd blijft. De eerste policy die erop leunt is migratie 0014 (`survey_review`), en die bestaat nog niet.
+
+  Dat is precies waarom de derde tegenproef groen bleef — zie de sectie hieronder over migratie 0013.
+
 - **Beheerkant fase 1 — de tenantgrens is dicht (2026-07-31, branch `feat/identiteit-en-membership`).** De laag die ontbrak is er:
 
   ```
@@ -731,7 +762,7 @@ Praktische valkuilen die daadwerkelijk zijn tegengekomen, niet bedacht. Ze staan
 
 **Drizzle verpakt databasefouten: een triggermelding staat in `cause`, niet in `message`.** Een test die met `rejects.toThrow(/bevroren/)` op `message` matcht, wordt daardoor óók groen bij een tikfout in de SQL — dan test hij niets. Lees `(fout as Error & { cause?: Error }).cause?.message`.
 
-**Testsuites die dezelfde tenant-id gebruiken botsen bij de tweede run.** Templates zijn uniek op `(tenant_id, name, version)` en de lokale testdatabase blijft staan. In gebruik: `…e1` (survey-routes), `…f1`/`…f2` (token-isolatie), `…d1`/`…d2`/`…d3` (vragenlijst). Kies een eigen paar, en geef testtemplates een unieke versie in plaats van een vast nummer.
+**Testsuites die dezelfde tenant-id gebruiken botsen bij de tweede run.** Templates zijn uniek op `(tenant_id, name, version)` en de lokale testdatabase blijft staan. **Sinds 2026-07-31 deelt `test/test-ids.ts` de id's uit, per suite een eigen blok, en bewaakt `test/test-ids.spec.ts` dat er geen dubbelen ontstaan** — inclusief een controle dat geen suite een id hardcodeert langs het register heen. Een nieuwe suite voegt daar een blok toe en gebruikt `TEST_IDS['naam']`; zelf een UUID kiezen faalt de unittest. Geef testtemplates daarnaast een unieke versie in plaats van een vast nummer.
 
 **Docker 29 weigert een containernaam van één teken.** Het oude `--name t` uit dit document faalde met "Invalid container name"; de opstartcommando's hierboven zijn gecorrigeerd naar `mcm2test`.
 
@@ -742,6 +773,12 @@ Praktische valkuilen die daadwerkelijk zijn tegengekomen, niet bedacht. Ze staan
 **Drizzle geeft een JS-array door als `record`, niet als `text[]`.** Een `INSERT` in een array-kolom faalt met "column X is of type text[] but expression is of type record". Werkende vorm: `ARRAY(SELECT jsonb_array_elements_text(${JSON.stringify(waarden)}::jsonb))`. Zelf een array-literal opbouwen kan ook, maar vraagt quoting van komma's, aanhalingstekens en accolades die in de waarden kunnen voorkomen — precies waar een injectiefout in sluipt.
 
 **Een nullable kolom maken raakt méér dan de tabel.** Migratie 0005 maakte `survey_response.vendor_id` nullable voor UC2, maar `resolve_survey_token()` joinde daar nog op — waardoor elke interne beoordeling 410 gaf. Bij het versoepelen van een kolom hoort een zoektocht naar elke plek die hem gebruikt: functies, views, policies. `grep -rn "vendor_id" drizzle/` had dit gevonden.
+
+**Bouw je een grens in twee stappen, dan is stap één onbewaakt tot stap twee er is.** Migratie 0013 voegt `app.current_actor` toe zonder één policy die hem gebruikt — bewust, zodat hij apart groen kan zijn. Gevolg: het leverancierspad zich laten voordoen als medewerker liet **alle 268 tests groen**. Terecht, want er viel niets te meten. En tegelijk het gevaarlijkste moment: precies het venster waarin iemand een nieuwe route bouwt en de actor van het verkeerde voorbeeld overneemt. **Hoort in stap één een test die de afspraak zélf bewaakt** — desnoods door de broncode te lezen, zoals `actor-context.e2e-spec.ts` en `test-ids.spec.ts` doen. Wachten tot stap twee betekent dat de fout er ondertussen in kan sluipen.
+
+**Een lang script hoort zijn goedkoopste controle als eerste te doen.** `verify:volledig` strandde twee keer op een bezette poort 5001/3000 — beide keren pas ná stap 1, die minuten duurt inclusief een wegwerpdatabase en 269 tests. De controle die het had voorkomen kost 2,5 seconde. Bijkomend: die poorten werden ook gebruikt om te bepalen óf de stack gezond was, dus een draaiende dev-server maakte de doorloop niet alleen traag maar ook onbetrouwbaar. **Vraag bij elke voorwaarde: wat kost het om dit vooraf te controleren, en wat kost het als het pas halverwege blijkt?**
+
+**Een test die een extern proces start, past zelden binnen de standaard 5 seconden.** `demo-seed.e2e-spec` viel reproduceerbaar om op een timeout omdat hij het seed-script twee keer als apart Node-proces draait (~1,6 s per keer, gemeten). Binnen de volledige suite — twintig suites parallel — was dat structureel te krap. De foutmelding wees naar hashing terwijl er niets mis was met hashing, dezelfde verwarrende faalvorm als de botsende test-id's. **Meet wat de test doet en geef hem een limiet die daarbij past, met de reden erbij.**
 
 ## Niet als bewezen beschouwen
 

--- a/docs/architectuur-en-verificatie.md
+++ b/docs/architectuur-en-verificatie.md
@@ -1,6 +1,6 @@
 # MCM2 — de tenantgrens, en hoe elke laag ervan bewezen wordt
 
-**Opgesteld:** 2026-07-31 · **Bijgewerkt:** 2026-07-31 na externe review
+**Opgesteld:** 2026-07-31 · **Bijgewerkt:** 2026-08-03 (actorgrens, migratie 0013)
 **Bedoeld voor:** de eigenaar en een externe reviewer
 **Leesbare webversie:** https://claude.ai/code/artifact/31d7819a-a7d9-4079-b224-c51d08497450
 
@@ -13,9 +13,9 @@ overgenomen uit eerdere verslagen.
 
 | | |
 |---|---|
-| E2e-tests | 210 in 15 suites |
+| E2e-tests | 269 in 20 suites |
 | Unittests | 161 in 8 suites |
-| Migraties | 0000 t/m 0011 |
+| Migraties | 0000 t/m 0013 |
 
 > **Onderhoud.** Dit document veroudert zodra de code verandert. Bij een wijziging
 > aan de tenantgrens, de testopzet of de verificatiepoort hoort een wijziging hier.
@@ -93,6 +93,47 @@ ingestelde klant te tonen.
 Dat werkt alleen wanneer de databaserol die regel niet mag negeren. Vandaar dat de
 applicatie draait als een rol **zonder** `BYPASSRLS` — en dat de applicatie weigert op te
 starten als dat recht er wél blijkt te zijn (`DatabaseService.onModuleInit`).
+
+### Waar de tenantgrens niet genoeg is: de actor (migratie 0013)
+
+Alles hierboven beantwoordt één vraag: **van welke klant is deze rij?** Voor vrijwel het
+hele systeem is dat de juiste vraag. Er is één plek waar het niet volstaat.
+
+De leverancier en de medewerker zitten in **dezelfde tenant**. Dat moet ook: de respons van
+een leverancier is klantgegeven van Transdev. Maar zodra Transdev een oordeel over die
+leverancier vastlegt, ontstaat er een rij die binnen dezelfde tenant valt en die de
+leverancier juist níét mag zien.
+
+Tot 2026-08-03 kon de database dat onderscheid niet maken. `withTenant()` zette precies één
+variabele, en beide paden riepen hem identiek aan:
+
+```
+leverancier (tokenlookup)  →  withTenant(tenantId)  →  app.current_tenant_id
+medewerker  (sessiecookie) →  withTenant(tenantId)  →  app.current_tenant_id
+```
+
+De enige bescherming zou dus zijn dat er geen route bestaat die het oordeel teruggeeft.
+**Dat is bescherming door afwezigheid** — precies het patroon dat in §4 als faalvorm staat
+beschreven: ze houdt stand tot iemand een route bouwt die "de respons met alles eromheen"
+ophaalt, en die persoon hoeft deze regel niet te kennen.
+
+Sinds migratie 0013 legt elke transactie ook vast **wie** hem opent:
+
+```
+app.current_actor  =  'medewerker' | 'leverancier' | 'onbekend'
+```
+
+Niet gezet betekent `onbekend`, en dat is de striktste stand. Een vergeten actor faalt
+dicht, niet open — de omgekeerde keuze zou betekenen dat elke nieuwe aanroeper die het
+vergeet stilzwijgend de ruimste rechten krijgt.
+
+**Wat hiervan bewezen is en wat niet.** Bewezen: de waarde komt correct in de database aan,
+blijft per transactie geïsoleerd (ook bij gelijktijdige transacties) en lekt niet naar een
+volgende transactie via de verbindingenpool. Niet bewezen: dat een policy hem correct
+gebruikt — die bestaat nog niet. Migratie 0013 verandert bewust geen gedrag; migratie 0014
+(`survey_review`) is de eerste die erop leunt.
+
+Dat verklaart ook een tegenproef die groen bleef; zie §4.
 
 ---
 
@@ -185,7 +226,7 @@ worden.
 > te vangen bewust in. Zie de test omvallen. Draai terug. Pas dan telt groen als bewijs.
 > Zonder die stap weet je alleen dat de test draait, niet dat hij iets bewaakt.
 
-Dat is geen theorie. In dit project heeft de tegenproef **vier keer** een gat gevonden dat
+Dat is geen theorie. In dit project heeft de tegenproef **vijf keer** een gat gevonden dat
 de groene tests niet lieten zien.
 
 ### De guardtest die 18 keer groen was en toch een gat liet
@@ -211,6 +252,34 @@ aanroept levert die waarschuwing niet op.
 Dat is het vermelden waard omdat het laat zien dat een tegenproef zélf ook fout kan zijn.
 Pas met een constructie waar de regel wél op afgaat, werd de poort rood. **Een mislukte
 tegenproef is geen bewijs dat de code goed is.**
+
+### De tegenproef die groen bleef omdat er nog niets te meten viel
+
+De ernstigste sabotage van 2026-08-03: het leverancierspad zich laten aankondigen als
+`medewerker`. Slaagt dat, dan krijgt een leverancier straks toegang tot beoordelingen over
+zichzelf — precies waar de actorgrens voor bestaat.
+
+**Alle 268 tests bleven groen.**
+
+En dat was terecht. Migratie 0013 voegt `app.current_actor` toe zonder één policy die hem
+gebruikt (§2). Er ís geen gedrag dat een verkeerde actor kan opmerken; de eerste policy die
+erop leunt komt in migratie 0014.
+
+Dat maakt het niet ongevaarlijk maar juist het tegendeel. **Tussen de twee migraties is de
+doorgifte volledig onbewaakt** — en dat is precies het venster waarin iemand een nieuwe
+survey-route bouwt en de actor vergeet of van het verkeerde voorbeeld overneemt. De fout
+zou dan pas zichtbaar worden op het moment dat de policy hem gaat gebruiken, in code die er
+al maanden staat.
+
+Een gedragstest is hier onmogelijk. Opgelost met een test die de **broncode zelf** leest en
+controleert dat de vier leverancierspaden zich als `leverancier` aankondigen
+(`actor-context.e2e-spec.ts`). Lelijker dan een gedragstest, en dezelfde afweging als
+`test-ids.spec.ts`, dat bewaakt dat suites geen UUID's langs het register heen hardcoderen.
+Na toevoeging faalt de sabotage wél.
+
+**De les, en die is breder dan dit geval:** bouw je een grens in twee stappen — eerst het
+mechanisme, dan de regel die erop leunt — dan hoort er in stap één een test die de afspraak
+zélf bewaakt. Wachten tot stap twee betekent dat de fout er ondertussen in kan sluipen.
 
 ### Waar de tests hun verwachting vandaan halen
 
@@ -249,26 +318,34 @@ Entra-tenant, en dat is *strenger* in plaats van losser. Een echte provider geef
 verlopen token af, of een token met een vervalste handtekening — en juist dat zijn de
 aanvallen. Met een lokaal gegenereerd sleutelpaar zijn die wél te maken.
 
-### E2e-tests — 210, tegen een wegwerpdatabase
+### E2e-tests — 269 in 20 suites, tegen een wegwerpdatabase
+
+Aantallen gemeten op 2026-08-03 tegen een database die vanaf niets is opgebouwd met
+migraties 0000 t/m 0013, niet geschat.
 
 | Suite | Bewaakt | Tests |
 |---|---|---:|
 | `antwoord-indienen` | Valideren vóór wegschrijven; tweede poging afgewezen (410) | 25 |
+| `vendor-detail` | Detail, wijzigen en verwijderen; een reviewer mag lezen maar niet schrijven | 23 |
 | `survey-token-isolatie` | Een token geeft toegang tot precies één respons | 21 |
 | `vragenlijst-import` | Import blijft binnen één tenant | 21 |
 | `tenant-context-guard` | **De sessieguard: geen tenantcontext zonder sessie** | 21 |
 | `vragenlijst-ophalen` | Alleen eigen vragenlijsten zichtbaar | 20 |
+| `vendor-routes` | De beheerroutes over HTTP, met twee tenants | 18 |
 | `bijlage-upload` | Inhoud bepaalt het bestandstype, niet de naam | 18 |
+| `schema-conformiteit` | Policies, FORCE RLS, tabeleigenaarschap en `search_path` — uit het schema afgeleid | 17 |
 | `vragenlijst-seed` | Inlezen van de acht Transdev-vragen | 15 |
 | `sessie` | Aanmaken, verlopen, intrekken; de tabel is afgesloten | 14 |
 | `membership-isolatie` | Lidmaatschap bepaalt de tenant, niet de invoer | 13 |
-| `schema-conformiteit` | Policies, FORCE RLS, tabeleigenaarschap en `search_path` — uit het schema afgeleid | 17 |
 | `survey-routes` | De volledige UC1-flow over HTTP | 12 |
+| `demo-seed` | De demo-tenant is idempotent en lekt niet naar een andere tenant | 8 |
 | `drizzle-tenant-context` | Isolatie ook via de querylaag, niet alleen ruwe SQL | 6 |
 | `tenant-rls-isolation` | Lezen én schrijven over de tenantgrens heen | 5 |
+| `actor-context` | **De actorgrens: medewerker, leverancier en onbekend** | 5 |
+| `sessie-route` | `/auth/sessie` geeft alleen naam, tenantnaam en rol terug | 5 |
 | `app`, `health` | De applicatie start en antwoordt | 2 |
 
-Vier van deze suites bestaan uitsluitend om de tenantgrens te toetsen, en ze doen dat
+Vijf van deze suites bestaan uitsluitend om de tenantgrens te toetsen, en ze doen dat
 langs verschillende wegen: ruwe SQL, de Drizzle-querylaag, het tokenpad en het sessiepad.
 Dat is bewust — **een garantie die maar op één manier getest is, is getest voor één manier
 van gebruiken.**
@@ -346,8 +423,9 @@ Die bewakingstest is het punt. De guard-suite had dit probleem eerder "opgelost"
 alleen een commentaarregel die voor botsingen waarschuwde — **een afspraak die niemand
 controleert, is geen afspraak.**
 
-Resultaat: **vijf keer achter elkaar 205 groen**, waar eerder ongeveer één op de vier runs
-faalde.
+Resultaat, gemeten op 2026-07-31: **vijf keer achter elkaar 205 groen**, waar eerder
+ongeveer één op de vier runs faalde. De suite is sindsdien naar 269 tests gegroeid en
+blijft stabiel; het register deelt inmiddels 17 blokken uit.
 
 ---
 
@@ -360,6 +438,7 @@ moeten lezen. Alles hierboven is gemeten; alles hieronder is dat niet.
 |---|---|---|
 | ~~Claims uit Microsoft Entra~~ | **Gemeten 2026-07-31** | `oid` is 36 tekens (UUID), `sub` 43 en dus géén UUID — het lengteverschil bevestigt de keuze voor `oid`. Zie §11. |
 | ~~De sessieguard in gebruik~~ | **Aangesloten 2026-07-31** | `GET`/`POST /vendors` draaien erachter, met 18 e2e-tests en een tegenproef. |
+| De actorgrens in een policy | **Onbewezen** | `app.current_actor` komt aantoonbaar in de database aan en blijft per transactie geïsoleerd (5 tests). Maar **geen enkele policy gebruikt hem** — migratie 0013 verandert bewust geen gedrag. Dat een leverancier straks écht buiten een beoordeling blijft, wordt pas bewezen door migratie 0014 plus de tegenproef die `survey_review` aan het leverancierspad toevoegt. Tot dan is de doorgifte alleen bewaakt door een test die de broncode leest; zie §4. |
 | Wachtwoordrotatie `postgres` | **Niet gedaan** | Issue #1. De beheerrol heeft nog het oorspronkelijke wachtwoord. |
 | Gelijktijdige uploads | **Onbewezen** | De `FOR UPDATE`-vergrendeling is er, maar met die vergrendeling verwijderd bleven alle tests groen. De race was niet uit te lokken zonder kunstgrepen in productiecode. |
 | Gezondheid van een uitgerolde omgeving | **Bestaat niet** | De e2e-tests beantwoorden dit nooit — ze zijn destructief van aard. Er is een aparte, alleen-lezende rookproef nodig: **Issue #61**. |


### PR DESCRIPTION
Alleen documentatie — geen code aangeraakt. `verify:snel` groen (format, lint, typecheck, 161 unittests).

## Inhoudelijk toegevoegd

- **De actorgrens als eigen laag** in `architectuur-en-verificatie.md`: waar de tenantgrens niet volstaat, en waarom "zelfde tenant = mag het zien" bij een beoordeling voor het eerst niet opgaat.
- **De tegenproef die groen bleef** omdat er nog niets te meten viel, met de les erbij: bouw je een grens in twee stappen, dan hoort er in stap één een test die de afspraak zélf bewaakt.
- **De poortcontrole in `verify:volledig`**, inclusief waarom dat ook een correctheidsprobleem was en niet alleen tijdverlies — `wachtOpStack()` pollt op 5001 en 3000, dus een draaiende dev-server maakte de doorloop onbetrouwbaar.
- **Twee lessen in STATUS.md**: een lang script hoort zijn goedkoopste controle als eerste te doen, en een test die een extern proces start past zelden binnen de standaard 5 seconden.

## Rechtgezet

De e2e-tabel stond op **210 tests in 15 suites**; het zijn er **269 in 20**. Per suite opnieuw gemeten tegen een verse database met migraties 0000 t/m 0013 — niet geschat. Vier suites ontbraken volledig (`vendor-detail`, `vendor-routes`, `demo-seed`, `sessie-route`).

Verder:
- migratiebereik 0011 → 0013
- STATUS.md verwees nog naar het plan van 2026-07-30, dat af is
- de lijst "in gebruik zijnde test-id's" was achterhaald én misleidend: `…e1` is intussen membership-isolatie, en er is sinds 2026-07-31 een register dat dit bewaakt
- de handmatige e2e-instructie noemde 228 tests in 16 suites

## Wat níét bewezen is, staat er ook

Toegevoegd aan §8: **geen enkele policy gebruikt de actor nog.** Migratie 0013 verandert bewust geen gedrag. Dat een leverancier écht buiten een beoordeling blijft, wordt pas bewezen door migratie 0014 plus de tegenproef die `survey_review` aan het leverancierspad toevoegt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
