### PR TITLE
feat(mail): ResendMailKanaal — het mailkanaal werkt aantoonbaar

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -124,3 +124,26 @@ FEATURE_VENDORS_ENABLED=false
 # Inrichting: docs/runbooks/backupcontrole.md stap 1.
 TELEGRAM_BOT_TOKEN=
 TELEGRAM_CHAT_ID=
+
+# ── Mailkanaal: uitnodigingen naar leveranciers ──────────────────────────────
+#
+# Besluit eigenaar 2026-08-06: één platformverstuurder via Resend, niet een
+# eigen SMTP per tenant. De klant is herkenbaar via de afzendernaam
+# ("Transdev via MCM2"), het adres blijft van het platform. Zo is er geen
+# SPF-record van de klant nodig voordat er mail uit kan.
+#
+# Zie docs/superpowers/specs/2026-08-06-mailkanaal.md
+#
+# LEEG LATEN = er wordt GEEN mail verstuurd; uitnodigingen belanden in het log.
+# Dat is de veilige toestand en bruikbaar in CI, in de demo en zonder sleutel.
+#
+# BEIDE invullen of BEIDE leeg laten. Half ingesteld faalt bij opstarten —
+# stil terugvallen op het logkanaal zou betekenen dat je denkt dat er mail
+# uitgaat terwijl er niets gebeurt.
+#
+# Let op de limieten van het gratis plan: 3.000 mails per maand én 100 per dag
+# (harde cap, geen overage). Bij een bulkronde van vijfhonderd worden er
+# vierhonderd geweigerd — zie §3b van het ontwerp.
+RESEND_API_KEY=
+# Moet op een in Resend geverifieerd domein staan.
+MAIL_AFZENDER_ADRES=

--- a/docs/runbooks/mailkanaal-inrichten.md
+++ b/docs/runbooks/mailkanaal-inrichten.md
@@ -1,0 +1,244 @@
+# Runbook — het mailkanaal inrichten (Resend)
+
+**Type:** C — toegang en credentials
+**Eigenaar:** de eigenaar (Chris)
+**Laatste update:** 2026-08-06
+**Vereiste toegang:** Resend-account, DNS-beheer van het verzenddomein
+
+> **Status: ingericht en werkend op 2026-08-06.** Domein `send.myvendormanager.nl` is
+> geverifieerd, een testbericht is aantoonbaar verstuurd. De stappen hieronder zijn de
+> herhaalbare procedure — voor een nieuw domein, een nieuwe omgeving, of om te controleren
+> of het nog klopt.
+
+> Ontwerp en onderbouwing: `docs/superpowers/specs/2026-08-06-mailkanaal.md`
+
+---
+
+## Wat hier staat en waarom
+
+MCM2 verstuurt uitnodigingen namens de tenant, via één platformverstuurder. De klant is
+herkenbaar aan de afzendernaam; het adres blijft van het platform:
+
+```
+Van:      "Transdev via MCM2" <uitvraag@send.myvendormanager.nl>
+Reply-To: contractmanagement@transdev.nl
+```
+
+Waarom niet het adres van de klant zelf: dat vraagt dat de klant ons in zijn SPF opneemt en
+met zijn DKIM laat ondertekenen — een traject met hun IT-afdeling per klant, voordat er ook
+maar één mail uit kan. Zie ontwerp §3.
+
+---
+
+## Stap 1 — Een verzenddomein kiezen
+
+**Gebruik een subdomein, niet het hoofddomein.** Ingericht op 2026-08-06 als
+`send.myvendormanager.nl`.
+
+Twee redenen:
+
+1. **Reputatie blijft gescheiden.** Gaat er iets mis met een bulkronde — veel bounces op
+   verouderde adressen — dan raakt dat het subdomein en niet de gewone mail op het
+   hoofddomein.
+2. **Bestaande records blijven ongemoeid.** Er staat al een MX en een SPF op het hoofddomein.
+   Bij een subdomein hoeft daar niets aan te veranderen; de nieuwe records staan in een
+   andere tak.
+
+Dat tweede punt is niet theoretisch: op `alingadvies.nl` staan **twee** SPF-records, wat
+ongeldig is volgens RFC 7208. Met een subdomein kan die situatie per constructie niet
+ontstaan.
+
+**Regio:** Ireland (`eu-west-1`) — EU, past bij de AVG-uitgangspunten van het project.
+
+---
+
+## Stap 2 — Domein toevoegen in Resend
+
+1. resend.com → **Domains** → **Add domain**
+2. Naam: het subdomein, bijv. `send.myvendormanager.nl`
+3. Regio: **Ireland (eu-west-1)**
+4. **Add domain**
+
+**"Enable Receiving" laten uitstaan.** Bounces komen via webhooks binnen, niet via een
+postbus (ontwerp §4). Aanzetten voegt een MX-record toe dat niet gebruikt wordt.
+
+Het veld "Your Name" rechts in beeld is een voorbeeldweergave, geen invoerveld. De
+afzendernaam wordt per bericht meegegeven vanuit MCM2 en komt per tenant uit de database —
+daarom staat hij niet bij Resend ingesteld.
+
+---
+
+## Stap 3 — DNS-records plaatsen
+
+Resend toont drie records. Voor `send.myvendormanager.nl` waren dat:
+
+| Type | Naam (zoals Resend toont) | Inhoud |
+|---|---|---|
+| TXT | `resend._domainkey.send` | `p=MIGfMA0GCSq…IDAQAB` (DKIM, ±216 tekens) |
+| TXT | `send.send` | `v=spf1 include:amazonses.com ~all` |
+| MX | `send.send` | `feedback-smtp.eu-west-1.amazonses.com`, prioriteit 10 |
+
+### De valkuil: relatief of volledig?
+
+Resend toont **relatieve** namen (`send.send`). Veel DNS-panelen willen de **volledige**
+hostnaam. Bij mijndomein.nl is dat het geval — daar staat `soverin1._domainkey.jouwdomein.nl`
+voluit in de zone.
+
+Voor mijndomein wordt het dus:
+
+```
+resend._domainkey.send.myvendormanager.nl
+send.send.myvendormanager.nl
+send.send.myvendormanager.nl
+```
+
+**Die dubbele `send` is correct**: één keer voor het subdomein, één keer voor het label dat
+Resend eronder hangt.
+
+**Hoe je weet welke vorm jouw paneel wil:** kijk naar een bestaand record. Staat er `@`, dan
+is het relatief. Staat het domein er voluit, dan volledige namen.
+
+Zet je het fout, dan ontstaat `…myvendormanager.nl.myvendormanager.nl` en verifieert Resend
+nooit — zonder duidelijke foutmelding. Dat is de meest gemaakte fout in deze stap.
+
+### Verder
+
+- **Punt aan het eind** bij MX en CNAME, zoals de bestaande records in de zone. Bij TXT niet.
+- **De DKIM-waarde in één stuk**, zonder regeleindes. Eén ontbrekend teken maakt de
+  handtekening ongeldig.
+- **Niets verwijderen.** Alle drie de records zijn toevoegingen.
+
+---
+
+## Stap 4 — Controleren vóór je op verifiëren drukt
+
+```bash
+nslookup -type=TXT resend._domainkey.send.myvendormanager.nl 8.8.8.8
+nslookup -type=TXT send.send.myvendormanager.nl 8.8.8.8
+nslookup -type=MX  send.send.myvendormanager.nl 8.8.8.8
+```
+
+**Gebruik expliciet een publieke resolver (`8.8.8.8`).** Op 2026-08-06 gaf de lokale
+router-resolver een leeg antwoord voor het SPF-record terwijl het record correct stond — een
+cache die nog niet ververst was. Dat leest als een fout die er niet is.
+
+**Verwacht:** alle drie de records met de waarden uit stap 3.
+
+Daarna in Resend: **"I've added the records"**. Verificatie duurt 5–30 minuten.
+
+---
+
+## Stap 5 — API-sleutel en configuratie
+
+1. Resend → **API Keys** → **Create API Key**
+2. Naam: `MCM2`. **Een eigen sleutel** — niet die van JouwContractmanager hergebruiken.
+3. Permissie: **Sending access** volstaat.
+4. Kopieer meteen; hij wordt één keer getoond.
+
+In `.env`:
+
+```
+RESEND_API_KEY=re_...
+MAIL_AFZENDER_ADRES=uitvraag@send.myvendormanager.nl
+```
+
+**Beide invullen of beide leeg laten.** Half ingesteld weigert de applicatie op te starten —
+stil terugvallen op het logkanaal zou betekenen dat je denkt dat er mail uitgaat terwijl er
+niets gebeurt.
+
+**Het afzenderadres moet op het geverifieerde domein staan.** Een adres op het hoofddomein
+weigert Resend met `invalid_from_address`.
+
+`.env` staat in `.gitignore` en hoort daar te blijven.
+
+---
+
+## Stap 6 — De verzending testen
+
+**Dit is geen optionele stap.** Zonder deze test weet je pas of het mailkanaal werkt op het
+moment dat je het het hardst nodig hebt — dezelfde redenering als bij
+`npm run backup:controle:test`.
+
+```bash
+npm run build
+npm run mail:test -- jouwadres@example.com
+```
+
+**Verwacht:**
+
+```
+Verstuurt via Resend vanaf uitvraag@send.myvendormanager.nl.
+
+Geslaagd — bericht-id f47455a6-...
+```
+
+Controleer in het ontvangen bericht:
+
+- de afzender toont de display name, niet alleen het adres
+- beantwoorden gaat naar het `Reply-To`-adres
+- het bericht staat niet in de spammap
+
+**Belandt het in spam:** bij een nieuw verzenddomein zonder opgebouwde reputatie is dat niet
+ongewoon, zeker bij Hotmail en Outlook. Het betekent niet dat de records fout staan. De
+reputatie bouwt op naarmate er meer legitieme mail uitgaat.
+
+### De tegenproef
+
+```bash
+npm run mail:test -- geen-geldig-adres
+```
+
+**Verwacht:** `MISLUKT: Ongeldig ontvangeradres`, exitcode 1, en er gaat geen netwerkaanroep
+uit. Slaagt dit wél, dan is de validatie stuk.
+
+---
+
+## Wat dit nog niet afdekt
+
+**Een niet-bestaand maar geldig gevormd adres levert "Geslaagd" op.** Getest op 2026-08-06
+met `bestaat-echt-niet-mcm2test@gmail.com`: Resend accepteert het bericht, de bounce komt
+pas later, en zonder webhook horen we die nooit.
+
+Dat is geen fout maar precies het gat dat ontwerp §4 beschrijft: vandaag is een
+niet-aangekomen uitnodiging onzichtbaar. Het webhook-endpoint (stap 5 uit ontwerp §9) sluit
+dat.
+
+**Tot die tijd:** een uitnodiging die niet aankomt, blijkt pas als de deadline verstrijkt.
+Wie wil weten of iets is aangekomen, kijkt in Resend onder **Emails** — daar staat de status
+per bericht.
+
+---
+
+## Limieten van het gratis plan
+
+| | Gratis | Pro |
+|---|---|---|
+| Per maand | 3.000 | 50.000+ |
+| **Per dag** | **100 (harde cap)** | geen daglimiet |
+| Domeinen | 1 | 10 |
+
+**De daglimiet is de belangrijkste.** Bij een bulkronde van vijfhonderd worden er honderd
+verstuurd en vierhonderd geweigerd — Resend rekent niets bij, het stopt gewoon. De
+verzendcode legt dat vast als een fout op de ronde (`daily_quota_exceeded`), maar de
+uitnodigingen zijn die dag niet verstuurd.
+
+**Eén domein** betekent ook: JouwContractmanager gebruikt zijn eigen gratis plan voor
+`jouwcontractmanager.nl`. Die twee delen niets.
+
+---
+
+## Bij problemen
+
+**"Domain not verified" blijft staan:** controleer met stap 4 of de records er wereldwijd
+staan. Meestal is de hostnaam dubbel aangevuld — zie de valkuil in stap 3.
+
+**`invalid_from_address`:** het adres in `MAIL_AFZENDER_ADRES` staat niet op het geverifieerde
+domein.
+
+**`daily_quota_exceeded`:** de 100 van vandaag zijn op. Morgen weer, of upgraden.
+
+**Applicatie start niet op met een melding over `MAIL_AFZENDER_ADRES` of `RESEND_API_KEY`:**
+één van beide is ingevuld en de andere niet. Vul beide in, of laat beide leeg.
+
+**Niets komt aan maar Resend meldt "Delivered":** kijk in de spammap van de ontvanger. Bij een
+nieuw domein is dat de waarschijnlijkste verklaring.

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "multer": "2.2.0",
         "pg": "8.22.0",
         "reflect-metadata": "^0.2.2",
+        "resend": "^6.18.1",
         "rxjs": "^7.8.1"
       },
       "devDependencies": {
@@ -3461,6 +3462,12 @@
         "@sinonjs/commons": "^3.0.1"
       }
     },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+      "license": "MIT"
+    },
     "node_modules/@tokenizer/inflate": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/@tokenizer/inflate/-/inflate-0.4.1.tgz",
@@ -6544,6 +6551,12 @@
       "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
       "license": "MIT"
     },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "license": "Unlicense"
+    },
     "node_modules/fast-uri": {
       "version": "3.1.4",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
@@ -9502,6 +9515,12 @@
         "node": ">=4"
       }
     },
+    "node_modules/postal-mime": {
+      "version": "2.7.5",
+      "resolved": "https://registry.npmjs.org/postal-mime/-/postal-mime-2.7.5.tgz",
+      "integrity": "sha512-GNEXKvWFQnbgO5NlrGzVa0FmWzBZ24PersAWErttSg1Hjpf0ATxTwS5DOMGaOpTG6bUh5cTr7xi0jAD942wCJA==",
+      "license": "MIT-0"
+    },
     "node_modules/postgres-bytea": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
@@ -9752,6 +9771,27 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resend": {
+      "version": "6.18.1",
+      "resolved": "https://registry.npmjs.org/resend/-/resend-6.18.1.tgz",
+      "integrity": "sha512-XN8XIaDdKF+ziSQ3K23ndUcyhP7U3ze2gky6SPgYkuAOq54mH4Wdhwm7QylEQ3zlz0NzdX7/l1AgmJUZbdPI/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "postal-mime": "2.7.5",
+        "standardwebhooks": "1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@react-email/render": "*"
+      },
+      "peerDependenciesMeta": {
+        "@react-email/render": {
+          "optional": true
+        }
       }
     },
     "node_modules/resolve-cwd": {
@@ -10138,6 +10178,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
       }
     },
     "node_modules/statuses": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "backup:controle": "node scripts/backup-controle.js",
     "backup:controle:volledig": "node scripts/backup-controle.js --volledig",
     "backup:controle:test": "node scripts/backup-controle.js --test",
+    "mail:test": "node scripts/mail-test.js",
     "db:generate": "drizzle-kit generate",
     "db:check": "drizzle-kit check",
     "migrate:deploy": "node scripts/migrate.js",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "multer": "2.2.0",
     "pg": "8.22.0",
     "reflect-metadata": "^0.2.2",
+    "resend": "^6.18.1",
     "rxjs": "^7.8.1"
   },
   "devDependencies": {

--- a/scripts/mail-test.js
+++ b/scripts/mail-test.js
@@ -1,0 +1,79 @@
+#!/usr/bin/env node
+// Verstuurt één echte testmail via het mailkanaal.
+//
+// ── Waarom dit script bestaat ───────────────────────────────────────────────
+//
+// De unit-tests bootsen de Resend-SDK na. Ze bewijzen dat onze vertaling van
+// "wat Resend teruggeeft" naar "wat de aanroeper moet weten" klopt — maar niet
+// dat er werkelijk een mail aankomt. Daarvoor is een geverifieerd domein en een
+// echte verzending nodig.
+//
+// Dat is tegenproef 1 uit het mailkanaal-ontwerp §7, en het is dezelfde
+// gedachte als `npm run backup:controle:test`: de melding zelf een keer
+// aantoonbaar laten werken, vóór het moment waarop je hem nodig hebt.
+//
+// ── Gebruik ─────────────────────────────────────────────────────────────────
+//
+//   node scripts/mail-test.js <ontvanger>
+//
+// Zonder RESEND_API_KEY in .env verstuurt dit niets en zegt het dat ook —
+// zelfde no-op-gedrag als scripts/telegram.js.
+//
+// Zie docs/superpowers/specs/2026-08-06-mailkanaal.md
+require('dotenv').config();
+
+const ontvanger = process.argv[2];
+
+if (!ontvanger) {
+  console.error('Gebruik: node scripts/mail-test.js <ontvanger@example.com>');
+  process.exit(1);
+}
+
+// De TypeScript-bron via de build. Dit script draait bewust tegen dezelfde code
+// die de applicatie gebruikt: een eigen Resend-aanroep hier zou iets anders
+// testen dan wat er in productie gebeurt.
+const { leesMailConfig } = require('../dist/mail/mail.config');
+const { ResendMailKanaal } = require('../dist/mail/resend-mail-kanaal');
+const { LogMailKanaal } = require('../dist/mail/log-mail-kanaal');
+
+async function main() {
+  const config = leesMailConfig();
+
+  const kanaal = config ? new ResendMailKanaal(config) : new LogMailKanaal();
+
+  if (!config) {
+    console.log('Geen RESEND_API_KEY — er wordt niets verstuurd (logkanaal).\n');
+  } else {
+    console.log(`Verstuurt via Resend vanaf ${config.afzenderAdres}.\n`);
+  }
+
+  const stempel = new Date().toLocaleString('nl-NL');
+
+  const resultaat = await kanaal.verstuur({
+    aan: ontvanger,
+    afzenderNaam: 'Demo-organisatie via MCM2',
+    antwoordAan: 'contractmanagement@demo.nl',
+    onderwerp: `MCM2 testbericht — ${stempel}`,
+    tekst:
+      `Dit is een testbericht van het MCM2-mailkanaal.\n\n` +
+      `Als je dit leest, werkt de keten: verstuurd via Resend, ` +
+      `afgeleverd op ${ontvanger}.\n\n` +
+      `Controleer in dit bericht:\n` +
+      `  - de afzender toont "Demo-organisatie via MCM2"\n` +
+      `  - beantwoorden gaat naar contractmanagement@demo.nl\n` +
+      `  - het bericht staat niet in de spammap\n\n` +
+      `Verstuurd op ${stempel}.\n`,
+  });
+
+  console.log(`Geslaagd — bericht-id ${resultaat.providerId}`);
+  console.log(`\nControleer de inbox van ${ontvanger}.`);
+  console.log('Niets aangekomen? Kijk in Resend onder Emails wat de status is.');
+}
+
+main().catch((err) => {
+  console.error(`\nMISLUKT: ${err.message}`);
+  if (err.tijdelijk === false) {
+    console.error('Dit is een blijvende fout — opnieuw proberen helpt niet.');
+  }
+  process.exitCode = 1;
+});

--- a/src/mail/mail.config.spec.ts
+++ b/src/mail/mail.config.spec.ts
@@ -1,0 +1,130 @@
+import { MailConfigFout, leesMailConfig } from './mail.config';
+
+/**
+ * De configuratie kent drie toestanden, en het onderscheid daartussen is de
+ * hele reden dat dit bestand bestaat:
+ *
+ *   niets ingesteld  → null, draai met LogMailKanaal (geen fout)
+ *   volledig         → een MailConfig
+ *   half             → een fout bij opstarten
+ *
+ * Die laatste is de gevaarlijke: stil terugvallen op het logkanaal betekent dat
+ * de beheerder denkt dat er mail uitgaat terwijl er niets gebeurt.
+ */
+
+const COMPLEET: NodeJS.ProcessEnv = {
+  RESEND_API_KEY: 're_test_sleutel',
+  MAIL_AFZENDER_ADRES: 'uitvraag@mcm2mail.nl',
+};
+
+describe('leesMailConfig', () => {
+  describe('niets ingesteld — geen fout', () => {
+    it('geeft null bij een lege omgeving', () => {
+      expect(leesMailConfig({})).toBeNull();
+    });
+
+    it('geeft null als beide variabelen leeg zijn', () => {
+      // Een lege variabele in .env is een veelgemaakte fout. Als "leeg" iets
+      // anders zou betekenen dan "afwezig", zou de ene helft van het team
+      // draaien met een logkanaal en de andere met een crash.
+      expect(
+        leesMailConfig({ RESEND_API_KEY: '', MAIL_AFZENDER_ADRES: '  ' }),
+      ).toBeNull();
+    });
+  });
+
+  describe('volledig ingesteld', () => {
+    it('leest sleutel en afzenderadres', () => {
+      const config = leesMailConfig(COMPLEET);
+
+      expect(config).not.toBeNull();
+      expect(config?.apiSleutel).toBe('re_test_sleutel');
+      expect(config?.afzenderAdres).toBe('uitvraag@mcm2mail.nl');
+    });
+
+    it('haalt witruimte weg', () => {
+      const config = leesMailConfig({
+        RESEND_API_KEY: '  re_test_sleutel  ',
+        MAIL_AFZENDER_ADRES: '  uitvraag@mcm2mail.nl  ',
+      });
+
+      expect(config?.apiSleutel).toBe('re_test_sleutel');
+      expect(config?.afzenderAdres).toBe('uitvraag@mcm2mail.nl');
+    });
+  });
+
+  describe('half ingesteld — faalt hard', () => {
+    it('faalt met alleen een afzenderadres', () => {
+      expect(() =>
+        leesMailConfig({ MAIL_AFZENDER_ADRES: 'uitvraag@mcm2mail.nl' }),
+      ).toThrow(MailConfigFout);
+    });
+
+    it('faalt met alleen een sleutel', () => {
+      expect(() =>
+        leesMailConfig({ RESEND_API_KEY: 're_test_sleutel' }),
+      ).toThrow(MailConfigFout);
+    });
+
+    it('noemt in de fout welke variabele ontbreekt', () => {
+      // Een foutmelding die niet zegt wát er mist, kost de lezer een zoektocht
+      // door de broncode.
+      expect(() => leesMailConfig({ MAIL_AFZENDER_ADRES: 'a@b.nl' })).toThrow(
+        /RESEND_API_KEY/,
+      );
+      expect(() => leesMailConfig({ RESEND_API_KEY: 're_x' })).toThrow(
+        /MAIL_AFZENDER_ADRES/,
+      );
+    });
+
+    it('valt niet stil terug op het logkanaal', () => {
+      // De kern van deze hele paragraaf: half ingesteld mag nooit null
+      // opleveren. Zou dat wel zo zijn, dan start MCM2 op alsof alles klopt en
+      // verstuurt het niets.
+      expect(() => leesMailConfig({ RESEND_API_KEY: 're_x' })).toThrow();
+    });
+  });
+
+  describe('afzenderadres wordt gevalideerd', () => {
+    it('weigert een adres zonder @', () => {
+      // Resend geeft hierop `invalid_from_address` — maar pas bij de eerste
+      // verzending, als de ronde al loopt.
+      expect(() =>
+        leesMailConfig({ ...COMPLEET, MAIL_AFZENDER_ADRES: 'geen-adres' }),
+      ).toThrow(MailConfigFout);
+    });
+
+    it('weigert een adres zonder punt in het domein', () => {
+      expect(() =>
+        leesMailConfig({
+          ...COMPLEET,
+          MAIL_AFZENDER_ADRES: 'uitvraag@localhost',
+        }),
+      ).toThrow(MailConfigFout);
+    });
+
+    it('noemt het foute adres in de melding', () => {
+      expect(() =>
+        leesMailConfig({ ...COMPLEET, MAIL_AFZENDER_ADRES: 'geen-adres' }),
+      ).toThrow(/geen-adres/);
+    });
+  });
+
+  describe('de sleutel lekt niet', () => {
+    it('zet de sleutel niet in een foutmelding', () => {
+      // MCM2-CLAUDE.md §6: nooit loggen, nooit in een foutmelding. Een
+      // configuratiefout is precies het moment waarop dat per ongeluk gebeurt.
+      const geheim = 're_dit_is_geheim_abc123';
+
+      try {
+        leesMailConfig({
+          RESEND_API_KEY: geheim,
+          MAIL_AFZENDER_ADRES: 'fout-adres',
+        });
+        throw new Error('had moeten falen');
+      } catch (err) {
+        expect((err as Error).message).not.toContain(geheim);
+      }
+    });
+  });
+});

--- a/src/mail/mail.config.ts
+++ b/src/mail/mail.config.ts
@@ -1,0 +1,94 @@
+import { isGeldigMailadres } from './mail-adres';
+
+/**
+ * Configuratie van het mailkanaal.
+ *
+ * Anders dan `auth.config.ts` faalt dit **niet** hard bij ontbrekende
+ * variabelen. Zonder sleutel draait MCM2 met `LogMailKanaal`: er gaat dan
+ * aantoonbaar niets de deur uit, en dat is de veilige toestand. Zelfde keuze
+ * als in `scripts/telegram.js` — ontbrekende configuratie is een no-op met een
+ * logregel, geen crash. Zo blijft de applicatie bruikbaar in CI, in de demo, en
+ * op een machine zonder sleutel.
+ *
+ * Wat wél hard faalt: een configuratie die er half is. Een sleutel zonder
+ * afzenderadres betekent dat iemand het bedoelde in te stellen en halverwege
+ * is gestopt — dan is stil doorgaan met loggen erger dan opstarten weigeren,
+ * want de beheerder denkt dat er mail uitgaat.
+ *
+ * Zie docs/superpowers/specs/2026-08-06-mailkanaal.md §6.
+ */
+
+export interface MailConfig {
+  /** De Resend API-sleutel. Nooit loggen — zie MCM2-CLAUDE.md §6. */
+  readonly apiSleutel: string;
+  /**
+   * Het adres waarvandaan alles verstuurd wordt, bijv. `uitvraag@mcm2mail.nl`.
+   *
+   * Moet op een in Resend geverifieerd domein staan. Dit is het platformadres;
+   * de klantnaam zit in de display name die per bericht wordt meegegeven
+   * (ontwerp §3).
+   */
+  readonly afzenderAdres: string;
+}
+
+export class MailConfigFout extends Error {
+  constructor(melding: string) {
+    super(melding);
+    this.name = 'MailConfigFout';
+  }
+}
+
+const SLEUTEL = 'RESEND_API_KEY';
+const AFZENDER = 'MAIL_AFZENDER_ADRES';
+
+function leeg(waarde: string | undefined): boolean {
+  return waarde === undefined || waarde.trim() === '';
+}
+
+/**
+ * Leest de configuratie, of geeft `null` als er niets is ingesteld.
+ *
+ * `null` betekent: draai met `LogMailKanaal`. Dat is geen fout.
+ */
+export function leesMailConfig(
+  env: NodeJS.ProcessEnv = process.env,
+): MailConfig | null {
+  const apiSleutel = env[SLEUTEL];
+  const afzenderAdres = env[AFZENDER];
+
+  // Allebei leeg: bewust niet geconfigureerd.
+  if (leeg(apiSleutel) && leeg(afzenderAdres)) {
+    return null;
+  }
+
+  // Eén van beide: half ingesteld. Dat is een fout, geen keuze.
+  if (leeg(apiSleutel)) {
+    throw new MailConfigFout(
+      `${AFZENDER} is ingesteld maar ${SLEUTEL} ontbreekt. ` +
+        `Zonder sleutel kan er niets verstuurd worden; laat beide leeg om met het logkanaal te draaien.`,
+    );
+  }
+  if (leeg(afzenderAdres)) {
+    throw new MailConfigFout(
+      `${SLEUTEL} is ingesteld maar ${AFZENDER} ontbreekt. ` +
+        `Resend weigert een verzending zonder geverifieerd afzenderadres.`,
+    );
+  }
+
+  const adres = afzenderAdres!.trim();
+
+  // Een fout afzenderadres levert bij Resend `invalid_from_address` op — pas
+  // bij de eerste verzending, en dan is de ronde al gestart. Hier vangen is
+  // het verschil tussen "opstarten mislukt" en "zeventien leveranciers kregen
+  // niets".
+  if (!isGeldigMailadres(adres)) {
+    throw new MailConfigFout(
+      `${AFZENDER} is geen geldig e-mailadres: ${adres}`,
+    );
+  }
+
+  return {
+    apiSleutel: apiSleutel!.trim(),
+    afzenderAdres: adres,
+  };
+}

--- a/src/mail/mail.module.spec.ts
+++ b/src/mail/mail.module.spec.ts
@@ -3,46 +3,100 @@ import { Test } from '@nestjs/testing';
 import { LogMailKanaal } from './log-mail-kanaal';
 import { MailKanaal } from './mail-kanaal';
 import { MailModule } from './mail.module';
+import { ResendMailKanaal } from './resend-mail-kanaal';
+
+jest.mock('resend', () => ({
+  Resend: jest.fn().mockImplementation(() => ({ emails: { send: jest.fn() } })),
+}));
 
 /**
  * De knip uit ontwerp §5 bestaat pas echt als een aanroeper `MailKanaal` kan
  * vragen zonder te weten welke implementatie hij krijgt.
  *
- * Zonder deze test is de abstractie decoratie: hij staat in het bestand, maar
- * niets dwingt af dat de rest van de applicatie hem ook gebruikt.
+ * Zonder deze tests is de abstractie decoratie: hij staat in het bestand, maar
+ * niets dwingt af dat de keuze klopt — en die keuze bepaalt of er werkelijk
+ * mail de deur uit gaat.
  */
 describe('MailModule', () => {
-  it('levert een MailKanaal aan wie erom vraagt', async () => {
-    const moduleRef = await Test.createTestingModule({
-      imports: [MailModule],
-    }).compile();
+  const oorspronkelijkeEnv = process.env;
 
-    const kanaal = moduleRef.get(MailKanaal);
-
-    expect(kanaal).toBeInstanceOf(MailKanaal);
+  beforeEach(() => {
+    // Een kopie zonder de mailvariabelen: anders bepaalt de .env van de
+    // ontwikkelaar de uitkomst, en dan is de test op de ene machine groen en
+    // op de andere rood.
+    process.env = { ...oorspronkelijkeEnv };
+    delete process.env.RESEND_API_KEY;
+    delete process.env.MAIL_AFZENDER_ADRES;
   });
 
-  it('levert nu LogMailKanaal — er wordt aantoonbaar niets verstuurd', async () => {
-    // Zolang ResendMailKanaal niet bestaat (stap 3 uit ontwerp §9) is dit de
-    // veilige toestand. Deze test valt om zodra iemand de keuze wijzigt, en dat
-    // is precies de bedoeling: een kanaal dat echt verstuurt hoort een bewuste
-    // wijziging te zijn, geen bijvangst.
-    const moduleRef = await Test.createTestingModule({
-      imports: [MailModule],
-    }).compile();
-
-    expect(moduleRef.get(MailKanaal)).toBeInstanceOf(LogMailKanaal);
+  afterEach(() => {
+    process.env = oorspronkelijkeEnv;
   });
 
-  it('geeft dezelfde instantie voor MailKanaal en LogMailKanaal', async () => {
-    // `useExisting` en niet `useClass`: anders bestaan er twee instanties met
-    // elk een eigen verzendlijst, en dan controleert een test de ene lijst
-    // terwijl de code in de andere schrijft. Dat is een testfout die er
-    // uitziet als een codefout.
-    const moduleRef = await Test.createTestingModule({
-      imports: [MailModule],
-    }).compile();
+  async function bouw() {
+    return Test.createTestingModule({ imports: [MailModule] }).compile();
+  }
 
-    expect(moduleRef.get(MailKanaal)).toBe(moduleRef.get(LogMailKanaal));
+  describe('zonder configuratie', () => {
+    it('levert een MailKanaal', async () => {
+      const moduleRef = await bouw();
+
+      expect(moduleRef.get(MailKanaal)).toBeInstanceOf(MailKanaal);
+    });
+
+    it('kiest LogMailKanaal — er gaat aantoonbaar niets uit', async () => {
+      // De veilige toestand. Een half werkend mailkanaal dat soms wél
+      // verstuurt is erger dan een kanaal dat eerlijk niets doet.
+      const moduleRef = await bouw();
+
+      expect(moduleRef.get(MailKanaal)).toBeInstanceOf(LogMailKanaal);
+    });
+
+    it('geeft dezelfde instantie voor MailKanaal en LogMailKanaal', async () => {
+      // Twee instanties zouden twee verzendlijsten betekenen: een test
+      // controleert de ene terwijl de code in de andere schrijft. Dat is een
+      // testfout die eruitziet als een codefout.
+      const moduleRef = await bouw();
+
+      expect(moduleRef.get(MailKanaal)).toBe(moduleRef.get(LogMailKanaal));
+    });
+  });
+
+  describe('met volledige configuratie', () => {
+    beforeEach(() => {
+      process.env.RESEND_API_KEY = 're_test_sleutel';
+      process.env.MAIL_AFZENDER_ADRES = 'uitvraag@mcm2mail.nl';
+    });
+
+    it('kiest ResendMailKanaal', async () => {
+      const moduleRef = await bouw();
+
+      expect(moduleRef.get(MailKanaal)).toBeInstanceOf(ResendMailKanaal);
+    });
+
+    it('levert niet langer het logkanaal', async () => {
+      // De keuze moet echt wisselen. Zou dit LogMailKanaal blijven, dan is een
+      // ingestelde sleutel betekenisloos en gaat er niets uit terwijl de
+      // beheerder denkt van wel.
+      const moduleRef = await bouw();
+
+      expect(moduleRef.get(MailKanaal)).not.toBeInstanceOf(LogMailKanaal);
+    });
+  });
+
+  describe('met halve configuratie', () => {
+    it('weigert op te starten met alleen een sleutel', async () => {
+      // Stil terugvallen op het logkanaal zou betekenen dat iemand die
+      // halverwege het instellen is gestopt, denkt dat er mail uitgaat.
+      process.env.RESEND_API_KEY = 're_test_sleutel';
+
+      await expect(bouw()).rejects.toThrow(/MAIL_AFZENDER_ADRES/);
+    });
+
+    it('weigert op te starten met alleen een afzenderadres', async () => {
+      process.env.MAIL_AFZENDER_ADRES = 'uitvraag@mcm2mail.nl';
+
+      await expect(bouw()).rejects.toThrow(/RESEND_API_KEY/);
+    });
   });
 });

--- a/src/mail/mail.module.ts
+++ b/src/mail/mail.module.ts
@@ -1,29 +1,36 @@
-import { Module } from '@nestjs/common';
+import { Logger, Module } from '@nestjs/common';
 
 import { LogMailKanaal } from './log-mail-kanaal';
 import { MailKanaal } from './mail-kanaal';
+import { leesMailConfig } from './mail.config';
+import { ResendMailKanaal } from './resend-mail-kanaal';
 
 /**
- * Het mailkanaal, met één implementatie en een expliciete keuze welke.
+ * Het mailkanaal, met een keuze op basis van configuratie.
  *
- * ── Waarom `useClass` en niet gewoon `LogMailKanaal` als provider ───────────
+ * ── Waarom een factory en niet gewoon een klasse als provider ───────────────
  *
  * De aanroeper vraagt om `MailKanaal` en krijgt wat hier gekozen is. Zonder die
- * indirectie zou elke service `LogMailKanaal` importeren, en dan is de knip uit
- * `mail-kanaal.ts` er wel op papier maar niet in de praktijk — precies de
- * situatie die de wissel van M365 naar Resend duur zou maken.
+ * indirectie zou elke service een concrete implementatie importeren, en dan is
+ * de knip uit `mail-kanaal.ts` er wel op papier maar niet in de praktijk —
+ * precies de situatie die de wissel van M365 naar Resend duur zou maken.
  *
- * ── De keuze staat nu vast op LogMailKanaal ─────────────────────────────────
+ * ── De keuze ────────────────────────────────────────────────────────────────
  *
- * `ResendMailKanaal` bestaat nog niet: dat is stap 3 uit ontwerp §9 en het
- * wacht op een verzenddomein. Tot die tijd verstuurt MCM2 aantoonbaar niets —
- * en dat is de veilige toestand. Een half werkend mailkanaal dat soms wél
- * verstuurt is erger dan een kanaal dat eerlijk niets doet.
+ *   sleutel + afzenderadres ingesteld  → ResendMailKanaal, er gaat echt mail uit
+ *   geen van beide ingesteld           → LogMailKanaal, er gaat aantoonbaar niets uit
+ *   één van beide ingesteld            → opstarten faalt (zie mail.config.ts)
  *
- * Zodra `ResendMailKanaal` er is, wordt dit een keuze op basis van
- * configuratie: een sleutel aanwezig → Resend, geen sleutel → log. Dezelfde
- * vorm als `scripts/telegram.js`, waar ontbrekende configuratie een no-op met
- * logregel oplevert in plaats van een crash.
+ * Dezelfde vorm als `scripts/telegram.js`: ontbrekende configuratie is een
+ * no-op met een logregel, geen crash. Zo blijft MCM2 bruikbaar in CI, in de
+ * demo, en op een machine zonder sleutel.
+ *
+ * ── De opstartregel is geen decoratie ───────────────────────────────────────
+ *
+ * Bij het kiezen wordt gelogd wát er gekozen is en vanaf welk adres. Het
+ * verschil tussen "er gaat mail uit" en "er gaat niets uit" mag niet af te
+ * leiden zijn uit het uitblijven van klachten — dat is dezelfde stille faalvorm
+ * als de backup die vier dagen stillag (Issue #86, STATUS.md).
  *
  * Zie docs/superpowers/specs/2026-08-06-mailkanaal.md §5 en §9.
  */
@@ -32,7 +39,26 @@ import { MailKanaal } from './mail-kanaal';
     LogMailKanaal,
     {
       provide: MailKanaal,
-      useExisting: LogMailKanaal,
+      inject: [LogMailKanaal],
+      useFactory: (log: LogMailKanaal): MailKanaal => {
+        const logger = new Logger('MailModule');
+        const config = leesMailConfig();
+
+        if (!config) {
+          logger.warn(
+            'Geen RESEND_API_KEY ingesteld — er wordt GEEN mail verstuurd. ' +
+              'Uitnodigingen belanden alleen in het log.',
+          );
+          return log;
+        }
+
+        // De sleutel staat er bewust niet in, het afzenderadres wel: dat is
+        // geen geheim en het is precies wat je wilt kunnen controleren.
+        logger.log(
+          `Mail wordt verstuurd via Resend vanaf ${config.afzenderAdres}.`,
+        );
+        return new ResendMailKanaal(config);
+      },
     },
   ],
   exports: [MailKanaal, LogMailKanaal],

--- a/src/mail/resend-mail-kanaal.spec.ts
+++ b/src/mail/resend-mail-kanaal.spec.ts
@@ -1,0 +1,273 @@
+import { MailBericht, MailKanaal, MailVerzendFout } from './mail-kanaal';
+import { MailConfig } from './mail.config';
+import { ResendMailKanaal } from './resend-mail-kanaal';
+
+/**
+ * De Resend-SDK wordt hier nagebootst. Deze tests raken geen netwerk: ze meten
+ * onze vertaling van "wat Resend teruggeeft" naar "wat de aanroeper moet weten",
+ * en dat is precies het stuk waar de stille faalvormen zitten.
+ *
+ * Wat ze NIET bewijzen: dat een mail werkelijk aankomt. Dat vraagt een
+ * geverifieerd domein en een echte verzending — stap 3 uit ontwerp §9, en
+ * tegenproef 1.
+ */
+
+/**
+ * De opties waarmee onze code Resend aanroept.
+ *
+ * Expliciet getypeerd en niet `any`: zo controleren de tests hieronder de
+ * werkelijke velden en niet wat de compiler toevallig doorlaat.
+ */
+interface VerstuurOpties {
+  from: string;
+  to: string;
+  subject: string;
+  text: string;
+  replyTo?: string;
+}
+
+const verstuurMock = jest.fn<Promise<unknown>, [VerstuurOpties]>();
+
+jest.mock('resend', () => ({
+  Resend: jest.fn().mockImplementation(() => ({
+    emails: { send: verstuurMock },
+  })),
+}));
+
+/** De opties van de n-de aanroep, getypeerd. */
+function opties(n = 0): VerstuurOpties {
+  return verstuurMock.mock.calls[n][0];
+}
+
+const CONFIG: MailConfig = {
+  apiSleutel: 're_test_sleutel',
+  afzenderAdres: 'uitvraag@mcm2mail.nl',
+};
+
+const BERICHT: MailBericht = {
+  aan: 'chris+demo-vendor1@gmail.com',
+  afzenderNaam: 'Transdev via MCM2',
+  antwoordAan: 'contractmanagement@transdev.nl',
+  onderwerp: 'Uitnodiging vragenlijst',
+  tekst: 'Vul de vragenlijst in via de link.',
+};
+
+/** Wat de SDK teruggeeft bij succes. */
+function geslaagd(id = 'resend-id-123') {
+  return { data: { id }, error: null };
+}
+
+/** Wat de SDK teruggeeft bij een fout — geen throw, maar een error-veld. */
+function geweigerd(name: string, message = 'ging mis') {
+  return { data: null, error: { name, message } };
+}
+
+describe('ResendMailKanaal', () => {
+  let kanaal: ResendMailKanaal;
+
+  beforeEach(() => {
+    verstuurMock.mockReset();
+    kanaal = new ResendMailKanaal(CONFIG);
+  });
+
+  it('is een MailKanaal', () => {
+    expect(kanaal).toBeInstanceOf(MailKanaal);
+  });
+
+  describe('de afzenderconstructie — ontwerp §3', () => {
+    it('zet de klantnaam in de display name en ons adres erachter', async () => {
+      verstuurMock.mockResolvedValue(geslaagd());
+
+      await kanaal.verstuur(BERICHT);
+
+      expect(verstuurMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          from: '"Transdev via MCM2" <uitvraag@mcm2mail.nl>',
+        }),
+      );
+    });
+
+    it('stuurt Reply-To naar het adres van de tenant', async () => {
+      // Zonder dit komen vragen van leveranciers bij ons terecht, en wij kunnen
+      // ze niet beantwoorden.
+      verstuurMock.mockResolvedValue(geslaagd());
+
+      await kanaal.verstuur(BERICHT);
+
+      expect(verstuurMock).toHaveBeenCalledWith(
+        expect.objectContaining({ replyTo: 'contractmanagement@transdev.nl' }),
+      );
+    });
+
+    it('laat replyTo weg als de tenant geen antwoordadres heeft', async () => {
+      // Een lege replyTo is een validatiefout bij Resend. Dan zou één
+      // ontbrekende instelling de hele ronde tegenhouden.
+      verstuurMock.mockResolvedValue(geslaagd());
+
+      await kanaal.verstuur({
+        aan: BERICHT.aan,
+        afzenderNaam: BERICHT.afzenderNaam,
+        onderwerp: BERICHT.onderwerp,
+        tekst: BERICHT.tekst,
+      });
+
+      expect(opties()).not.toHaveProperty('replyTo');
+    });
+
+    it('weert tekens waarmee een tenantnaam de header kan breken', async () => {
+      // De afzendernaam komt uit de database en is door een tenantbeheerder in
+      // te vullen. Een `<` of een aanhalingsteken erin mag geen tweede adres
+      // kunnen binnensmokkelen.
+      verstuurMock.mockResolvedValue(geslaagd());
+
+      await kanaal.verstuur({
+        ...BERICHT,
+        afzenderNaam: 'Kwaad" <aanvaller@elders.nl> "',
+      });
+
+      const from = opties().from;
+      expect(from).toBe('"Kwaad aanvaller@elders.nl" <uitvraag@mcm2mail.nl>');
+      expect(from).not.toContain('<aanvaller@elders.nl>');
+    });
+
+    it('valt terug op het kale adres bij een lege afzendernaam', async () => {
+      verstuurMock.mockResolvedValue(geslaagd());
+
+      await kanaal.verstuur({ ...BERICHT, afzenderNaam: '   ' });
+
+      expect(opties().from).toBe('uitvraag@mcm2mail.nl');
+    });
+  });
+
+  describe('geslaagde verzending', () => {
+    it('geeft het bericht-id van Resend terug', async () => {
+      // Dit id is de sleutel waarmee een latere bounce gekoppeld wordt
+      // (ontwerp §4). Zonder dat is een statusmelding niet te herleiden.
+      verstuurMock.mockResolvedValue(geslaagd('abc-123'));
+
+      const resultaat = await kanaal.verstuur(BERICHT);
+
+      expect(resultaat.providerId).toBe('abc-123');
+    });
+
+    it('stuurt onderwerp en tekst mee', async () => {
+      verstuurMock.mockResolvedValue(geslaagd());
+
+      await kanaal.verstuur(BERICHT);
+
+      expect(verstuurMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          to: 'chris+demo-vendor1@gmail.com',
+          subject: 'Uitnodiging vragenlijst',
+          text: 'Vul de vragenlijst in via de link.',
+        }),
+      );
+    });
+  });
+
+  describe('de daglimiet — tegenproef 6', () => {
+    it('werpt bij daily_quota_exceeded in plaats van stil te slagen', async () => {
+      // Het gratis plan stopt bij 100 per dag en rekent niets bij. Zou dit
+      // stil doorgaan, dan staat er "verstuurd" bij vierhonderd leveranciers
+      // die niets hebben gekregen — en dat blijkt pas bij de deadline.
+      //
+      // De foutcode wordt hier meegecontroleerd, en dat is geen franje: een
+      // sabotage waarbij het hele `error`-veld genegeerd werd, liet deze test
+      // aanvankelijk groen. Hij viel dan door naar de "geen id"-controle en
+      // wierp om de verkeerde reden — precies het soort test dat §15b een
+      // meting zonder betekenis noemt.
+      verstuurMock.mockResolvedValue(
+        geweigerd('daily_quota_exceeded', 'limiet bereikt'),
+      );
+
+      await expect(kanaal.verstuur(BERICHT)).rejects.toThrow(
+        /daily_quota_exceeded/,
+      );
+    });
+
+    it('merkt de daglimiet aan als tijdelijk', async () => {
+      // Morgen mag het weer. Dat maakt het tijdelijk — maar de aanroeper moet
+      // het nog steeds als mislukt vastleggen.
+      verstuurMock.mockResolvedValue(geweigerd('daily_quota_exceeded'));
+
+      await expect(kanaal.verstuur(BERICHT)).rejects.toMatchObject({
+        tijdelijk: true,
+      });
+    });
+
+    it.each([
+      'rate_limit_exceeded',
+      'monthly_quota_exceeded',
+      'internal_server_error',
+    ])('merkt %s aan als tijdelijk', async (code) => {
+      verstuurMock.mockResolvedValue(geweigerd(code));
+
+      await expect(kanaal.verstuur(BERICHT)).rejects.toMatchObject({
+        tijdelijk: true,
+      });
+    });
+  });
+
+  describe('blijvende fouten', () => {
+    it.each([
+      'invalid_from_address',
+      'validation_error',
+      'invalid_api_key',
+      'restricted_api_key',
+    ])('merkt %s aan als niet-tijdelijk', async (code) => {
+      // Opnieuw proberen heeft geen zin: er is een instelling fout. Het
+      // onderscheid stuurt of de ronde mag herverzenden.
+      verstuurMock.mockResolvedValue(geweigerd(code));
+
+      await expect(kanaal.verstuur(BERICHT)).rejects.toMatchObject({
+        tijdelijk: false,
+      });
+    });
+
+    it('noemt de foutcode in de melding', async () => {
+      verstuurMock.mockResolvedValue(
+        geweigerd('invalid_from_address', 'domein niet geverifieerd'),
+      );
+
+      await expect(kanaal.verstuur(BERICHT)).rejects.toThrow(
+        /invalid_from_address/,
+      );
+    });
+  });
+
+  describe('een antwoord zonder id', () => {
+    it('werpt in plaats van een leeg providerId terug te geven', async () => {
+      // Zonder id is een latere bounce niet te koppelen. Stil doorgaan levert
+      // een gat in de keten op dat pas weken later opvalt.
+      verstuurMock.mockResolvedValue({ data: null, error: null });
+
+      await expect(kanaal.verstuur(BERICHT)).rejects.toThrow(/geen bericht-id/);
+    });
+  });
+
+  describe('validatie vóór de netwerkaanroep', () => {
+    it('weigert een ongeldig ontvangeradres', async () => {
+      await expect(
+        kanaal.verstuur({ ...BERICHT, aan: 'geen-adres' }),
+      ).rejects.toThrow(MailVerzendFout);
+    });
+
+    it('roept Resend niet aan bij een ongeldig adres', async () => {
+      // Een netwerkaanroep die zeker faalt, kost tijd en telt mee voor de
+      // daglimiet.
+      await expect(
+        kanaal.verstuur({ ...BERICHT, aan: 'geen-adres' }),
+      ).rejects.toThrow();
+
+      expect(verstuurMock).not.toHaveBeenCalled();
+    });
+
+    it('accepteert plusadressering', async () => {
+      verstuurMock.mockResolvedValue(geslaagd());
+
+      await expect(
+        kanaal.verstuur({ ...BERICHT, aan: 'chris+demo-vendor5@gmail.com' }),
+      ).resolves.toBeDefined();
+    });
+  });
+});

--- a/src/mail/resend-mail-kanaal.ts
+++ b/src/mail/resend-mail-kanaal.ts
@@ -1,0 +1,136 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Resend } from 'resend';
+
+import { isGeldigMailadres } from './mail-adres';
+import {
+  MailBericht,
+  MailKanaal,
+  MailVerzendFout,
+  VerzendResultaat,
+} from './mail-kanaal';
+import type { MailConfig } from './mail.config';
+
+/**
+ * Verstuurt via Resend — de platformverstuurder uit ontwerp §1.
+ *
+ * ── De afzenderconstructie ──────────────────────────────────────────────────
+ *
+ * Wat een leverancier ziet:
+ *
+ *   Van:      Transdev via MCM2 <uitvraag@mcm2mail.nl>
+ *   Reply-To: contractmanagement@transdev.nl
+ *
+ * De klantnaam zit in de display name, het adres blijft van het platform. Zo is
+ * de klant herkenbaar (Issue #13) zonder dat we zijn domein nodig hebben — en
+ * het adres zegt de waarheid over wie er verstuurt. `Reply-To` zorgt dat
+ * antwoorden bij de klant terechtkomen; wij kunnen ze toch niet beantwoorden.
+ *
+ * ── Waarom foutafhandeling hier het echte werk is ───────────────────────────
+ *
+ * Resend werpt niet, maar geeft `{ data, error }` terug. Wie alleen naar `data`
+ * kijkt, mist elke fout — en dat is precies de stille faalvorm die dit project
+ * elders bestrijdt. Vandaar dat elke uitkomst hier expliciet wordt vertaald
+ * naar ofwel een `providerId` ofwel een `MailVerzendFout`.
+ *
+ * Het gratis plan stopt hard bij 100 mails per dag zonder iets bij te rekenen.
+ * Bij een bulkronde van vijfhonderd worden er vierhonderd geweigerd, en dat mag
+ * niet als "verstuurd" in de ronde belanden (ontwerp §3b, tegenproef 6).
+ *
+ * Zie docs/superpowers/specs/2026-08-06-mailkanaal.md
+ */
+
+/**
+ * Foutcodes waarbij opnieuw proberen zin heeft.
+ *
+ * De quota-fouten staan hier bewust bij: die lossen zichzelf op als de dag- of
+ * maandgrens verstrijkt. Dat maakt ze *tijdelijk*, maar niet onschuldig — de
+ * aanroeper moet ze nog steeds als mislukt vastleggen, want zonder ingrijpen
+ * krijgt die leverancier vandaag geen uitnodiging.
+ */
+const TIJDELIJK = new Set([
+  'rate_limit_exceeded',
+  'daily_quota_exceeded',
+  'monthly_quota_exceeded',
+  'internal_server_error',
+  'application_error',
+  'concurrent_idempotent_requests',
+]);
+
+@Injectable()
+export class ResendMailKanaal extends MailKanaal {
+  private readonly logger = new Logger(ResendMailKanaal.name);
+  private readonly resend: Resend;
+
+  constructor(private readonly config: MailConfig) {
+    super();
+    this.resend = new Resend(config.apiSleutel);
+  }
+
+  async verstuur(bericht: MailBericht): Promise<VerzendResultaat> {
+    if (!isGeldigMailadres(bericht.aan)) {
+      throw new MailVerzendFout(
+        `Ongeldig ontvangeradres: ${bericht.aan}`,
+        false,
+      );
+    }
+
+    const { data, error } = await this.resend.emails.send({
+      from: this.afzender(bericht.afzenderNaam),
+      to: bericht.aan,
+      subject: bericht.onderwerp,
+      text: bericht.tekst,
+      // Alleen meesturen als de tenant het heeft ingevuld. Een lege replyTo
+      // levert bij Resend een validatiefout op, en dan gaat er niets uit omdat
+      // één instelling ontbreekt.
+      ...(bericht.antwoordAan ? { replyTo: bericht.antwoordAan } : {}),
+    });
+
+    if (error) {
+      const tijdelijk = TIJDELIJK.has(error.name);
+
+      // Het adres staat er bewust niet in: dit draait in productie en een
+      // logregel is de klassieke plek waar persoonsgegevens weglekken.
+      // MCM2-CLAUDE.md §6 en `maskerende-logger.ts`.
+      this.logger.error(
+        `Verzenden mislukt (${error.name}${tijdelijk ? ', tijdelijk' : ''}).`,
+      );
+
+      throw new MailVerzendFout(
+        `Resend weigerde de verzending: ${error.name} — ${error.message}`,
+        tijdelijk,
+        error,
+      );
+    }
+
+    // Kan in theorie niet samen met een lege `error`, maar de types van de SDK
+    // staan het toe. Zonder providerId is een latere bounce niet te koppelen
+    // (ontwerp §4), dus stil doorgaan zou een gat in de keten opleveren dat pas
+    // weken later opvalt.
+    if (!data?.id) {
+      throw new MailVerzendFout(
+        'Resend gaf geen bericht-id terug; de verzending is niet te volgen.',
+        true,
+      );
+    }
+
+    return { providerId: data.id };
+  }
+
+  /**
+   * Bouwt `Naam <adres>`.
+   *
+   * De display name wordt tussen aanhalingstekens gezet en interne
+   * aanhalingstekens worden verwijderd. Zonder dat kan een tenantnaam met een
+   * `"` of een `<` erin de header breken — of erger, een tweede adres
+   * binnensmokkelen. De naam komt uit de database en is dus door een
+   * tenantbeheerder in te vullen; hem hier niet vertrouwen is de goedkoopste
+   * plek om dat af te vangen.
+   */
+  private afzender(naam: string): string {
+    const schoon = naam.replace(/["\r\n<>]/g, '').trim();
+
+    return schoon.length > 0
+      ? `"${schoon}" <${this.config.afzenderAdres}>`
+      : this.config.afzenderAdres;
+  }
+}


### PR DESCRIPTION
Stap 2 en 3 uit het mailkanaal-ontwerp §9. Vanaf nu gaat er echt mail de deur uit.

**Aantoonbaar werkend op 2026-08-06.** Domein `send.myvendormanager.nl` geverifieerd, testbericht verstuurd en afgeleverd, afzendernaam en `Reply-To` gecontroleerd in de ontvangen mail. Dat is tegenproef 1 uit het ontwerp — de nagebootste SDK bewijst de vertaling, dit bewijst de keten.

## De afzenderconstructie

```
Van:      "Transdev via MCM2" <uitvraag@send.myvendormanager.nl>
Reply-To: contractmanagement@transdev.nl
```

De afzendernaam komt per tenant uit de database. Aanhalingstekens, punthaken en regeleindes worden eruit gefilterd: de naam is door een tenantbeheerder in te vullen, en zonder filtering kan die de header breken of een tweede adres binnensmokkelen.

## Foutafhandeling is hier het echte werk

Resend werpt niet maar geeft `{ data, error }` terug. Wie alleen naar `data` kijkt, mist elke fout — precies de stille faalvorm die dit project elders bestrijdt. Elke uitkomst wordt expliciet vertaald naar een `providerId` of een `MailVerzendFout`, met onderscheid tussen tijdelijk (`daily_quota_exceeded`, `rate_limit_exceeded`) en blijvend (`invalid_from_address`, `invalid_api_key`). Dat onderscheid stuurt straks of een ronde mag herverzenden.

## Drie configuratietoestanden

| | |
|---|---|
| beide variabelen ingesteld | Resend, er gaat echt mail uit |
| geen van beide | logkanaal, er gaat aantoonbaar niets uit |
| **half ingesteld** | **opstarten faalt** |

Die laatste is de kern: stil terugvallen op het logkanaal zou betekenen dat iemand die halverwege het instellen is gestopt, denkt dat er mail uitgaat terwijl er niets gebeurt. Bij opstarten wordt gelogd welk kanaal actief is en vanaf welk adres.

## Een subdomein, niet het hoofddomein

`send.myvendormanager.nl`. Twee redenen: de reputatie blijft gescheiden van de gewone mail, en de bestaande MX/SPF-records op het hoofddomein hoeven niet gewijzigd.

Dat tweede is niet theoretisch — op `alingadvies.nl` staan **twee** SPF-records, wat ongeldig is volgens RFC 7208. Met een subdomein kan die situatie per constructie niet ontstaan.

## Tegenproeven (§15b)

Vier sabotages op de code:

| Sabotage | Gevolg |
|---|---|
| filtering afzendernaam eruit | 1 om — header-injectietest |
| `error`-veld genegeerd | 6 om — daglimiet + blijvende fouten |
| `daily_quota` niet tijdelijk | 1 om — tijdelijkheidstest |
| module kiest altijd log | 2 om — keuzetests |

Plus de echte tegenproef op het werkende kanaal: `npm run mail:test -- geen-geldig-adres` faalt zichtbaar met exitcode 1 en doet geen netwerkaanroep.

**Twee dingen die daarbij naar boven kwamen en zijn gerepareerd.**

De eerste sabotage werd aanvankelijk niet toegepast doordat een heredoc de backslashes in het zoekpatroon opat — de tests waren dus groen tegen ongewijzigde code. Het sabotagescript faalt nu hard als het patroon niet gevonden wordt, zodat een niet-toegepaste sabotage niet als geslaagde tegenproef gelezen kan worden.

De tweede was een echte testzwakte: bij het negeren van het `error`-veld bleef de daglimiet-test groen. Hij viel door naar de "geen id"-controle en wierp om de verkeerde reden — groen bij een werkende én bij een kapotte implementatie, precies wat §15b een meting zonder betekenis noemt. Die test controleert nu de foutcode zelf.

## Runbook

`docs/runbooks/mailkanaal-inrichten.md` — de herhaalbare procedure, met twee valkuilen die tijdens het inrichten bleken:

**De hostnamen.** Resend toont relatieve namen (`send.send`), mijndomein wil volledige. Fout ingevuld ontstaat `...nl.myvendormanager.nl` en verifieert het nooit, zonder duidelijke foutmelding.

**De DNS-cache.** Bij het controleren gaf de lokale resolver een leeg antwoord voor het SPF-record terwijl het correct stond. Het runbook schrijft daarom expliciet een publieke resolver voor — een lege uitkomst leest anders als een fout die er niet is.

## Wat dit nog niet dekt

**Een geldig gevormd maar niet-bestaand adres levert "Geslaagd" op.** Getest met `bestaat-echt-niet-mcm2test@gmail.com`: Resend accepteert, de bounce komt later, en zonder webhook horen we die nooit.

Geen bug maar het gat dat ontwerp §4 beschrijft — en het bewijs waarom stap 5 (het webhook-endpoint) nodig is. Vastgelegd in het runbook onder "Wat dit nog niet afdekt".

**De daglimiet van 100** blijft staan als aandachtspunt voor bulkrondes (ontwerp §3b).

## Verificatie

- 240 unit-tests groen
- 316 e2e-tests groen (tegen een wegwerpcontainer, opgeruimd na afloop)
- `typecheck` en `lint:check` schoon
- echte verzending afgeleverd en visueel gecontroleerd

## Nieuw commando

```
npm run mail:test -- adres@example.com
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)