### PR TITLE
fix(backup): eerlijke Docker-melding en geen Node-crash bij afsluiten

### DIFF
--- a/docs/runbooks/backupcontrole.md
+++ b/docs/runbooks/backupcontrole.md
@@ -231,6 +231,12 @@ Get-Content "$env:USERPROFILE\OneDrive - Aling Advies\MCM2-backups\backup-contro
 Het `.cmd` geeft zelf altijd exitcode 0 terug, zodat Taakplanner de taak niet als kapot
 markeert terwijl hij juist deed wat hij moest doen.
 
+**Een andere code dan 0 of 1 hoort er niet te staan.** Zie je bijvoorbeeld
+`code -1073740791` met daarboven een regel `Assertion failed: !(handle->flags & ...)`, dan is
+Node zelf gecrasht na het versturen. De meldingen zijn dan wél verstuurd — maar de controle
+eindigde niet netjes. Dat is opgelost op 2026-08-06 (`process.exitCode` in plaats van
+`process.exit()`); komt het terug, dan is er iets anders aan de hand.
+
 ---
 
 ## Wat je van de melding mag verwachten

--- a/docs/runbooks/backupcontrole.md
+++ b/docs/runbooks/backupcontrole.md
@@ -36,6 +36,10 @@ Dit runbook richt de controle in die beide gevallen wél zou hebben gemeld.
 | B | Zit alles erin wat erin hoort? | dagelijks |
 | C | Komt het er na een echte restore ook weer uit? | wekelijks |
 
+Laag B en C hebben allebei Docker nodig. Staat Docker uit, dan worden ze **overgeslagen**
+met één eigen melding — zie "Docker draait niet" hieronder. Laag A werkt zonder Docker en
+blijft dus altijd doorlopen.
+
 Laag B vergelijkt de dump met `docs/runbooks/backup-verwachting.json` — een handgeschreven
 lijst van wat erin hoort. Die lijst wordt bewust **niet** uit de migraties afgeleid: dan zou
 de controle zichzelf verifiëren, en precies dat maakte de fout van 4 augustus onzichtbaar.
@@ -238,6 +242,33 @@ Dat is opzet: een probleem dat vijf dagen duurt moet niet vijf keer melden, want
 het bericht negeren — en dan is de melding net zo stil als het logbestand.
 
 **Bij herstel:** `✅ Hersteld na 4d 2u: de dump is weer compleet`
+
+**Als Docker niet draait:**
+
+```
+🔴 MCM2 backup — 06-08, 08:12
+
+Docker draait niet, dus de inhoud van de backup is niet gecontroleerd.
+Over de dump zelf is hiermee niets gezegd — niet goed en niet fout.
+```
+
+Dit is de waarschijnlijkste storing van allemaal: Docker Desktop start niet mee met Windows,
+dus elke herstart zonder handmatige start levert een dag zonder backup op. Waarschijnlijk staat
+er dan óók een `MISLUKT` in `backup-taak.log` — de dump heeft dezelfde container nodig.
+
+**Oplossen:** start Docker Desktop (die staat in
+`%LOCALAPPDATA%\Programs\DockerDesktop`, niet in Program Files), draai dan:
+
+```powershell
+npm run backup:dump        # de gemiste dump alsnog maken
+npm run backup:controle    # en controleren
+```
+
+> **Waarom dit een eigen melding heeft.** Tot 2026-08-06 meldde de controle in dit geval
+> *"De inhoudsopgave is niet leesbaar. Dat wijst op een beschadigde of afgebroken dump."*
+> Dat klopte niet: de dump was in orde, alleen Docker stond uit. Zo'n bericht is gevaarlijker
+> dan geen bericht — het laat je schrikken voor iets anders dan er aan de hand is, en dat is
+> precies hoe je leert meldingen te negeren.
 
 **Als alles goed gaat:** één keer per week een levensteken met de stand van zaken. Dit is het
 belangrijkste onderdeel van de hele opzet: zonder levensteken weet je bij uitblijvende

--- a/scripts/backup-controle.js
+++ b/scripts/backup-controle.js
@@ -90,6 +90,27 @@ function haalNieuwsteBackup() {
   return { dump: dumps[0], aantal: dumps.length };
 }
 
+// ── Draait Docker? ──────────────────────────────────────────────────────────
+//
+// Laag B en C hebben allebei een container nodig. Staat Docker uit, dan falen
+// ze — maar met een melding die iets heel anders suggereert dan er aan de hand
+// is. Op 2026-08-06 gebeurde dat: "De inhoudsopgave is niet leesbaar. Dat wijst
+// op een beschadigde of afgebroken dump." De dump was volstrekt in orde; alleen
+// Docker Desktop stond uit.
+//
+// Dat is de gevaarlijkste soort melding. Hij liegt niet over dát er iets mis is,
+// maar wel over wát — en een bericht dat je twee keer voor niets laat schrikken,
+// leer je negeren. Dan is de melding net zo stil als het logbestand.
+//
+// Dit is bovendien de waarschijnlijkste storing van allemaal: Docker Desktop
+// start niet mee met Windows, dus elke herstart zonder handmatige start levert
+// een dag zonder backup op. Precies daarom verdient hij een eigen, eerlijke
+// melding in plaats van een afgeleide.
+function dockerDraait() {
+  const res = spawnSync('docker', ['info'], { encoding: 'utf8' });
+  return res.status === 0;
+}
+
 /** Draait een commando in de postgres-container tegen de backupmap. */
 function inContainer(commando) {
   return spawnSync(
@@ -295,28 +316,50 @@ async function main() {
     regels.push(`Laatste dump: ${dump.naam} (${actualiteit.leeftijd} oud)`);
   }
 
-  // Laag B — de kern
-  const compleetheid = controleerCompleetheid(dump);
-  if (!compleetheid.goed) {
-    problemen.push({ sleutel: 'incompleet', bericht: compleetheid.bericht });
+  // Draait Docker? Zonder container geen laag B en geen laag C. Dan is één
+  // eerlijke melding beter dan twee afgeleide die de verkeerde kant op wijzen.
+  //
+  // Bewust GEEN herstelmelding voor de andere sleutels hier: we weten niets
+  // over de compleetheid, en "hersteld" beweren op grond van onwetendheid is
+  // erger dan zwijgen. Die statussen blijven staan tot een run die het
+  // werkelijk kon vaststellen.
+  if (!dockerDraait()) {
+    problemen.push({
+      sleutel: 'docker_uit',
+      bericht:
+        'Docker draait niet, dus de inhoud van de backup is niet gecontroleerd.\n' +
+        'Over de dump zelf is hiermee niets gezegd — niet goed en niet fout.\n\n' +
+        'Start Docker Desktop en draai daarna:\n' +
+        '  npm run backup:controle\n\n' +
+        'Let op: de backup van vanochtend is dan waarschijnlijk ook mislukt,\n' +
+        'want die heeft dezelfde container nodig.',
+    });
   } else {
-    await telegram.meldHerstel('incompleet', 'de dump is weer compleet');
-    regels.push(`Compleet: ${compleetheid.aantalGevonden} tabellen`);
-    if (compleetheid.waarschuwing) {
-      problemen.push({ sleutel: 'lijst_verouderd', bericht: compleetheid.waarschuwing });
-    } else {
-      await telegram.meldHerstel('lijst_verouderd', 'de verwachtingslijst is weer bij');
-    }
-  }
+    await telegram.meldHerstel('docker_uit', 'Docker draait weer');
 
-  // Laag C — alleen bij --volledig
-  if (modus === '--volledig') {
-    const herstel = controleerHerstelbaarheid(dump);
-    if (!herstel.goed) {
-      problemen.push({ sleutel: 'onherstelbaar', bericht: herstel.bericht });
+    // Laag B — de kern
+    const compleetheid = controleerCompleetheid(dump);
+    if (!compleetheid.goed) {
+      problemen.push({ sleutel: 'incompleet', bericht: compleetheid.bericht });
     } else {
-      await telegram.meldHerstel('onherstelbaar', 'de dump is weer herstelbaar');
-      regels.push(`Herstelproef: ${herstel.aantal} tabellen teruggezet`);
+      await telegram.meldHerstel('incompleet', 'de dump is weer compleet');
+      regels.push(`Compleet: ${compleetheid.aantalGevonden} tabellen`);
+      if (compleetheid.waarschuwing) {
+        problemen.push({ sleutel: 'lijst_verouderd', bericht: compleetheid.waarschuwing });
+      } else {
+        await telegram.meldHerstel('lijst_verouderd', 'de verwachtingslijst is weer bij');
+      }
+    }
+
+    // Laag C — alleen bij --volledig
+    if (modus === '--volledig') {
+      const herstel = controleerHerstelbaarheid(dump);
+      if (!herstel.goed) {
+        problemen.push({ sleutel: 'onherstelbaar', bericht: herstel.bericht });
+      } else {
+        await telegram.meldHerstel('onherstelbaar', 'de dump is weer herstelbaar');
+        regels.push(`Herstelproef: ${herstel.aantal} tabellen teruggezet`);
+      }
     }
   }
 

--- a/scripts/backup-controle.js
+++ b/scripts/backup-controle.js
@@ -284,13 +284,15 @@ async function main() {
     );
     if (!gelukt && telegram.geconfigureerd) {
       console.error('MISLUKT — zie de foutmelding hierboven.');
-      process.exit(1);
+      process.exitCode = 1;
+      return;
     }
     if (!telegram.geconfigureerd) {
       console.error(
         '\nTELEGRAM_BOT_TOKEN en/of TELEGRAM_CHAT_ID ontbreken in .env.\nZonder die twee is er geen melding — zie het runbook.',
       );
-      process.exit(1);
+      process.exitCode = 1;
+      return;
     }
     console.log('OK — testbericht verstuurd.');
     return;
@@ -305,7 +307,8 @@ async function main() {
   if (fout) {
     await telegram.meldProbleem('geen_backup', `MCM2 backup\n\n${fout}`);
     console.error(fout);
-    process.exit(1);
+    process.exitCode = 1;
+    return;
   }
 
   const actualiteit = controleerActualiteit(dump);
@@ -388,10 +391,24 @@ async function main() {
   for (const regel of regels) console.log(`  ${regel}`);
   for (const probleem of problemen) console.log(`  PROBLEEM: ${probleem.bericht.split('\n')[0]}`);
 
-  process.exit(problemen.length > 0 ? 1 : 0);
+  // Bewust process.exitCode en niet process.exit().
+  //
+  // process.exit() kapt af terwijl libuv de HTTPS-verbinding naar Telegram nog
+  // aan het opruimen is. Op Windows crasht Node daar sinds v24 op:
+  //
+  //   Assertion failed: !(handle->flags & UV_HANDLE_CLOSING), src\win\async.c
+  //
+  // Dat gebeurde op 2026-08-06 en gaf exitcode -1073740791 in plaats van 1.
+  // De berichten wáren al verstuurd, dus er ging niets verloren — maar het log
+  // eindigde met een crash, en een controle die zelf crasht is er precies één
+  // die je niet vertrouwt op het moment dat het ertoe doet.
+  //
+  // Met exitCode rondt Node de verbinding netjes af en eindigt daarna vanzelf.
+  // Gemeten: binnen 0,6 seconde, want fetch houdt geen sockets open.
+  process.exitCode = problemen.length > 0 ? 1 : 0;
 }
 
 main().catch((err) => {
   console.error(`Onverwachte fout in de backupcontrole: ${err.message}`);
-  process.exit(1);
+  process.exitCode = 1;
 });


### PR DESCRIPTION
Twee gerelateerde reparaties naar aanleiding van de storing van 2026-08-06.

## Aanleiding

Docker Desktop stond uit. Daardoor mislukte de dump op 5 en 6 augustus, en meldde de controle vanmorgen twee dingen — waarvan er één misleidend was.

## 1. Eigen melding als Docker niet draait

Laag B en C hebben allebei een container nodig. Stond Docker uit, dan faalde laag B met:

> De inhoudsopgave is niet leesbaar. Dat wijst op een beschadigde of afgebroken dump.

Dat klopte niet — de dump was volstrekt in orde. Zo'n bericht is gevaarlijker dan geen bericht: het liegt niet over dát er iets mis is, maar wel over wát. En een melding die je twee keer voor niets laat schrikken, leer je negeren.

Nu wordt Docker eerst gecontroleerd. Is hij weg, dan volgt één melding die zegt wat er werkelijk aan de hand is, inclusief dat er over de dump zelf niets is vastgesteld — niet goed en niet fout. Laag B en C worden overgeslagen in plaats van misleidend te falen; laag A werkt zonder Docker en loopt door.

Bewust géén herstelmelding voor de andere sleutels in dit pad: "hersteld" beweren op grond van onwetendheid is erger dan zwijgen.

## 2. Geen Node-crash meer bij het afsluiten

`process.exit()` kapt af terwijl libuv de HTTPS-verbinding naar Telegram nog opruimt. Node 24 op Windows crasht daarop:

```
Assertion failed: !(handle->flags & UV_HANDLE_CLOSING), src\win\async.c:76
```

Op 6 augustus gaf dat exitcode `-1073740791` in plaats van 1. De meldingen waren toen al verstuurd, dus er ging niets verloren — maar het log eindigde met een crash, en een controle die zelf crasht is er precies één die je niet vertrouwt op het moment dat het ertoe doet.

## Verificatie

Docker-afwezigheid nagebootst met een shim in PATH (Docker niet echt gestopt). Zowel de dagelijkse als de `--volledig`-variant: één melding, geen mislukte herstelproef, exitcode 1.

De assertion is gereproduceerd met twee gelijktijdige problemen — twee `fetch`-aanroepen achter elkaar, exact het scenario van 6 augustus. Bij één melding treedt de crash niet op, dus die opzet is maatgevend:

| | exitcode | assertion |
|---|---|---|
| oude code | 127 | ja, 3 van 3 |
| nieuwe code | 1 | nee, 5 van 5 |

Daarna de echte taak gedraaid: 18 tabellen compleet, 18 teruggezet in de herstelproef, `GEEN PROBLEMEN`.

## Wat dit niet oplost

De meldingen zijn nu eerlijk, maar voorkomen het verlies niet — draait Docker niet om 07:00, dan mis je die dag een backup. Dit was de derde keer dezelfde oorzaak (zie ook STATUS.md over 1–3 augustus). Docker Desktop meestarten met Windows wordt apart geregeld.

🤖 Generated with [Claude Code](https://claude.com/claude-code)