### PR TITLE
fix(scripts): schrijvende scripts noemen hun doelwit en weigeren buiten lokaal

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,16 @@ DATABASE_URL="postgresql://clm_api_runtime.PROJECT_REF:PASSWORD@aws-1-eu-west-1.
 # applicatie zelf gebruikt. clm_migrator is eigenaar van clm/ref/audit en
 # voert schemawijzigingen uit; de runtime (DATABASE_URL hierboven) gebruikt
 # een losse, beperktere rol. Zie ADR-009.
+#
+# LET OP — dit is een APARTE variabele van DATABASE_URL hierboven. Wie alleen
+# DATABASE_URL omzet om tegen een testcontainer te draaien, verandert hier
+# niets: dotenv vult deze regel alsnog aan uit dit bestand. Dat ging op
+# 2026-08-06 mis en is de aanleiding voor Issue #86.
+#
+# Sinds die issue weigeren migrate:deploy en de seeds te draaien tegen een
+# database die niet op deze machine staat. Is dat wél de bedoeling, geef dan
+# expliciet `-- --extern` mee. De scripts drukken bovendien vóór elke
+# schrijfactie af tegen welke host ze praten.
 MIGRATION_DATABASE_URL="postgresql://clm_migrator.PROJECT_REF:PASSWORD@aws-1-eu-west-1.pooler.supabase.com:5432/postgres?schema=public"
 
 # Backupdump — een rol die ALLE rijen ziet.

--- a/docs/runbooks/baseline-migratiestand.md
+++ b/docs/runbooks/baseline-migratiestand.md
@@ -216,7 +216,8 @@ PROEF — er is niets geschreven.
 - *"AFGEBROKEN — er staan al N migratie(s) vastgelegd"* → deze database is al gebaselined. Sla
   stap 4 over en ga door naar stap 5.
 - *"AFGEBROKEN — er staat geen enkele tabel"* → verkeerde database. Op een lege database draai
-  je gewoon `npm run migrate:deploy`.
+  je gewoon `npm run migrate:deploy` (met `-- --extern` als die database niet op deze machine
+  staat).
 
 ---
 
@@ -254,15 +255,32 @@ convergentie uit 0014.
 **Actie:**
 
 ```powershell
-npm run migrate:deploy
+npm run migrate:deploy -- --extern
 ```
+
+> **Waarom hier `--extern` staat.** Sinds Issue #86 weigert `migrate:deploy` te draaien tegen
+> een database die niet op deze machine staat, tenzij je dat expliciet meegeeft. Deze runbook
+> richt zich op een replica of op productie — dus niet-lokaal, dus de vlag is nodig.
+>
+> Dat is precies de bedoeling: op 2026-08-06 draaide dit commando per ongeluk tegen productie
+> omdat `.env` daarheen wees, en het meldde gewoon "Migraties voltooid". De vlag maakt van die
+> vergissing een bewuste handeling.
+>
+> Draai je tegen een lokale wegwerpcontainer, laat de vlag dan weg.
 
 **Verwacht resultaat:**
 
 ```
-Migraties draaien als rol 'clm_migrator'.
+Migraties: <host>:5432/postgres als rol 'clm_migrator' [NIET-LOKAAL]
+Doelwit is niet-lokaal, maar --extern is meegegeven. Doorgaan.
+
+Verbonden als rol 'clm_migrator'.
 Migraties voltooid.
 ```
+
+**Lees de eerste regel voordat je verdergaat.** Daar staat tegen welke database je werkelijk
+draait. Staat daar een andere host dan je bedoelde, breek dan af — er is op dat moment nog
+niets gewijzigd.
 
 Dit duurt op de replica enkele seconden.
 

--- a/scripts/db-doelwit.js
+++ b/scripts/db-doelwit.js
@@ -1,0 +1,138 @@
+// Benoemt waar een script naartoe praat, vóórdat het iets doet.
+//
+// Aanleiding (Issue #86): `npm run migrate:deploy` draaide tegen Supabase
+// productie terwijl de bedoeling een wegwerpcontainer was. Het script meldde
+// "Migraties draaien als rol 'clm_migrator'" en daarna "Migraties voltooid" —
+// beide waar, en geen van beide verklapte dat het de verkeerde database was.
+// Die rol heet lokaal precies zo.
+//
+// Drie dingen kwamen samen: dotenv vult stilzwijgend aan wat je op de
+// commandoregel niet noemt, het script noemde de rol maar niet het doelwit, en
+// DATABASE_URL en MIGRATION_DATABASE_URL lijken genoeg op elkaar om "ik heb de
+// database omgezet" een halve waarheid te maken.
+//
+// Dit bestand lost het eerste en tweede op. Het derde blijft: dotenv-gedrag
+// veranderen zou zijn eigen verrassingen opleveren (Issue #86, voorstel 3).
+
+// Hosts die als "op deze machine" gelden. Alles daarbuiten is een echte
+// database die iemand anders ook gebruikt, ook als het geen productie is.
+const LOKALE_HOSTS = new Set([
+  'localhost',
+  '127.0.0.1',
+  '::1',
+  '[::1]',
+  'host.docker.internal',
+]);
+
+/**
+ * Ontleedt een Postgres-URL tot iets dat veilig te tonen is.
+ *
+ * Geeft nooit het wachtwoord terug — ook niet in `beschrijving`. Een script dat
+ * zijn doelwit afdrukt komt in CI-logs, in terminalhistorie en in
+ * schermafdrukken terecht (MCM2-CLAUDE.md §6).
+ *
+ * Een onleesbare URL is geen reden om te stoppen: dan is `leesbaar` false en
+ * blijft het aan de aanroeper om te beslissen. De URL zelf komt daarbij niet in
+ * de melding, want juist een kapotte URL bevat vaak een wachtwoord dat een
+ * teken mist.
+ */
+function ontleed(url) {
+  if (!url) {
+    return { leesbaar: false, lokaal: false, beschrijving: '(geen URL gezet)' };
+  }
+
+  let ontleed;
+  try {
+    ontleed = new URL(url);
+  } catch {
+    return {
+      leesbaar: false,
+      lokaal: false,
+      beschrijving: '(onleesbare URL)',
+    };
+  }
+
+  const host = ontleed.hostname;
+  const poort = ontleed.port || '5432';
+  // pathname is '/postgres' → de naam zonder schuine streep.
+  const database = ontleed.pathname.replace(/^\//, '') || '(geen naam)';
+  const rol = ontleed.username || '(geen rol)';
+
+  return {
+    leesbaar: true,
+    host,
+    poort,
+    database,
+    rol,
+    lokaal: LOKALE_HOSTS.has(host),
+    beschrijving: `${host}:${poort}/${database}`,
+  };
+}
+
+/**
+ * Drukt af waar dit script naartoe praat.
+ *
+ * Bewust vóór de eerste schrijfactie aan te roepen en niet erna: een melding
+ * achteraf vertelt je welke database je zojuist hebt gewijzigd, en dat is te
+ * laat om er nog iets aan te doen.
+ */
+function meldDoelwit(url, wat) {
+  const d = ontleed(url);
+  const plek = d.lokaal ? 'lokaal' : 'NIET-LOKAAL';
+  console.log(`${wat}: ${d.beschrijving} als rol '${d.rol}' [${plek}]`);
+  return d;
+}
+
+/**
+ * Weigert door te gaan tegen een niet-lokaal doelwit zonder expliciete
+ * toestemming.
+ *
+ * Bewust een vlag en geen interactieve vraag. Een vraag werkt niet in CI, niet
+ * in `verify:volledig` en niet in een geplande taak — daar hangt hij, of erger:
+ * hij leest een lege stdin als "ja". Een vlag is zichtbaar in de
+ * terminalhistorie en in de pipeline, en dat is precies de bedoeling: je moet
+ * later kunnen terugzien dat iemand dit bewust deed.
+ *
+ * CI blijft hierdoor groen zonder aanpassing: die draait tegen localhost.
+ * Geverifieerd voor alle geautomatiseerde aanroepers (demo-omgeving.js,
+ * verify-volledig.js, provider-migratietest.js) — die zetten hun eigen
+ * MIGRATION_DATABASE_URL naar localhost.
+ */
+function eisToestemmingBuitenLokaal(url, { wat, vlag = '--extern' }) {
+  const d = ontleed(url);
+
+  if (!d.leesbaar) {
+    console.error(
+      `\n${wat} kan niet doorgaan: de database-URL is ${d.beschrijving}.\n` +
+        'Controleer de betreffende variabele in .env.\n',
+    );
+    process.exitCode = 1;
+    return false;
+  }
+
+  if (d.lokaal) return true;
+
+  const toegestaan =
+    process.argv.includes(vlag) || process.env.MCM2_EXTERNE_DB === 'ja';
+
+  if (toegestaan) {
+    console.log(
+      `Doelwit is niet-lokaal, maar ${vlag} is meegegeven. Doorgaan.\n`,
+    );
+    return true;
+  }
+
+  console.error(
+    `\n${wat} GESTOPT — het doelwit is niet lokaal.\n\n` +
+      `  Doel: ${d.beschrijving} (rol '${d.rol}')\n\n` +
+      'Dit kan de productiedatabase zijn. Was dat niet de bedoeling, dan staat\n' +
+      'de verkeerde waarde in .env: dotenv vult aan wat je op de commandoregel\n' +
+      'niet noemt.\n\n' +
+      `Is het wél de bedoeling, geef dan ${vlag} mee:\n` +
+      `  npm run <script> -- ${vlag}\n`,
+  );
+  process.exitCode = 1;
+  return false;
+}
+
+module.exports = { ontleed, meldDoelwit, eisToestemmingBuitenLokaal };

--- a/scripts/migrate.js
+++ b/scripts/migrate.js
@@ -11,6 +11,8 @@ const { drizzle } = require('drizzle-orm/node-postgres');
 const { migrate } = require('drizzle-orm/node-postgres/migrator');
 const { Pool } = require('pg');
 
+const { meldDoelwit, eisToestemmingBuitenLokaal } = require('./db-doelwit.js');
+
 const url = process.env.MIGRATION_DATABASE_URL;
 
 if (!url) {
@@ -20,14 +22,26 @@ if (!url) {
   process.exit(1);
 }
 
+// Vóór de verbinding, niet erna: zie Issue #86. Op 2026-08-06 draaide dit
+// script tegen productie terwijl een wegwerpcontainer bedoeld was, en meldde
+// alleen de rolnaam — die lokaal precies zo heet.
+meldDoelwit(url, 'Migraties');
+
+if (!eisToestemmingBuitenLokaal(url, { wat: 'Migraties' })) {
+  process.exit(1);
+}
+
 async function main() {
   const pool = new Pool({ connectionString: url });
 
   try {
+    // De rol staat al in de doelwitmelding hierboven; dit is de bevestiging
+    // dat de database hem ook werkelijk zo ziet — een URL kan iets anders
+    // beweren dan er na verbinden geldt.
     const { rows } = await pool.query(
       'SELECT current_user AS role, rolbypassrls FROM pg_roles WHERE rolname = current_user',
     );
-    console.log(`Migraties draaien als rol '${rows[0]?.role}'.`);
+    console.log(`Verbonden als rol '${rows[0]?.role}'.`);
 
     await migrate(drizzle(pool), { migrationsFolder: './drizzle' });
     console.log('Migraties voltooid.');

--- a/scripts/seed-demo-tenant.js
+++ b/scripts/seed-demo-tenant.js
@@ -35,6 +35,8 @@ const { sql } = require('drizzle-orm');
 const { drizzle } = require('drizzle-orm/node-postgres');
 const { Pool } = require('pg');
 
+const { meldDoelwit, eisToestemmingBuitenLokaal } = require('./db-doelwit.js');
+
 // Vast UUID, zodat het script idempotent is en `--verwijder` precies weet wat
 // het weghaalt. Bewust niet 1111.../2222..., die zijn in gebruik bij
 // otap-doorloop.js en de e2e-suites.
@@ -363,8 +365,18 @@ async function rondeAanmaken(db, vendors) {
       );
 
       const stadia = [
-        { sleutel: 'open', mockId: vendors[0], status: 'pending', antwoorden: 0 },
-        { sleutel: 'concept', mockId: vendors[1], status: 'pending', antwoorden: 3 },
+        {
+          sleutel: 'open',
+          mockId: vendors[0],
+          status: 'pending',
+          antwoorden: 0,
+        },
+        {
+          sleutel: 'concept',
+          mockId: vendors[1],
+          status: 'pending',
+          antwoorden: 3,
+        },
         {
           sleutel: 'ingediend',
           mockId: vendors[2],
@@ -419,7 +431,8 @@ async function rondeAanmaken(db, vendors) {
           // leeg blijven, en dat houden we ook zo — anders toont de demo een
           // toelichting waar een echte invuller er geen hoeft te geven.
           const toelichting =
-            vraag.answer_type === 'confirmation' && antwoord.code === 'confirmed'
+            vraag.answer_type === 'confirmation' &&
+            antwoord.code === 'confirmed'
               ? null
               : 'Voorbeeldantwoord uit de demo-seed.';
 
@@ -577,6 +590,15 @@ async function main() {
     process.exit(1);
   }
 
+  // Vóór de eerste schrijfactie. Dit script schrijft niet alleen, het kan met
+  // --verwijder ook opruimen — op de verkeerde database is dat onherstelbaar
+  // zonder backup (Issue #86).
+  meldDoelwit(url, 'Seed demo-tenant');
+
+  if (!eisToestemmingBuitenLokaal(url, { wat: 'Seed demo-tenant' })) {
+    process.exit(1);
+  }
+
   const moetVerwijderen = process.argv.includes('--verwijder');
   const pool = new Pool({ connectionString: url });
   const db = drizzle(pool);
@@ -654,9 +676,7 @@ async function main() {
       `'${DEMO_SUBJECT_PREFIX}' en is geen echte Entra-oid. Koppel een echte oid`,
       '\nom in te loggen — zie docs/STATUS.md.',
     );
-    console.log(
-      `Opruimen: node scripts/seed-demo-tenant.js --verwijder`,
-    );
+    console.log(`Opruimen: node scripts/seed-demo-tenant.js --verwijder`);
   } finally {
     await pool.end();
   }

--- a/scripts/seed-vragenlijsten.js
+++ b/scripts/seed-vragenlijsten.js
@@ -24,6 +24,8 @@ const { sql } = require('drizzle-orm');
 const { drizzle } = require('drizzle-orm/node-postgres');
 const { Pool } = require('pg');
 
+const { meldDoelwit, eisToestemmingBuitenLokaal } = require('./db-doelwit.js');
+
 const SEEDMAP = path.join(__dirname, '..', 'db', 'seeds');
 
 const UUID_REGEX =
@@ -38,14 +40,22 @@ const UUID_REGEX =
  * stilzwijgend niet gelden voor de seed.
  */
 function laadValidatie() {
-  const uitDist = path.join(__dirname, '..', 'dist', 'survey', 'vragenlijst-schema.js');
+  const uitDist = path.join(
+    __dirname,
+    '..',
+    'dist',
+    'survey',
+    'vragenlijst-schema.js',
+  );
 
   if (fs.existsSync(uitDist)) {
     return require(uitDist);
   }
 
   require('ts-node/register');
-  return require(path.join(__dirname, '..', 'src', 'survey', 'vragenlijst-schema.ts'));
+  return require(
+    path.join(__dirname, '..', 'src', 'survey', 'vragenlijst-schema.ts'),
+  );
 }
 
 function bestandenUitArgumenten(argumenten) {
@@ -161,6 +171,14 @@ async function main() {
     console.error(
       'DATABASE_URL ontbreekt. De seed draait via de runtime-rol clm_api_runtime, net als de applicatie.',
     );
+    process.exit(1);
+  }
+
+  // Vóór de eerste schrijfactie: deze seed schrijft vragenlijsten weg en kan
+  // dus productiedata raken (Issue #86).
+  meldDoelwit(url, 'Seed vragenlijsten');
+
+  if (!eisToestemmingBuitenLokaal(url, { wat: 'Seed vragenlijsten' })) {
     process.exit(1);
   }
 

--- a/test/db-doelwit.spec.ts
+++ b/test/db-doelwit.spec.ts
@@ -1,0 +1,195 @@
+// Tests voor scripts/db-doelwit.js — de poort uit Issue #86.
+//
+// Wat hier bewezen moet worden is niet "de functie doet iets", maar precies de
+// twee dingen die op 2026-08-06 misgingen:
+//   1. een niet-lokaal doelwit wordt herkend als niet-lokaal;
+//   2. het wachtwoord staat in geen enkele melding.
+//
+// Het tweede is de reden dat er assertions op de úítvoer staan en niet alleen
+// op de retourwaarde: een script dat zijn doelwit afdrukt, drukt af in CI-logs
+// en schermafdrukken (MCM2-CLAUDE.md §6).
+
+/* eslint-disable @typescript-eslint/no-require-imports,
+                  @typescript-eslint/no-unsafe-assignment,
+                  @typescript-eslint/no-unsafe-call,
+                  @typescript-eslint/no-unsafe-member-access */
+const {
+  ontleed,
+  meldDoelwit,
+  eisToestemmingBuitenLokaal,
+} = require('../scripts/db-doelwit.js');
+
+// Een verzonnen wachtwoord dat nergens echt bestaat; het staat hier om te
+// kunnen bewijzen dat het níét in de uitvoer terechtkomt.
+const GEHEIM = 'zeer-geheim-wachtwoord-123';
+const LOKAAL = `postgresql://clm_migrator:${GEHEIM}@localhost:5432/postgres`;
+const EXTERN = `postgresql://clm_migrator:${GEHEIM}@db.abcdefgh.supabase.co:5432/postgres?schema=public`;
+
+describe('ontleed', () => {
+  it('leest host, poort, databasenaam en rol uit een URL', () => {
+    const d = ontleed(EXTERN);
+    expect(d.leesbaar).toBe(true);
+    expect(d.host).toBe('db.abcdefgh.supabase.co');
+    expect(d.poort).toBe('5432');
+    expect(d.database).toBe('postgres');
+    expect(d.rol).toBe('clm_migrator');
+  });
+
+  it('noemt het wachtwoord niet in de beschrijving', () => {
+    expect(ontleed(EXTERN).beschrijving).not.toContain(GEHEIM);
+  });
+
+  it('vult de standaardpoort in als de URL er geen noemt', () => {
+    expect(ontleed('postgresql://rol@host/db').poort).toBe('5432');
+  });
+
+  it.each([
+    ['localhost', true],
+    ['127.0.0.1', true],
+    ['host.docker.internal', true],
+    ['db.abcdefgh.supabase.co', false],
+    // Bewust: een host die met localhost begint is niet localhost. Zou de
+    // controle op "begint met" leunen, dan glipt dit erdoor.
+    ['localhost.evil.example', false],
+  ])('herkent %s als lokaal=%s', (host, verwacht) => {
+    expect(ontleed(`postgresql://rol:pw@${host}:5432/postgres`).lokaal).toBe(
+      verwacht,
+    );
+  });
+
+  it('valt niet om over een onleesbare URL', () => {
+    const d = ontleed('dit is geen url');
+    expect(d.leesbaar).toBe(false);
+    expect(d.lokaal).toBe(false);
+  });
+
+  it('behandelt een ontbrekende URL als onleesbaar en niet-lokaal', () => {
+    expect(ontleed(undefined).leesbaar).toBe(false);
+    expect(ontleed(undefined).lokaal).toBe(false);
+  });
+});
+
+describe('meldDoelwit', () => {
+  let uitvoer: string[];
+  let log: jest.SpyInstance;
+
+  beforeEach(() => {
+    uitvoer = [];
+    log = jest
+      .spyOn(console, 'log')
+      .mockImplementation((m: string) => void uitvoer.push(String(m)));
+  });
+  afterEach(() => log.mockRestore());
+
+  it('noemt host, database en rol', () => {
+    meldDoelwit(EXTERN, 'Migraties');
+    expect(uitvoer.join('\n')).toContain(
+      'db.abcdefgh.supabase.co:5432/postgres',
+    );
+    expect(uitvoer.join('\n')).toContain('clm_migrator');
+  });
+
+  it('markeert een niet-lokaal doelwit zichtbaar', () => {
+    meldDoelwit(EXTERN, 'Migraties');
+    expect(uitvoer.join('\n')).toContain('NIET-LOKAAL');
+  });
+
+  it('markeert een lokaal doelwit als lokaal', () => {
+    meldDoelwit(LOKAAL, 'Migraties');
+    expect(uitvoer.join('\n')).toContain('lokaal');
+    expect(uitvoer.join('\n')).not.toContain('NIET-LOKAAL');
+  });
+
+  it('lekt het wachtwoord niet', () => {
+    meldDoelwit(EXTERN, 'Migraties');
+    expect(uitvoer.join('\n')).not.toContain(GEHEIM);
+  });
+});
+
+describe('eisToestemmingBuitenLokaal', () => {
+  let fouten: string[];
+  let err: jest.SpyInstance;
+  let log: jest.SpyInstance;
+  const argv = process.argv;
+  const env = process.env.MCM2_EXTERNE_DB;
+
+  beforeEach(() => {
+    fouten = [];
+    err = jest
+      .spyOn(console, 'error')
+      .mockImplementation((m: string) => void fouten.push(String(m)));
+    log = jest.spyOn(console, 'log').mockImplementation(() => undefined);
+    process.exitCode = undefined;
+    delete process.env.MCM2_EXTERNE_DB;
+  });
+
+  afterEach(() => {
+    err.mockRestore();
+    log.mockRestore();
+    process.argv = argv;
+    if (env === undefined) delete process.env.MCM2_EXTERNE_DB;
+    else process.env.MCM2_EXTERNE_DB = env;
+    process.exitCode = undefined;
+  });
+
+  it('laat een lokaal doelwit door zonder vlag', () => {
+    process.argv = ['node', 'script.js'];
+    expect(eisToestemmingBuitenLokaal(LOKAAL, { wat: 'Migraties' })).toBe(true);
+    expect(process.exitCode).toBeUndefined();
+  });
+
+  // Dit is de kern van Issue #86.
+  it('stopt bij een niet-lokaal doelwit zonder vlag', () => {
+    process.argv = ['node', 'script.js'];
+    expect(eisToestemmingBuitenLokaal(EXTERN, { wat: 'Migraties' })).toBe(
+      false,
+    );
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('noemt bij weigering het doelwit, zodat je ziet wat er mis was', () => {
+    process.argv = ['node', 'script.js'];
+    eisToestemmingBuitenLokaal(EXTERN, { wat: 'Migraties' });
+    expect(fouten.join('\n')).toContain('db.abcdefgh.supabase.co');
+  });
+
+  it('lekt bij weigering het wachtwoord niet', () => {
+    process.argv = ['node', 'script.js'];
+    eisToestemmingBuitenLokaal(EXTERN, { wat: 'Migraties' });
+    expect(fouten.join('\n')).not.toContain(GEHEIM);
+  });
+
+  it('laat een niet-lokaal doelwit door mét de vlag', () => {
+    process.argv = ['node', 'script.js', '--extern'];
+    expect(eisToestemmingBuitenLokaal(EXTERN, { wat: 'Migraties' })).toBe(true);
+    expect(process.exitCode).toBeUndefined();
+  });
+
+  it('laat een niet-lokaal doelwit door via de omgevingsvariabele', () => {
+    process.argv = ['node', 'script.js'];
+    process.env.MCM2_EXTERNE_DB = 'ja';
+    expect(eisToestemmingBuitenLokaal(EXTERN, { wat: 'Migraties' })).toBe(true);
+  });
+
+  it('accepteert alleen exact "ja" als omgevingswaarde', () => {
+    process.argv = ['node', 'script.js'];
+    process.env.MCM2_EXTERNE_DB = 'true';
+    expect(eisToestemmingBuitenLokaal(EXTERN, { wat: 'Migraties' })).toBe(
+      false,
+    );
+  });
+
+  it('stopt bij een onleesbare URL in plaats van hem als lokaal te zien', () => {
+    process.argv = ['node', 'script.js'];
+    expect(eisToestemmingBuitenLokaal('kapot', { wat: 'Migraties' })).toBe(
+      false,
+    );
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('gebruikt de opgegeven vlagnaam in de melding', () => {
+    process.argv = ['node', 'script.js'];
+    eisToestemmingBuitenLokaal(EXTERN, { wat: 'Seed', vlag: '--productie' });
+    expect(fouten.join('\n')).toContain('--productie');
+  });
+});


### PR DESCRIPTION
Sluit #86.

## Wat er misging

Op 2026-08-06 draaide `npm run migrate:deploy` tegen **Supabase productie** terwijl een wegwerpcontainer bedoeld was. Het script meldde:

```
Migraties draaien als rol 'clm_migrator'.
Migraties voltooid.
```

Groen, geruststellend, en gericht op de verkeerde database. Die rol heet lokaal precies zo, dus de melding onderscheidde de twee niet.

Geen schade — er was niets nieuws toe te passen. Dat was geluk, geen ontwerp. Fase C brengt wél nieuwe migraties mee.

## De oorzaak

`dotenv` vult stilzwijgend aan wat je op de commandoregel niet noemt. Wie `DATABASE_URL` omzet om tegen een testcontainer te draaien, denkt de omgeving te sturen — maar `MIGRATION_DATABASE_URL` komt alsnog uit `.env`, en die wijst naar productie.

## Wat dit toevoegt

`scripts/db-doelwit.js`, gebruikt door de drie schrijvende scripts:

**1. Elk script noemt zijn doelwit vóór de eerste schrijfactie**

```
Migraties: localhost:55450/postgres als rol 'clm_migrator' [lokaal]
```

Host, poort, databasenaam en rol — **nooit het wachtwoord**. Deze regels komen in CI-logs, terminalhistorie en schermafdrukken terecht (§6). Daar zijn expliciete tests op.

**2. Een niet-lokaal doelwit wordt geweigerd zonder `--extern`**

Bewust een vlag en geen interactieve vraag: een vraag hangt in CI en in geplande taken, of leest een lege stdin als "ja". Een vlag staat in de terminalhistorie, dus achteraf is zichtbaar dat iemand dit bewust deed.

Toegepast op `migrate.js`, `seed-vragenlijsten.js` en `seed-demo-tenant.js` — de scripts die productiedata kunnen wijzigen. `seed-demo-tenant.js` kan met `--verwijder` ook opruimen; op de verkeerde database is dat onherstelbaar zonder backup.

## CI blijft groen zonder aanpassing

Alle geautomatiseerde aanroepers draaien tegen `localhost`. Geverifieerd in `demo-omgeving.js`, `verify-volledig.js` en `provider-migratietest.js`, plus de `rls-isolation`-job in CI.

Aangetoond met een **echte migratierun** tegen de lokale demo-database: doelwit gemeld als `[lokaal]`, verbonden, migraties voltooid, exit 0.

## Tegenproeven (§15b)

| Sabotage | Uitkomst |
|---|---|
| `startsWith` i.p.v. exacte hostvergelijking | precies de test op `localhost.evil.example` viel om |
| waarschuwen zonder blokkeren | precies de twee blokkadetests vielen om |

Na herstel beide keren 23 groen. De tweede is de belangrijkste: die bewijst dat de tests de *blokkade* meten en niet alleen de melding — precies de faalvorm die #86 beschrijft.

**De oorspronkelijke vergissing nagespeeld:** alleen `DATABASE_URL` omzetten terwijl `.env` naar productie wijst. Dat stopt nu vóór er verbinding is, met een melding die de host noemt.

## Definition of done uit #86

- [x] Elk schrijvend script logt host, poort en databasenaam vóór de eerste schrijfactie
- [x] `migrate:deploy` tegen een niet-lokaal doelwit eist een vlag
- [x] CI blijft groen zonder handmatige tussenkomst
- [x] Runbook `baseline-migratiestand.md` bijgewerkt — die richt zich op een replica/productie en documenteert nu `-- --extern`

Voorstel 3 uit het issue (dotenv negeren bij een expliciete waarde) is **niet** uitgevoerd: het issue noemt dat zelf al twijfelachtig, en voorstel 1 en 2 dekken de faalvorm.

## Getoetst

289 unittests groen (was 266, +23 nieuw), lint/format/typecheck schoon.

> **Let op:** GitHub Actions had vandaag een storing (`major_outage`). Draait er geen CI op deze PR, dan is dat de reden. Bovenstaande is lokaal gedraaid.