### PR TITLE
feat(survey): beoordelaar koppelen aan een vragenlijst (fase C3)

### DIFF
--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,11 +1,130 @@
 # MCM2 — actuele status
 
 ## Laatst bijgewerkt
-2026-08-04, avond (**fase A én B van het surveybeheerplan zijn af en gemerged.** De tenant kan nu een leverancier aanvinken, een ronde starten en werkende uitnodigingslinks krijgen — de eerste productiecode die `genereerToken()` aanroept. Daarnaast: `npm run demo` zet de hele stack in één commando neer, en de browsertests ruimen op wat ze aanmaken. Vier PR's gemerged: #79, #80, #81, #82 plus frontend #5 en #6. `verify:volledig` groen: 316 backend, 39 browser.)
+2026-08-06, avond (**er gaat echte mail uit én fase C is backend-compleet.** Een uitnodiging bereikte aantoonbaar een externe inbox via Resend. Daarna de hele beoordeelketen gebouwd: antwoorden lezen, oordelen vastleggen, beoordelaars koppelen. 358 e2e-tests groen. **Vijf PR's staan open en zijn niet gemerged — GitHub Actions lag de hele middag plat.**)
 
-**Volgende stap:** fase C uit `docs/superpowers/plans/2026-08-03-surveybeheer.md` — voortgang volgen, antwoorden lezen en beoordelen. Je kunt nu wel uitnodigen, maar niet zien wát een leverancier heeft ingevuld: het rondescherm toont alleen wie ingediend heeft.
+---
 
-### Wat er vandaag bijkwam
+## 🔴 MORGEN BEGINNEN: vijf openstaande PR's, in deze volgorde
+
+**Stap 1 — kijk of GitHub Actions weer werkt.**
+
+```powershell
+curl -s https://www.githubstatus.com/api/v2/components.json | ConvertFrom-Json |
+  Select-Object -ExpandProperty components | Where-Object name -eq 'Actions'
+```
+
+Op 2026-08-06 stond die op `major_outage`, vanaf 15:22 UTC, en dat duurde de hele middag.
+Gevolg: **geen enkele van de vijf PR's heeft CI gedraaid.**
+
+**Stap 2 — merge in deze volgorde.** De laatste drie zijn geketend; door elkaar mergen levert
+conflicten op.
+
+| Volgorde | PR | Wat | Gericht op |
+|---|---|---|---|
+| 1 | **#92** | `workflow_dispatch` + bijgewerkte documenten | `main` |
+| 2 | **#93** | Issue #86 — scripts noemen hun doelwit | `main` |
+| 3 | **#94** | Fase C1 — antwoorden lezen | `main` |
+| 4 | **#95** | Fase C2 — beoordelen (migratie 0015) | #94 |
+| 5 | **#97** | Fase C3 — beoordelaar koppelen (migratie 0016) | #95 |
+
+> **Let op bij #95 en #97:** die zijn gericht op de branch eronder, niet op `main`. Merge je #94
+> eerst, dan verspringt de basis van #95 vanzelf naar `main`. Controleer dat vóór het mergen.
+
+**Stap 3 — dicht het CI-gat.** Zodra #92 in `main` staat werkt handmatig starten:
+
+```powershell
+gh workflow run ci.yml --ref main
+```
+
+De Docker-productiebuild en de RLS tenant-isolatietest hebben `main` sinds 14:50 UTC niet meer
+gecontroleerd. Doe dit vóórdat je verder bouwt — er zitten twee migraties in de stapel.
+
+**Stap 4 — dan pas verder.** De schermen voor fase C (zie hieronder).
+
+---
+
+**Daarna: de frontend van fase C.** De backend is compleet en getest; er is nog geen enkel
+scherm. Drie stuks volgens het plan (§Fase C, "Frontend"):
+
+1. **Voortgang per ronde** — ingediend / open / verlopen
+2. **Antwoorden lezen** per respons, met het beoordeelblok eronder: drie knoppen plus een
+   toelichtingsveld, en daaronder de eerdere oordelen op datum
+3. **Twee werkvoorraden**, geen twee filters op dezelfde lijst (ADR-013) — met een schakelaar
+   "van mij" / "hele organisatie"
+
+Twee dingen die daarbij geen detail zijn:
+- **Het huidige oordeel hoort in de voortgangslijst**, niet alleen op het detailscherm. Anders
+  moet je zeventien schermen openen om te zien wie er nog openstaat.
+- **`nadere_vragen` leest als een openstaande actie, geen eindoordeel.** Het scherm moet zeggen
+  dat de leverancier hier niets van merkt en dat de beheerder zelf contact opneemt. Een knop die
+  suggereert dat er iets verstuurd wordt terwijl dat niet gebeurt, is erger dan geen knop.
+
+Ook nog open: het **vragenlijst-overzichtscherm** ("levert nu nauwelijks zinvolle informatie",
+eigenaar 2026-08-06).
+
+---
+
+### Wat er op 2026-08-06 bijkwam
+
+**Het mailkanaal** (#87, #88). Eén platformverstuurder via Resend op `send.myvendormanager.nl`,
+geen eigen SMTP per tenant. De klant is herkenbaar aan de afzendernaam ("Transdev via MCM2"),
+het adres blijft van het platform — zo hoeft er geen SPF-record van de klant te zijn voordat er
+mail uit kan. Zonder sleutel valt alles terug op een logkanaal; half ingesteld faalt bewust hard
+bij opstarten.
+
+**Uitnodigingen worden echt verstuurd** (#89). Mislukt één adres, dan gaan de overige door en
+rapporteert de response per deelnemer. Serieel, niet parallel — voorspelbaar onder de dagcap van
+100 mails. Aantoonbaar: een echte mail kwam aan, een ongeldig adres werd geweigerd.
+
+**Een contactpersoon is te bewerken** (frontend). Voorheen alleen weggooien en opnieuw invoeren.
+
+**ADR-013 — het rolmodel** (#90). Beheerder aan de vendor, beoordelaar aan de vragenlijst. De
+koppeling is **een hulpmiddel, geen autorisatiegrens**.
+
+**De exit-route** (#91). `docs/architectuur/exit-route-hosting.md`, een levend document. Valkey
+eruit — er bleek geen enkele regel code mee te praten.
+
+**Fase C, backend compleet** (#94, #95, #97 — nog niet gemerged):
+
+| PR | Wat | Migratie |
+|---|---|---|
+| #94 | `GET /admin/survey/responses/:id/answers` | geen |
+| #95 | `clm.survey_review` + twee routes | 0015 |
+| #97 | `clm.template_reviewer` + vier routes | 0016 |
+
+Drie dingen daaruit die het onthouden waard zijn:
+
+- **C1 joint vanaf de vraag, niet vanaf het antwoord.** Een half ingevulde respons moet de
+  openstaande vragen tónen; joinen vanaf `survey_answer` laat ze verdwijnen en doet een halve
+  respons compleet lijken.
+- **`survey_review` is de eerste tabel waar de tenantgrens niet volstaat.** Een leverancier zit
+  in dezelfde tenant als de medewerker die hem beoordeelt, maar mag het oordeel nooit lezen.
+  Eerste policy die `clm.current_actor()` gebruikt — de functie stond sinds 0013 ongebruikt.
+- **`BeoordelingService` kent `template_reviewer` niet** (nul verwijzingen, geverifieerd). Dat is
+  ADR-013 besluit 3: de koppeling bepaalt wat je ziet, niet wat je mag. Wie hier later iets
+  bouwt dat op de koppeling wéigert, gaat daartegen in.
+
+### Wat er onderweg boven kwam (2026-08-06)
+
+| Bevinding | Waar |
+|---|---|
+| **Een tegenproef die niets bewees.** Een heredoc at de backslashes op; sabotage nooit toegepast, 22 tests groen tegen ónveranderde code. Sabotage gaat nu via een bestand en faalt hard als het patroon ontbreekt | werkwijze |
+| `migrate:deploy` gedraaid met alleen `DATABASE_URL` gezet; het script leest `MIGRATION_DATABASE_URL` en die wees naar **productie**. Meldde "Migraties voltooid" tegen de verkeerde database. Geen schade (no-op) → **Issue #86**, opgelost in #93 | `scripts/` |
+| **`db:generate` is onbruikbaar** — snapshots lopen tot 0007 terwijl er 16 migraties zijn. Het genereerde een migratie die `sessie`, `tenant_membership` en een `user`-kolom opnieuw wilde aanmaken → **Issue #96** | `drizzle/meta/` |
+| De bewakingstest op test-id's kijkt alleen naar UUID's tussen **enkele** aanhalingstekens; dezelfde waarde binnen een template-string glipt erdoor. Nog geen issue | `test/test-ids.spec.ts` |
+| Verouderde context uit een automatisch geladen skill stelde dat Bizaline naar Azure migreert; als feit overgenomen in een architectuurdocument. Bron opgespoord, vier bestanden geactualiseerd met een gedateerd "Stand per"-kopje | buiten dit project |
+| Een geldig gevormd maar niet-bestaand mailadres levert "Geslaagd" op. Geen fout, wel het bewijs dat de bounce-webhook nodig is | mailkanaal |
+
+<details>
+<summary>Vorige stand (2026-08-04, avond)</summary>
+
+**Fase A én B van het surveybeheerplan zijn af en gemerged.** De tenant kan een leverancier
+aanvinken, een ronde starten en werkende uitnodigingslinks krijgen — de eerste productiecode die
+`genereerToken()` aanroept. Vier PR's gemerged: #79, #80, #81, #82 plus frontend #5 en #6.
+`verify:volledig` groen: 316 backend, 39 browser.
+
+### Wat er toen bijkwam
 
 **Fase A — vragenlijsten bekijken** (#79, frontend #5). Vier leesroutes onder `/admin/survey`, plus de schermen. Bewust alleen lezen.
 
@@ -27,6 +146,8 @@
 | Zoektests leunden op kolomposities; met de selectiekolom erbij keek er één naar het KvK-nummer i.p.v. de plaats | `e2e/navigatie-en-zoeken.spec.ts` |
 
 **Nieuwe werkwijzeregel (§15c in `MCM2-CLAUDE.md`, PR #82).** Namen en paden opzoeken, niet reconstrueren. Aanleiding: zes van de negen correctierondes deze sessie waren vermijdbaar, en alle zes stonden in code die al gelezen was. Wat dat kost is niet de tijd maar het onderscheid tussen een rode test die iets betekent en een rode test die slordigheid is.
+
+</details>
 
 <details>
 <summary>Vorige stand (2026-08-04, middag)</summary>
@@ -95,13 +216,22 @@ Eigen CI en eigen releasecyclus per repo — bewust, zodat een tekstwijziging in
    Wie wil begrijpen **waarom** de tenantgrens is zoals hij is, en hoe elke laag ervan bewezen wordt: `docs/architectuur-en-verificatie.md`. Dat document beschrijft de architectuur, het principe achter de testopzet (elke beveiligingstest krijgt een tegenproef) en — het belangrijkste hoofdstuk — wat er nog **niet** bewezen is. Het veroudert zodra de code verandert, dus werk het bij wanneer je de tenantgrens of de testopzet raakt.
 3. Verifieer git-status zelf (`git status`, `git branch -a`) tegen wat hieronder staat — vertrouw niet blind op deze snapshot. **Doe dat in beide repositories.**
 4. Check de open GitHub Issues (`gh issue list --repo AlingAdvies/MCM2 --state open`) voor de actuele backlog — dit document verwijst naar issue-nummers, maar de Issues zelf zijn de bron van waarheid over wat daadwerkelijk nog open staat.
-5. **Werk verder volgens het plan** (`docs/superpowers/plans/2026-07-30-beheerkant-en-demo-tenant.md`), niet volgens losse ingevingen. Het plan heeft bovenaan een voortgangstabel. Uitdrukkelijke wens van de eigenaar op 2026-07-30: **de vier fases in volgorde afwerken.** De eerstvolgende concrete stap staat hieronder onder punt 6.
+5. **Werk verder volgens het plan** — sinds 2026-08-03 is dat
+   `docs/superpowers/plans/2026-08-03-surveybeheer.md`. Niet volgens losse ingevingen.
+   Uitdrukkelijke wens van de eigenaar: **de fases in volgorde afwerken.**
+
+   > **Stand 2026-08-06:** fase A, B en C zijn gebouwd; C staat nog in vijf ongemergede PR's.
+   > **Begin bij het rode blok bovenaan dit document**, niet bij punt 6 hieronder — dat
+   > beschrijft de situatie van vóór fase A.
 
    Twee dingen die daarbij horen en makkelijk wegzakken:
    - **Issue #59 — `npm audit` meldt 29 kwetsbaarheden.** Niet vergeten, maar ook niet nu oplossen: `npm audit --omit=dev` geeft **0**, dus er zit niets van in het productie-image. De voorgestelde automatische fix zet eslint jaren terug en breekt de lint-configuratie. Hoort bij de eerste major-onderhoudsronde op devDependencies, samen met Dependabot (#22). **Controleer wel bij elke sessie dat `npm audit --omit=dev` nul blijft** — wordt dat meer dan nul, dan is het geen onderhoudspunt meer maar een blocker.
    - **Issue #58 — de backup hangt af van deze laptop.** Draait dagelijks, maar niet als de machine uitstaat. Vóór de pilotstart (rond 1 september) naar iets onafhankelijks.
 
-6. **Eerste concrete vervolgstap: surveybeheer, dan fase 4.** Fase 1 en 2 zijn op 2026-07-31 afgerond, fase 2b, 2c en 3 op 2026-08-03.
+6. **Historisch — de situatie van 2026-08-03.** Dit punt beschrijft waaróm het surveybeheerplan
+   er kwam. Voor de actuele vervolgstap: zie het rode blok bovenaan.
+
+   Fase 1 en 2 zijn op 2026-07-31 afgerond, fase 2b, 2c en 3 op 2026-08-03.
 
    **Advies over de volgorde (2026-08-03):** eerst functionaliteit, dan fase 4. De doorloop test wat er ís; elke functie die er daarna bij komt, moet er alsnog in. Fase 4 later doen betekent niet dat het werk verdwijnt — het voorkomt dat het twee keer gebeurt. Voorwaarde is wel dat elke fase blijft eindigen met `verify:volledig` groen plus een tegenproef (§15, §15b), anders wordt fase 4 een opruimactie in plaats van een uitbreiding.
 
@@ -464,6 +594,23 @@ Raakt **#12** (acceptatieomgeving — wordt zwaarder: twee containers), **#18** 
 Transdev Vendor IT Compliance Survey als eerste verticale MVP-slice.
 
 ## Actieve blokkades
+
+- **ACTIEF 2026-08-06 — `main` is sinds 14:50 UTC niet door CI gecontroleerd, en er staan vijf
+  PR's te wachten.** GitHub Actions had die middag een storing met de officiële status
+  `major_outage` (incident gestart 15:22 UTC): *"Workflow runs are failing or delayed in
+  starting, and some queued jobs may time out."*
+
+  **Het onderscheid dat anders verloren gaat:** de rode run op `main` na PR #90 heeft drie
+  `cancelled` jobs zonder één falende stap. Er is niets uitgevoerd, dus niets gezakt. Een
+  `failure` noemt de stap die zakte; een `cancelled` betekent dat de klus is afgebroken vóór er
+  iets gebeurde. `main` is niet stuk.
+
+  **Waarom dit een blokkade is:** de Docker-productiebuild en de RLS tenant-isolatietest hebben
+  `main` sinds de merge van PR #89 niet meer gezien. In de wachtende stapel zitten **twee
+  migraties** (0015 en 0016). Lokaal is alles groen bevonden — 358 e2e-tests, ook tegen een
+  database die vanaf leeg is opgebouwd — maar lokaal is niet CI.
+
+  **Oplossen:** zie het blok bovenaan dit document, stap 1 t/m 3.
 
 - **OPGELOST 2026-08-04, middag — de backup mist negen van de achttien tabellen.** De migratiestand is geïnitialiseerd en de keten 0002 t/m 0014 toegepast: 9 tabellen werden er 18, schema-conformiteit GOEDGEKEURD (17/17), backupcontrole 0 problemen, dump van 21,2 kB naar 77,7 kB. Issues #25 en #29 gesloten. Procedure in `docs/runbooks/baseline-migratiestand.md`.
 

--- a/docs/superpowers/plans/2026-08-03-surveybeheer.md
+++ b/docs/superpowers/plans/2026-08-03-surveybeheer.md
@@ -1,9 +1,30 @@
 # Implementatieplan — surveybeheer voor de tenant
 
-**Datum:** 2026-08-03 (bijgewerkt 2026-08-03 na vier besluiten van de eigenaar)
-**Status:** TER BEOORDELING — nog niet goedgekeurd, nog geen code
+**Datum:** 2026-08-03 (bijgewerkt 2026-08-06 met de voortgang)
+**Status:** GOEDGEKEURD — in uitvoering
 **Aanleiding:** de beheerkant kan leveranciers beheren maar geen enkele vragenlijst uitzetten
 **Raakt:** ontwerp `2026-07-28-vragenlijst-ontwerp.md` §7 (stap 10 van de bouwvolgorde), Issue #13, #15, #16
+
+## Voortgang
+
+| Fase | Backend | Frontend | PR's |
+|---|---|---|---|
+| **A** — vragenlijsten en rondes bekijken | ✅ gemerged | ✅ gemerged | #79, frontend #5 |
+| **B** — ronde starten en uitnodigen | ✅ gemerged | ✅ gemerged | #81, frontend #6 |
+| **C1** — antwoorden lezen | ✅ gebouwd, **PR open** | ❌ nog niet | #94 |
+| **C2** — beoordelen (migratie 0015) | ✅ gebouwd, **PR open** | ❌ nog niet | #95 |
+| **C3** — beoordelaar koppelen (migratie 0016) | ✅ gebouwd, **PR open** | ❌ nog niet | #97 |
+| **D** — uitnodigingen mailen | ✅ gemerged | n.v.t. | #87, #88, #89 |
+
+**Fase D is vóór C gebouwd**, op verzoek van de eigenaar (2026-08-06): eerst een leverancier
+echt kunnen uitnodigen, dan de antwoorden kunnen lezen. Er gaat sindsdien aantoonbaar mail uit
+via Resend.
+
+**Fase C is in drie PR's geknipt** (besluit eigenaar 2026-08-06): lezen → beoordelen →
+koppelen. Elke stap is los te beoordelen en los terug te draaien; C1 heeft geen migratie nodig
+en dicht op zichzelf al het grootste gat.
+
+**Wat er nog niet is: alle schermen van fase C.** Zie §Fase C, "Frontend".
 
 > **Let op bij het lezen naast het ontwerp van 28 juli:** §1b daarvan wijst "request
 > revisions" af. Dit plan gaat daar niet tegenin — het legt een oordeel vast zonder de

--- a/drizzle/0016_template_reviewer.sql
+++ b/drizzle/0016_template_reviewer.sql
@@ -1,0 +1,116 @@
+-- =============================================================================
+-- clm.template_reviewer — wie beoordeelt welke vragenlijst.
+--
+-- Aanleiding: ADR-013, besluit 2. De domeincontext van de eigenaar
+-- (2026-08-06): een contractmanager beheert een leverancier, maar de
+-- beoordeling van een vakinhoudelijke vragenlijst hoort bij iemand anders —
+-- bij Transdev de CISO voor IT-compliance.
+--
+-- ── Aan de vragenlijst, niet aan de vendor of de ronde ───────────────────────
+--
+-- Beoordelen is vakinhoud, geen eigenaarschap. Wie een IT-compliancelijst kan
+-- beoordelen, kan dat voor élke vendor. De contractmanager van vendor X kan dat
+-- voor géén enkele, ook niet voor zijn eigen vendor.
+--
+-- Beheren is eigenaarschap (vendor.owner_user_id, bestaat al sinds 0000),
+-- beoordelen is expertise. Die twee hangen daarom aan verschillende objecten.
+--
+-- Het schaalt ook de goede kant op: komt er een Privacy/AVG-vragenlijst bij,
+-- dan koppel je daar de FG aan zonder één vendor of ronde aan te raken.
+--
+-- ── Deze tabel is een HULPMIDDEL, geen autorisatiegrens ──────────────────────
+--
+-- ADR-013 besluit 3, en het minst vanzelfsprekende besluit erin. Deze koppeling
+-- bepaalt wat iemand standaard in zijn werkvoorraad ziet, NIET wat hij mag.
+-- Elke reviewer binnen de tenant mag elke inzending beoordelen.
+--
+-- Waarom niet exclusief: een harde grens legt het proces stil zodra de
+-- gekoppelde beoordelaar ziek is. Dan wijzigt iemand met databasetoegang de
+-- koppeling — een noodgreep buiten de app om, zonder spoor. Erger dan het
+-- probleem.
+--
+-- De fallback is de contractmanager, die intern regelt dat een bevoegd persoon
+-- beoordeelt. Dat werkt alleen als de app het niet blokkeert.
+--
+-- Dat is verdedigbaar omdat elk oordeel met naam en datum vastligt en nooit
+-- wordt overschreven (migratie 0015). Wie buiten zijn vakgebied beoordeelt,
+-- doet dat zichtbaar. Zonder die historie zou de grens hard moeten zijn.
+--
+-- **Gevolg voor wie hier later iets bouwt:** een route die deze tabel gebruikt
+-- om toegang te WEIGEREN gaat in tegen dit besluit. Hij hoort te bepalen wat
+-- er standaard getoond wordt, meer niet.
+--
+-- ── Geen unieke sleutel op template_id ───────────────────────────────────────
+--
+-- Meerdere beoordelaars per vragenlijst zijn toegestaan. Bij Transdev is het er
+-- waarschijnlijk één, maar die ene gaat met vakantie. Nu toestaan kost niets;
+-- later verruimen is een migratie op productiedata.
+-- =============================================================================
+
+CREATE TABLE "clm"."template_reviewer" (
+	"tenant_id" uuid NOT NULL,
+	"template_id" uuid NOT NULL,
+	"user_id" uuid NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"created_by" uuid,
+	CONSTRAINT "template_reviewer_template_id_user_id_pk"
+	    PRIMARY KEY("template_id","user_id")
+);
+--> statement-breakpoint
+
+ALTER TABLE "clm"."template_reviewer"
+    ADD CONSTRAINT "template_reviewer_tenant_id_tenant_tenant_id_fk"
+    FOREIGN KEY ("tenant_id") REFERENCES "clm"."tenant"("tenant_id")
+    ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+
+-- CASCADE: verdwijnt de vragenlijst, dan is de koppeling betekenisloos.
+ALTER TABLE "clm"."template_reviewer"
+    ADD CONSTRAINT "template_reviewer_template_id_survey_template_template_id_fk"
+    FOREIGN KEY ("template_id") REFERENCES "clm"."survey_template"("template_id")
+    ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+
+-- CASCADE: verdwijnt de gebruiker, dan verdwijnt zijn koppeling mee. Anders
+-- dan bij survey_review.reviewer_user_id, dat juist restrict is — een
+-- vastgelegd oordeel moet zijn naam houden, een werkvoorraad niet.
+ALTER TABLE "clm"."template_reviewer"
+    ADD CONSTRAINT "template_reviewer_user_id_user_user_id_fk"
+    FOREIGN KEY ("user_id") REFERENCES "clm"."user"("user_id")
+    ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+
+-- SET NULL: administratie, geen oordeel. De koppeling blijft bruikbaar als
+-- degene die hem legde is vertrokken.
+ALTER TABLE "clm"."template_reviewer"
+    ADD CONSTRAINT "template_reviewer_created_by_user_user_id_fk"
+    FOREIGN KEY ("created_by") REFERENCES "clm"."user"("user_id")
+    ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+
+CREATE INDEX "template_reviewer_tenant_id_idx"
+    ON "clm"."template_reviewer" USING btree ("tenant_id");--> statement-breakpoint
+
+-- Op user_id, want de vraag "wat wacht er op mij" begint bij de ingelogde
+-- gebruiker en niet bij de vragenlijst.
+CREATE INDEX "template_reviewer_user_id_idx"
+    ON "clm"."template_reviewer" USING btree ("user_id");--> statement-breakpoint
+
+-- ── Row Level Security ──────────────────────────────────────────────────────
+
+ALTER TABLE clm.template_reviewer ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+ALTER TABLE clm.template_reviewer FORCE ROW LEVEL SECURITY;--> statement-breakpoint
+
+-- Zelfde vorm als survey_review (migratie 0015): tenant én actor. Een
+-- leverancier hoort niet te kunnen zien wie zijn inzending beoordeelt — dat
+-- is dezelfde redenering als bij het oordeel zelf.
+CREATE POLICY template_reviewer_isolation ON clm.template_reviewer
+    USING (
+        tenant_id = clm.current_tenant_id()
+        AND clm.current_actor() = 'medewerker'
+    )
+    WITH CHECK (
+        tenant_id = clm.current_tenant_id()
+        AND clm.current_actor() = 'medewerker'
+    );--> statement-breakpoint
+
+COMMENT ON TABLE clm.template_reviewer IS
+    'Koppelt een gebruiker aan een vragenlijst die hij beoordeelt. HULPMIDDEL, geen autorisatiegrens (ADR-013 besluit 3): bepaalt wat iemand in zijn werkvoorraad ziet, niet wat hij mag. Elke reviewer binnen de tenant mag elke inzending beoordelen.';--> statement-breakpoint
+
+GRANT SELECT, INSERT, DELETE ON clm.template_reviewer TO clm_api_runtime;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -113,6 +113,13 @@
       "when": 1786045342915,
       "tag": "0015_survey_review",
       "breakpoints": true
+    },
+    {
+      "idx": 16,
+      "version": "7",
+      "when": 1786046641509,
+      "tag": "0016_template_reviewer",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -591,6 +591,67 @@ export const surveyReview = clm.table(
   ],
 );
 
+/**
+ * Wie een vragenlijst beoordeelt (ADR-013, besluit 2).
+ *
+ * ── Aan de vragenlijst, niet aan de vendor of de ronde ──────────────────────
+ *
+ * Beoordelen is vakinhoud, geen eigenaarschap. Wie een IT-compliancelijst kan
+ * beoordelen — bij Transdev de CISO — kan dat voor élke vendor. De
+ * contractmanager van vendor X kan dat voor géén enkele, ook niet voor zijn
+ * eigen vendor.
+ *
+ * Dat onderscheid is de kern van ADR-013: beheren is eigenaarschap, beoordelen
+ * is expertise. Die twee horen niet aan hetzelfde object.
+ *
+ * ── Een hulpmiddel, geen autorisatiegrens ───────────────────────────────────
+ *
+ * Deze koppeling bepaalt wat iemand in zijn werkvoorraad ziet, **niet wat hij
+ * mag** (ADR-013 besluit 3). Elke reviewer binnen de tenant mag elke inzending
+ * beoordelen. Een harde grens zou het proces stilleggen zodra de gekoppelde
+ * beoordelaar ziek is, en dan wijzigt iemand met databasetoegang de koppeling —
+ * een noodgreep buiten de app om, zonder spoor.
+ *
+ * De fallback is de contractmanager, die intern regelt dat een bevoegd persoon
+ * beoordeelt. Dat werkt alleen als de app het niet blokkeert.
+ *
+ * ── Geen unieke sleutel op template_id ──────────────────────────────────────
+ *
+ * Meerdere beoordelaars zijn toegestaan. Bij Transdev is het er waarschijnlijk
+ * één, maar die ene gaat met vakantie. Nu toestaan kost niets; later verruimen
+ * is een migratie op productiedata.
+ */
+export const templateReviewer = clm.table(
+  'template_reviewer',
+  {
+    tenantId: uuid('tenant_id')
+      .notNull()
+      .references(() => tenant.tenantId, { onDelete: 'restrict' }),
+    templateId: uuid('template_id')
+      .notNull()
+      .references(() => surveyTemplate.templateId, { onDelete: 'cascade' }),
+    userId: uuid('user_id')
+      .notNull()
+      .references(() => user.userId, { onDelete: 'cascade' }),
+    createdAt: timestamp('created_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    // Wie de koppeling legde. Anders dan bij survey_review geen restrict:
+    // dit is administratie, geen oordeel — een koppeling blijft bruikbaar
+    // als degene die hem legde is vertrokken.
+    createdBy: uuid('created_by').references(() => user.userId, {
+      onDelete: 'set null',
+    }),
+  },
+  (t) => [
+    // Samengestelde primaire sleutel: dezelfde persoon twee keer aan dezelfde
+    // lijst koppelen is geen fout die stil hoort te slagen.
+    primaryKey({ columns: [t.templateId, t.userId] }),
+    index('template_reviewer_tenant_id_idx').on(t.tenantId),
+    index('template_reviewer_user_id_idx').on(t.userId),
+  ],
+);
+
 // ─── audit schema ──────────────────────────────────────────────────────────
 
 export const auditEvent = audit.table(

--- a/src/survey/beoordelaar.service.ts
+++ b/src/survey/beoordelaar.service.ts
@@ -1,0 +1,255 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { sql } from 'drizzle-orm';
+
+import { DatabaseService } from '../db/database.service';
+
+/**
+ * Beoordelaars koppelen aan een vragenlijst (ADR-013, besluit 2 en 3).
+ *
+ * ── Wat deze koppeling wél en niet doet ─────────────────────────────────────
+ *
+ * Wél: bepalen wat iemand standaard in zijn werkvoorraad ziet.
+ * Niet: bepalen wat iemand mág.
+ *
+ * Dat onderscheid is besluit 3 uit ADR-013 en het minst vanzelfsprekende deel
+ * ervan. Elke reviewer binnen de tenant mag elke inzending beoordelen. Deze
+ * service kent daarom geen enkele methode die iets weigert — er is niets in dit
+ * bestand dat toegang controleert, en dat is opzet.
+ *
+ * **Voor wie hier later iets bouwt:** gebruik `template_reviewer` nooit om een
+ * beoordeling te blokkeren. Een harde grens legt het proces stil zodra de
+ * gekoppelde beoordelaar ziek is, en dan wijzigt iemand met databasetoegang de
+ * koppeling — een noodgreep buiten de app om, zonder spoor.
+ *
+ * De fallback is de contractmanager, die intern regelt dat een bevoegd persoon
+ * beoordeelt. Dat werkt alleen als de app het niet blokkeert. Verdedigbaar
+ * omdat elk oordeel met naam en datum vastligt (migratie 0015): wie buiten zijn
+ * vakgebied beoordeelt, doet dat zichtbaar.
+ */
+
+export interface Beoordelaar {
+  userId: string;
+  naam: string;
+  email: string;
+  createdAt: string;
+}
+
+/** Eén inzending die op deze beoordelaar wacht. */
+export interface WerkvoorraadItem {
+  responseId: string;
+  runId: string;
+  templateId: string;
+  templateNaam: string;
+  vendorId: string | null;
+  vendorNaam: string | null;
+  submittedAt: string | null;
+  /** Het laatste oordeel, of null wanneer er nog geen is. */
+  laatsteOordeel: string | null;
+  aantalOordelen: number;
+}
+
+interface BeoordelaarRij extends Record<string, unknown> {
+  user_id: string;
+  naam: string;
+  email: string;
+  created_at: Date | string;
+}
+
+interface WerkvoorraadRij extends Record<string, unknown> {
+  response_id: string;
+  run_id: string;
+  template_id: string;
+  template_naam: string;
+  vendor_id: string | null;
+  vendor_naam: string | null;
+  submitted_at: Date | string | null;
+  laatste_oordeel: string | null;
+  aantal_oordelen: string | number;
+}
+
+function iso(waarde: Date | string | null): string | null {
+  if (waarde === null) return null;
+  return waarde instanceof Date ? waarde.toISOString() : String(waarde);
+}
+
+@Injectable()
+export class BeoordelaarService {
+  constructor(private readonly db: DatabaseService) {}
+
+  /** Wie er aan deze vragenlijst gekoppeld zijn. */
+  async lijst(tenantId: string, templateId: string): Promise<Beoordelaar[]> {
+    return this.db.withTenant(
+      tenantId,
+      async (tx) => {
+        await this.eisBestaandeVragenlijst(tx, templateId);
+
+        const resultaat = await tx.execute<BeoordelaarRij>(
+          sql`SELECT tr.user_id,
+                     u.full_name AS naam,
+                     u.email,
+                     tr.created_at
+                FROM clm.template_reviewer tr
+                JOIN clm."user" u ON u.user_id = tr.user_id
+               WHERE tr.template_id = ${templateId}
+               ORDER BY u.full_name`,
+        );
+
+        return resultaat.rows.map((r) => ({
+          userId: r.user_id,
+          naam: r.naam,
+          email: r.email,
+          createdAt: iso(r.created_at) ?? '',
+        }));
+      },
+      'medewerker',
+    );
+  }
+
+  /**
+   * Koppelt een gebruiker aan een vragenlijst.
+   *
+   * Idempotent: twee keer koppelen levert geen fout op. De samengestelde
+   * primaire sleutel zou een 23505 geven, en dat is een databasefoutmelding
+   * waar een beheerder niets aan heeft voor iets dat feitelijk al klopt.
+   */
+  async koppel(
+    tenantId: string,
+    templateId: string,
+    userId: string,
+    doorUserId: string,
+  ): Promise<void> {
+    return this.db.withTenant(
+      tenantId,
+      async (tx) => {
+        await this.eisBestaandeVragenlijst(tx, templateId);
+
+        // Binnen deze tenant, anders koppel je iemand van een andere
+        // organisatie. RLS dekt dat al af voor het lezen, maar een verzonnen
+        // user_id zou hier op een foreign key stuklopen met een 500.
+        const gebruiker = await tx.execute(
+          sql`SELECT 1 FROM clm."user" WHERE user_id = ${userId}`,
+        );
+
+        if (gebruiker.rows.length === 0) {
+          throw new NotFoundException('Deze gebruiker bestaat niet.');
+        }
+
+        await tx.execute(
+          sql`INSERT INTO clm.template_reviewer
+                     (tenant_id, template_id, user_id, created_by)
+              VALUES (${tenantId}, ${templateId}, ${userId}, ${doorUserId})
+              ON CONFLICT (template_id, user_id) DO NOTHING`,
+        );
+      },
+      'medewerker',
+    );
+  }
+
+  /**
+   * Haalt een koppeling weg.
+   *
+   * Hard verwijderen en geen `deleted_at`: dit is administratie, geen
+   * geschiedenis. Wie ooit gekoppeld was doet er niet toe — wie beoordeeld
+   * heeft wél, en dat staat in `survey_review` en blijft daar staan.
+   */
+  async ontkoppel(
+    tenantId: string,
+    templateId: string,
+    userId: string,
+  ): Promise<void> {
+    return this.db.withTenant(
+      tenantId,
+      async (tx) => {
+        await this.eisBestaandeVragenlijst(tx, templateId);
+
+        await tx.execute(
+          sql`DELETE FROM clm.template_reviewer
+               WHERE template_id = ${templateId} AND user_id = ${userId}`,
+        );
+      },
+      'medewerker',
+    );
+  }
+
+  /**
+   * Wat er op deze beoordelaar wacht: ingediende responses op vragenlijsten
+   * waaraan hij gekoppeld is.
+   *
+   * ── Waarom dit een eigen lijst is en geen filter ────────────────────────────
+   *
+   * ADR-013: "wat wacht er op mij" betekent voor de twee rollen iets wezenlijk
+   * anders. De CISO wil niet zien wie er nog moet invullen — daar gaat hij niet
+   * over. De contractmanager wil niet de beoordeelstapel van de hele
+   * organisatie. Eén lijst met een filter bedient allebei half.
+   *
+   * ── Alleen ingediend ────────────────────────────────────────────────────────
+   *
+   * Een respons die nog openstaat valt niet te beoordelen (migratie 0015-logica
+   * in BeoordelingService). Hem hier tonen zou een werkvoorraad opleveren waar
+   * je niets mee kunt.
+   */
+  async werkvoorraad(
+    tenantId: string,
+    userId: string,
+  ): Promise<WerkvoorraadItem[]> {
+    return this.db.withTenant(
+      tenantId,
+      async (tx) => {
+        const resultaat = await tx.execute<WerkvoorraadRij>(
+          sql`SELECT s.response_id,
+                     s.run_id,
+                     r.template_id,
+                     t.name AS template_naam,
+                     s.vendor_id,
+                     v.name AS vendor_naam,
+                     s.submitted_at,
+                     (SELECT rv.verdict
+                        FROM clm.survey_review rv
+                       WHERE rv.response_id = s.response_id
+                         AND rv.deleted_at IS NULL
+                       ORDER BY rv.created_at DESC
+                       LIMIT 1)                       AS laatste_oordeel,
+                     (SELECT count(*)
+                        FROM clm.survey_review rv
+                       WHERE rv.response_id = s.response_id
+                         AND rv.deleted_at IS NULL)   AS aantal_oordelen
+                FROM clm.survey_response s
+                JOIN clm.survey_run r      ON r.run_id = s.run_id
+                JOIN clm.survey_template t ON t.template_id = r.template_id
+                JOIN clm.template_reviewer tr
+                       ON tr.template_id = t.template_id
+                      AND tr.user_id = ${userId}
+                LEFT JOIN clm.vendor v     ON v.vendor_id = s.vendor_id
+               WHERE s.submitted_at IS NOT NULL
+               ORDER BY s.submitted_at DESC`,
+        );
+
+        return resultaat.rows.map((r) => ({
+          responseId: r.response_id,
+          runId: r.run_id,
+          templateId: r.template_id,
+          templateNaam: r.template_naam,
+          vendorId: r.vendor_id,
+          vendorNaam: r.vendor_naam,
+          submittedAt: iso(r.submitted_at),
+          laatsteOordeel: r.laatste_oordeel,
+          aantalOordelen: Number(r.aantal_oordelen),
+        }));
+      },
+      'medewerker',
+    );
+  }
+
+  private async eisBestaandeVragenlijst(
+    tx: Parameters<Parameters<DatabaseService['withTenant']>[1]>[0],
+    templateId: string,
+  ): Promise<void> {
+    const gevonden = await tx.execute(
+      sql`SELECT 1 FROM clm.survey_template WHERE template_id = ${templateId}`,
+    );
+
+    if (gevonden.rows.length === 0) {
+      throw new NotFoundException('Deze vragenlijst bestaat niet.');
+    }
+  }
+}

--- a/src/survey/ronde-invoer.ts
+++ b/src/survey/ronde-invoer.ts
@@ -327,3 +327,15 @@ export function leesNieuweBeoordeling(body: unknown): NieuweBeoordelingInvoer {
 
   return { verdict, toelichting };
 }
+
+/**
+ * Leest wie er als beoordelaar gekoppeld wordt (fase C3).
+ *
+ * Alleen een user-id. De vragenlijst komt uit het pad en de tenant uit de
+ * sessie — die horen niet in een body waar een client ze kan verzinnen.
+ */
+export function leesBeoordelaar(body: unknown): string {
+  const invoer = leesObject(body);
+
+  return leesUuid(invoer.userId, 'userId');
+}

--- a/src/survey/survey.module.ts
+++ b/src/survey/survey.module.ts
@@ -9,6 +9,7 @@ import { SurveyTokenService } from './survey-token.service';
 import { AntwoordIndienService } from './antwoord-indienen.service';
 import { BestandOpslagService } from './bestand-opslag.service';
 import { BijlageService } from './bijlage.service';
+import { BeoordelaarService } from './beoordelaar.service';
 import { BeoordelingService } from './beoordeling.service';
 import { RondeBeheerService } from './ronde-beheer.service';
 import { VragenlijstBeheerController } from './vragenlijst-beheer.controller';
@@ -45,6 +46,7 @@ import { VragenlijstLeesService } from './vragenlijst-lezen.service';
     VragenlijstBeheerService,
     RondeBeheerService,
     BeoordelingService,
+    BeoordelaarService,
     VragenlijstImportService,
     VragenlijstLeesService,
     AntwoordIndienService,
@@ -58,6 +60,7 @@ import { VragenlijstLeesService } from './vragenlijst-lezen.service';
     VragenlijstBeheerService,
     RondeBeheerService,
     BeoordelingService,
+    BeoordelaarService,
     VragenlijstImportService,
     VragenlijstLeesService,
     AntwoordIndienService,

--- a/src/survey/vragenlijst-beheer.controller.ts
+++ b/src/survey/vragenlijst-beheer.controller.ts
@@ -2,6 +2,7 @@ import {
   BadRequestException,
   Body,
   Controller,
+  Delete,
   Get,
   HttpCode,
   Param,
@@ -20,12 +21,14 @@ import {
 import { RondeBeheerService } from './ronde-beheer.service';
 import {
   InvoerFout,
+  leesBeoordelaar,
   leesNieuweBeoordeling,
   type NieuweBeoordelingInvoer,
   leesNieuweRonde,
   leesStatus,
   leesUitnodigingen,
 } from './ronde-invoer';
+import { BeoordelaarService } from './beoordelaar.service';
 import { BeoordelingService } from './beoordeling.service';
 import { VragenlijstBeheerService } from './vragenlijst-beheer.service';
 
@@ -76,6 +79,7 @@ export class VragenlijstBeheerController {
     private readonly verzender: UitnodigingVerzender,
     // Onderstreept omdat `beoordelingen` al de naam van een routemethode is.
     private readonly beoordelingen_: BeoordelingService,
+    private readonly beoordelaars: BeoordelaarService,
   ) {}
 
   /** Alle vragenlijsten van deze tenant, met aantallen vragen en rondes. */
@@ -190,6 +194,89 @@ export class VragenlijstBeheerController {
     );
 
     return { beoordeling };
+  }
+
+  /**
+   * Wat er op de ingelogde gebruiker wacht: ingediende responses op
+   * vragenlijsten waaraan hij als beoordelaar gekoppeld is.
+   *
+   * Bewust een eigen route en geen filter op de rondelijst (ADR-013). "Wat
+   * wacht er op mij" betekent voor een contractmanager iets wezenlijk anders
+   * dan voor een beoordelaar: de CISO wil niet zien wie er nog moet invullen,
+   * de contractmanager niet de beoordeelstapel van de hele organisatie.
+   *
+   * Geen `@VereistRol`: iedereen mag zijn eigen werkvoorraad zien. Is hij
+   * nergens aan gekoppeld, dan is de lijst leeg — dat is een geldig antwoord,
+   * geen fout.
+   */
+  @Get('mijn-beoordelingen')
+  async mijnBeoordelingen(@Req() request: RequestMetSessie) {
+    const sessie = request.sessie!;
+
+    const werkvoorraad = await this.beoordelaars.werkvoorraad(
+      sessie.tenantId,
+      sessie.userId,
+    );
+
+    return { werkvoorraad };
+  }
+
+  /** Wie er aan deze vragenlijst gekoppeld zijn als beoordelaar. */
+  @Get('templates/:id/reviewers')
+  async reviewers(@Req() request: RequestMetSessie, @Param('id') id: string) {
+    const sessie = request.sessie!;
+
+    const beoordelaars = await this.beoordelaars.lijst(sessie.tenantId, id);
+
+    return { beoordelaars };
+  }
+
+  /**
+   * Koppelt een beoordelaar aan een vragenlijst.
+   *
+   * **`@VereistRol('admin')`, anders dan bij beoordelen zelf.** Beoordelen is
+   * de rol van een reviewer; bepalen wíé er beoordeelt is beheer. Zonder die
+   * grens kan een reviewer zichzelf aan elke lijst hangen, en dan zegt de
+   * koppeling niets meer over hoe de organisatie het bedoeld heeft.
+   *
+   * Let op: dit beperkt níét wie er mag beoordelen (ADR-013 besluit 3). Elke
+   * reviewer mag elke inzending beoordelen; deze koppeling bepaalt alleen wat
+   * er in iemands werkvoorraad verschijnt.
+   *
+   * Idempotent: twee keer koppelen is geen fout.
+   */
+  @Post('templates/:id/reviewers')
+  @VereistRol('admin')
+  @HttpCode(204)
+  async koppelReviewer(
+    @Req() request: RequestMetSessie,
+    @Param('id') id: string,
+    @Body() body: unknown,
+  ) {
+    const sessie = request.sessie!;
+
+    let userId: string;
+    try {
+      userId = leesBeoordelaar(body);
+    } catch (err) {
+      throw this.naarHttpFout(err);
+    }
+
+    await this.beoordelaars.koppel(sessie.tenantId, id, userId, sessie.userId);
+  }
+
+  /** Haalt een koppeling weg. 204 ook als hij er niet was. */
+  @Delete('templates/:id/reviewers/:userId')
+  @VereistRol('admin')
+  @HttpCode(204)
+  async ontkoppelReviewer(
+    @Req() request: RequestMetSessie,
+    @Param('id') id: string,
+    @Param('userId') userId: string,
+  ) {
+    const sessie = request.sessie!;
+
+    await this.beoordelaars.ontkoppel(sessie.tenantId, id, userId);
   }
 
   // ── Fase B: schrijven ──────────────────────────────────────────────────────

--- a/test/beoordelaar-koppelen.e2e-spec.ts
+++ b/test/beoordelaar-koppelen.e2e-spec.ts
@@ -1,0 +1,438 @@
+import { INestApplication } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import cookieParser from 'cookie-parser';
+import { Client } from 'pg';
+import request from 'supertest';
+import type { App } from 'supertest/types';
+
+import { AppModule } from '../src/app.module';
+import { cookieInstellingen } from '../src/auth/sessie';
+import { SessieService } from '../src/auth/sessie.service';
+import { TEST_IDS } from './test-ids';
+
+/**
+ * Beoordelaars koppelen aan een vragenlijst (fase C3, ADR-013).
+ *
+ * Deze suite bouwt de vier tegenproeven uit ADR-013 §Tegenproeven, en de
+ * derde en vierde horen als **paar** gelezen te worden:
+ *
+ *   3. Een reviewer die NIET gekoppeld is, kan wél beoordelen.
+ *      Slaagt dit niet, dan is er per ongeluk een harde grens gebouwd en ligt
+ *      het proces stil zodra de gekoppelde beoordelaar ziek is.
+ *
+ *   4. Diezelfde reviewer ziet die inzending NIET in zijn werkvoorraad.
+ *      De keerzijde: zonder deze test kan de koppeling decoratie zijn zonder
+ *      dat iets dat merkt.
+ *
+ * Alleen samen tonen ze dat de koppeling doet wat ADR-013 besluit 3 zegt:
+ * bepalen wat je ziet, niet wat je mag.
+ */
+
+const {
+  tenantA,
+  tenantB,
+  adminA,
+  reviewerGekoppeld,
+  reviewerLos,
+  adminB,
+  templateA: TEMPLATE_A,
+  templateB: TEMPLATE_B,
+  runA: RUN_A,
+  vendorA: VENDOR_A,
+  responseIngediend: RESPONSE_INGEDIEND,
+  bestaatNiet: BESTAAT_NIET,
+} = TEST_IDS['beoordelaar-koppelen'];
+
+const SUBJECT_ADMIN = `oid-bk-a-${Date.now()}`;
+const SUBJECT_GEKOPPELD = `oid-bk-g-${Date.now()}`;
+const SUBJECT_LOS = `oid-bk-l-${Date.now()}`;
+const SUBJECT_B = `oid-bk-b-${Date.now()}`;
+
+const TOKEN_HASH = `${'3'.repeat(48)}cccccccccccccccc`;
+
+interface BeoordelaarsBody {
+  beoordelaars: Array<{ userId: string; naam: string; email: string }>;
+}
+
+interface WerkvoorraadBody {
+  werkvoorraad: Array<{
+    responseId: string;
+    templateNaam: string;
+    vendorNaam: string | null;
+    laatsteOordeel: string | null;
+    aantalOordelen: number;
+  }>;
+}
+
+async function verwijderTestdata(client: Client) {
+  for (const tenant of [tenantA, tenantB]) {
+    await client.query('BEGIN');
+    await client.query(`SET LOCAL app.current_tenant_id = '${tenant}'`);
+    await client.query(`SET LOCAL app.current_actor = 'medewerker'`);
+    for (const tabel of [
+      'clm.template_reviewer',
+      'clm.survey_review',
+      'clm.survey_answer',
+      'clm.survey_response',
+      'clm.survey_run',
+      'clm.survey_question',
+      'clm.survey_template',
+      'clm.vendor',
+      'clm.tenant_membership',
+      'clm."user"',
+      'clm.tenant',
+    ]) {
+      await client.query(`DELETE FROM ${tabel} WHERE tenant_id = $1`, [tenant]);
+    }
+    await client.query('COMMIT');
+  }
+}
+
+describe('Beoordelaar koppelen aan een vragenlijst (e2e)', () => {
+  let app: INestApplication<App>;
+  let server: App;
+  let client: Client;
+  let cookieAdmin: string;
+  let cookieGekoppeld: string;
+  let cookieLos: string;
+  let cookieB: string;
+
+  beforeAll(async () => {
+    client = new Client({ connectionString: process.env.DATABASE_URL });
+    await client.connect();
+    await verwijderTestdata(client);
+
+    await client.query('BEGIN');
+    await client.query(`SET LOCAL app.current_tenant_id = '${tenantA}'`);
+    await client.query(`SET LOCAL app.current_actor = 'medewerker'`);
+
+    await client.query(
+      'INSERT INTO clm.tenant (tenant_id, name) VALUES ($1, $2)',
+      [tenantA, 'Tenant A (koppelen)'],
+    );
+    for (const [userId, subject, naam, rol] of [
+      [adminA, SUBJECT_ADMIN, 'Admin van A', 'admin'],
+      [reviewerGekoppeld, SUBJECT_GEKOPPELD, 'CISO (gekoppeld)', 'reviewer'],
+      [reviewerLos, SUBJECT_LOS, 'Collega (niet gekoppeld)', 'reviewer'],
+    ] as const) {
+      await client.query(
+        `INSERT INTO clm."user" (user_id, tenant_id, email, full_name, external_subject)
+         VALUES ($1, $2, $3, $4, $5)`,
+        [userId, tenantA, `${subject}@voorbeeld.nl`, naam, subject],
+      );
+      await client.query(
+        `INSERT INTO clm.tenant_membership (user_id, tenant_id, role)
+         VALUES ($1, $2, $3)`,
+        [userId, tenantA, rol],
+      );
+    }
+
+    await client.query(
+      `INSERT INTO clm.survey_template (template_id, tenant_id, name, version)
+       VALUES ($1, $2, 'IT-compliance', 1)`,
+      [TEMPLATE_A, tenantA],
+    );
+    await client.query(
+      `INSERT INTO clm.survey_run
+         (run_id, tenant_id, template_id, status, survey_kind, is_test, started_at)
+       VALUES ($1, $2, $3, 'active', 'vendor_compliance', true, now())`,
+      [RUN_A, tenantA, TEMPLATE_A],
+    );
+    await client.query(
+      `INSERT INTO clm.vendor (vendor_id, tenant_id, name)
+       VALUES ($1, $2, 'Leverancier van A')`,
+      [VENDOR_A, tenantA],
+    );
+    await client.query(
+      `INSERT INTO clm.survey_response
+         (response_id, tenant_id, run_id, vendor_id, subject_vendor_id,
+          token_hash, status, expires_at, submitted_at)
+       VALUES ($1, $2, $3, $4, $4, $5, 'submitted',
+               now() + interval '30 days', now())`,
+      [RESPONSE_INGEDIEND, tenantA, RUN_A, VENDOR_A, TOKEN_HASH],
+    );
+    await client.query('COMMIT');
+
+    // Tenant B met een eigen vragenlijst, zodat de tenantgrens iets te
+    // verbergen heeft.
+    await client.query('BEGIN');
+    await client.query(`SET LOCAL app.current_tenant_id = '${tenantB}'`);
+    await client.query(`SET LOCAL app.current_actor = 'medewerker'`);
+    await client.query(
+      'INSERT INTO clm.tenant (tenant_id, name) VALUES ($1, $2)',
+      [tenantB, 'Tenant B (koppelen)'],
+    );
+    await client.query(
+      `INSERT INTO clm."user" (user_id, tenant_id, email, full_name, external_subject)
+       VALUES ($1, $2, $3, 'Admin van B', $4)`,
+      [adminB, tenantB, `${SUBJECT_B}@voorbeeld.nl`, SUBJECT_B],
+    );
+    await client.query(
+      `INSERT INTO clm.tenant_membership (user_id, tenant_id, role)
+       VALUES ($1, $2, 'admin')`,
+      [adminB, tenantB],
+    );
+    await client.query(
+      `INSERT INTO clm.survey_template (template_id, tenant_id, name, version)
+       VALUES ($1, $2, 'lijst-van-B', 1)`,
+      [TEMPLATE_B, tenantB],
+    );
+    await client.query('COMMIT');
+
+    const moduleRef = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleRef.createNestApplication();
+    app.use(cookieParser());
+    await app.init();
+    server = app.getHttpServer();
+
+    const sessies = app.get(SessieService);
+    const naam = cookieInstellingen().naam;
+    for (const [subject, doel] of [
+      [SUBJECT_ADMIN, 'admin'],
+      [SUBJECT_GEKOPPELD, 'gekoppeld'],
+      [SUBJECT_LOS, 'los'],
+      [SUBJECT_B, 'b'],
+    ] as const) {
+      const sessie = await sessies.aanmaken(subject);
+      expect(sessie).not.toBeNull();
+      const cookie = `${naam}=${sessie!.token}`;
+      if (doel === 'admin') cookieAdmin = cookie;
+      else if (doel === 'gekoppeld') cookieGekoppeld = cookie;
+      else if (doel === 'los') cookieLos = cookie;
+      else cookieB = cookie;
+    }
+
+    // De koppeling die het hele verhaal draagt: alleen de CISO is gekoppeld.
+    await request(server)
+      .post(`/admin/survey/templates/${TEMPLATE_A}/reviewers`)
+      .set('Cookie', cookieAdmin)
+      .send({ userId: reviewerGekoppeld })
+      .expect(204);
+  }, 30000);
+
+  afterAll(async () => {
+    await app.close();
+    await verwijderTestdata(client);
+    await client.end();
+  }, 30000);
+
+  describe('koppelen en ontkoppelen', () => {
+    it('toont de gekoppelde beoordelaar met naam', async () => {
+      const antwoord = await request(server)
+        .get(`/admin/survey/templates/${TEMPLATE_A}/reviewers`)
+        .set('Cookie', cookieAdmin)
+        .expect(200);
+
+      const body = antwoord.body as BeoordelaarsBody;
+
+      expect(body.beoordelaars).toHaveLength(1);
+      expect(body.beoordelaars[0].userId).toBe(reviewerGekoppeld);
+      expect(body.beoordelaars[0].naam).toBe('CISO (gekoppeld)');
+    });
+
+    it('is idempotent: twee keer koppelen geeft geen fout', async () => {
+      await request(server)
+        .post(`/admin/survey/templates/${TEMPLATE_A}/reviewers`)
+        .set('Cookie', cookieAdmin)
+        .send({ userId: reviewerGekoppeld })
+        .expect(204);
+
+      const antwoord = await request(server)
+        .get(`/admin/survey/templates/${TEMPLATE_A}/reviewers`)
+        .set('Cookie', cookieAdmin)
+        .expect(200);
+
+      expect((antwoord.body as BeoordelaarsBody).beoordelaars).toHaveLength(1);
+    });
+
+    it('staat meerdere beoordelaars per vragenlijst toe', async () => {
+      // ADR-013: bij Transdev is het er waarschijnlijk één, maar die ene gaat
+      // met vakantie.
+      await request(server)
+        .post(`/admin/survey/templates/${TEMPLATE_A}/reviewers`)
+        .set('Cookie', cookieAdmin)
+        .send({ userId: adminA })
+        .expect(204);
+
+      const antwoord = await request(server)
+        .get(`/admin/survey/templates/${TEMPLATE_A}/reviewers`)
+        .set('Cookie', cookieAdmin)
+        .expect(200);
+
+      expect((antwoord.body as BeoordelaarsBody).beoordelaars).toHaveLength(2);
+
+      // Weer weghalen, anders verstoort het de werkvoorraadtests hieronder.
+      await request(server)
+        .delete(`/admin/survey/templates/${TEMPLATE_A}/reviewers/${adminA}`)
+        .set('Cookie', cookieAdmin)
+        .expect(204);
+    });
+
+    it('geeft 204 bij ontkoppelen van iemand die niet gekoppeld was', async () => {
+      await request(server)
+        .delete(
+          `/admin/survey/templates/${TEMPLATE_A}/reviewers/${reviewerLos}`,
+        )
+        .set('Cookie', cookieAdmin)
+        .expect(204);
+    });
+
+    it('weigert een gebruiker die niet bestaat', async () => {
+      await request(server)
+        .post(`/admin/survey/templates/${TEMPLATE_A}/reviewers`)
+        .set('Cookie', cookieAdmin)
+        .send({ userId: BESTAAT_NIET })
+        .expect(404);
+    });
+
+    it('weigert een ongeldig user-id met een 400', async () => {
+      await request(server)
+        .post(`/admin/survey/templates/${TEMPLATE_A}/reviewers`)
+        .set('Cookie', cookieAdmin)
+        .send({ userId: 'geen-uuid' })
+        .expect(400);
+    });
+
+    // Koppelen is beheer, beoordelen is de rol van een reviewer. Zonder deze
+    // grens kan een reviewer zichzelf aan elke lijst hangen.
+    it('laat een REVIEWER niet koppelen — dat is beheer', async () => {
+      await request(server)
+        .post(`/admin/survey/templates/${TEMPLATE_A}/reviewers`)
+        .set('Cookie', cookieGekoppeld)
+        .send({ userId: reviewerLos })
+        .expect(403);
+    });
+
+    it('laat een REVIEWER niet ontkoppelen', async () => {
+      await request(server)
+        .delete(
+          `/admin/survey/templates/${TEMPLATE_A}/reviewers/${reviewerGekoppeld}`,
+        )
+        .set('Cookie', cookieGekoppeld)
+        .expect(403);
+    });
+  });
+
+  // ── Tegenproef 1 uit ADR-013 ────────────────────────────────────────────────
+  describe('de tenantgrens', () => {
+    it('geeft tenant B een 404 op de vragenlijst van A', async () => {
+      await request(server)
+        .get(`/admin/survey/templates/${TEMPLATE_A}/reviewers`)
+        .set('Cookie', cookieB)
+        .expect(404);
+    });
+
+    it('laat tenant B geen beoordelaar koppelen aan een lijst van A', async () => {
+      await request(server)
+        .post(`/admin/survey/templates/${TEMPLATE_A}/reviewers`)
+        .set('Cookie', cookieB)
+        .send({ userId: adminB })
+        .expect(404);
+    });
+
+    it('toont B geen enkele koppeling van A', async () => {
+      const antwoord = await request(server)
+        .get(`/admin/survey/templates/${TEMPLATE_B}/reviewers`)
+        .set('Cookie', cookieB)
+        .expect(200);
+
+      expect((antwoord.body as BeoordelaarsBody).beoordelaars).toHaveLength(0);
+    });
+  });
+
+  // ── Tegenproef 2 uit ADR-013 ────────────────────────────────────────────────
+  describe('een leverancier komt er niet bij', () => {
+    it('kan geen enkele koppeling lezen', async () => {
+      await client.query('BEGIN');
+      await client.query(`SET LOCAL app.current_tenant_id = '${tenantA}'`);
+      await client.query(`SET LOCAL app.current_actor = 'leverancier'`);
+
+      const { rows } = await client.query(
+        'SELECT * FROM clm.template_reviewer WHERE template_id = $1',
+        [TEMPLATE_A],
+      );
+
+      await client.query('COMMIT');
+
+      expect(rows).toHaveLength(0);
+    });
+
+    it('een medewerker ziet ze wél — de test hierboven meet geen lege tabel', async () => {
+      await client.query('BEGIN');
+      await client.query(`SET LOCAL app.current_tenant_id = '${tenantA}'`);
+      await client.query(`SET LOCAL app.current_actor = 'medewerker'`);
+
+      const { rows } = await client.query(
+        'SELECT * FROM clm.template_reviewer WHERE template_id = $1',
+        [TEMPLATE_A],
+      );
+
+      await client.query('COMMIT');
+
+      expect(rows.length).toBeGreaterThan(0);
+    });
+  });
+
+  /**
+   * ── Tegenproef 3 en 4 uit ADR-013 — het paar ────────────────────────────────
+   *
+   * Dit is het belangrijkste besluit uit ADR-013 (besluit 3): de koppeling
+   * bepaalt wat je ziet, niet wat je mag.
+   */
+  describe('de koppeling is een hulpmiddel, geen grens', () => {
+    // Tegenproef 3. Slaagt dit niet, dan is er per ongeluk een harde grens
+    // gebouwd en ligt het proces stil zodra de CISO ziek is.
+    it('laat een NIET-gekoppelde reviewer wél beoordelen', async () => {
+      await request(server)
+        .post(`/admin/survey/responses/${RESPONSE_INGEDIEND}/reviews`)
+        .set('Cookie', cookieLos)
+        .send({
+          verdict: 'goed',
+          toelichting: 'Ingevallen voor de CISO.',
+        })
+        .expect(201);
+    });
+
+    // Tegenproef 4. De keerzijde: zonder deze test kan de koppeling decoratie
+    // zijn zonder dat iets dat merkt.
+    it('toont die inzending NIET in de werkvoorraad van de niet-gekoppelde reviewer', async () => {
+      const antwoord = await request(server)
+        .get('/admin/survey/mijn-beoordelingen')
+        .set('Cookie', cookieLos)
+        .expect(200);
+
+      expect((antwoord.body as WerkvoorraadBody).werkvoorraad).toHaveLength(0);
+    });
+
+    it('toont hem WEL in de werkvoorraad van de gekoppelde reviewer', async () => {
+      const antwoord = await request(server)
+        .get('/admin/survey/mijn-beoordelingen')
+        .set('Cookie', cookieGekoppeld)
+        .expect(200);
+
+      const body = antwoord.body as WerkvoorraadBody;
+
+      expect(body.werkvoorraad).toHaveLength(1);
+      expect(body.werkvoorraad[0].responseId).toBe(RESPONSE_INGEDIEND);
+      expect(body.werkvoorraad[0].templateNaam).toBe('IT-compliance');
+      expect(body.werkvoorraad[0].vendorNaam).toBe('Leverancier van A');
+    });
+
+    it('toont het laatste oordeel bij de inzending in de werkvoorraad', async () => {
+      // ADR-013: anders moet je zeventien schermen openen om te zien wie er nog
+      // openstaat, en dan wordt de lijst niet gebruikt.
+      const antwoord = await request(server)
+        .get('/admin/survey/mijn-beoordelingen')
+        .set('Cookie', cookieGekoppeld)
+        .expect(200);
+
+      const body = antwoord.body as WerkvoorraadBody;
+
+      expect(body.werkvoorraad[0].laatsteOordeel).toBe('goed');
+      expect(body.werkvoorraad[0].aantalOordelen).toBeGreaterThan(0);
+    });
+  });
+});

--- a/test/test-ids.ts
+++ b/test/test-ids.ts
@@ -178,6 +178,32 @@ export const TEST_IDS = {
      */
     vendorOpen: '00000000-0000-0000-0000-0000000000e3',
   },
+  // Fase C3 — beoordelaar koppelen. Staarten e4 t/m ec; e5 is al vergeven via
+  // id(), vandaar de sprong. Gecontroleerd tegen alleTestIds().
+  'beoordelaar-koppelen': {
+    tenantA: '00000000-0000-0000-0000-0000000000e4',
+    tenantB: '00000000-0000-0000-0000-0000000000e6',
+    adminA: '00000000-0000-0000-0000-0000000000e7',
+    /** Gekoppeld aan de vragenlijst — ziet hem in zijn werkvoorraad. */
+    reviewerGekoppeld: '00000000-0000-0000-0000-0000000000e8',
+    /** Niet gekoppeld — mag wél beoordelen, ziet hem níét in zijn voorraad. */
+    reviewerLos: '00000000-0000-0000-0000-0000000000e9',
+    adminB: '00000000-0000-0000-0000-0000000000ea',
+    templateA: '00000000-0000-0000-0000-0000000000eb',
+    templateB: '00000000-0000-0000-0000-0000000000ec',
+    runA: '00000000-0000-0000-0000-0000000000ed',
+    vendorA: '00000000-0000-0000-0000-0000000000ee',
+    responseIngediend: '00000000-0000-0000-0000-0000000000ef',
+    /**
+     * Bestaat met opzet NIET in de database — voor de 404-tests.
+     *
+     * Staat hier omdat de bewakingstest elke letterlijke test-UUID in een
+     * e2e-suite in dit register wil zien. Andere suites gebruiken dezelfde
+     * waarde binnen een template-string in een URL, en die vorm herkent het
+     * patroon niet; als losse waarde wordt hij wél gevangen.
+     */
+    bestaatNiet: '00000000-0000-0000-0000-00000000dead',
+  },
 } as const;
 
 /** Alle uitgedeelde id's, plat. Gebruikt door de bewakingstest. */


### PR DESCRIPTION
Laatste van drie PR's voor fase C (backend). **Gericht op `feat/fase-c2-beoordelen`** (PR #95).

Voert **ADR-013 besluit 2 en 3** uit. Migratie **0016** met `clm.template_reviewer`, plus vier routes:

```
GET    /admin/survey/mijn-beoordelingen
GET    /admin/survey/templates/:id/reviewers
POST   /admin/survey/templates/:id/reviewers
DELETE /admin/survey/templates/:id/reviewers/:userId
```

## Aan de vragenlijst, niet aan de vendor

Beoordelen is vakinhoud, geen eigenaarschap. Wie een IT-compliancelijst kan beoordelen — bij Transdev de CISO — kan dat voor **élke** vendor. De contractmanager van vendor X kan dat voor **géén** enkele, ook niet voor zijn eigen vendor.

Beheren is eigenaarschap (`vendor.owner_user_id`, bestaat al sinds 0000), beoordelen is expertise. Die twee hangen daarom aan verschillende objecten. Het schaalt ook de goede kant op: komt er een Privacy/AVG-lijst bij, dan koppel je daar de FG aan zonder één vendor of ronde aan te raken.

## Het belangrijkste punt: een hulpmiddel, geen grens

Dit is ADR-013 besluit 3, en het minst vanzelfsprekende deel ervan. De koppeling bepaalt **wat iemand ziet**, niet **wat hij mag**. Elke reviewer binnen de tenant mag elke inzending beoordelen.

`BeoordelingService` bevat **nul verwijzingen** naar `template_reviewer` — geverifieerd, en dat is opzet.

Waarom niet exclusief: een harde grens legt het proces stil zodra de gekoppelde beoordelaar ziek is. Dan wijzigt iemand met databasetoegang de koppeling — een noodgreep buiten de app om, zonder spoor. Erger dan het probleem. De fallback is de contractmanager, die intern regelt dat een bevoegd persoon beoordeelt; dat werkt alleen als de app het niet blokkeert.

Dat is verdedigbaar omdat elk oordeel met naam en datum vastligt (migratie 0015). **Wie buiten zijn vakgebied beoordeelt, doet dat zichtbaar.** Zonder die historie zou de grens hard moeten zijn.

In de migratie en de service staat dit expliciet, gericht aan wie hier later iets bouwt.

## Wat wél hard blijft

Koppelen vraagt `@VereistRol('admin')`. Beoordelen is de rol van een reviewer; bepalen *wie* er beoordeelt is beheer. Zonder die grens kan een reviewer zichzelf aan elke lijst hangen, en dan zegt de koppeling niets meer over hoe de organisatie het bedoeld heeft.

## De werkvoorraad is een eigen route

Geen filter op de rondelijst (ADR-013). "Wat wacht er op mij" betekent voor de twee rollen iets wezenlijk anders: de CISO wil niet zien wie er nog moet invullen, de contractmanager niet de beoordeelstapel van de hele organisatie. Eén lijst met een filter bedient allebei half.

Het laatste oordeel staat **bij de inzending in de lijst** — anders moet je zeventien schermen openen om te zien wat er nog openstaat, en dan wordt de lijst niet gebruikt.

## De vier tegenproeven uit ADR-013

Alle vier gebouwd. De derde en vierde horen als **paar** gelezen te worden:

| # | Wat | Waarom |
|---|---|---|
| 1 | Tenant A ziet geen koppelingen van B | RLS is geen eigenschap die je erft |
| 2 | Een leverancierspad kan niets lezen | actor-eis in `USING` én `WITH CHECK` |
| 3 | Een **niet-gekoppelde** reviewer kan wél beoordelen | slaagt dit niet, dan is er per ongeluk een harde grens |
| 4 | Diezelfde reviewer ziet het **niet** in zijn werkvoorraad | anders is de koppeling decoratie |

Alleen samen tonen 3 en 4 dat de koppeling doet wat besluit 3 zegt.

## Twee sabotages (§15b)

| Sabotage | Uitkomst |
|---|---|
| werkvoorraad negeert de koppeling (`JOIN` → `LEFT JOIN`) | precies tegenproef 4 viel om |
| koppeling als harde grens in `BeoordelingService` | precies tegenproef 3 viel om |

Beide hersteld, daarna weer 17 groen. De tweede is de waardevolste: hij bewijst dat de suite het *verkeerd bouwen* van dit besluit vangt.

## Getoetst

- **358 e2e-tests groen** (was 341), 24 suites
- 266 unittests, lint/format/typecheck schoon
- **De volledige e2e-suite ook gedraaid tegen een database die vanaf leeg is opgebouwd**: 20 tabellen (was 19), RLS geforceerd op de nieuwe tabel, alle 24 suites groen. Dat is meer dan de `rls-isolation`-job in CI doet.

## Eén bevinding onderweg

De bewakingstest op test-id's kijkt alleen naar UUID's tussen **enkele aanhalingstekens**. Bestaande suites gebruiken dezelfde `...dead`-placeholder binnen een template-string in een URL, en die vorm glipt erdoor. Mijn losse waarde werd wél gevangen. Ik heb hem netjes in het register gezet; het gat in de bewaking zelf heb ik laten staan — dat hoort niet in deze PR.

> GitHub Actions had een storing (`major_outage`). Bovenstaande is lokaal gedraaid, inclusief tegen een verse database.