### PR TITLE
feat(mail): uitnodigingen worden daadwerkelijk verstuurd

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -147,3 +147,12 @@ TELEGRAM_CHAT_ID=
 RESEND_API_KEY=
 # Moet op een in Resend geverifieerd domein staan.
 MAIL_AFZENDER_ADRES=
+
+# Waar het leveranciersportaal draait. Dit is de FRONTEND, niet deze API:
+# de uitnodigingsmail verwijst naar /portal/survey/<token> in MCM2-frontend.
+#
+# Staat dit fout, dan krijgt elke leverancier een link die nergens heen gaat --
+# en dat merk je pas als er niemand invult. Zonder waarde valt het terug op
+# http://localhost:3000, wat in een echte mail zichtbaar fout is in plaats van
+# stil verkeerd.
+PORTAAL_BASIS_URL=http://localhost:3000

--- a/src/mail/mail.module.ts
+++ b/src/mail/mail.module.ts
@@ -4,6 +4,7 @@ import { LogMailKanaal } from './log-mail-kanaal';
 import { MailKanaal } from './mail-kanaal';
 import { leesMailConfig } from './mail.config';
 import { ResendMailKanaal } from './resend-mail-kanaal';
+import { UitnodigingVerzender } from './uitnodiging-verzender.service';
 
 /**
  * Het mailkanaal, met een keuze op basis van configuratie.
@@ -37,6 +38,7 @@ import { ResendMailKanaal } from './resend-mail-kanaal';
 @Module({
   providers: [
     LogMailKanaal,
+    UitnodigingVerzender,
     {
       provide: MailKanaal,
       inject: [LogMailKanaal],
@@ -61,6 +63,6 @@ import { ResendMailKanaal } from './resend-mail-kanaal';
       },
     },
   ],
-  exports: [MailKanaal, LogMailKanaal],
+  exports: [MailKanaal, LogMailKanaal, UitnodigingVerzender],
 })
 export class MailModule {}

--- a/src/mail/uitnodiging-bericht.spec.ts
+++ b/src/mail/uitnodiging-bericht.spec.ts
@@ -1,0 +1,127 @@
+import {
+  UitnodigingGegevens,
+  stelUitnodigingSamen,
+} from './uitnodiging-bericht';
+
+/**
+ * De uitnodigingstekst is het enige wat een leverancier van MCM2 ziet vóór hij
+ * besluit te klikken. Deze tests leggen vast wat er in moet staan — niet de
+ * exacte formulering, want die mag veranderen, maar de elementen zonder welke
+ * de mail zijn doel mist.
+ */
+
+const GEGEVENS: UitnodigingGegevens = {
+  ontvanger: 'contact+vendor1@gmail.com',
+  vendorNaam: 'Acme Infrastructuur B.V.',
+  tenantNaam: 'Transdev',
+  vragenlijstNaam: 'Jaarlijkse IT-risicovragenlijst',
+  link: 'https://mcm2.example.nl/portal/survey/abc123',
+  verlooptOp: '2026-09-01T12:00:00.000Z',
+  antwoordAan: 'contractmanagement@transdev.nl',
+};
+
+describe('stelUitnodigingSamen', () => {
+  describe('de afzender — ontwerp §3', () => {
+    it('zet de opdrachtgever voorop in de afzendernaam', () => {
+      // Dit is wat de leverancier in zijn inbox ziet. Zonder herkenbare
+      // opdrachtgever klikt hij niet, of meldt hij de mail als phishing.
+      const bericht = stelUitnodigingSamen(GEGEVENS);
+
+      expect(bericht.afzenderNaam).toBe('Transdev via MCM2');
+    });
+
+    it('stuurt antwoorden naar de opdrachtgever', () => {
+      const bericht = stelUitnodigingSamen(GEGEVENS);
+
+      expect(bericht.antwoordAan).toBe('contractmanagement@transdev.nl');
+    });
+
+    it('noemt de opdrachtgever in het onderwerp', () => {
+      const bericht = stelUitnodigingSamen(GEGEVENS);
+
+      expect(bericht.onderwerp).toContain('Transdev');
+      expect(bericht.onderwerp).toContain('Jaarlijkse IT-risicovragenlijst');
+    });
+  });
+
+  describe('de inhoud', () => {
+    it('bevat de link voluit', () => {
+      // Voluit en niet verstopt achter een woord: een leverancier die de
+      // afzender niet vertrouwt, moet de URL kunnen bekijken zonder te klikken.
+      const bericht = stelUitnodigingSamen(GEGEVENS);
+
+      expect(bericht.tekst).toContain(
+        'https://mcm2.example.nl/portal/survey/abc123',
+      );
+    });
+
+    it('noemt de leverancier bij naam', () => {
+      const bericht = stelUitnodigingSamen(GEGEVENS);
+
+      expect(bericht.tekst).toContain('Acme Infrastructuur B.V.');
+    });
+
+    it('legt uit waarom de ontvanger dit krijgt', () => {
+      // Zonder die uitleg leest de mail als ongevraagde post.
+      const bericht = stelUitnodigingSamen(GEGEVENS);
+
+      expect(bericht.tekst).toMatch(/omdat u als leverancier/i);
+    });
+
+    it('noemt de vervaldatum leesbaar, niet als ISO-tijdstempel', () => {
+      // "1 september 2026" en niet "2026-09-01T12:00:00.000Z". Bij een uiterste
+      // datum is een misgelezen dag/maand het verschil tussen op tijd en te laat.
+      const bericht = stelUitnodigingSamen(GEGEVENS);
+
+      expect(bericht.tekst).toContain('1 september 2026');
+      expect(bericht.tekst).not.toContain('2026-09-01T');
+    });
+
+    it('waarschuwt dat indienen definitief is', () => {
+      // Het portaal kent geen herziening na indienen (vragenlijst-ontwerp §1b).
+      // Dat hoort de leverancier te weten vóórdat hij begint.
+      const bericht = stelUitnodigingSamen(GEGEVENS);
+
+      expect(bericht.tekst).toMatch(/niet meer gewijzigd/i);
+    });
+  });
+
+  describe('zonder antwoordadres', () => {
+    const zonder: UitnodigingGegevens = {
+      ...GEGEVENS,
+      antwoordAan: undefined,
+    };
+
+    it('laat antwoordAan weg', () => {
+      expect(stelUitnodigingSamen(zonder).antwoordAan).toBeUndefined();
+    });
+
+    it('nodigt niet uit om te antwoorden', () => {
+      // Zou de tekst "beantwoord dit bericht" zeggen zonder Reply-To, dan komt
+      // het antwoord bij ons terecht en kunnen wij het niet beantwoorden.
+      const bericht = stelUitnodigingSamen(zonder);
+
+      expect(bericht.tekst).not.toMatch(/beantwoord dit bericht/i);
+      expect(bericht.tekst).toMatch(/neem contact op/i);
+    });
+  });
+
+  describe('robuustheid', () => {
+    it('valt terug op de ruwe waarde bij een onleesbare datum', () => {
+      // Liever een lelijke datum dan "Invalid Date" in een mail aan een klant.
+      const bericht = stelUitnodigingSamen({
+        ...GEGEVENS,
+        verlooptOp: 'geen-datum',
+      });
+
+      expect(bericht.tekst).toContain('geen-datum');
+      expect(bericht.tekst).not.toContain('Invalid Date');
+    });
+
+    it('stuurt naar het opgegeven adres', () => {
+      const bericht = stelUitnodigingSamen(GEGEVENS);
+
+      expect(bericht.aan).toBe('contact+vendor1@gmail.com');
+    });
+  });
+});

--- a/src/mail/uitnodiging-bericht.ts
+++ b/src/mail/uitnodiging-bericht.ts
@@ -1,0 +1,109 @@
+import type { MailBericht } from './mail-kanaal';
+
+/**
+ * Stelt de uitnodigingsmail samen die een leverancier ontvangt.
+ *
+ * ── Waarom dit een eigen bestand is ─────────────────────────────────────────
+ *
+ * De tekst van deze mail is het enige wat een leverancier van MCM2 ziet vóór
+ * hij besluit te klikken. Dat maakt hem belangrijker dan zijn omvang
+ * suggereert: een bericht dat leest als phishing wordt niet aangeklikt, en dan
+ * komt de vragenlijst niet binnen.
+ *
+ * Los van de verzendcode zodat de tekst te lezen en te testen is zonder een
+ * mailkanaal, een database of een netwerkverbinding.
+ *
+ * ── Wat deze tekst bewust wél en niet doet ──────────────────────────────────
+ *
+ * Wél: de opdrachtgever bij naam noemen, zeggen waarom de leverancier dit
+ * krijgt, en de link volledig uitschrijven. Een leverancier die de afzender
+ * niet vertrouwt, moet de URL kunnen bekijken zonder te klikken.
+ *
+ * Niet: urgentie opkloppen, of doen alsof het bericht persoonlijk getypt is.
+ * Beide zijn phishing-signalen — voor de ontvanger én voor spamfilters.
+ *
+ * Platte tekst en geen HTML. Sjablonen staan buiten scope (beheermenu-spec
+ * §3b), en een kale tekstmail komt door filters waar opgemaakte mail op
+ * struikelt.
+ *
+ * Zie docs/superpowers/specs/2026-08-06-mailkanaal.md
+ */
+
+export interface UitnodigingGegevens {
+  /** Het adres van de contactpersoon bij de leverancier. */
+  readonly ontvanger: string;
+  /** Naam van de leverancier, zoals die in de tenant bekendstaat. */
+  readonly vendorNaam: string;
+  /** Naam van de opdrachtgever — dit is wat de ontvanger moet herkennen. */
+  readonly tenantNaam: string;
+  /** Naam van de vragenlijst, bijv. "Jaarlijkse IT-risicovragenlijst". */
+  readonly vragenlijstNaam: string;
+  /** De volledige portaal-URL inclusief token. */
+  readonly link: string;
+  /** Tot wanneer de link werkt (ISO-datum). */
+  readonly verlooptOp: string;
+  /** Waar een antwoord van de leverancier heen gaat. */
+  readonly antwoordAan?: string;
+}
+
+/**
+ * Datum in de vorm die een Nederlandse lezer verwacht: `12 augustus 2026`.
+ *
+ * Bewust niet `12-08-2026`: bij een uiterste datum is een misgelezen dag/maand
+ * het verschil tussen op tijd en te laat.
+ */
+function leesbareDatum(iso: string): string {
+  const datum = new Date(iso);
+
+  if (Number.isNaN(datum.getTime())) {
+    return iso;
+  }
+
+  return datum.toLocaleDateString('nl-NL', {
+    day: 'numeric',
+    month: 'long',
+    year: 'numeric',
+  });
+}
+
+export function stelUitnodigingSamen(
+  gegevens: UitnodigingGegevens,
+): MailBericht {
+  const uiterlijk = leesbareDatum(gegevens.verlooptOp);
+
+  const tekst = [
+    `Beste contactpersoon van ${gegevens.vendorNaam},`,
+    ``,
+    `${gegevens.tenantNaam} vraagt u de vragenlijst "${gegevens.vragenlijstNaam}" in te vullen.`,
+    `U ontvangt dit bericht omdat u als leverancier bij ${gegevens.tenantNaam} bekendstaat.`,
+    ``,
+    `Vul de vragenlijst in via deze link:`,
+    gegevens.link,
+    ``,
+    `De link is persoonlijk en werkt tot en met ${uiterlijk}.`,
+    `Na het indienen kan de vragenlijst niet meer gewijzigd worden.`,
+    ``,
+    // Deze regel voorkomt de mail die anders bij ons terechtkomt en die wij
+    // niet kunnen beantwoorden: alleen de opdrachtgever weet of een
+    // leverancier nog een contract heeft (ontwerp §4).
+    gegevens.antwoordAan
+      ? `Vragen over deze uitvraag? Beantwoord dit bericht, dan komt het bij ${gegevens.tenantNaam} terecht.`
+      : `Vragen over deze uitvraag? Neem contact op met uw contactpersoon bij ${gegevens.tenantNaam}.`,
+    ``,
+    `Met vriendelijke groet,`,
+    gegevens.tenantNaam,
+    ``,
+    `---`,
+    `Dit bericht is verstuurd via MCM2, het contractmanagementsysteem van ${gegevens.tenantNaam}.`,
+  ].join('\n');
+
+  return {
+    aan: gegevens.ontvanger,
+    // De opdrachtgever voorop: dat is wat de ontvanger in zijn inbox ziet en
+    // waaraan hij herkent dat dit legitiem is (Issue #13, ontwerp §3).
+    afzenderNaam: `${gegevens.tenantNaam} via MCM2`,
+    antwoordAan: gegevens.antwoordAan,
+    onderwerp: `${gegevens.tenantNaam} vraagt om ingevulde vragenlijst: ${gegevens.vragenlijstNaam}`,
+    tekst,
+  };
+}

--- a/src/mail/uitnodiging-verzender.service.spec.ts
+++ b/src/mail/uitnodiging-verzender.service.spec.ts
@@ -1,0 +1,261 @@
+import { LogMailKanaal } from './log-mail-kanaal';
+import { MailKanaal, MailVerzendFout } from './mail-kanaal';
+import {
+  TeVersturenUitnodiging,
+  UitnodigingVerzender,
+} from './uitnodiging-verzender.service';
+
+/**
+ * De kernvraag van deze service: wat gebeurt er als één van de vijf faalt?
+ *
+ * Alles terugdraaien kan niet — de tokens staan al in de database. Stil
+ * doorgaan mag niet — dan blijkt een gemiste leverancier pas bij de deadline.
+ * Deze tests leggen de derde weg vast: doorgaan, en per deelnemer teruggeven
+ * wat er gebeurd is.
+ */
+
+const CONTEXT = {
+  tenantNaam: 'Transdev',
+  vragenlijstNaam: 'Jaarlijkse IT-risicovragenlijst',
+  antwoordAan: 'contractmanagement@transdev.nl',
+};
+
+function uitnodiging(
+  n: number,
+  overschrijf: Partial<TeVersturenUitnodiging> = {},
+): TeVersturenUitnodiging {
+  return {
+    responseId: `response-${n}`,
+    vendorNaam: `Leverancier ${n}`,
+    ontvanger: `contact+vendor${n}@gmail.com`,
+    link: `https://mcm2.example.nl/portal/survey/token${n}`,
+    verlooptOp: '2026-09-01T12:00:00.000Z',
+    ...overschrijf,
+  };
+}
+
+/** Een kanaal dat faalt op de adressen die je opgeeft. */
+class FalendKanaal extends MailKanaal {
+  readonly verstuurd: string[] = [];
+
+  constructor(
+    private readonly faaltOp: Set<string>,
+    private readonly tijdelijk = false,
+  ) {
+    super();
+  }
+
+  verstuur(bericht: { aan: string }) {
+    if (this.faaltOp.has(bericht.aan)) {
+      return Promise.reject(
+        new MailVerzendFout('Resend weigerde de verzending', this.tijdelijk),
+      );
+    }
+    this.verstuurd.push(bericht.aan);
+    return Promise.resolve({ providerId: `id-${this.verstuurd.length}` });
+  }
+}
+
+describe('UitnodigingVerzender', () => {
+  describe('als alles goed gaat', () => {
+    let kanaal: LogMailKanaal;
+    let verzender: UitnodigingVerzender;
+
+    beforeEach(() => {
+      kanaal = new LogMailKanaal();
+      verzender = new UitnodigingVerzender(kanaal);
+    });
+
+    it('verstuurt er één per uitnodiging', async () => {
+      const uitkomsten = await verzender.verstuurAllemaal(
+        [uitnodiging(1), uitnodiging(2), uitnodiging(3)],
+        CONTEXT,
+      );
+
+      expect(uitkomsten).toHaveLength(3);
+      expect(uitkomsten.every((u) => u.verstuurd)).toBe(true);
+      expect(kanaal.verzonden).toHaveLength(3);
+    });
+
+    it('geeft per uitnodiging een providerId terug', async () => {
+      // Dat id is de sleutel waarmee een latere bounce gekoppeld wordt
+      // (ontwerp §4). Ontbreekt het, dan is die statusmelding niet te herleiden.
+      const uitkomsten = await verzender.verstuurAllemaal(
+        [uitnodiging(1)],
+        CONTEXT,
+      );
+
+      expect(uitkomsten[0].providerId).toBeDefined();
+    });
+
+    it('gebruikt de tenantnaam in de afzender', async () => {
+      await verzender.verstuurAllemaal([uitnodiging(1)], CONTEXT);
+
+      expect(kanaal.laatste?.afzenderNaam).toBe('Transdev via MCM2');
+      expect(kanaal.laatste?.antwoordAan).toBe(
+        'contractmanagement@transdev.nl',
+      );
+    });
+
+    it('houdt de volgorde aan', async () => {
+      // Serieel en niet parallel: bij de daglimiet weet je dan precies vanaf
+      // welke leverancier het misging.
+      await verzender.verstuurAllemaal(
+        [uitnodiging(1), uitnodiging(2), uitnodiging(3)],
+        CONTEXT,
+      );
+
+      expect(kanaal.verzonden.map((b) => b.aan)).toEqual([
+        'contact+vendor1@gmail.com',
+        'contact+vendor2@gmail.com',
+        'contact+vendor3@gmail.com',
+      ]);
+    });
+  });
+
+  describe('als er één faalt', () => {
+    it('gaat door met de rest', async () => {
+      // Dit is de kern. Stoppen bij de eerste fout zou betekenen dat drie
+      // leveranciers geen uitnodiging krijgen omdat de tweede een fout adres had.
+      const kanaal = new FalendKanaal(new Set(['contact+vendor2@gmail.com']));
+      const verzender = new UitnodigingVerzender(kanaal);
+
+      const uitkomsten = await verzender.verstuurAllemaal(
+        [uitnodiging(1), uitnodiging(2), uitnodiging(3)],
+        CONTEXT,
+      );
+
+      expect(uitkomsten).toHaveLength(3);
+      expect(kanaal.verstuurd).toEqual([
+        'contact+vendor1@gmail.com',
+        'contact+vendor3@gmail.com',
+      ]);
+    });
+
+    it('markeert alleen de mislukte als niet-verstuurd', async () => {
+      const kanaal = new FalendKanaal(new Set(['contact+vendor2@gmail.com']));
+      const verzender = new UitnodigingVerzender(kanaal);
+
+      const uitkomsten = await verzender.verstuurAllemaal(
+        [uitnodiging(1), uitnodiging(2), uitnodiging(3)],
+        CONTEXT,
+      );
+
+      expect(uitkomsten.map((u) => u.verstuurd)).toEqual([true, false, true]);
+    });
+
+    it('geeft de reden mee, zodat het scherm hem kan tonen', async () => {
+      // Zonder reden weet de beheerder dat er iets misging maar niet wat, en
+      // dan kan hij niet gericht ingrijpen.
+      const kanaal = new FalendKanaal(new Set(['contact+vendor1@gmail.com']));
+      const verzender = new UitnodigingVerzender(kanaal);
+
+      const [uitkomst] = await verzender.verstuurAllemaal(
+        [uitnodiging(1)],
+        CONTEXT,
+      );
+
+      expect(uitkomst.fout).toContain('Resend weigerde');
+      expect(uitkomst.vendorNaam).toBe('Leverancier 1');
+    });
+
+    it('geeft door of opnieuw proberen zin heeft', async () => {
+      const tijdelijk = new UitnodigingVerzender(
+        new FalendKanaal(new Set(['contact+vendor1@gmail.com']), true),
+      );
+      const blijvend = new UitnodigingVerzender(
+        new FalendKanaal(new Set(['contact+vendor1@gmail.com']), false),
+      );
+
+      const [a] = await tijdelijk.verstuurAllemaal([uitnodiging(1)], CONTEXT);
+      const [b] = await blijvend.verstuurAllemaal([uitnodiging(1)], CONTEXT);
+
+      expect(a.tijdelijk).toBe(true);
+      expect(b.tijdelijk).toBe(false);
+    });
+
+    it('werpt niet — de aanroeper moet de hele lijst krijgen', async () => {
+      // Zou dit werpen, dan verliest de aanroeper de uitkomst van de
+      // uitnodigingen die wél gelukt zijn.
+      const kanaal = new FalendKanaal(
+        new Set(['contact+vendor1@gmail.com', 'contact+vendor2@gmail.com']),
+      );
+      const verzender = new UitnodigingVerzender(kanaal);
+
+      await expect(
+        verzender.verstuurAllemaal([uitnodiging(1), uitnodiging(2)], CONTEXT),
+      ).resolves.toHaveLength(2);
+    });
+  });
+
+  describe('leverancier zonder e-mailadres', () => {
+    it('meldt dat als een mislukking, niet als succes', async () => {
+      // Ontbrekende stamdata hoort net zo zichtbaar te zijn als een geweigerde
+      // verzending. Anders is die leverancier stilzwijgend overgeslagen.
+      const kanaal = new LogMailKanaal();
+      const verzender = new UitnodigingVerzender(kanaal);
+
+      const [uitkomst] = await verzender.verstuurAllemaal(
+        [uitnodiging(1, { ontvanger: undefined })],
+        CONTEXT,
+      );
+
+      expect(uitkomst.verstuurd).toBe(false);
+      expect(uitkomst.fout).toMatch(/geen e-mailadres/i);
+    });
+
+    it('probeert niet te versturen', async () => {
+      const kanaal = new LogMailKanaal();
+      const verzender = new UitnodigingVerzender(kanaal);
+
+      await verzender.verstuurAllemaal(
+        [uitnodiging(1, { ontvanger: undefined })],
+        CONTEXT,
+      );
+
+      expect(kanaal.verzonden).toHaveLength(0);
+    });
+
+    it('houdt de andere leveranciers niet tegen', async () => {
+      const kanaal = new LogMailKanaal();
+      const verzender = new UitnodigingVerzender(kanaal);
+
+      const uitkomsten = await verzender.verstuurAllemaal(
+        [uitnodiging(1, { ontvanger: undefined }), uitnodiging(2)],
+        CONTEXT,
+      );
+
+      expect(uitkomsten[0].verstuurd).toBe(false);
+      expect(uitkomsten[1].verstuurd).toBe(true);
+    });
+  });
+
+  describe('zonder antwoordadres', () => {
+    it('verstuurt gewoon door', async () => {
+      // Een tenant die zijn contactadres niet heeft ingevuld mag geen ronde
+      // blokkeren.
+      const kanaal = new LogMailKanaal();
+      const verzender = new UitnodigingVerzender(kanaal);
+
+      const uitkomsten = await verzender.verstuurAllemaal([uitnodiging(1)], {
+        tenantNaam: 'Transdev',
+        vragenlijstNaam: 'Vragenlijst',
+      });
+
+      expect(uitkomsten[0].verstuurd).toBe(true);
+      expect(kanaal.laatste?.antwoordAan).toBeUndefined();
+    });
+  });
+
+  describe('lege lijst', () => {
+    it('doet niets en geeft niets terug', async () => {
+      const kanaal = new LogMailKanaal();
+      const verzender = new UitnodigingVerzender(kanaal);
+
+      await expect(verzender.verstuurAllemaal([], CONTEXT)).resolves.toEqual(
+        [],
+      );
+      expect(kanaal.verzonden).toHaveLength(0);
+    });
+  });
+});

--- a/src/mail/uitnodiging-verzender.service.ts
+++ b/src/mail/uitnodiging-verzender.service.ts
@@ -1,0 +1,158 @@
+import { Injectable, Logger } from '@nestjs/common';
+
+import { MailKanaal, MailVerzendFout } from './mail-kanaal';
+import { stelUitnodigingSamen } from './uitnodiging-bericht';
+
+/**
+ * Verstuurt de uitnodigingen van een ronde.
+ *
+ * ── De kernvraag: wat als er één van de vijf faalt? ─────────────────────────
+ *
+ * Niet alles terugdraaien. De tokens staan dan al in de database en zijn
+ * geldig; ze weggooien omdat een mailserver hikte, betekent dat vier
+ * leveranciers die de uitnodiging wél kregen op een dode link klikken.
+ *
+ * Niet stil doorgaan ook. Dat is precies de faalvorm die dit project elders
+ * bestrijdt: de beheerder ziet "verstuurd", en dat één leverancier niets kreeg
+ * blijkt pas als de deadline verstrijkt.
+ *
+ * Dus: **doorgaan met de rest, en per deelnemer teruggeven wat er gebeurd is.**
+ * De aanroeper krijgt een lijst waarin elke uitnodiging ofwel een providerId
+ * heeft ofwel een foutmelding. Het scherm kan dan tonen "4 verstuurd, 1
+ * mislukt" met de reden erbij, en de beheerder kan gericht ingrijpen.
+ *
+ * Dat is dezelfde keuze als in `backup-controle.js`, waar elk probleem apart
+ * gemeld wordt in plaats van bij de eerste te stoppen.
+ *
+ * ── Waarom dit niet in de transactie zit ────────────────────────────────────
+ *
+ * `RondeBeheerService.uitnodigen()` maakt de tokens in één transactie: faalt
+ * één invoeging, dan rolt alles terug. Mail versturen hoort daar niet in.
+ *
+ * Een verstuurde mail is niet terug te draaien. Zou de verzending binnen de
+ * transactie zitten en de laatste invoeging faalt, dan zijn de tokens weg maar
+ * de uitnodigingen verstuurd — leveranciers met een link naar niets. Eerst
+ * vastleggen, dan versturen, is de enige volgorde die dat uitsluit.
+ *
+ * Zie docs/superpowers/specs/2026-08-06-mailkanaal.md
+ */
+
+export interface TeVersturenUitnodiging {
+  readonly responseId: string;
+  readonly vendorNaam: string;
+  /** Kan ontbreken: niet elke leverancier heeft een contactpersoon met adres. */
+  readonly ontvanger?: string;
+  readonly link: string;
+  readonly verlooptOp: string;
+}
+
+export interface VerzendUitkomst {
+  readonly responseId: string;
+  readonly vendorNaam: string;
+  readonly ontvanger?: string;
+  /** Waar of de mail bij de provider is aangenomen. */
+  readonly verstuurd: boolean;
+  /** Alleen bij succes: de sleutel voor een latere statusmelding. */
+  readonly providerId?: string;
+  /** Alleen bij mislukking: wat er misging, in lezersvorm. */
+  readonly fout?: string;
+  /** Alleen bij mislukking: of opnieuw proberen zin heeft. */
+  readonly tijdelijk?: boolean;
+}
+
+@Injectable()
+export class UitnodigingVerzender {
+  private readonly logger = new Logger(UitnodigingVerzender.name);
+
+  constructor(private readonly mail: MailKanaal) {}
+
+  async verstuurAllemaal(
+    uitnodigingen: readonly TeVersturenUitnodiging[],
+    context: {
+      tenantNaam: string;
+      vragenlijstNaam: string;
+      antwoordAan?: string;
+    },
+  ): Promise<VerzendUitkomst[]> {
+    const uitkomsten: VerzendUitkomst[] = [];
+
+    // Bewust één voor één en niet met Promise.all: bij de daglimiet van Resend
+    // (100 per dag, ontwerp §3b) levert parallel versturen een onvoorspelbaar
+    // deel geweigerde berichten op. Serieel blijft de volgorde bepaald, en dan
+    // weet je precies vanaf welke leverancier het misging.
+    for (const uitnodiging of uitnodigingen) {
+      uitkomsten.push(await this.verstuurEen(uitnodiging, context));
+    }
+
+    const mislukt = uitkomsten.filter((u) => !u.verstuurd).length;
+
+    if (mislukt > 0) {
+      this.logger.warn(
+        `${uitkomsten.length - mislukt} van de ${uitkomsten.length} uitnodigingen verstuurd; ${mislukt} mislukt.`,
+      );
+    } else {
+      this.logger.log(`${uitkomsten.length} uitnodiging(en) verstuurd.`);
+    }
+
+    return uitkomsten;
+  }
+
+  private async verstuurEen(
+    uitnodiging: TeVersturenUitnodiging,
+    context: {
+      tenantNaam: string;
+      vragenlijstNaam: string;
+      antwoordAan?: string;
+    },
+  ): Promise<VerzendUitkomst> {
+    const basis = {
+      responseId: uitnodiging.responseId,
+      vendorNaam: uitnodiging.vendorNaam,
+      ontvanger: uitnodiging.ontvanger,
+    };
+
+    // Geen contactpersoon met e-mailadres. Dat is geen technische fout maar
+    // ontbrekende stamdata, en het hoort net zo zichtbaar te zijn als een
+    // geweigerde verzending — anders is de leverancier stilzwijgend overgeslagen.
+    if (!uitnodiging.ontvanger) {
+      return {
+        ...basis,
+        verstuurd: false,
+        fout: 'Geen e-mailadres bekend bij deze leverancier.',
+        tijdelijk: false,
+      };
+    }
+
+    try {
+      const { providerId } = await this.mail.verstuur(
+        stelUitnodigingSamen({
+          ontvanger: uitnodiging.ontvanger,
+          vendorNaam: uitnodiging.vendorNaam,
+          tenantNaam: context.tenantNaam,
+          vragenlijstNaam: context.vragenlijstNaam,
+          link: uitnodiging.link,
+          verlooptOp: uitnodiging.verlooptOp,
+          antwoordAan: context.antwoordAan,
+        }),
+      );
+
+      return { ...basis, verstuurd: true, providerId };
+    } catch (err) {
+      const fout = err instanceof MailVerzendFout;
+
+      // Het adres staat bewust niet in de logregel — MCM2-CLAUDE.md §6.
+      this.logger.error(
+        `Uitnodiging voor ${uitnodiging.vendorNaam} niet verstuurd: ` +
+          (err instanceof Error ? err.message : 'onbekende fout'),
+      );
+
+      return {
+        ...basis,
+        verstuurd: false,
+        fout:
+          err instanceof Error ? err.message : 'Onbekende fout bij versturen.',
+        tijdelijk: fout ? err.tijdelijk : false,
+      };
+    }
+  }
+}

--- a/src/survey/ronde-beheer.service.ts
+++ b/src/survey/ronde-beheer.service.ts
@@ -62,6 +62,31 @@ export interface Uitnodiging {
    */
   token: string;
   expiresAt: string;
+  /**
+   * Het adres van de primaire contactpersoon, als die er is.
+   *
+   * Kan ontbreken: niet elke leverancier heeft een contactpersoon met een
+   * e-mailadres. Dat is geen fout hier — het token bestaat en de link werkt.
+   * Wel iets dat zichtbaar moet zijn bij het versturen, anders is die
+   * leverancier stilzwijgend overgeslagen.
+   */
+  contactEmail?: string;
+}
+
+/**
+ * Wat er nodig is om de uitnodigingsmails te kunnen samenstellen.
+ *
+ * Komt uit dezelfde transactie als de tokens, zodat er geen tweede query nodig
+ * is die tussentijds iets anders kan zien.
+ */
+export interface UitnodigingContext {
+  tenantNaam: string;
+  vragenlijstNaam: string;
+}
+
+export interface UitnodigingResultaat {
+  uitnodigingen: Uitnodiging[];
+  context: UitnodigingContext;
 }
 
 export interface RondeGestart {
@@ -87,6 +112,8 @@ interface RunRij extends Record<string, unknown> {
 interface VendorRij extends Record<string, unknown> {
   vendor_id: string;
   name: string;
+  /** `null` als de leverancier geen contactpersoon met e-mailadres heeft. */
+  contact_email: string | null;
 }
 
 function iso(waarde: Date | string | null): string | null {
@@ -272,12 +299,24 @@ export class RondeBeheerService {
     tenantId: string,
     runId: string,
     invoer: Uitnodigingen,
-  ): Promise<Uitnodiging[]> {
+  ): Promise<UitnodigingResultaat> {
     return this.db.withTenant(
       tenantId,
       async (tx) => {
-        const rondes = await tx.execute<{ status: string }>(
-          sql`SELECT status FROM clm.survey_run WHERE run_id = ${runId}`,
+        // Naast de status ook de namen ophalen die de uitnodigingsmail nodig
+        // heeft. In dezelfde query en dus dezelfde transactie: een tweede
+        // uitvraag achteraf kan een gewijzigde tenantnaam zien, en dan staat er
+        // in de mail iets anders dan wat er op het scherm stond.
+        const rondes = await tx.execute<{
+          status: string;
+          template_naam: string;
+          tenant_naam: string;
+        }>(
+          sql`SELECT r.status, t.name AS template_naam, tn.name AS tenant_naam
+                FROM clm.survey_run r
+                JOIN clm.survey_template t ON t.template_id = r.template_id
+                JOIN clm.tenant tn ON tn.tenant_id = r.tenant_id
+               WHERE r.run_id = ${runId}`,
         );
 
         const ronde = rondes.rows[0];
@@ -299,11 +338,30 @@ export class RondeBeheerService {
         // Alle opgegeven leveranciers in één keer opzoeken. RLS filtert
         // vanzelf wat van een andere tenant is; die id's ontbreken dan
         // gewoon in het resultaat en worden hieronder gemeld als onbekend.
+        // Het adres van de primaire contactpersoon komt hier meteen mee.
+        //
+        // DISTINCT ON met een expliciete volgorde: een leverancier kan meerdere
+        // contactpersonen hebben, en zonder die volgorde is het willekeurig wie
+        // de uitnodiging krijgt. `is_primary` eerst, daarna de oudste — dat is
+        // voorspelbaar en herhaalbaar.
+        //
+        // LEFT JOIN, geen INNER: een leverancier zonder contactpersoon hoort
+        // gewoon in de lijst te staan. Het token wordt aangemaakt en de link
+        // werkt; alleen het versturen lukt niet, en dat meldt de verzender.
         const gevonden = await tx.execute<VendorRij>(
-          sql`SELECT vendor_id, name
-                FROM clm.vendor
-               WHERE vendor_id = ANY(${sql.param(invoer.vendorIds)}::uuid[])
-                 AND deleted_at IS NULL`,
+          sql`SELECT v.vendor_id, v.name, c.email AS contact_email
+                FROM clm.vendor v
+                LEFT JOIN LATERAL (
+                       SELECT email
+                         FROM clm.vendor_contact
+                        WHERE vendor_id = v.vendor_id
+                          AND deleted_at IS NULL
+                          AND email IS NOT NULL
+                        ORDER BY is_primary DESC, created_at ASC
+                        LIMIT 1
+                     ) c ON true
+               WHERE v.vendor_id = ANY(${sql.param(invoer.vendorIds)}::uuid[])
+                 AND v.deleted_at IS NULL`,
         );
 
         const perId = new Map(
@@ -380,10 +438,17 @@ export class RondeBeheerService {
             vendorNaam: vendor.name,
             token,
             expiresAt: verloopt.toISOString(),
+            contactEmail: vendor.contact_email ?? undefined,
           });
         }
 
-        return uitnodigingen;
+        return {
+          uitnodigingen,
+          context: {
+            tenantNaam: ronde.tenant_naam,
+            vragenlijstNaam: ronde.template_naam,
+          },
+        };
       },
       'medewerker',
     );

--- a/src/survey/survey.module.ts
+++ b/src/survey/survey.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common';
 
 import { AuthModule } from '../auth/auth.module';
+import { MailModule } from '../mail/mail.module';
 import { SurveyAuditService } from './survey-audit.service';
 import { SurveyResponseController } from './survey-response.controller';
 import { SurveyTokenGuard } from './survey-token.guard';
@@ -28,9 +29,13 @@ import { VragenlijstLeesService } from './vragenlijst-lezen.service';
  * vandaan en heeft `SessieService` nodig. Zonder die import faalt het opstarten
  * met "Nest can't resolve dependencies of the TenantContextGuard" — zichtbaar,
  * niet stil. Zelfde reden als in VendorModule.
+ *
+ * `MailModule` levert `UitnodigingVerzender`, waarmee de uitnodigingsroute de
+ * tokenlinks daadwerkelijk verstuurt. Zonder die module bestaan de tokens wel
+ * maar krijgt niemand ze — dat was de stand tot 2026-08-06.
  */
 @Module({
-  imports: [AuthModule],
+  imports: [AuthModule, MailModule],
   controllers: [SurveyResponseController, VragenlijstBeheerController],
   providers: [
     SurveyAuditService,

--- a/src/survey/vragenlijst-beheer.controller.ts
+++ b/src/survey/vragenlijst-beheer.controller.ts
@@ -11,6 +11,7 @@ import {
   UseGuards,
 } from '@nestjs/common';
 
+import { UitnodigingVerzender } from '../mail/uitnodiging-verzender.service';
 import { RolGuard, VereistRol } from '../auth/rol.guard';
 import {
   TenantContextGuard,
@@ -69,6 +70,7 @@ export class VragenlijstBeheerController {
   constructor(
     private readonly beheer: VragenlijstBeheerService,
     private readonly rondes: RondeBeheerService,
+    private readonly verzender: UitnodigingVerzender,
   ) {}
 
   /** Alle vragenlijsten van deze tenant, met aantallen vragen en rondes. */
@@ -186,13 +188,63 @@ export class VragenlijstBeheerController {
       throw this.naarHttpFout(err);
     }
 
-    const uitnodigingen = await this.rondes.uitnodigen(
+    const { uitnodigingen, context } = await this.rondes.uitnodigen(
       sessie.tenantId,
       id,
       invoer,
     );
 
-    return { uitnodigingen };
+    // Versturen gebeurt ná de transactie, nooit erin.
+    //
+    // Een verstuurde mail is niet terug te draaien. Zat de verzending in de
+    // transactie en faalde de laatste invoeging, dan waren de tokens weg maar
+    // de uitnodigingen verstuurd — leveranciers met een link naar niets. Eerst
+    // vastleggen, dan versturen, is de enige volgorde die dat uitsluit.
+    const verzending = await this.verzender.verstuurAllemaal(
+      uitnodigingen.map((u) => ({
+        responseId: u.responseId,
+        vendorNaam: u.vendorNaam,
+        ontvanger: u.contactEmail,
+        link: this.portaalLink(u.token),
+        verlooptOp: u.expiresAt,
+      })),
+      context,
+    );
+
+    const perResponse = new Map(verzending.map((v) => [v.responseId, v]));
+
+    return {
+      // De tokens blijven in het antwoord staan, óók als de mail geslaagd is.
+      // Dit is het enige moment waarop ze bestaan; er is geen route die ze
+      // opnieuw kan tonen. Gaat de mail alsnog verloren, dan is dit de laatste
+      // kans om de link handmatig door te geven.
+      uitnodigingen: uitnodigingen.map((u) => {
+        const uitkomst = perResponse.get(u.responseId);
+        return {
+          ...u,
+          verstuurd: uitkomst?.verstuurd ?? false,
+          verzendFout: uitkomst?.fout,
+        };
+      }),
+      verzonden: verzending.filter((v) => v.verstuurd).length,
+      mislukt: verzending.filter((v) => !v.verstuurd).length,
+    };
+  }
+
+  /**
+   * De URL die de leverancier in de mail krijgt.
+   *
+   * `PORTAAL_BASIS_URL` en niet de API-URL: het portaal is een pagina in de
+   * frontend, niet een route op deze backend. Ontbreekt de variabele, dan valt
+   * dit terug op de lokale ontwikkelpoort — zichtbaar fout in een mail, in
+   * plaats van een lege link waar niemand iets van merkt.
+   */
+  private portaalLink(token: string): string {
+    const basis = (
+      process.env.PORTAAL_BASIS_URL ?? 'http://localhost:3000'
+    ).replace(/\/+$/, '');
+
+    return `${basis}/portal/survey/${token}`;
   }
 
   private leesRonde(body: unknown) {

--- a/test/ronde-beheer-routes.e2e-spec.ts
+++ b/test/ronde-beheer-routes.e2e-spec.ts
@@ -63,10 +63,14 @@ interface Uitnodiging {
   vendorNaam: string;
   token: string;
   expiresAt: string;
+  verstuurd: boolean;
+  verzendFout?: string;
 }
 
 interface UitnodigingAntwoord {
   uitnodigingen: Uitnodiging[];
+  verzonden: number;
+  mislukt: number;
 }
 
 interface RondeAntwoord {
@@ -203,6 +207,17 @@ describe('Ronde-beheerroutes (e2e)', () => {
         [id, tenantA, naam, kvk],
       );
     }
+
+    // Alleen VENDOR_1 krijgt een contactpersoon met e-mailadres. Dat verschil
+    // is opzettelijk: de uitnodigingsroute moet beide gevallen aankunnen, en
+    // een leverancier zonder adres hoort zichtbaar te mislukken in plaats van
+    // stilzwijgend overgeslagen te worden.
+    await client.query(
+      `INSERT INTO clm.vendor_contact
+              (vendor_id, tenant_id, full_name, email, is_primary)
+       VALUES ($1, $2, 'Contact Eerste', 'contact+vendor1@example.test', true)`,
+      [VENDOR_1, tenantA],
+    );
 
     // Zacht verwijderd: hij bestaat nog als rij maar mag niet uitgenodigd.
     await client.query(
@@ -355,6 +370,73 @@ describe('Ronde-beheerroutes (e2e)', () => {
   });
 
   // ── Uitnodigen ────────────────────────────────────────────────────────────
+
+  it('verstuurt de uitnodiging en meldt per leverancier wat er gebeurd is', async () => {
+    // In de e2e-omgeving staat geen RESEND_API_KEY, dus draait het logkanaal:
+    // er gaat niets over het netwerk. Wat hier bewezen wordt is de keten
+    // eromheen — dat de route verstuurt, en dat de uitkomst per leverancier
+    // terugkomt in plaats van in een logregel te verdwijnen.
+    //
+    // VENDOR_1 heeft een contactpersoon, VENDOR_2 niet. Beide horen in het
+    // antwoord te staan met hun eigen uitkomst.
+    const runId = await nieuweRonde();
+
+    const antwoord = await request(server)
+      .post(`/admin/survey/runs/${runId}/participants`)
+      .set('Cookie', cookieAdminA)
+      .send({ vendorIds: [VENDOR_1, VENDOR_2] })
+      .expect(201);
+
+    const body = antwoord.body as UitnodigingAntwoord;
+
+    expect(body.verzonden).toBe(1);
+    expect(body.mislukt).toBe(1);
+
+    const eerste = body.uitnodigingen.find((u) => u.vendorId === VENDOR_1);
+    const tweede = body.uitnodigingen.find((u) => u.vendorId === VENDOR_2);
+
+    expect(eerste?.verstuurd).toBe(true);
+    expect(eerste?.verzendFout).toBeUndefined();
+
+    // Zonder e-mailadres geen uitnodiging — en dat staat er met reden bij.
+    expect(tweede?.verstuurd).toBe(false);
+    expect(tweede?.verzendFout).toMatch(/geen e-mailadres/i);
+
+    // Het token blijft in het antwoord staan, ook voor wie geen mail kreeg.
+    // Dit is het enige moment waarop het bestaat; voor die leverancier is dit
+    // de enige manier om de link alsnog door te geven.
+    expect(tweede?.token).toMatch(/^[A-Za-z0-9_-]{43}$/);
+  });
+
+  it('maakt de tokens ook aan als de mail niet verstuurd kan worden', async () => {
+    // Versturen gebeurt ná de transactie. Een mislukte mail mag de tokens niet
+    // terugdraaien: vier leveranciers die de uitnodiging wél kregen zouden dan
+    // op een dode link klikken.
+    const runId = await nieuweRonde();
+
+    const antwoord = await request(server)
+      .post(`/admin/survey/runs/${runId}/participants`)
+      .set('Cookie', cookieAdminA)
+      .send({ vendorIds: [VENDOR_2] })
+      .expect(201);
+
+    const body = antwoord.body as UitnodigingAntwoord;
+
+    expect(body.mislukt).toBe(1);
+
+    // Tenantcontext expliciet zetten, anders filtert RLS elke rij weg en lijkt
+    // de tabel leeg — zelfde patroon als de hash-test hieronder.
+    await client.query('BEGIN');
+    await client.query(`SET LOCAL app.current_tenant_id = '${tenantA}'`);
+    const rijen = await client.query(
+      'SELECT response_id FROM clm.survey_response WHERE run_id = $1',
+      [runId],
+    );
+    await client.query('COMMIT');
+
+    // De deelnemer staat er, ondanks de mislukte verzending.
+    expect(rijen.rows).toHaveLength(1);
+  });
 
   it('geeft een bruikbaar token terug en bewaart alleen de hash', async () => {
     const runId = await nieuweRonde();


### PR DESCRIPTION
De laatste schakel van de keten. Tot nu toe maakte `POST runs/:id/participants` de tokens aan en gaf ze terug in het antwoord — maar er ging geen mail uit. De beheerder moest de links zelf kopiëren en versturen, terwijl alle infrastructuur ervoor al stond.

## De kernvraag: wat als er één van de vijf faalt?

**Alles terugdraaien kan niet.** De tokens staan dan al in de database en zijn geldig. Ze weggooien omdat een mailserver hikte, betekent dat vier leveranciers die de uitnodiging wél kregen op een dode link klikken.

**Stil doorgaan mag niet.** Dat is precies de faalvorm die dit project elders bestrijdt: de beheerder ziet "verstuurd", en dat één leverancier niets kreeg blijkt pas als de deadline verstrijkt.

**Dus de derde weg:** doorgaan met de rest, en per deelnemer teruggeven wat er gebeurd is.

```json
{
  "uitnodigingen": [
    { "vendorNaam": "Acme B.V.", "token": "...", "verstuurd": true },
    { "vendorNaam": "Beta B.V.", "token": "...", "verstuurd": false,
      "verzendFout": "Geen e-mailadres bekend bij deze leverancier." }
  ],
  "verzonden": 1,
  "mislukt": 1
}
```

Het scherm kan dan "4 verstuurd, 1 mislukt" tonen met de reden erbij, en de beheerder kan gericht ingrijpen.

## Drie ontwerpkeuzes

**Versturen gebeurt ná de transactie, nooit erin.** Een verstuurde mail is niet terug te draaien. Zat de verzending in de transactie en faalde de laatste invoeging, dan waren de tokens weg maar de uitnodigingen verstuurd — leveranciers met een link naar niets.

**De tokens blijven in het antwoord staan, ook bij een geslaagde mail.** Dit is het enige moment waarop ze bestaan; er is geen route die ze opnieuw kan tonen. Gaat de mail alsnog verloren, dan is dit de laatste kans om de link handmatig door te geven.

**Serieel versturen, niet parallel.** Bij de daglimiet van Resend (100/dag) levert parallel een onvoorspelbaar deel geweigerde berichten op. Serieel weet je precies vanaf welke leverancier het misging.

## De uitnodigingstekst

In een eigen bestand, want het is het enige wat een leverancier van MCM2 ziet vóór hij besluit te klikken — en een bericht dat leest als phishing wordt niet aangeklikt.

Wél: opdrachtgever bij naam, uitleg waarom hij dit krijgt, link voluit uitgeschreven (wie de afzender niet vertrouwt moet de URL kunnen bekijken zonder te klikken). Niet: opgeklopte urgentie of doen alsof het persoonlijk getypt is — beide zijn phishing-signalen, voor de lezer én voor spamfilters.

## Het adres van de leverancier

Komt uit `clm.vendor_contact` via een `LEFT JOIN LATERAL` met expliciete volgorde: `is_primary` eerst, dan de oudste. Zonder die volgorde is het willekeurig wie de uitnodiging krijgt bij meerdere contactpersonen.

`LEFT JOIN` en geen `INNER`: een leverancier zonder contactpersoon hoort gewoon in de lijst. Het token wordt aangemaakt en de link werkt — alleen het versturen lukt niet, en dat telt als **mislukt**, niet als overgeslagen. Ontbrekende stamdata hoort net zo zichtbaar te zijn als een geweigerde verzending.

## Tegenproeven (§15b)

| Sabotage | Gevolg |
|---|---|
| stop bij eerste mislukking | 4 om — de doorgaan-tests |
| ontbrekend adres telt als geslaagd | 2 om — de stamdata-tests |
| contactadres niet doorgegeven | 1 om — de nieuwe e2e |

Bij de derde bleek een eerdere poging waardeloos: die **brak de build**, waardoor de suite `0 total` gaf. Dat had gelezen kunnen worden als "geen falende tests". Een sabotage die niet compileert bewijst niets — vervangen door een die wel compileert en het gedrag raakt.

De bestaande e2e voor deze route bleef groen onder alle sabotages: die las alleen `uitnodigingen` en raakte het mailpad niet. Twee tests toegevoegd die dat wél doen.

## Verificatie

- 266 unit-tests groen
- 318 e2e-tests groen (twee nieuwe)
- `typecheck` en `lint:check` schoon

## Nieuw in .env

```
PORTAAL_BASIS_URL=http://localhost:3000
```

Waar het leveranciersportaal draait — de **frontend**, niet deze API. Staat dit fout, dan krijgt elke leverancier een link die nergens heen gaat, en dat merk je pas als er niemand invult.

🤖 Generated with [Claude Code](https://claude.com/claude-code)