### PR TITLE
feat(survey): antwoorden van een respons lezen (fase C1)

### DIFF
--- a/src/survey/vragenlijst-beheer.controller.ts
+++ b/src/survey/vragenlijst-beheer.controller.ts
@@ -111,6 +111,27 @@ export class VragenlijstBeheerController {
     return this.beheer.ronde(sessie.tenantId, id);
   }
 
+  /**
+   * De antwoorden van één respons — wat de leverancier feitelijk heeft
+   * ingevuld, in de volgorde van de vragenlijst.
+   *
+   * Geen `@VereistRol`: lezen mag ook een reviewer, net als de andere
+   * GET-routes hierboven. Voor hem is dit zelfs de kernroute — beoordelen kan
+   * niet zonder de antwoorden te zien.
+   *
+   * 404 als de respons niet bestaat binnen deze tenant. Dat "binnen deze
+   * tenant" doet RLS, niet deze route: een respons van een andere tenant is
+   * onzichtbaar en levert dezelfde 404 op als een verzonnen id. Het verschil
+   * tussen "bestaat niet" en "mag je niet zien" hoort niet naar buiten te
+   * lekken.
+   */
+  @Get('responses/:id/answers')
+  async antwoorden(@Req() request: RequestMetSessie, @Param('id') id: string) {
+    const sessie = request.sessie!;
+
+    return this.beheer.antwoorden(sessie.tenantId, id);
+  }
+
   // ── Fase B: schrijven ──────────────────────────────────────────────────────
   //
   // Vanaf hier staat op elke route `@VereistRol('admin')`. Een reviewer mag

--- a/src/survey/vragenlijst-beheer.service.ts
+++ b/src/survey/vragenlijst-beheer.service.ts
@@ -105,6 +105,70 @@ export interface RondeDetail extends RondeSamenvatting {
   deelnemers: DeelnemerSamenvatting[];
 }
 
+/** Eén bijlage bij een antwoord. */
+export interface BijlageSamenvatting {
+  attachmentId: string;
+  /** Zoals de leverancier hem aanleverde — nooit als pad gebruiken. */
+  originalName: string;
+  contentType: string;
+  byteSize: number;
+  createdAt: string;
+}
+
+/**
+ * Eén vraag met het antwoord dat erop gegeven is.
+ *
+ * De vraag staat er altijd, het antwoord kan ontbreken. Dat onderscheid is het
+ * hele punt van dit scherm: een niet-beantwoorde vraag is informatie, en die
+ * zou verdwijnen als we alleen de rijen uit `survey_answer` zouden tonen.
+ *
+ * De waarde staat in aparte velden per soort, precies zoals de database hem
+ * bewaart (schema.ts regel 480 e.v.). Ze hier samenvoegen tot één `waarde`-veld
+ * zou de beheerkant laten gokken wat er in staat, en een rating die als tekst
+ * aankomt is niet meer te sorteren.
+ */
+export interface AntwoordDetail {
+  questionId: string;
+  questionKey: string;
+  position: number;
+  title: string;
+  body: string;
+  answerType: string;
+  isRequired: boolean;
+  categoryId: string | null;
+  categorieNaam: string | null;
+  /** Null wanneer deze vraag niet is beantwoord. */
+  antwoord: {
+    answerId: string;
+    answerCode: string | null;
+    answerCodes: string[] | null;
+    answerText: string | null;
+    /** NUMERIC komt als string uit pg; hier als getal, of null. */
+    answerNumber: number | null;
+    comment: string | null;
+    createdAt: string;
+    updatedAt: string | null;
+  } | null;
+  bijlagen: BijlageSamenvatting[];
+}
+
+/** Alle antwoorden van één respons, in de volgorde van de vragenlijst. */
+export interface AntwoordenDetail {
+  responseId: string;
+  runId: string;
+  templateId: string;
+  templateNaam: string;
+  vendorId: string | null;
+  vendorNaam: string | null;
+  status: string;
+  submittedAt: string | null;
+  expiresAt: string | null;
+  /** Echte vragen, dus zonder `instruction`. */
+  aantalVragen: number;
+  aantalBeantwoord: number;
+  antwoorden: AntwoordDetail[];
+}
+
 interface TemplateRij extends Record<string, unknown> {
   template_id: string;
   name: string;
@@ -150,6 +214,47 @@ interface RondeRij extends Record<string, unknown> {
   revoked_at: Date | string | null;
   aantal_deelnemers: string | number;
   aantal_ingediend: string | number;
+}
+
+interface AntwoordRij extends Record<string, unknown> {
+  question_id: string;
+  question_key: string;
+  position: number;
+  title: string;
+  body: string;
+  answer_type: string;
+  is_required: boolean;
+  category_id: string | null;
+  categorie_naam: string | null;
+  answer_id: string | null;
+  answer_code: string | null;
+  answer_codes: string[] | null;
+  answer_text: string | null;
+  answer_number: string | number | null;
+  comment: string | null;
+  antwoord_created_at: Date | string | null;
+  antwoord_updated_at: Date | string | null;
+}
+
+interface BijlageRij extends Record<string, unknown> {
+  attachment_id: string;
+  question_id: string;
+  original_name: string;
+  content_type: string;
+  byte_size: number;
+  created_at: Date | string;
+}
+
+interface ResponsRij extends Record<string, unknown> {
+  response_id: string;
+  run_id: string;
+  template_id: string;
+  template_naam: string;
+  vendor_id: string | null;
+  vendor_naam: string | null;
+  status: string;
+  submitted_at: Date | string | null;
+  expires_at: Date | string | null;
 }
 
 interface DeelnemerRij extends Record<string, unknown> {
@@ -409,6 +514,166 @@ export class VragenlijstBeheerService {
             expiresAt: iso(d.expires_at),
             submittedAt: iso(d.submitted_at),
           })),
+        };
+      },
+      'medewerker',
+    );
+  }
+
+  /**
+   * De antwoorden van één respons, in de volgorde van de vragenlijst.
+   *
+   * ── Waarom een LEFT JOIN vanaf de vraag ────────────────────────────────────
+   *
+   * De vragen zijn leidend, niet de antwoorden. Een respons die half is
+   * ingevuld hoort de openstaande vragen te tonen, niet weg te laten: "vraag 7
+   * is niet beantwoord" is precies wat een beoordelaar moet zien. Zouden we
+   * vanaf `survey_answer` joinen, dan verdwijnt die informatie stilzwijgend en
+   * lijkt een halve respons compleet.
+   *
+   * `instruction`-items blijven staan. Ze horen bij de lijst zoals de
+   * leverancier hem zag, en zonder die schermen loopt de nummering niet meer
+   * gelijk met wat hij voor zich had.
+   *
+   * ── Bijlagen apart ─────────────────────────────────────────────────────────
+   *
+   * Eén vraag kan meerdere bijlagen hebben (`max_files`). In dezelfde query
+   * zouden de antwoordvelden zich per bijlage herhalen, en dan moet de
+   * aanroeper gaan ontdubbelen. Twee queries binnen dezelfde transactie is hier
+   * eenvoudiger dan één slimme.
+   *
+   * Nadrukkelijk géén `storage_key`: dat is een intern pad. Downloaden loopt
+   * via een eigen route met eigen controle, niet via dit overzicht.
+   */
+  async antwoorden(
+    tenantId: string,
+    responseId: string,
+  ): Promise<AntwoordenDetail> {
+    return this.db.withTenant(
+      tenantId,
+      async (tx) => {
+        const responses = await tx.execute<ResponsRij>(
+          sql`SELECT s.response_id,
+                     s.run_id,
+                     r.template_id,
+                     t.name AS template_naam,
+                     s.vendor_id,
+                     v.name AS vendor_naam,
+                     s.status,
+                     s.submitted_at,
+                     s.expires_at
+                FROM clm.survey_response s
+                JOIN clm.survey_run r      ON r.run_id = s.run_id
+                JOIN clm.survey_template t ON t.template_id = r.template_id
+                LEFT JOIN clm.vendor v     ON v.vendor_id = s.vendor_id
+               WHERE s.response_id = ${responseId}`,
+        );
+
+        const respons = responses.rows[0];
+        if (!respons) {
+          throw new NotFoundException('Deze respons bestaat niet.');
+        }
+
+        const rijen = await tx.execute<AntwoordRij>(
+          sql`SELECT q.question_id,
+                     q.question_key,
+                     q.position,
+                     q.title,
+                     q.body,
+                     q.answer_type,
+                     q.is_required,
+                     q.category_id,
+                     c.name AS categorie_naam,
+                     a.answer_id,
+                     a.answer_code,
+                     a.answer_codes,
+                     a.answer_text,
+                     a.answer_number,
+                     a.comment,
+                     a.created_at AS antwoord_created_at,
+                     a.updated_at AS antwoord_updated_at
+                FROM clm.survey_question q
+                LEFT JOIN clm.survey_category c ON c.category_id = q.category_id
+                LEFT JOIN clm.survey_answer a
+                       ON a.question_id = q.question_id
+                      AND a.response_id = ${responseId}
+               WHERE q.template_id = ${respons.template_id}
+               ORDER BY q.position`,
+        );
+
+        const bijlagen = await tx.execute<BijlageRij>(
+          sql`SELECT attachment_id,
+                     question_id,
+                     original_name,
+                     content_type,
+                     byte_size,
+                     created_at
+                FROM clm.survey_attachment
+               WHERE response_id = ${responseId}
+               ORDER BY created_at`,
+        );
+
+        const perVraag = new Map<string, BijlageSamenvatting[]>();
+        for (const b of bijlagen.rows) {
+          const lijst = perVraag.get(b.question_id) ?? [];
+          lijst.push({
+            attachmentId: b.attachment_id,
+            originalName: b.original_name,
+            contentType: b.content_type,
+            byteSize: b.byte_size,
+            createdAt: iso(b.created_at) ?? '',
+          });
+          perVraag.set(b.question_id, lijst);
+        }
+
+        const antwoorden = rijen.rows.map((r) => ({
+          questionId: r.question_id,
+          questionKey: r.question_key,
+          position: r.position,
+          title: r.title,
+          body: r.body,
+          answerType: r.answer_type,
+          isRequired: r.is_required,
+          categoryId: r.category_id,
+          categorieNaam: r.categorie_naam,
+          antwoord: r.answer_id
+            ? {
+                answerId: r.answer_id,
+                answerCode: r.answer_code,
+                answerCodes: r.answer_codes,
+                answerText: r.answer_text,
+                // NUMERIC komt als string uit de pg-driver; Number(null) is 0
+                // en dat zou een leeg antwoord als een nul tonen.
+                answerNumber:
+                  r.answer_number === null ? null : Number(r.answer_number),
+                comment: r.comment,
+                createdAt: iso(r.antwoord_created_at) ?? '',
+                updatedAt: iso(r.antwoord_updated_at),
+              }
+            : null,
+          bijlagen: perVraag.get(r.question_id) ?? [],
+        }));
+
+        // Instructieschermen tellen niet mee: daar valt niets te beantwoorden.
+        // Dezelfde afbakening als aantalVragen in lijst() en detail().
+        const echteVragen = antwoorden.filter(
+          (a) => a.answerType !== 'instruction',
+        );
+
+        return {
+          responseId: respons.response_id,
+          runId: respons.run_id,
+          templateId: respons.template_id,
+          templateNaam: respons.template_naam,
+          vendorId: respons.vendor_id,
+          vendorNaam: respons.vendor_naam,
+          status: respons.status,
+          submittedAt: iso(respons.submitted_at),
+          expiresAt: iso(respons.expires_at),
+          aantalVragen: echteVragen.length,
+          aantalBeantwoord: echteVragen.filter((a) => a.antwoord !== null)
+            .length,
+          antwoorden,
         };
       },
       'medewerker',

--- a/test/vragenlijst-beheer-routes.e2e-spec.ts
+++ b/test/vragenlijst-beheer-routes.e2e-spec.ts
@@ -93,6 +93,9 @@ async function verwijderTestdata(client: Client): Promise<void> {
     await client.query('BEGIN');
     await client.query(`SET LOCAL app.current_tenant_id = '${tenant}'`);
     for (const tabel of [
+      // Antwoorden vóór de respons: survey_answer heeft een FK naar
+      // survey_response, dus andersom weigert Postgres de DELETE.
+      'clm.survey_answer',
       'clm.survey_response',
       'clm.survey_run',
       'clm.survey_question',
@@ -212,6 +215,21 @@ describe('Vragenlijst-beheerroutes (e2e)', () => {
           token_hash, status, expires_at)
        VALUES ($1, $2, $3, $4, $4, $5, 'pending', now() + interval '30 days')`,
       [RESPONSE_A, tenantA, RUN_A, VENDOR_A, TOKEN_HASH],
+    );
+
+    // Precies één van de twee echte vragen beantwoorden. Dat is bewust een
+    // halve respons: de antwoordenroute moet de onbeantwoorde vraag tónen en
+    // niet weglaten, en dat is met twee beantwoorde vragen niet te bewijzen.
+    await client.query(
+      // 'confirmed' en niet 'ja': de vormconstraint uit migratie 0005 staat bij
+      // answer_type 'confirmation' alleen confirmed/not_confirmed/
+      // not_applicable/cannot_upload toe.
+      `INSERT INTO clm.survey_answer
+         (tenant_id, response_id, question_id, answer_type, answer_code, comment)
+       SELECT $1, $2, q.question_id, 'confirmation', 'confirmed', 'Toelichting bij v1'
+         FROM clm.survey_question q
+        WHERE q.template_id = $3 AND q.question_key = 'v1'`,
+      [tenantA, RESPONSE_A, TEMPLATE_A],
     );
     await client.query('COMMIT');
 
@@ -406,6 +424,141 @@ describe('Vragenlijst-beheerroutes (e2e)', () => {
         .get(`/admin/survey/templates/${TEMPLATE_A}`)
         .set('Cookie', cookieReviewer)
         .expect(200);
+    });
+  });
+
+  describe('de antwoorden van één respons (fase C)', () => {
+    interface AntwoordenBody {
+      responseId: string;
+      vendorNaam: string | null;
+      templateNaam: string;
+      aantalVragen: number;
+      aantalBeantwoord: number;
+      antwoorden: Array<{
+        questionKey: string;
+        answerType: string;
+        position: number;
+        antwoord: {
+          answerCode: string | null;
+          comment: string | null;
+        } | null;
+        bijlagen: unknown[];
+      }>;
+    }
+
+    async function haalAntwoorden(cookie: string) {
+      const antwoord = await request(server)
+        .get(`/admin/survey/responses/${RESPONSE_A}/answers`)
+        .set('Cookie', cookie)
+        .expect(200);
+      return antwoord.body as AntwoordenBody;
+    }
+
+    it('toont de respons met leverancier en vragenlijst erbij', async () => {
+      const body = await haalAntwoorden(cookieA);
+
+      expect(body.responseId).toBe(RESPONSE_A);
+      expect(body.vendorNaam).toBe('Leverancier van A');
+      expect(body.templateNaam).toBe('beheer-test-lijst');
+    });
+
+    // Dit is de kern van de route. Een respons waarvan één vraag open staat
+    // moet die vraag tónen; zouden we vanaf survey_answer joinen, dan
+    // verdwijnt hij en lijkt een halve respons compleet.
+    it('toont ook de vraag die NIET beantwoord is', async () => {
+      const body = await haalAntwoorden(cookieA);
+
+      const v2 = body.antwoorden.find((a) => a.questionKey === 'v2');
+
+      expect(v2).toBeDefined();
+      expect(v2!.antwoord).toBeNull();
+    });
+
+    it('geeft het antwoord terug op de vraag die wél beantwoord is', async () => {
+      const body = await haalAntwoorden(cookieA);
+
+      const v1 = body.antwoorden.find((a) => a.questionKey === 'v1');
+
+      expect(v1!.antwoord).not.toBeNull();
+      expect(v1!.antwoord!.answerCode).toBe('confirmed');
+      expect(v1!.antwoord!.comment).toBe('Toelichting bij v1');
+    });
+
+    it('telt 1 van 2 beantwoord, zonder het instructiescherm mee te rekenen', async () => {
+      const body = await haalAntwoorden(cookieA);
+
+      // Drie items, waarvan één instructie: dat zijn twee echte vragen.
+      // Dezelfde afbakening als de lijst- en detailroute hierboven.
+      expect(body.aantalVragen).toBe(2);
+      expect(body.aantalBeantwoord).toBe(1);
+    });
+
+    it('houdt het instructiescherm in de lijst, op volgorde', async () => {
+      const body = await haalAntwoorden(cookieA);
+
+      // De leverancier zág dat scherm. Laat je het weg, dan loopt de
+      // nummering niet meer gelijk met wat hij voor zich had.
+      expect(body.antwoorden.map((a) => a.questionKey)).toEqual([
+        'intro',
+        'v1',
+        'v2',
+      ]);
+      expect(body.antwoorden[0].answerType).toBe('instruction');
+    });
+
+    it('geeft de token_hash ook hier NOOIT terug', async () => {
+      const antwoord = await request(server)
+        .get(`/admin/survey/responses/${RESPONSE_A}/answers`)
+        .set('Cookie', cookieA)
+        .expect(200);
+
+      const alsTekst = JSON.stringify(antwoord.body);
+
+      expect(alsTekst).not.toContain(TOKEN_HASH);
+      expect(alsTekst).not.toContain('deadbeefcafe1234');
+      expect(alsTekst).not.toContain('token_hash');
+      expect(alsTekst).not.toContain('tokenHash');
+    });
+
+    it('geeft de storage_key van een bijlage nooit terug', async () => {
+      // Het interne pad hoort niet uit een overzichtsroute te komen;
+      // downloaden loopt via een eigen route met eigen controle.
+      const antwoord = await request(server)
+        .get(`/admin/survey/responses/${RESPONSE_A}/answers`)
+        .set('Cookie', cookieA)
+        .expect(200);
+
+      const alsTekst = JSON.stringify(antwoord.body);
+
+      expect(alsTekst).not.toContain('storage_key');
+      expect(alsTekst).not.toContain('storageKey');
+    });
+
+    it('laat een reviewer de antwoorden lezen', async () => {
+      // Voor een reviewer is dit de kernroute: beoordelen kan niet zonder de
+      // antwoorden te zien.
+      await request(server)
+        .get(`/admin/survey/responses/${RESPONSE_A}/answers`)
+        .set('Cookie', cookieReviewer)
+        .expect(200);
+    });
+
+    it('geeft tenant B een 404 op de respons van A', async () => {
+      // Niet 403: het verschil tussen "bestaat niet" en "mag je niet zien"
+      // hoort niet naar buiten te lekken. RLS maakt de rij onzichtbaar.
+      await request(server)
+        .get(`/admin/survey/responses/${RESPONSE_A}/answers`)
+        .set('Cookie', cookieB)
+        .expect(404);
+    });
+
+    it('geeft 404 op een niet-bestaande respons', async () => {
+      await request(server)
+        .get(
+          '/admin/survey/responses/00000000-0000-0000-0000-00000000dead/answers',
+        )
+        .set('Cookie', cookieA)
+        .expect(404);
     });
   });
 


### PR DESCRIPTION
Eerste van drie PR's voor fase C. Deze voegt **geen tabel en geen migratie** toe — alleen een leesroute.

## Waarom

Je kon een ronde uitzetten, uitnodigingen versturen en zien wie had ingediend. Maar niet **wát** er was ingevuld. Dat is het gat dat `STATUS.md` als volgende stap noemt.

## De route

```
GET /admin/survey/responses/:id/answers
```

Geeft de vragen in de volgorde van de vragenlijst, met het antwoord erbij wanneer dat er is, plus de bijlagen per vraag.

## De kern: joinen vanaf de vraag, niet vanaf het antwoord

```sql
FROM clm.survey_question q
LEFT JOIN clm.survey_answer a ON a.question_id = q.question_id
                             AND a.response_id = $1
```

De vragen zijn leidend. Een half ingevulde respons hoort de openstaande vragen te **tonen** — *"vraag 7 is niet beantwoord"* is precies wat een beoordelaar moet zien. Zou je vanaf `survey_answer` joinen, dan verdwijnt die informatie stilzwijgend en lijkt een halve respons compleet.

Dat is dezelfde faalvorm die dit project al vaker heeft gevangen: **het meldt succes terwijl er iets anders is dan je denkt.**

## Keuzes die uitleg verdienen

**Instructieschermen blijven staan, maar tellen niet mee.** De leverancier zág die schermen; laat je ze weg, dan loopt de nummering niet gelijk met wat hij voor zich had. In `aantalVragen` tellen ze niet mee — dezelfde afbakening als `lijst()` en `detail()`.

**Waarden in aparte velden per soort**, precies zoals de database ze bewaart. Samenvoegen tot één `waarde`-veld zou de beheerkant laten gokken wat erin staat, en een rating die als tekst aankomt is niet meer te sorteren.

**Bijlagen in een tweede query.** Eén vraag kan meerdere bijlagen hebben; in dezelfde query zouden de antwoordvelden zich per bijlage herhalen en moet de aanroeper ontdubbelen. Twee queries binnen dezelfde transactie is eenvoudiger dan één slimme.

**Geen `@VereistRol`.** Lezen mag ook een reviewer, net als de andere GET-routes. Voor hem is dit zelfs de kernroute — beoordelen kan niet zonder de antwoorden te zien.

## Tegenproef (§15b)

`LEFT JOIN` vervangen door `JOIN`. Precies de drie tests die de onbeantwoorde vraag bewaken vielen om:

- *toont ook de vraag die NIET beantwoord is*
- *telt 1 van 2 beantwoord*
- *houdt het instructiescherm in de lijst, op volgorde*

Na herstel weer 28 groen. Dat bewijst dat de tests de LEFT JOIN meten en niet alleen dat er data terugkomt.

## Wat de tests bewaken

Tien nieuwe e2e-tests, waaronder:

- tenant B krijgt **404** op de respons van A — niet 403; het verschil tussen "bestaat niet" en "mag je niet zien" hoort niet te lekken
- de `token_hash` komt nergens in het antwoord voor (hele body doorzocht, niet één veld)
- de `storage_key` van een bijlage evenmin — downloaden loopt via een eigen route met eigen controle
- een reviewer mag de antwoorden lezen

## Getoetst

328 e2e-tests groen (was 318), 289 unittests, lint/format/typecheck schoon.

**Eén kanttekening:** bij de eerste volledige e2e-run vielen twee tests om in een andere suite. In vier daaropvolgende runs — en op onveranderd `main` — is dat niet reproduceerbaar. Ik houd het op onderlinge beïnvloeding tussen suites (er staan al eerdere bevindingen daarover in STATUS.md), maar ik heb het niet kunnen vastpinnen en meld het daarom in plaats van het weg te laten.

> GitHub Actions had vandaag een storing (`major_outage`); draait er geen CI op deze PR, dan is dat de reden. Bovenstaande is lokaal gedraaid tegen een echte Postgres met RLS.