### PR TITLE
Fase B: een ronde starten en leveranciers uitnodigen

### DIFF
--- a/src/survey/ronde-beheer.service.ts
+++ b/src/survey/ronde-beheer.service.ts
@@ -1,0 +1,403 @@
+import {
+  BadRequestException,
+  ConflictException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { sql } from 'drizzle-orm';
+
+import { DatabaseService } from '../db/database.service';
+import { genereerToken, hashToken } from './survey-token';
+import {
+  magOvergaan,
+  mogelijkeOvergangen,
+  type NieuweRonde,
+  type Uitnodigingen,
+} from './ronde-invoer';
+
+/**
+ * Rondes starten en leveranciers uitnodigen (fase B van
+ * docs/superpowers/plans/2026-08-03-surveybeheer.md).
+ *
+ * ── Dit is de eerste productiecode die tokens uitgeeft ───────────────────────
+ *
+ * Tot nu toe riepen alleen `seed-demo-tenant.js` en `otap-doorloop.js`
+ * `genereerToken()` aan. Er bestond dus geen weg waarlangs een échte uitnodiging
+ * tot stand kwam. Die weg is dit bestand.
+ *
+ * Dat maakt het de gevoeligste plek van dit plan: de tokenlaag is al bewezen en
+ * groen, en alles hier moet die laag gebruiken zoals hij bedoeld is — niet
+ * ernaast bouwen.
+ *
+ * ── Het ruwe token bestaat één keer ──────────────────────────────────────────
+ *
+ * `uitnodigen()` geeft de ruwe tokens terug in zijn antwoord. Dat is de enige
+ * keer dat ze bestaan; de database bewaart alleen `hashToken(...)`. Er is geen
+ * "toon nogmaals", en dat is geen omissie maar het ontwerp: wie een databasedump
+ * in handen krijgt kan daarmee geen enkele openstaande survey openen.
+ *
+ * Het gevolg voor de aanroeper is dat het antwoord van deze methode het enige
+ * moment is waarop de links doorgegeven kunnen worden. Het scherm moet dat
+ * zeggen vóórdat de beheerder wegklikt.
+ *
+ * ── Waarom hier geen e-mail verstuurd wordt ──────────────────────────────────
+ *
+ * Verleidelijk, want de tokens zijn hier beschikbaar. Maar e-mail hangt aan de
+ * SMTP-instellingen per tenant, en die zijn ontworpen maar niet gebouwd (spec
+ * 2026-08-04-beheermenu-tenantinstellingen). Fase D voegt het toe. Tot dan
+ * kopieert de beheerder de links zelf — een bewuste tussenstap, geen
+ * halfbakken versie.
+ */
+
+/** Eén uitgegeven uitnodiging, met het ruwe token erbij. */
+export interface Uitnodiging {
+  responseId: string;
+  vendorId: string;
+  vendorNaam: string;
+  /**
+   * Het ruwe token. Bestaat alleen in dit antwoord en nergens anders.
+   *
+   * Bewust niet `tokenHash`: die is voor niemand nuttig en zou een aanvaller
+   * die het antwoord onderschept de helft van het werk geven.
+   */
+  token: string;
+  expiresAt: string;
+}
+
+export interface RondeGestart {
+  runId: string;
+  templateId: string;
+  templateNaam: string;
+  status: string;
+  surveyKind: string;
+  isTest: boolean;
+  closesAt: string | null;
+}
+
+interface RunRij extends Record<string, unknown> {
+  run_id: string;
+  template_id: string;
+  template_naam: string;
+  status: string;
+  survey_kind: string;
+  is_test: boolean;
+  closes_at: Date | string | null;
+}
+
+interface VendorRij extends Record<string, unknown> {
+  vendor_id: string;
+  name: string;
+}
+
+function iso(waarde: Date | string | null): string | null {
+  if (waarde === null || waarde === undefined) return null;
+  return waarde instanceof Date ? waarde.toISOString() : String(waarde);
+}
+
+@Injectable()
+export class RondeBeheerService {
+  constructor(private readonly db: DatabaseService) {}
+
+  /**
+   * Maakt een nieuwe ronde aan, in status `draft`.
+   *
+   * ── Waarom draft en niet meteen actief ──────────────────────────────────────
+   *
+   * Een actieve ronde bevriest de vragenlijst (trigger
+   * `survey_question_bevriezing`, migratie 0005). Dat is onomkeerbaar: daarna
+   * kan er geen vraag meer bij, weg of anders.
+   *
+   * Door in `draft` te beginnen kan de beheerder de deelnemers samenstellen en
+   * de sluitdatum kiezen vóórdat die grendel valt. Het scherm legt dat uit op
+   * het moment dat hij op starten drukt, niet erna met een foutmelding.
+   */
+  async maakRonde(
+    tenantId: string,
+    invoer: NieuweRonde,
+  ): Promise<RondeGestart> {
+    return this.db.withTenant(
+      tenantId,
+      async (tx) => {
+        // Eerst kijken of de vragenlijst bestaat binnen deze tenant. Zonder
+        // deze controle levert een onbekend template_id een foreign-key-fout
+        // op — een 500 met een databasemelding, waar een 404 hoort.
+        const templates = await tx.execute<{ name: string }>(
+          sql`SELECT name FROM clm.survey_template
+               WHERE template_id = ${invoer.templateId}`,
+        );
+
+        if (templates.rows.length === 0) {
+          throw new NotFoundException('Deze vragenlijst bestaat niet.');
+        }
+
+        // Een vragenlijst zonder vragen is geen vragenlijst. Uitzetten zou een
+        // leverancier een lege lijst voorschotelen, en de ronde daarna
+        // bevriezen op die lege toestand.
+        const vragen = await tx.execute<{ aantal: string }>(
+          sql`SELECT count(*) AS aantal FROM clm.survey_question
+               WHERE template_id = ${invoer.templateId}
+                 AND answer_type <> 'instruction'`,
+        );
+
+        if (Number(vragen.rows[0]?.aantal ?? 0) === 0) {
+          throw new BadRequestException({
+            message:
+              'Deze vragenlijst bevat geen vragen. Er valt niets uit te vragen.',
+            veld: 'templateId',
+          });
+        }
+
+        const aangemaakt = await tx.execute<RunRij>(
+          sql`INSERT INTO clm.survey_run
+                  (tenant_id, template_id, survey_kind, status, closes_at,
+                   is_test)
+              VALUES (${tenantId}, ${invoer.templateId}, ${invoer.surveyKind},
+                      'draft', ${invoer.closesAt?.toISOString() ?? null},
+                      ${invoer.isTest})
+              RETURNING run_id, template_id, status, survey_kind, is_test,
+                        closes_at`,
+        );
+
+        const r = aangemaakt.rows[0];
+
+        return {
+          runId: r.run_id,
+          templateId: r.template_id,
+          templateNaam: templates.rows[0].name,
+          status: r.status,
+          surveyKind: r.survey_kind,
+          isTest: r.is_test,
+          closesAt: iso(r.closes_at),
+        };
+      },
+      'medewerker',
+    );
+  }
+
+  /**
+   * Verandert de status van een ronde.
+   *
+   * De toegestane overgangen staan in `ronde-invoer.ts`. De CHECK-constraint in
+   * de database bewaakt wélke waarden bestaan; welke vólgorde geldig is, is een
+   * regel van de applicatie.
+   *
+   * ── Wat er gebeurt bij draft → active ───────────────────────────────────────
+   *
+   * `started_at` blijft staan op wat het was (`now()` bij het aanmaken). De
+   * bevriezing gebeurt niet hier maar in de database: de trigger op
+   * `survey_question` weigert vanaf dat moment elke wijziging aan een
+   * vragenlijst waarop een actieve ronde loopt.
+   */
+  async wijzigStatus(
+    tenantId: string,
+    runId: string,
+    nieuweStatus: string,
+  ): Promise<RondeGestart> {
+    return this.db.withTenant(
+      tenantId,
+      async (tx) => {
+        const huidige = await tx.execute<RunRij>(
+          sql`SELECT r.run_id, r.template_id, t.name AS template_naam,
+                     r.status, r.survey_kind, r.is_test, r.closes_at
+                FROM clm.survey_run r
+                JOIN clm.survey_template t ON t.template_id = r.template_id
+               WHERE r.run_id = ${runId}`,
+        );
+
+        const r = huidige.rows[0];
+
+        if (!r) {
+          throw new NotFoundException('Deze ronde bestaat niet.');
+        }
+
+        if (r.status === nieuweStatus) {
+          // Geen fout: twee keer op dezelfde knop drukken hoort geen melding op
+          // te leveren die eruitziet alsof er iets mis is.
+          return this.naarGestart(r);
+        }
+
+        if (!magOvergaan(r.status, nieuweStatus)) {
+          const mogelijk = mogelijkeOvergangen(r.status);
+
+          throw new ConflictException(
+            mogelijk.length === 0
+              ? `Deze ronde is ${r.status} en kan niet meer van status veranderen.`
+              : `Een ronde met status '${r.status}' kan alleen naar: ${mogelijk.join(', ')}.`,
+          );
+        }
+
+        const bijgewerkt = await tx.execute<RunRij>(
+          sql`UPDATE clm.survey_run
+                 SET status = ${nieuweStatus}
+               WHERE run_id = ${runId}
+              RETURNING run_id, template_id, status, survey_kind, is_test,
+                        closes_at`,
+        );
+
+        return this.naarGestart({
+          ...bijgewerkt.rows[0],
+          template_naam: r.template_naam,
+        });
+      },
+      'medewerker',
+    );
+  }
+
+  /**
+   * Nodigt leveranciers uit voor een ronde en geeft hun tokens terug.
+   *
+   * ── Alles in één transactie, en waarom dat hier telt ────────────────────────
+   *
+   * `withTenant()` draait de hele callback in één transactie. Faalt er één
+   * invoeging, dan rolt alles terug — inclusief de al gegenereerde tokens, die
+   * dan nergens meer bestaan.
+   *
+   * Dat is precies wat je wilt. Het alternatief — per leverancier los invoegen —
+   * levert bij een fout halverwege een ronde op waarin sommige tokens wél in de
+   * database staan maar de beheerder ze niet meer te zien krijgt. Die
+   * leveranciers zouden dan een uitnodiging hebben die niemand kan versturen.
+   *
+   * ── Waarom een onbekende leverancier de hele oproep afwijst ─────────────────
+   *
+   * Besluit van de opdrachtgever (2026-07-29, plan §2c): een onbekend adres
+   * wordt geweigerd en teruggemeld, niet stilzwijgend aangemaakt. Dat levert
+   * binnen een jaar dubbele records op, en het leveranciersbestand is de lijst
+   * waar de rapportage op leunt.
+   *
+   * Hier is het strikter dan alleen "niet aanmaken": één onbekende id wijst het
+   * hele verzoek af. Een deelselectie uitnodigen zou de beheerder in de waan
+   * laten dat iedereen een link heeft.
+   */
+  async uitnodigen(
+    tenantId: string,
+    runId: string,
+    invoer: Uitnodigingen,
+  ): Promise<Uitnodiging[]> {
+    return this.db.withTenant(
+      tenantId,
+      async (tx) => {
+        const rondes = await tx.execute<{ status: string }>(
+          sql`SELECT status FROM clm.survey_run WHERE run_id = ${runId}`,
+        );
+
+        const ronde = rondes.rows[0];
+
+        if (!ronde) {
+          throw new NotFoundException('Deze ronde bestaat niet.');
+        }
+
+        // Uitnodigen mag in draft (nog samenstellen) en in active (er komt
+        // iemand bij — besluit eigenaar 2026-08-04). Niet in finished of
+        // archived: die zijn afgesloten, en een nieuwe link uitgeven zou de
+        // rapportage over die ronde achteraf veranderen.
+        if (ronde.status !== 'draft' && ronde.status !== 'active') {
+          throw new ConflictException(
+            `Deze ronde is ${ronde.status}. Er kunnen geen leveranciers meer bij.`,
+          );
+        }
+
+        // Alle opgegeven leveranciers in één keer opzoeken. RLS filtert
+        // vanzelf wat van een andere tenant is; die id's ontbreken dan
+        // gewoon in het resultaat en worden hieronder gemeld als onbekend.
+        const gevonden = await tx.execute<VendorRij>(
+          sql`SELECT vendor_id, name
+                FROM clm.vendor
+               WHERE vendor_id = ANY(${sql.param(invoer.vendorIds)}::uuid[])
+                 AND deleted_at IS NULL`,
+        );
+
+        const perId = new Map(
+          gevonden.rows.map((v) => [v.vendor_id.toLowerCase(), v]),
+        );
+
+        const onbekend = invoer.vendorIds.filter(
+          (id) => !perId.has(id.toLowerCase()),
+        );
+
+        if (onbekend.length > 0) {
+          throw new BadRequestException({
+            message:
+              onbekend.length === 1
+                ? 'Eén van de gekozen leveranciers bestaat niet meer. Ververs de lijst en probeer opnieuw.'
+                : `${onbekend.length} van de gekozen leveranciers bestaan niet meer. Ververs de lijst en probeer opnieuw.`,
+            veld: 'vendorIds',
+          });
+        }
+
+        // Wie al is uitgenodigd, overslaan in plaats van de hele oproep laten
+        // stranden op de unieke index (run_id, vendor_id).
+        //
+        // Dat is een bewust verschil met de onbekende leverancier hierboven.
+        // Daar wijst het op verouderde schermdata; hier op iemand die twee keer
+        // aanvinkt, en dan is de bedoeling duidelijk: hij hoort erbij, en dat
+        // is hij al.
+        const bestaand = await tx.execute<{ vendor_id: string }>(
+          sql`SELECT vendor_id FROM clm.survey_response
+               WHERE run_id = ${runId}
+                 AND vendor_id = ANY(${sql.param(invoer.vendorIds)}::uuid[])`,
+        );
+
+        const alUitgenodigd = new Set(
+          bestaand.rows.map((r) => r.vendor_id.toLowerCase()),
+        );
+
+        const teDoen = invoer.vendorIds.filter(
+          (id) => !alUitgenodigd.has(id.toLowerCase()),
+        );
+
+        if (teDoen.length === 0) {
+          throw new ConflictException(
+            'Deze leveranciers zijn al uitgenodigd voor deze ronde.',
+          );
+        }
+
+        const verloopt = new Date(
+          Date.now() + invoer.geldigheidDagen * 24 * 60 * 60 * 1000,
+        );
+
+        const uitnodigingen: Uitnodiging[] = [];
+
+        for (const vendorId of teDoen) {
+          const vendor = perId.get(vendorId.toLowerCase())!;
+
+          // Hier gebeurt het. Eén token per deelnemer, uit randomBytes(32),
+          // en alleen de hash gaat de database in.
+          const token = genereerToken();
+
+          const rij = await tx.execute<{ response_id: string }>(
+            sql`INSERT INTO clm.survey_response
+                    (tenant_id, run_id, vendor_id, subject_vendor_id,
+                     token_hash, status, expires_at)
+                VALUES (${tenantId}, ${runId}, ${vendorId}, ${vendorId},
+                        ${hashToken(token)}, 'pending',
+                        ${verloopt.toISOString()})
+                RETURNING response_id`,
+          );
+
+          uitnodigingen.push({
+            responseId: rij.rows[0].response_id,
+            vendorId,
+            vendorNaam: vendor.name,
+            token,
+            expiresAt: verloopt.toISOString(),
+          });
+        }
+
+        return uitnodigingen;
+      },
+      'medewerker',
+    );
+  }
+
+  private naarGestart(r: RunRij): RondeGestart {
+    return {
+      runId: r.run_id,
+      templateId: r.template_id,
+      templateNaam: r.template_naam,
+      status: r.status,
+      surveyKind: r.survey_kind,
+      isTest: r.is_test,
+      closesAt: iso(r.closes_at),
+    };
+  }
+}

--- a/src/survey/ronde-invoer.ts
+++ b/src/survey/ronde-invoer.ts
@@ -1,0 +1,279 @@
+/**
+ * Validatie van wat een browser opstuurt bij het starten van een ronde en het
+ * uitnodigen van leveranciers (fase B van het surveybeheerplan).
+ *
+ * Zelfde stijl als `vendor-invoer.ts`: handmatig, met `unknown` als invoer, en
+ * een `InvoerFout` die het veld meedraagt zodat het scherm de melding naast het
+ * juiste invoerveld kan tonen. Bewust geen class-validator ernaast — zie de
+ * uitleg daar.
+ *
+ * ── Waarom de validatie hier strenger is dan bij een leverancier ─────────────
+ *
+ * Bij een leverancier zijn de regels ruim: een naam mag van alles bevatten, en
+ * te streng valideren levert vooral valse afwijzingen op.
+ *
+ * Hier ligt dat anders. Elke waarde die hier doorheen komt leidt tot het
+ * uitgeven van tokens aan externe partijen. Een vergissing in het aantal dagen
+ * of in de lijst leveranciers is niet terug te draaien: de tokens zijn dan al
+ * uitgegeven, en het ruwe token bestaat maar één keer.
+ */
+
+export class InvoerFout extends Error {
+  constructor(
+    readonly veld: string,
+    melding: string,
+  ) {
+    super(melding);
+    this.name = 'InvoerFout';
+  }
+}
+
+/**
+ * Hoe lang een uitnodigingslink geldig is.
+ *
+ * De standaard van 30 dagen komt uit het tokenontwerp (OV-2) en is wat de
+ * demo-seed gebruikt. Instelbaar op verzoek van de eigenaar (2026-08-04), met
+ * grenzen eromheen:
+ *
+ * - **Minimaal 1 dag.** Een link die dezelfde dag verloopt is geen uitnodiging
+ *   maar een valstrik — de leverancier heeft geen gelegenheid om te antwoorden.
+ * - **Maximaal 180 dagen.** Een half jaar is ruim voor elke jaarcyclus. Langer
+ *   maakt van een uitnodiging een permanente toegangssleutel, en dat is precies
+ *   wat het tokenontwerp wil vermijden: de link ís de sleutel, er zit geen
+ *   wachtwoord achter.
+ */
+export const GELDIGHEID_STANDAARD_DAGEN = 30;
+export const GELDIGHEID_MIN_DAGEN = 1;
+export const GELDIGHEID_MAX_DAGEN = 180;
+
+/**
+ * Hoeveel leveranciers er in één keer uitgenodigd mogen worden.
+ *
+ * Niet omdat het datamodel het niet aankan, maar omdat één verzoek één
+ * transactie is: bij 500 deelnemers duurt die lang genoeg om een time-out te
+ * riskeren, en dan is onduidelijk welke tokens wél zijn uitgegeven. Bij dit
+ * aantal is dat geen risico.
+ *
+ * Loopt een tenant hier tegenaan, dan is dat een aanleiding om over
+ * achtergrondverwerking na te denken — niet om deze grens stilletjes te
+ * verhogen.
+ */
+export const MAX_DEELNEMERS_PER_VERZOEK = 200;
+
+/** De soorten ronde die het datamodel kent (CHECK op survey_run, migratie 0003). */
+const SOORTEN = ['vendor_compliance', 'internal_review'] as const;
+
+export type RondeSoort = (typeof SOORTEN)[number];
+
+export interface NieuweRonde {
+  templateId: string;
+  surveyKind: RondeSoort;
+  /** Wanneer de ronde sluit. Null betekent: geen sluitdatum. */
+  closesAt: Date | null;
+  isTest: boolean;
+}
+
+export interface Uitnodigingen {
+  vendorIds: string[];
+  geldigheidDagen: number;
+}
+
+/** UUID's zoals Postgres ze uitgeeft. Niet-hoofdlettergevoelig. */
+const UUID_PATROON =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+function leesUuid(waarde: unknown, veld: string): string {
+  if (typeof waarde !== 'string' || !UUID_PATROON.test(waarde)) {
+    throw new InvoerFout(veld, `${veld} is geen geldige verwijzing.`);
+  }
+
+  return waarde;
+}
+
+function leesObject(body: unknown): Record<string, unknown> {
+  if (typeof body !== 'object' || body === null || Array.isArray(body)) {
+    throw new InvoerFout('body', 'Er is geen geldige invoer meegestuurd.');
+  }
+
+  return body as Record<string, unknown>;
+}
+
+/**
+ * Leest de invoer voor een nieuwe ronde.
+ *
+ * `surveyKind` mag ontbreken en wordt dan `vendor_compliance` — de
+ * leveranciersuitvraag (UC1), en de enige soort waarvoor in deze fase een
+ * scherm bestaat. Het datamodel kent `internal_review` al, dus de route
+ * accepteert hem, maar er is geen weg in de frontend die hem stuurt.
+ */
+export function leesNieuweRonde(body: unknown): NieuweRonde {
+  const invoer = leesObject(body);
+
+  const templateId = leesUuid(invoer.templateId, 'templateId');
+
+  const soort = invoer.surveyKind ?? 'vendor_compliance';
+
+  if (!SOORTEN.includes(soort as RondeSoort)) {
+    throw new InvoerFout(
+      'surveyKind',
+      `Onbekende soort ronde. Toegestaan: ${SOORTEN.join(', ')}.`,
+    );
+  }
+
+  return {
+    templateId,
+    surveyKind: soort as RondeSoort,
+    closesAt: leesSluitdatum(invoer.closesAt),
+    // Alleen expliciet `true` telt. Een ronde die per ongeluk als test wordt
+    // gemarkeerd valt buiten de rapportage, en dat hoort een bewuste keuze te
+    // zijn — niet het gevolg van een meegestuurde string "false".
+    isTest: invoer.isTest === true,
+  };
+}
+
+/**
+ * Leest de sluitdatum.
+ *
+ * Mag ontbreken: een ronde zonder sluitdatum is geldig in het datamodel
+ * (`closes_at` is nullable). Wél afgewezen wordt een datum in het verleden —
+ * dat is altijd een vergissing, en het levert een ronde op die sluit voordat
+ * iemand hem kan invullen.
+ */
+function leesSluitdatum(waarde: unknown): Date | null {
+  if (waarde === undefined || waarde === null || waarde === '') {
+    return null;
+  }
+
+  if (typeof waarde !== 'string') {
+    throw new InvoerFout('closesAt', 'De sluitdatum moet een datum zijn.');
+  }
+
+  const datum = new Date(waarde);
+
+  if (Number.isNaN(datum.getTime())) {
+    throw new InvoerFout('closesAt', 'Dit is geen geldige datum.');
+  }
+
+  if (datum.getTime() <= Date.now()) {
+    throw new InvoerFout(
+      'closesAt',
+      'De sluitdatum ligt in het verleden. Kies een datum in de toekomst.',
+    );
+  }
+
+  return datum;
+}
+
+/**
+ * Leest de lijst leveranciers die uitgenodigd worden, plus hoe lang hun link
+ * geldig is.
+ *
+ * ── Waarom dubbele id's hier stranden en niet in de database ────────────────
+ *
+ * Op `survey_response` ligt een unieke index over (run_id, vendor_id). Twee keer
+ * dezelfde leverancier zou daar dus alsnog op een 23505 vastlopen — maar dan
+ * midden in een transactie waarin al tokens gegenereerd zijn, met een
+ * databasefoutmelding die de beheerder niets zegt.
+ *
+ * Hier afvangen levert een bruikbare melding op vóórdat er iets gebeurt.
+ */
+export function leesUitnodigingen(body: unknown): Uitnodigingen {
+  const invoer = leesObject(body);
+
+  if (!Array.isArray(invoer.vendorIds) || invoer.vendorIds.length === 0) {
+    throw new InvoerFout(
+      'vendorIds',
+      'Kies minstens één leverancier om uit te nodigen.',
+    );
+  }
+
+  if (invoer.vendorIds.length > MAX_DEELNEMERS_PER_VERZOEK) {
+    throw new InvoerFout(
+      'vendorIds',
+      `Maximaal ${MAX_DEELNEMERS_PER_VERZOEK} leveranciers per keer.`,
+    );
+  }
+
+  const vendorIds = invoer.vendorIds.map((id, index) =>
+    leesUuid(id, `vendorIds[${index}]`),
+  );
+
+  const uniek = new Set(vendorIds.map((id) => id.toLowerCase()));
+
+  if (uniek.size !== vendorIds.length) {
+    throw new InvoerFout(
+      'vendorIds',
+      'Dezelfde leverancier staat er meer dan één keer in.',
+    );
+  }
+
+  return {
+    vendorIds,
+    geldigheidDagen: leesGeldigheid(invoer.geldigheidDagen),
+  };
+}
+
+function leesGeldigheid(waarde: unknown): number {
+  if (waarde === undefined || waarde === null || waarde === '') {
+    return GELDIGHEID_STANDAARD_DAGEN;
+  }
+
+  const dagen = typeof waarde === 'number' ? waarde : Number(waarde);
+
+  if (!Number.isInteger(dagen)) {
+    throw new InvoerFout(
+      'geldigheidDagen',
+      'Het aantal dagen moet een heel getal zijn.',
+    );
+  }
+
+  if (dagen < GELDIGHEID_MIN_DAGEN || dagen > GELDIGHEID_MAX_DAGEN) {
+    throw new InvoerFout(
+      'geldigheidDagen',
+      `Kies tussen ${GELDIGHEID_MIN_DAGEN} en ${GELDIGHEID_MAX_DAGEN} dagen.`,
+    );
+  }
+
+  return dagen;
+}
+
+/**
+ * De statusovergangen die een ronde mag maken.
+ *
+ * ── Waarom dit een lijst is en geen vrije keuze ─────────────────────────────
+ *
+ * De CHECK-constraint op `survey_run.status` bewaakt welke waarden bestaan,
+ * niet welke volgorde geldig is. Zonder deze tabel kan een afgeronde ronde
+ * terug naar `draft` — en dan zou de vragenlijst ontdooien terwijl er al
+ * antwoorden op binnen zijn.
+ *
+ * `archived` is een eindpunt: er gaat geen pijl uit weg.
+ */
+const OVERGANGEN: Record<string, readonly string[]> = {
+  draft: ['active'],
+  active: ['finished'],
+  finished: ['archived', 'active'],
+  archived: [],
+};
+
+export function magOvergaan(van: string, naar: string): boolean {
+  return (OVERGANGEN[van] ?? []).includes(naar);
+}
+
+export function leesStatus(body: unknown): string {
+  const invoer = leesObject(body);
+
+  if (typeof invoer.status !== 'string' || !(invoer.status in OVERGANGEN)) {
+    throw new InvoerFout(
+      'status',
+      `Onbekende status. Toegestaan: ${Object.keys(OVERGANGEN).join(', ')}.`,
+    );
+  }
+
+  return invoer.status;
+}
+
+/** Wat er vanuit een status nog mogelijk is — voor een bruikbare foutmelding. */
+export function mogelijkeOvergangen(van: string): readonly string[] {
+  return OVERGANGEN[van] ?? [];
+}

--- a/src/survey/survey.module.ts
+++ b/src/survey/survey.module.ts
@@ -8,6 +8,7 @@ import { SurveyTokenService } from './survey-token.service';
 import { AntwoordIndienService } from './antwoord-indienen.service';
 import { BestandOpslagService } from './bestand-opslag.service';
 import { BijlageService } from './bijlage.service';
+import { RondeBeheerService } from './ronde-beheer.service';
 import { VragenlijstBeheerController } from './vragenlijst-beheer.controller';
 import { VragenlijstBeheerService } from './vragenlijst-beheer.service';
 import { VragenlijstImportService } from './vragenlijst-import.service';
@@ -36,6 +37,7 @@ import { VragenlijstLeesService } from './vragenlijst-lezen.service';
     SurveyTokenService,
     SurveyTokenGuard,
     VragenlijstBeheerService,
+    RondeBeheerService,
     VragenlijstImportService,
     VragenlijstLeesService,
     AntwoordIndienService,
@@ -47,6 +49,7 @@ import { VragenlijstLeesService } from './vragenlijst-lezen.service';
     SurveyTokenService,
     SurveyTokenGuard,
     VragenlijstBeheerService,
+    RondeBeheerService,
     VragenlijstImportService,
     VragenlijstLeesService,
     AntwoordIndienService,

--- a/src/survey/vragenlijst-beheer.controller.ts
+++ b/src/survey/vragenlijst-beheer.controller.ts
@@ -1,10 +1,28 @@
-import { Controller, Get, Param, Req, UseGuards } from '@nestjs/common';
+import {
+  BadRequestException,
+  Body,
+  Controller,
+  Get,
+  HttpCode,
+  Param,
+  Patch,
+  Post,
+  Req,
+  UseGuards,
+} from '@nestjs/common';
 
-import { RolGuard } from '../auth/rol.guard';
+import { RolGuard, VereistRol } from '../auth/rol.guard';
 import {
   TenantContextGuard,
   type RequestMetSessie,
 } from '../auth/tenant-context.guard';
+import { RondeBeheerService } from './ronde-beheer.service';
+import {
+  InvoerFout,
+  leesNieuweRonde,
+  leesStatus,
+  leesUitnodigingen,
+} from './ronde-invoer';
 import { VragenlijstBeheerService } from './vragenlijst-beheer.service';
 
 /**
@@ -20,22 +38,23 @@ import { VragenlijstBeheerService } from './vragenlijst-beheer.service';
  *
  * Dit zijn de eerste routes waarmee de beheerkant iets van de survey ziet.
  *
- * ── Alleen lezen ────────────────────────────────────────────────────────────
+ * ── Lezen mag iedereen, schrijven alleen een admin ──────────────────────────
  *
- * Bewust geen POST of PATCH. Een ronde starten en deelnemers uitnodigen is
- * fase B, en dat raakt de tokenlaag die al bewezen en groen is. Die knip houdt
- * de gevoelige stap apart van het schermwerk.
+ * De GET-routes hebben géén `@VereistRol`: elke geldige sessie mag ze lezen.
+ * Dat is een besluit uit het plan (fase A) — **lezen mag ook een reviewer**,
+ * want resultaten inzien is precies zijn rol. Hem dat ontzeggen maakt de rol
+ * betekenisloos.
  *
- * ── Waarom géén @VereistRol('admin') ────────────────────────────────────────
+ * De schrijfroutes van fase B hebben die eis wél. Een ronde uitzetten geeft
+ * tokens uit aan externe partijen; dat is een andere bevoegdheid dan meekijken.
  *
- * `RolGuard` staat er wel, maar zonder eis: elke geldige sessie mag deze routes
- * lezen. Dat is een besluit uit het plan (fase A) — **lezen mag ook een
- * reviewer**, want resultaten inzien is precies zijn rol. Hem dat ontzeggen
- * maakt de rol betekenisloos.
+ * ── Fase B zit in een eigen service ─────────────────────────────────────────
  *
- * Fase B is anders: rondes starten en tokens uitgeven krijgt wél
- * `@VereistRol('admin')`. De guard staat hier alvast zodat die eis er later
- * bij kan zonder de klasse te herzien.
+ * `VragenlijstBeheerService` blijft uitsluitend lezen; `RondeBeheerService`
+ * schrijft. Die knip is er omdat de schrijfkant `genereerToken()` aanroept —
+ * de eerste productiecode die dat doet — en dat raakt de tokenlaag die al
+ * bewezen en groen is. Eén klasse die beide doet zou die grens onzichtbaar
+ * maken.
  *
  * ── Het pad ─────────────────────────────────────────────────────────────────
  *
@@ -47,7 +66,10 @@ import { VragenlijstBeheerService } from './vragenlijst-beheer.service';
 @Controller('admin/survey')
 @UseGuards(TenantContextGuard, RolGuard)
 export class VragenlijstBeheerController {
-  constructor(private readonly beheer: VragenlijstBeheerService) {}
+  constructor(
+    private readonly beheer: VragenlijstBeheerService,
+    private readonly rondes: RondeBeheerService,
+  ) {}
 
   /** Alle vragenlijsten van deze tenant, met aantallen vragen en rondes. */
   @Get('templates')
@@ -85,5 +107,117 @@ export class VragenlijstBeheerController {
     const sessie = request.sessie!;
 
     return this.beheer.ronde(sessie.tenantId, id);
+  }
+
+  // ── Fase B: schrijven ──────────────────────────────────────────────────────
+  //
+  // Vanaf hier staat op elke route `@VereistRol('admin')`. Een reviewer mag
+  // lezen — resultaten inzien ís zijn rol — maar een ronde uitzetten geeft
+  // tokens uit aan externe partijen, en dat is een andere bevoegdheid.
+
+  /**
+   * Maakt een nieuwe ronde aan, in status `draft`.
+   *
+   * 201 met de ronde erbij. 404 als de vragenlijst niet bestaat binnen deze
+   * tenant, 400 bij ongeldige invoer (met het veld erbij, zodat het scherm de
+   * melding op de juiste plek kan tonen).
+   */
+  @Post('runs')
+  @VereistRol('admin')
+  @HttpCode(201)
+  async maakRonde(@Req() request: RequestMetSessie, @Body() body: unknown) {
+    const sessie = request.sessie!;
+
+    return this.rondes.maakRonde(sessie.tenantId, this.leesRonde(body));
+  }
+
+  /**
+   * Verandert de status van een ronde: draft → active → finished → archived.
+   *
+   * 409 bij een overgang die niet mag, met erbij wat er wél kan.
+   */
+  @Patch('runs/:id/status')
+  @VereistRol('admin')
+  async wijzigStatus(
+    @Req() request: RequestMetSessie,
+    @Param('id') id: string,
+    @Body() body: unknown,
+  ) {
+    const sessie = request.sessie!;
+
+    let status: string;
+
+    try {
+      status = leesStatus(body);
+    } catch (err) {
+      throw this.naarHttpFout(err);
+    }
+
+    return this.rondes.wijzigStatus(sessie.tenantId, id, status);
+  }
+
+  /**
+   * Nodigt leveranciers uit en geeft de tokenlinks terug.
+   *
+   * ── Waarom dit antwoord bijzonder is ────────────────────────────────────────
+   *
+   * Dit is het enige moment waarop de ruwe tokens bestaan. De database bewaart
+   * alleen een hash; er is geen route die ze opnieuw kan tonen, en die komt er
+   * ook niet. Het scherm moet de beheerder daarop wijzen vóórdat hij wegklikt.
+   *
+   * 201 met de uitnodigingen. 400 wanneer een gekozen leverancier niet bestaat
+   * — dan wordt het hele verzoek afgewezen, niet een deel uitgevoerd.
+   */
+  @Post('runs/:id/participants')
+  @VereistRol('admin')
+  @HttpCode(201)
+  async uitnodigen(
+    @Req() request: RequestMetSessie,
+    @Param('id') id: string,
+    @Body() body: unknown,
+  ) {
+    const sessie = request.sessie!;
+
+    let invoer: ReturnType<typeof leesUitnodigingen>;
+
+    try {
+      invoer = leesUitnodigingen(body);
+    } catch (err) {
+      throw this.naarHttpFout(err);
+    }
+
+    const uitnodigingen = await this.rondes.uitnodigen(
+      sessie.tenantId,
+      id,
+      invoer,
+    );
+
+    return { uitnodigingen };
+  }
+
+  private leesRonde(body: unknown) {
+    try {
+      return leesNieuweRonde(body);
+    } catch (err) {
+      throw this.naarHttpFout(err);
+    }
+  }
+
+  /**
+   * Zet een InvoerFout om in een 400 met het veld erbij.
+   *
+   * Zelfde patroon als VendorController: het scherm kan de melding dan naast
+   * het juiste invoerveld tonen in plaats van bovenaan de pagina — dezelfde
+   * les als bij Issue #42.
+   */
+  private naarHttpFout(err: unknown): Error {
+    if (err instanceof InvoerFout) {
+      return new BadRequestException({
+        message: err.message,
+        veld: err.veld,
+      });
+    }
+
+    return err as Error;
   }
 }

--- a/test/demo-seed.e2e-spec.ts
+++ b/test/demo-seed.e2e-spec.ts
@@ -157,7 +157,17 @@ describe('Demo-seed (e2e)', () => {
     // rijen maakt, blokkeert precies het opnieuw opzetten van een omgeving
     // waar hij voor bedoeld is.
     expect(na).toEqual(voor);
-  });
+
+    // 20 seconden, net als de twee andere tests in deze suite die het
+    // seed-script starten.
+    //
+    // Deze test start het als apart Node-proces (~1,6 s gemeten) en telt
+    // twee keer. Binnen 5 seconden past dat alleen wanneer de machine verder
+    // niets doet; in de volledige suite doet hij dat wel. Dat is geen
+    // regressie maar een testopzet die van de belasting van de machine
+    // afhangt — precies de faalvorm die STATUS.md al beschreef voor deze
+    // suite, en die op 2026-08-04 opnieuw toesloeg.
+  }, 20_000);
 
   // ── De drie stadia ────────────────────────────────────────────────────────
 

--- a/test/ronde-beheer-routes.e2e-spec.ts
+++ b/test/ronde-beheer-routes.e2e-spec.ts
@@ -1,0 +1,743 @@
+import { INestApplication } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import cookieParser from 'cookie-parser';
+import { createHash } from 'node:crypto';
+import { Client } from 'pg';
+import request from 'supertest';
+import type { App } from 'supertest/types';
+
+import { AppModule } from '../src/app.module';
+import { cookieInstellingen } from '../src/auth/sessie';
+import { SessieService } from '../src/auth/sessie.service';
+import { TEST_IDS } from './test-ids';
+
+/**
+ * Rondes starten en leveranciers uitnodigen (fase B van het surveybeheerplan).
+ *
+ * ── Wat hier op het spel staat ──────────────────────────────────────────────
+ *
+ * Dit zijn de eerste routes die tokens uitgeven aan externe partijen. Een fout
+ * hier is niet terug te draaien: een uitgegeven token bestaat, en het ruwe
+ * token is na dit ene antwoord nergens meer op te vragen.
+ *
+ * De vragen die deze suite beantwoordt:
+ *
+ *   1. Krijgt de aanroeper werkelijk een bruikbaar token, en staat in de
+ *      database alleen de hash?
+ *   2. Kan een reviewer een ronde starten? (Nee — lezen mag, uitzetten niet.)
+ *   3. Kan tenant A een leverancier van tenant B uitnodigen?
+ *   4. Wat gebeurt er bij een status­overgang die niet mag?
+ *   5. Bevriest een actieve ronde de vragenlijst?
+ *
+ * ── Waarom de hash apart gecontroleerd wordt ────────────────────────────────
+ *
+ * Het is verleidelijk om alleen te toetsen dat er een token terugkomt. Maar de
+ * hele opzet van de tokenlaag staat of valt met wat er níét in de database
+ * staat. Een implementatie die het ruwe token opslaat werkt precies hetzelfde
+ * vanuit de browser — en is stuk op de enige manier die telt.
+ */
+
+const {
+  tenantA,
+  tenantB,
+  adminA,
+  reviewerA,
+  adminB,
+  templateA: TEMPLATE_A,
+  templateLeeg: TEMPLATE_LEEG,
+  templateB: TEMPLATE_B,
+  vendor1: VENDOR_1,
+  vendor2: VENDOR_2,
+  vendor3: VENDOR_3,
+  vendorB: VENDOR_B,
+  vendorWeg: VENDOR_WEG,
+} = TEST_IDS['ronde-beheer-routes'];
+
+const SUBJECT_ADMIN_A = `oid-rb-a-${Date.now()}`;
+const SUBJECT_REVIEWER = `oid-rb-r-${Date.now()}`;
+const SUBJECT_ADMIN_B = `oid-rb-b-${Date.now()}`;
+
+interface Uitnodiging {
+  responseId: string;
+  vendorId: string;
+  vendorNaam: string;
+  token: string;
+  expiresAt: string;
+}
+
+interface UitnodigingAntwoord {
+  uitnodigingen: Uitnodiging[];
+}
+
+interface RondeAntwoord {
+  runId: string;
+  templateNaam: string;
+  status: string;
+  surveyKind: string;
+  isTest: boolean;
+  closesAt: string | null;
+}
+
+async function verwijderTestdata(client: Client): Promise<void> {
+  for (const tenant of [tenantA, tenantB]) {
+    await client.query('BEGIN');
+    await client.query(`SET LOCAL app.current_tenant_id = '${tenant}'`);
+    for (const tabel of [
+      'clm.survey_answer',
+      'clm.survey_attachment',
+      'clm.survey_response',
+      'clm.survey_run',
+      'clm.survey_question',
+      'clm.survey_category',
+      'clm.survey_template',
+      'clm.vendor_contact',
+      'clm.vendor',
+      'clm.tenant_membership',
+      'clm."user"',
+      'clm.tenant',
+    ]) {
+      await client.query(`DELETE FROM ${tabel} WHERE tenant_id = $1`, [tenant]);
+    }
+    await client.query('COMMIT');
+  }
+}
+
+describe('Ronde-beheerroutes (e2e)', () => {
+  let app: INestApplication<App>;
+  let server: App;
+  let client: Client;
+  let cookieAdminA: string;
+  let cookieReviewer: string;
+  let cookieAdminB: string;
+  const cookieNaam = cookieInstellingen().naam;
+
+  beforeAll(async () => {
+    client = new Client({ connectionString: process.env.DATABASE_URL });
+    await client.connect();
+    await verwijderTestdata(client);
+
+    for (const [tenant, user, subject, naam, rol] of [
+      [tenantA, adminA, SUBJECT_ADMIN_A, 'Aisha de admin', 'admin'],
+      [tenantA, reviewerA, SUBJECT_REVIEWER, 'Ruben de reviewer', 'reviewer'],
+      [tenantB, adminB, SUBJECT_ADMIN_B, 'Bram uit B', 'admin'],
+    ] as const) {
+      await client.query('BEGIN');
+      await client.query(`SET LOCAL app.current_tenant_id = '${tenant}'`);
+
+      await client.query(
+        `INSERT INTO clm.tenant (tenant_id, name) VALUES ($1, $2)
+         ON CONFLICT DO NOTHING`,
+        [tenant, `rb-test-${tenant.slice(-2)}`],
+      );
+      await client.query(
+        `INSERT INTO clm."user" (user_id, tenant_id, full_name, external_subject)
+         VALUES ($1, $2, $3, $4)`,
+        [user, tenant, naam, subject],
+      );
+      await client.query(
+        `INSERT INTO clm.tenant_membership (user_id, tenant_id, role)
+         VALUES ($1, $2, $3)`,
+        [user, tenant, rol],
+      );
+      await client.query('COMMIT');
+    }
+
+    await client.query('BEGIN');
+    await client.query(`SET LOCAL app.current_tenant_id = '${tenantA}'`);
+
+    // Een vragenlijst met echte vragen, en één zonder — die tweede toetst dat
+    // je geen lege lijst kunt uitzetten.
+    for (const [id, naam] of [
+      [TEMPLATE_A, 'ronde-test-lijst'],
+      [TEMPLATE_LEEG, 'ronde-test-leeg'],
+    ] as const) {
+      await client.query(
+        `INSERT INTO clm.survey_template (template_id, tenant_id, name, version)
+         VALUES ($1, $2, $3, 1)`,
+        [id, tenantA, naam],
+      );
+    }
+
+    for (const [key, positie, type] of [
+      ['intro', 1, 'instruction'],
+      ['v1', 2, 'confirmation'],
+      ['v2', 3, 'confirmation'],
+    ] as const) {
+      await client.query(
+        `INSERT INTO clm.survey_question
+           (tenant_id, template_id, position, question_key, title, body,
+            answer_type, is_required, allows_upload, max_files, config)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, false, false, 0, '{}'::jsonb)`,
+        [
+          tenantA,
+          TEMPLATE_A,
+          positie,
+          key,
+          `Titel ${key}`,
+          `Toelichting bij ${key}`,
+          type,
+        ],
+      );
+    }
+
+    // De lege lijst krijgt alleen een instructie: die telt niet als vraag, dus
+    // dit is de valkuil die 'geen vragen' moet vangen.
+    await client.query(
+      `INSERT INTO clm.survey_question
+         (tenant_id, template_id, position, question_key, title, body,
+          answer_type, is_required, allows_upload, max_files, config)
+       VALUES ($1, $2, 1, 'alleen-intro', 'Alleen uitleg', 'Geen vraag',
+               'instruction', false, false, 0, '{}'::jsonb)`,
+      [tenantA, TEMPLATE_LEEG],
+    );
+
+    for (const [id, naam, kvk] of [
+      [VENDOR_1, 'Eerste Leverancier B.V.', '10000001'],
+      [VENDOR_2, 'Tweede Leverancier B.V.', '10000002'],
+      [VENDOR_3, 'Derde Leverancier B.V.', '10000003'],
+      [VENDOR_WEG, 'Verwijderde Leverancier B.V.', '10000004'],
+    ] as const) {
+      await client.query(
+        `INSERT INTO clm.vendor (vendor_id, tenant_id, name, kvk_number)
+         VALUES ($1, $2, $3, $4)`,
+        [id, tenantA, naam, kvk],
+      );
+    }
+
+    // Zacht verwijderd: hij bestaat nog als rij maar mag niet uitgenodigd.
+    await client.query(
+      `UPDATE clm.vendor SET deleted_at = now() WHERE vendor_id = $1`,
+      [VENDOR_WEG],
+    );
+
+    await client.query('COMMIT');
+
+    // Tenant B: eigen vragenlijst en eigen leverancier.
+    await client.query('BEGIN');
+    await client.query(`SET LOCAL app.current_tenant_id = '${tenantB}'`);
+    await client.query(
+      `INSERT INTO clm.survey_template (template_id, tenant_id, name, version)
+       VALUES ($1, $2, 'lijst-van-b', 1)`,
+      [TEMPLATE_B, tenantB],
+    );
+    await client.query(
+      `INSERT INTO clm.vendor (vendor_id, tenant_id, name, kvk_number)
+       VALUES ($1, $2, 'Leverancier van B B.V.', '20000001')`,
+      [VENDOR_B, tenantB],
+    );
+    await client.query('COMMIT');
+
+    const moduleRef = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleRef.createNestApplication();
+    app.use(cookieParser());
+    await app.init();
+    server = app.getHttpServer();
+
+    const sessies = app.get(SessieService);
+
+    const [a, r, b] = await Promise.all([
+      sessies.aanmaken(SUBJECT_ADMIN_A),
+      sessies.aanmaken(SUBJECT_REVIEWER),
+      sessies.aanmaken(SUBJECT_ADMIN_B),
+    ]);
+
+    cookieAdminA = `${cookieNaam}=${a!.token}`;
+    cookieReviewer = `${cookieNaam}=${r!.token}`;
+    cookieAdminB = `${cookieNaam}=${b!.token}`;
+  });
+
+  afterAll(async () => {
+    await app?.close();
+    await verwijderTestdata(client);
+    await client.end();
+  });
+
+  /** Maakt een verse ronde en geeft zijn id terug. */
+  async function nieuweRonde(templateId = TEMPLATE_A): Promise<string> {
+    const antwoord = await request(server)
+      .post('/admin/survey/runs')
+      .set('Cookie', cookieAdminA)
+      .send({ templateId })
+      .expect(201);
+
+    return (antwoord.body as RondeAntwoord).runId;
+  }
+
+  // ── Een ronde aanmaken ────────────────────────────────────────────────────
+
+  it('maakt een ronde aan in status draft', async () => {
+    const antwoord = await request(server)
+      .post('/admin/survey/runs')
+      .set('Cookie', cookieAdminA)
+      .send({ templateId: TEMPLATE_A })
+      .expect(201);
+
+    const ronde = antwoord.body as RondeAntwoord;
+
+    // Draft en niet active: de vragenlijst mag pas bevriezen wanneer de
+    // beheerder daar bewust voor kiest.
+    expect(ronde.status).toBe('draft');
+    expect(ronde.templateNaam).toBe('ronde-test-lijst');
+    expect(ronde.surveyKind).toBe('vendor_compliance');
+    expect(ronde.isTest).toBe(false);
+  });
+
+  it('neemt een sluitdatum over', async () => {
+    const overDertigDagen = new Date(
+      Date.now() + 30 * 24 * 60 * 60 * 1000,
+    ).toISOString();
+
+    const antwoord = await request(server)
+      .post('/admin/survey/runs')
+      .set('Cookie', cookieAdminA)
+      .send({ templateId: TEMPLATE_A, closesAt: overDertigDagen })
+      .expect(201);
+
+    expect((antwoord.body as RondeAntwoord).closesAt).not.toBeNull();
+  });
+
+  it('weigert een sluitdatum in het verleden', async () => {
+    const gisteren = new Date(Date.now() - 86_400_000).toISOString();
+
+    const antwoord = await request(server)
+      .post('/admin/survey/runs')
+      .set('Cookie', cookieAdminA)
+      .send({ templateId: TEMPLATE_A, closesAt: gisteren })
+      .expect(400);
+
+    // Het veld hoort erbij, zodat het scherm de melding naast het juiste
+    // invoerveld kan tonen in plaats van bovenaan de pagina.
+    expect((antwoord.body as { veld: string }).veld).toBe('closesAt');
+  });
+
+  it('weigert een vragenlijst zonder vragen', async () => {
+    // TEMPLATE_LEEG heeft alleen een instructiescherm. Uitzetten zou de
+    // leverancier een lijst zonder vragen voorschotelen en die toestand
+    // vervolgens bevriezen.
+    const antwoord = await request(server)
+      .post('/admin/survey/runs')
+      .set('Cookie', cookieAdminA)
+      .send({ templateId: TEMPLATE_LEEG })
+      .expect(400);
+
+    expect((antwoord.body as { message: string }).message).toContain(
+      'geen vragen',
+    );
+  });
+
+  it('geeft 404 voor een vragenlijst van een andere tenant', async () => {
+    // Niet 403: dat zou verklappen dat dit id ergens bestaat.
+    await request(server)
+      .post('/admin/survey/runs')
+      .set('Cookie', cookieAdminA)
+      .send({ templateId: TEMPLATE_B })
+      .expect(404);
+  });
+
+  it('weigert een reviewer die een ronde wil starten', async () => {
+    // Lezen mag hij (fase A), uitzetten niet. Dit is het verschil tussen
+    // meekijken en tokens uitgeven aan externe partijen.
+    await request(server)
+      .post('/admin/survey/runs')
+      .set('Cookie', cookieReviewer)
+      .send({ templateId: TEMPLATE_A })
+      .expect(403);
+  });
+
+  it('weigert een verzoek zonder sessie', async () => {
+    await request(server)
+      .post('/admin/survey/runs')
+      .send({ templateId: TEMPLATE_A })
+      .expect(401);
+  });
+
+  // ── Uitnodigen ────────────────────────────────────────────────────────────
+
+  it('geeft een bruikbaar token terug en bewaart alleen de hash', async () => {
+    const runId = await nieuweRonde();
+
+    const antwoord = await request(server)
+      .post(`/admin/survey/runs/${runId}/participants`)
+      .set('Cookie', cookieAdminA)
+      .send({ vendorIds: [VENDOR_1, VENDOR_2] })
+      .expect(201);
+
+    const { uitnodigingen } = antwoord.body as UitnodigingAntwoord;
+
+    expect(uitnodigingen).toHaveLength(2);
+
+    for (const uitnodiging of uitnodigingen) {
+      // 43 tekens base64url — de vorm die de tokenguard accepteert. Een token
+      // van een andere lengte wordt geweigerd vóórdat de database geraadpleegd
+      // wordt, dus dit is geen cosmetische controle.
+      expect(uitnodiging.token).toMatch(/^[A-Za-z0-9_-]{43}$/);
+
+      // En dit is de kern: in de database staat de hash, niet het token.
+      //
+      // De tenantcontext moet hier expliciet gezet worden. Zonder die regel
+      // filtert RLS elke rij weg en komt er nul terug — wat er als een lege
+      // tabel uitziet terwijl de data er gewoon staat. Kostte bij de eerste
+      // run een verkeerde conclusie; tegelijk is het het bewijs dat RLS ook
+      // buiten de applicatie om zijn werk doet.
+      await client.query('BEGIN');
+      await client.query(`SET LOCAL app.current_tenant_id = '${tenantA}'`);
+
+      const opgeslagen = await client.query<{ token_hash: string }>(
+        'SELECT token_hash FROM clm.survey_response WHERE response_id = $1',
+        [uitnodiging.responseId],
+      );
+
+      await client.query('COMMIT');
+
+      const verwacht = createHash('sha256')
+        .update(uitnodiging.token, 'utf8')
+        .digest('hex');
+
+      expect(opgeslagen.rows[0].token_hash).toBe(verwacht);
+      expect(opgeslagen.rows[0].token_hash).not.toBe(uitnodiging.token);
+    }
+
+    // Twee deelnemers, twee verschillende tokens. Eén generator die per
+    // ongeluk hetzelfde token hergebruikt zou hier opvallen.
+    expect(uitnodigingen[0].token).not.toBe(uitnodigingen[1].token);
+  });
+
+  it('gebruikt 30 dagen wanneer er geen geldigheid is opgegeven', async () => {
+    const runId = await nieuweRonde();
+
+    const antwoord = await request(server)
+      .post(`/admin/survey/runs/${runId}/participants`)
+      .set('Cookie', cookieAdminA)
+      .send({ vendorIds: [VENDOR_1] })
+      .expect(201);
+
+    const { uitnodigingen } = antwoord.body as UitnodigingAntwoord;
+    const dagen =
+      (new Date(uitnodigingen[0].expiresAt).getTime() - Date.now()) /
+      86_400_000;
+
+    expect(dagen).toBeGreaterThan(29.9);
+    expect(dagen).toBeLessThan(30.1);
+  });
+
+  it('neemt een afwijkende geldigheid over', async () => {
+    const runId = await nieuweRonde();
+
+    const antwoord = await request(server)
+      .post(`/admin/survey/runs/${runId}/participants`)
+      .set('Cookie', cookieAdminA)
+      .send({ vendorIds: [VENDOR_1], geldigheidDagen: 7 })
+      .expect(201);
+
+    const { uitnodigingen } = antwoord.body as UitnodigingAntwoord;
+    const dagen =
+      (new Date(uitnodigingen[0].expiresAt).getTime() - Date.now()) /
+      86_400_000;
+
+    expect(dagen).toBeGreaterThan(6.9);
+    expect(dagen).toBeLessThan(7.1);
+  });
+
+  it('weigert een geldigheid buiten de grenzen', async () => {
+    const runId = await nieuweRonde();
+
+    for (const dagen of [0, 181, 2.5]) {
+      const antwoord = await request(server)
+        .post(`/admin/survey/runs/${runId}/participants`)
+        .set('Cookie', cookieAdminA)
+        .send({ vendorIds: [VENDOR_1], geldigheidDagen: dagen })
+        .expect(400);
+
+      expect((antwoord.body as { veld: string }).veld).toBe('geldigheidDagen');
+    }
+  });
+
+  it('weigert een leverancier van een andere tenant, zonder er iets uit te geven', async () => {
+    const runId = await nieuweRonde();
+
+    const antwoord = await request(server)
+      .post(`/admin/survey/runs/${runId}/participants`)
+      .set('Cookie', cookieAdminA)
+      .send({ vendorIds: [VENDOR_1, VENDOR_B] })
+      .expect(400);
+
+    expect((antwoord.body as { veld: string }).veld).toBe('vendorIds');
+
+    // En VENDOR_1 heeft géén uitnodiging gekregen: het verzoek wordt in zijn
+    // geheel afgewezen. Een deelselectie uitnodigen zou de beheerder in de
+    // waan laten dat iedereen een link heeft.
+    const aantal = await client.query<{ count: string }>(
+      'SELECT count(*) FROM clm.survey_response WHERE run_id = $1',
+      [runId],
+    );
+
+    expect(Number(aantal.rows[0].count)).toBe(0);
+  });
+
+  it('weigert een zacht verwijderde leverancier', async () => {
+    const runId = await nieuweRonde();
+
+    await request(server)
+      .post(`/admin/survey/runs/${runId}/participants`)
+      .set('Cookie', cookieAdminA)
+      .send({ vendorIds: [VENDOR_WEG] })
+      .expect(400);
+  });
+
+  it('weigert dezelfde leverancier twee keer in één verzoek', async () => {
+    const runId = await nieuweRonde();
+
+    const antwoord = await request(server)
+      .post(`/admin/survey/runs/${runId}/participants`)
+      .set('Cookie', cookieAdminA)
+      .send({ vendorIds: [VENDOR_1, VENDOR_1] })
+      .expect(400);
+
+    expect((antwoord.body as { message: string }).message).toContain(
+      'meer dan één keer',
+    );
+  });
+
+  it('weigert een lege lijst leveranciers', async () => {
+    const runId = await nieuweRonde();
+
+    await request(server)
+      .post(`/admin/survey/runs/${runId}/participants`)
+      .set('Cookie', cookieAdminA)
+      .send({ vendorIds: [] })
+      .expect(400);
+  });
+
+  it('meldt het wanneer iedereen al is uitgenodigd', async () => {
+    const runId = await nieuweRonde();
+
+    await request(server)
+      .post(`/admin/survey/runs/${runId}/participants`)
+      .set('Cookie', cookieAdminA)
+      .send({ vendorIds: [VENDOR_1] })
+      .expect(201);
+
+    await request(server)
+      .post(`/admin/survey/runs/${runId}/participants`)
+      .set('Cookie', cookieAdminA)
+      .send({ vendorIds: [VENDOR_1] })
+      .expect(409);
+  });
+
+  it('slaat over wie er al in zit en nodigt de rest wel uit', async () => {
+    const runId = await nieuweRonde();
+
+    await request(server)
+      .post(`/admin/survey/runs/${runId}/participants`)
+      .set('Cookie', cookieAdminA)
+      .send({ vendorIds: [VENDOR_1] })
+      .expect(201);
+
+    const antwoord = await request(server)
+      .post(`/admin/survey/runs/${runId}/participants`)
+      .set('Cookie', cookieAdminA)
+      .send({ vendorIds: [VENDOR_1, VENDOR_2] })
+      .expect(201);
+
+    const { uitnodigingen } = antwoord.body as UitnodigingAntwoord;
+
+    // Alleen de nieuwe. VENDOR_1 krijgt geen tweede token — dat zou zijn
+    // eerste link stilzwijgend naast een tweede zetten.
+    expect(uitnodigingen).toHaveLength(1);
+    expect(uitnodigingen[0].vendorId).toBe(VENDOR_2);
+  });
+
+  it('weigert een reviewer die leveranciers wil uitnodigen', async () => {
+    const runId = await nieuweRonde();
+
+    await request(server)
+      .post(`/admin/survey/runs/${runId}/participants`)
+      .set('Cookie', cookieReviewer)
+      .send({ vendorIds: [VENDOR_1] })
+      .expect(403);
+  });
+
+  it('laat tenant B niet uitnodigen voor een ronde van tenant A', async () => {
+    const runId = await nieuweRonde();
+
+    // 404 en niet 403: de ronde bestaat niet vóór B, en dat hoort hij niet te
+    // kunnen afleiden uit het antwoord.
+    await request(server)
+      .post(`/admin/survey/runs/${runId}/participants`)
+      .set('Cookie', cookieAdminB)
+      .send({ vendorIds: [VENDOR_B] })
+      .expect(404);
+  });
+
+  // ── Status ────────────────────────────────────────────────────────────────
+
+  it('zet een ronde van draft naar active', async () => {
+    const runId = await nieuweRonde();
+
+    const antwoord = await request(server)
+      .patch(`/admin/survey/runs/${runId}/status`)
+      .set('Cookie', cookieAdminA)
+      .send({ status: 'active' })
+      .expect(200);
+
+    expect((antwoord.body as RondeAntwoord).status).toBe('active');
+  });
+
+  it('weigert een overgang die niet mag, met wat er wel kan', async () => {
+    const runId = await nieuweRonde();
+
+    const antwoord = await request(server)
+      .patch(`/admin/survey/runs/${runId}/status`)
+      .set('Cookie', cookieAdminA)
+      .send({ status: 'archived' })
+      .expect(409);
+
+    // De melding noemt de mogelijke vervolgstappen. Zonder dat weet de
+    // beheerder alleen dat het niet mag, niet wat wél kan.
+    expect((antwoord.body as { message: string }).message).toContain('active');
+  });
+
+  it('accepteert dezelfde status zonder te klagen', async () => {
+    const runId = await nieuweRonde();
+
+    // Twee keer op dezelfde knop drukken hoort geen foutmelding op te leveren.
+    await request(server)
+      .patch(`/admin/survey/runs/${runId}/status`)
+      .set('Cookie', cookieAdminA)
+      .send({ status: 'draft' })
+      .expect(200);
+  });
+
+  it('weigert een onbekende status', async () => {
+    const runId = await nieuweRonde();
+
+    await request(server)
+      .patch(`/admin/survey/runs/${runId}/status`)
+      .set('Cookie', cookieAdminA)
+      .send({ status: 'verzonnen' })
+      .expect(400);
+  });
+
+  it('weigert een reviewer die de status wil wijzigen', async () => {
+    const runId = await nieuweRonde();
+
+    await request(server)
+      .patch(`/admin/survey/runs/${runId}/status`)
+      .set('Cookie', cookieReviewer)
+      .send({ status: 'active' })
+      .expect(403);
+  });
+
+  it('laat geen deelnemers meer toe zodra de ronde is afgerond', async () => {
+    const runId = await nieuweRonde();
+
+    await request(server)
+      .patch(`/admin/survey/runs/${runId}/status`)
+      .set('Cookie', cookieAdminA)
+      .send({ status: 'active' })
+      .expect(200);
+
+    await request(server)
+      .patch(`/admin/survey/runs/${runId}/status`)
+      .set('Cookie', cookieAdminA)
+      .send({ status: 'finished' })
+      .expect(200);
+
+    // Een nieuwe link uitgeven zou de rapportage over die ronde achteraf
+    // veranderen.
+    await request(server)
+      .post(`/admin/survey/runs/${runId}/participants`)
+      .set('Cookie', cookieAdminA)
+      .send({ vendorIds: [VENDOR_3] })
+      .expect(409);
+  });
+
+  it('laat wel deelnemers toe aan een lopende ronde', async () => {
+    // Besluit eigenaar 2026-08-04: je vergeet er een, of er komt een
+    // leverancier bij. Dat moet kunnen zonder een nieuwe ronde te starten.
+    const runId = await nieuweRonde();
+
+    await request(server)
+      .post(`/admin/survey/runs/${runId}/participants`)
+      .set('Cookie', cookieAdminA)
+      .send({ vendorIds: [VENDOR_1] })
+      .expect(201);
+
+    await request(server)
+      .patch(`/admin/survey/runs/${runId}/status`)
+      .set('Cookie', cookieAdminA)
+      .send({ status: 'active' })
+      .expect(200);
+
+    await request(server)
+      .post(`/admin/survey/runs/${runId}/participants`)
+      .set('Cookie', cookieAdminA)
+      .send({ vendorIds: [VENDOR_2] })
+      .expect(201);
+  });
+
+  // ── De bevriezing ─────────────────────────────────────────────────────────
+
+  it('bevriest de vragenlijst zodra er een ronde op loopt', async () => {
+    const runId = await nieuweRonde();
+
+    await request(server)
+      .patch(`/admin/survey/runs/${runId}/status`)
+      .set('Cookie', cookieAdminA)
+      .send({ status: 'active' })
+      .expect(200);
+
+    // De trigger survey_question_bevriezing (migratie 0005) hoort dit te
+    // weigeren. Deze test staat hier en niet bij de migratie omdat fase B de
+    // eerste plek is waar een ronde via een róute actief wordt — als de
+    // grendel niet valt, merkt de beheerder dat pas wanneer een leverancier
+    // andere vragen krijgt dan waar de ronde over ging.
+    await expect(
+      (async () => {
+        await client.query('BEGIN');
+        await client.query(`SET LOCAL app.current_tenant_id = '${tenantA}'`);
+        await client.query(
+          `UPDATE clm.survey_question SET title = 'Gewijzigd na start'
+            WHERE template_id = $1 AND question_key = 'v1'`,
+          [TEMPLATE_A],
+        );
+        await client.query('COMMIT');
+      })(),
+    ).rejects.toThrow();
+
+    await client.query('ROLLBACK').catch(() => undefined);
+  });
+
+  // ── Het lek dat nooit mag ontstaan ────────────────────────────────────────
+
+  it('geeft de token_hash nooit terug in het rondedetail', async () => {
+    const runId = await nieuweRonde();
+
+    const uitgenodigd = await request(server)
+      .post(`/admin/survey/runs/${runId}/participants`)
+      .set('Cookie', cookieAdminA)
+      .send({ vendorIds: [VENDOR_1] })
+      .expect(201);
+
+    const { uitnodigingen } = uitgenodigd.body as UitnodigingAntwoord;
+    const hash = createHash('sha256')
+      .update(uitnodigingen[0].token, 'utf8')
+      .digest('hex');
+
+    const detail = await request(server)
+      .get(`/admin/survey/runs/${runId}`)
+      .set('Cookie', cookieAdminA)
+      .expect(200);
+
+    // De hele body doorzoeken en niet één veld: een lek test je bij de bron,
+    // niet op de plek waar je hoopt dat het niet opduikt (tegenproef 6).
+    const body = JSON.stringify(detail.body);
+
+    expect(body).not.toContain(hash);
+    expect(body).not.toContain(uitnodigingen[0].token);
+    expect(body).not.toContain('token');
+  });
+});

--- a/test/test-ids.ts
+++ b/test/test-ids.ts
@@ -137,6 +137,25 @@ export const TEST_IDS = {
     vendorA: '00000000-0000-0000-0000-0000000000ba',
     responseA: '00000000-0000-0000-0000-0000000000bc',
   },
+  'ronde-beheer-routes': {
+    tenantA: id('c3'),
+    tenantB: id('c4'),
+    adminA: id('c5'),
+    reviewerA: id('c6'),
+    adminB: id('c7'),
+    templateA: '00000000-0000-0000-0000-0000000000c8',
+    templateLeeg: '00000000-0000-0000-0000-0000000000c9',
+    // Niet ...ca en ...cb: die zijn al vergeven via id('ca') en id('cb') in
+    // het blok 'antwoord-indienen'. De bewakingstest ving dat, en dat is
+    // precies waarvoor hij bestaat — twee suites op dezelfde tenant leverden
+    // op 2026-07-31 een onregelmatig falende run op.
+    templateB: '00000000-0000-0000-0000-0000000000cc',
+    vendor1: '00000000-0000-0000-0000-0000000000cd',
+    vendor2: '00000000-0000-0000-0000-0000000000ce',
+    vendor3: '00000000-0000-0000-0000-0000000000cf',
+    vendorB: '00000000-0000-0000-0000-0000000000d4',
+    vendorWeg: '00000000-0000-0000-0000-0000000000d5',
+  },
 } as const;
 
 /** Alle uitgedeelde id's, plat. Gebruikt door de bewakingstest. */


### PR DESCRIPTION
## Wat dit toevoegt

De weg waarlangs een échte uitnodiging tot stand komt. Tot nu toe riepen alleen `seed-demo-tenant.js` en `otap-doorloop.js` `genereerToken()` aan — er was geen route waarmee een beheerder een leverancier iets kon sturen.

```
POST  /admin/survey/runs                    nieuwe ronde (draft)
PATCH /admin/survey/runs/:id/status         draft → active → finished → archived
POST  /admin/survey/runs/:id/participants   uitnodigen, geeft de tokens terug
```

Alle drie met `@VereistRol('admin')`. Lezen mag een reviewer — resultaten inzien ís zijn rol — maar tokens uitgeven aan externe partijen is een andere bevoegdheid.

De schrijfkant zit in een eigen `RondeBeheerService`; `VragenlijstBeheerService` blijft uitsluitend lezen. Die knip houdt de grens met de tokenlaag zichtbaar.

## Vier keuzes die vastliggen

**De ronde begint in `draft`.** Actief zetten bevriest de vragenlijst, en dat is onomkeerbaar. In draft kan de beheerder eerst samenstellen; de grendel valt pas wanneer hij dat wil.

**Alles in één transactie.** Faalt er één invoeging, dan rollen ook de al gegenereerde tokens terug. Per leverancier los invoegen zou bij een fout halverwege tokens in de database achterlaten die de beheerder nooit te zien krijgt — uitnodigingen die niemand kan versturen.

**Een onbekende leverancier wijst het hele verzoek af.** Niet een deel uitvoeren: dat zou de indruk wekken dat iedereen een link heeft. Wie al is uitgenodigd wordt wél overgeslagen — dat wijst op twee keer aanvinken, niet op verouderde schermdata.

**Uitnodigen mag in draft en active, niet daarna.** Besluit eigenaar 2026-08-04: je vergeet er een, of er komt een leverancier bij. Een link uitgeven op een afgeronde ronde zou de rapportage erover achteraf veranderen.

De geldigheid is instelbaar (1–180 dagen, standaard 30 uit OV-2). Onder de ondergrens is een link geen uitnodiging maar een valstrik; erboven wordt hij een permanente toegangssleutel — precies wat het tokenontwerp vermijdt.

## Drie tegenproeven

| Wat moedwillig kapotgemaakt | Wat er rood werd |
|---|---|
| Ruw token opslaan i.p.v. `hashToken()` | 7 tests |
| `@VereistRol('admin')` weghalen | 3 — precies de reviewer-tests |
| Bevriezingstrigger uitzetten | 1 — de juiste |

De hashcontrole leest bewust mét tenantcontext. Zonder die regel filtert RLS elke rij weg en lijkt de tabel leeg — dat kostte bij de eerste run een verkeerde conclusie, en is meteen het bewijs dat RLS ook buiten de applicatie om werkt.

## Twee dingen die de doorloop ving

**Botsende test-id's.** `...ca` en `...cb` waren al vergeven aan het blok `antwoord-indienen`. De bewakingstest zag het — dat is waarvoor hij bestaat.

**`demo-seed.e2e-spec.ts` viel om op 5 seconden.** Die test start het seed-script twee keer als apart proces (~1,6 s per keer) en past binnen 5 s alleen op een rustige machine. De twee andere tests in die suite hadden al 20 seconden; deze niet. Bekende faalvorm, staat in STATUS.md.

## Bewezen

- 28 nieuwe e2e-tests
- `verify:volledig` groen: 316 backend, 39 browser
- Productie loopt niet achter op het schema
- Handmatig doorlopen: drie leveranciers uitgenodigd, link geopend, vragenlijst verschijnt

## Wat dit niet doet

E-mail versturen. Dat hangt aan de SMTP-instellingen per tenant (ontworpen in spec 2026-08-04, niet gebouwd) en is fase D. Tot dan kopieert de beheerder de links zelf — een bewuste tussenstap, geen halfbakken versie.

Hoort bij MCM2-frontend#6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)