### PR TITLE
feat(survey): oordelen over een ingediende respons (fase C2)

### DIFF
--- a/drizzle/0015_survey_review.sql
+++ b/drizzle/0015_survey_review.sql
@@ -1,0 +1,118 @@
+-- =============================================================================
+-- clm.survey_review — het oordeel van een medewerker over één ingediende
+-- respons.
+--
+-- Aanleiding: fase C van docs/superpowers/plans/2026-08-03-surveybeheer.md,
+-- §2a. De eigenaar wil dat een Transdev-collega een ingevulde vragenlijst kan
+-- beoordelen. Dat lijkt op UC2 en is het niet: UC2 is een tweede vragenlijst,
+-- dit is één oordeel over een bestaande respons.
+--
+-- ── Waarom een eigen tabel en geen kolom op survey_response ──────────────────
+--
+-- Omdat er meerdere oordelen mogen zijn en geen enkele wordt overschreven.
+-- Elk oordeel staat met naam en datum vast. Dat is precies de reden dat een
+-- reviewer mag beoordelen zonder admin te zijn (plan §2a): hij kan niets
+-- stilletjes wijzigen, alleen iets toevoegen dat zichtbaar van hem is.
+--
+-- Een kolom op survey_response zou het vorige oordeel wissen en die redenering
+-- ondergraven — en juist in een compliance-dossier is "wat vond men er eerder
+-- van" de vraag die je later stelt.
+--
+-- ── Bewust GEEN unieke sleutel op response_id ────────────────────────────────
+--
+-- Meerdere oordelen zijn het punt, niet een gebrek. Een tweede beoordelaar mag
+-- ernaast komen te staan, en een herzien oordeel komt eronder in plaats van
+-- eroverheen.
+--
+-- ── De eerste tabel waar de tenantgrens niet volstaat ────────────────────────
+--
+-- Elke bestaande policy in dit project luidt:
+--
+--     USING (tenant_id = clm.current_tenant_id())
+--
+-- Dat klopt overal: zelfde tenant = mag het zien. Hier niet. Een leverancier
+-- zit in dezelfde tenant als de medewerker die hem beoordeelt, maar mag dat
+-- oordeel niet lezen — en dat verschil kon de database tot migratie 0013 niet
+-- zien.
+--
+-- Daarom eist de policy hieronder naast de tenant ook actor 'medewerker'.
+-- Dit is de eerste en voorlopig enige plek waar clm.current_actor() in een
+-- policy staat; 0013 legde alleen de functie aan.
+--
+-- ── De actor-eis staat ook in WITH CHECK ─────────────────────────────────────
+--
+-- Zonder dat zou een leverancierspad wél kunnen schrijven wat het niet kan
+-- lezen. Dat is een lek dat pas opvalt als de rij er al staat — en dan is er
+-- een oordeel vastgelegd door iets dat geen medewerker is.
+--
+-- ── Wat hier NIET in staat ───────────────────────────────────────────────────
+--
+-- "Beoordelen mag alleen op een ingediende respons" is een controle in de
+-- service, geen constraint. Reden: de foutmelding moet uitleggen wáárom het
+-- niet kan ("deze leverancier heeft nog niet ingediend"), en een CHECK levert
+-- alleen een constraintnaam op.
+-- =============================================================================
+
+CREATE TABLE "clm"."survey_review" (
+	"review_id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"tenant_id" uuid NOT NULL,
+	"response_id" uuid NOT NULL,
+	"verdict" text NOT NULL,
+	"toelichting" text DEFAULT '' NOT NULL,
+	"reviewer_user_id" uuid NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"deleted_at" timestamp with time zone
+);
+--> statement-breakpoint
+
+ALTER TABLE "clm"."survey_review"
+    ADD CONSTRAINT "survey_review_tenant_id_tenant_tenant_id_fk"
+    FOREIGN KEY ("tenant_id") REFERENCES "clm"."tenant"("tenant_id")
+    ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+
+ALTER TABLE "clm"."survey_review"
+    ADD CONSTRAINT "survey_review_response_id_survey_response_response_id_fk"
+    FOREIGN KEY ("response_id") REFERENCES "clm"."survey_response"("response_id")
+    ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+
+-- ON DELETE restrict, bewust niet SET NULL: een oordeel zonder naam is
+-- waardeloos in een compliance-dossier.
+ALTER TABLE "clm"."survey_review"
+    ADD CONSTRAINT "survey_review_reviewer_user_id_user_user_id_fk"
+    FOREIGN KEY ("reviewer_user_id") REFERENCES "clm"."user"("user_id")
+    ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+
+-- Dezelfde vorm als de bestaande statuscontroles (migratie 0005): een typefout
+-- in code wordt een databasefout en geen rij met onzin.
+ALTER TABLE "clm"."survey_review"
+    ADD CONSTRAINT "survey_review_verdict_check"
+    CHECK (verdict IN ('goed', 'nadere_vragen', 'niet_goed'));--> statement-breakpoint
+
+CREATE INDEX "survey_review_tenant_id_idx"
+    ON "clm"."survey_review" USING btree ("tenant_id");--> statement-breakpoint
+
+CREATE INDEX "survey_review_response_id_idx"
+    ON "clm"."survey_review" USING btree ("response_id");--> statement-breakpoint
+
+-- ── Row Level Security ──────────────────────────────────────────────────────
+
+ALTER TABLE clm.survey_review ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+
+-- FORCE conform migratie 0011: RLS geldt ook voor de eigenaar van de tabel.
+-- Zonder FORCE zou clm_migrator alle oordelen van alle tenants zien.
+ALTER TABLE clm.survey_review FORCE ROW LEVEL SECURITY;--> statement-breakpoint
+
+CREATE POLICY survey_review_isolation ON clm.survey_review
+    USING (
+        tenant_id = clm.current_tenant_id()
+        AND clm.current_actor() = 'medewerker'
+    )
+    WITH CHECK (
+        tenant_id = clm.current_tenant_id()
+        AND clm.current_actor() = 'medewerker'
+    );--> statement-breakpoint
+
+COMMENT ON TABLE clm.survey_review IS
+    'Oordelen over ingediende responses. Append-only in de praktijk: rijen worden nooit overschreven, intrekken gaat via deleted_at. Alleen leesbaar en schrijfbaar door actor medewerker — een leverancier mag het oordeel over zichzelf niet zien, ook al staat het in zijn eigen tenant.';--> statement-breakpoint
+
+GRANT SELECT, INSERT, UPDATE ON clm.survey_review TO clm_api_runtime;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -106,6 +106,13 @@
       "when": 1785801600000,
       "tag": "0014_baseline_convergentie",
       "breakpoints": true
+    },
+    {
+      "idx": 15,
+      "version": "7",
+      "when": 1786045342915,
+      "tag": "0015_survey_review",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -539,6 +539,58 @@ export const surveyAttachment = clm.table(
   ],
 );
 
+/**
+ * Het oordeel van een medewerker over één ingediende respons.
+ *
+ * ── Waarom een eigen tabel en niet een kolom op survey_response ─────────────
+ *
+ * Omdat er meerdere oordelen mogen zijn. Elk oordeel staat met naam en datum
+ * vast en wordt nooit overschreven (plan §2a). Dat is precies waarom een
+ * reviewer mag beoordelen zonder admin te zijn: hij kan niets stilletjes
+ * wijzigen, alleen iets toevoegen dat zichtbaar van hem is. Een kolom op de
+ * respons zou het vorige oordeel wissen en die redenering ondergraven.
+ *
+ * ── De eerste tabel waar de tenantgrens niet genoeg is ──────────────────────
+ *
+ * Overal elders geldt "zelfde tenant = mag het zien". Hier niet: een
+ * leverancier zit in dezelfde tenant als de medewerker die hem beoordeelt,
+ * maar mag dat oordeel niet lezen. Daarvoor is `app.current_actor` gemaakt
+ * (migratie 0013). De policy eist naast de tenant dus ook actor
+ * `medewerker` — zie migratie 0015.
+ */
+export const surveyReview = clm.table(
+  'survey_review',
+  {
+    reviewId: uuid('review_id').primaryKey().defaultRandom(),
+    tenantId: uuid('tenant_id')
+      .notNull()
+      .references(() => tenant.tenantId, { onDelete: 'restrict' }),
+    responseId: uuid('response_id')
+      .notNull()
+      .references(() => surveyResponse.responseId, { onDelete: 'restrict' }),
+    // goed | nadere_vragen | niet_goed. Als CHECK in de database, zodat een
+    // typefout in code een databasefout wordt en geen rij met onzin.
+    verdict: text('verdict').notNull(),
+    // NOT NULL met '' als lege waarde, net als survey_question.body: dan hoeft
+    // de aanroeper nergens onderscheid te maken tussen null en leeg.
+    toelichting: text('toelichting').notNull().default(''),
+    // Wie het oordeel gaf. Bewust geen onDelete: 'set null' — een oordeel
+    // zonder naam is waardeloos in een compliance-dossier.
+    reviewerUserId: uuid('reviewer_user_id')
+      .notNull()
+      .references(() => user.userId, { onDelete: 'restrict' }),
+    createdAt: timestamp('created_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    // Intrekken kan wel, wissen niet: de historie blijft leesbaar.
+    deletedAt: timestamp('deleted_at', { withTimezone: true }),
+  },
+  (t) => [
+    index('survey_review_tenant_id_idx').on(t.tenantId),
+    index('survey_review_response_id_idx').on(t.responseId),
+  ],
+);
+
 // ─── audit schema ──────────────────────────────────────────────────────────
 
 export const auditEvent = audit.table(

--- a/src/survey/beoordeling.service.ts
+++ b/src/survey/beoordeling.service.ts
@@ -1,0 +1,218 @@
+import {
+  BadRequestException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { sql } from 'drizzle-orm';
+
+import { DatabaseService } from '../db/database.service';
+
+/**
+ * Oordelen over ingediende responses (fase C van
+ * docs/superpowers/plans/2026-08-03-surveybeheer.md, §2a).
+ *
+ * ── Beoordelen is niet UC2 ───────────────────────────────────────────────────
+ *
+ * UC2 is een tweede vragenlijst met eigen vragen, en die is uitgesteld. Dit is
+ * één oordeel over één bestaande respons. Het verschil bepaalt de bouw: UC2
+ * vraagt een schermflow, deelnemersbeheer en een scoreberekening; dit vraagt
+ * één tabel en twee routes.
+ *
+ * ── Toevoegen, nooit overschrijven ───────────────────────────────────────────
+ *
+ * Er is geen update en geen delete. Een herzien oordeel komt eronder te staan,
+ * niet eroverheen. Dat is precies waarom een reviewer dit mag zonder admin te
+ * zijn (plan §2a): hij kan niets stilletjes wijzigen, alleen iets toevoegen dat
+ * zichtbaar van hem is. Zonder die historie zou hier admin nodig zijn.
+ *
+ * ── Wat `nadere_vragen` níét doet ────────────────────────────────────────────
+ *
+ * Het stuurt de vragenlijst niet terug naar de leverancier (besluit eigenaar
+ * 2026-08-03). Het oordeel wordt vastgelegd, de respons blijft dicht, en de
+ * beheerder neemt zelf contact op. Terugsturen zou vier bewezen onderdelen
+ * raken: de bevriezingstrigger, de SurveyTokenGuard, de verlooplogica en de
+ * audittrail.
+ *
+ * De leverancier merkt hier dus niets van. Het scherm moet dat zeggen — een
+ * knop die suggereert dat er iets verstuurd wordt terwijl dat niet gebeurt, is
+ * erger dan geen knop.
+ */
+
+/** De drie toegestane oordelen. Gelijk aan de CHECK uit migratie 0015. */
+export const OORDELEN = ['goed', 'nadere_vragen', 'niet_goed'] as const;
+export type Oordeel = (typeof OORDELEN)[number];
+
+export interface NieuweBeoordeling {
+  verdict: Oordeel;
+  toelichting: string;
+}
+
+export interface Beoordeling {
+  reviewId: string;
+  responseId: string;
+  verdict: string;
+  toelichting: string;
+  reviewerUserId: string;
+  /** Null wanneer de gebruiker geen naam heeft — dan toont het scherm het adres. */
+  reviewerNaam: string | null;
+  createdAt: string;
+}
+
+interface BeoordelingRij extends Record<string, unknown> {
+  review_id: string;
+  response_id: string;
+  verdict: string;
+  toelichting: string;
+  reviewer_user_id: string;
+  reviewer_naam: string | null;
+  created_at: Date | string;
+}
+
+function iso(waarde: Date | string | null): string | null {
+  if (waarde === null) return null;
+  return waarde instanceof Date ? waarde.toISOString() : String(waarde);
+}
+
+@Injectable()
+export class BeoordelingService {
+  constructor(private readonly db: DatabaseService) {}
+
+  /**
+   * Alle oordelen over één respons, nieuwste eerst.
+   *
+   * Ingetrokken oordelen (`deleted_at`) blijven buiten beschouwing, maar staan
+   * nog wel in de database — wissen zou de historie kapotmaken die deze tabel
+   * juist bewaart.
+   */
+  async lijst(tenantId: string, responseId: string): Promise<Beoordeling[]> {
+    return this.db.withTenant(
+      tenantId,
+      async (tx) => {
+        await this.eisBestaandeRespons(tx, responseId);
+
+        const resultaat = await tx.execute<BeoordelingRij>(
+          sql`SELECT r.review_id,
+                     r.response_id,
+                     r.verdict,
+                     r.toelichting,
+                     r.reviewer_user_id,
+                     u.full_name AS reviewer_naam,
+                     r.created_at
+                FROM clm.survey_review r
+                LEFT JOIN clm."user" u ON u.user_id = r.reviewer_user_id
+               WHERE r.response_id = ${responseId}
+                 AND r.deleted_at IS NULL
+               ORDER BY r.created_at DESC`,
+        );
+
+        return resultaat.rows.map((r) => this.naarBeoordeling(r));
+      },
+      'medewerker',
+    );
+  }
+
+  /**
+   * Legt een nieuw oordeel vast.
+   *
+   * ── Alleen op een ingediende respons ──────────────────────────────────────
+   *
+   * Bewust een controle hier en geen CHECK-constraint: de melding moet
+   * uitleggen wáárom het niet kan ("deze leverancier heeft nog niet
+   * ingediend"), en een constraint levert alleen een constraintnaam op.
+   *
+   * ── De reviewer komt uit de sessie, nooit uit de invoer ───────────────────
+   *
+   * Zou `reviewerUserId` uit de request komen, dan kan iemand een oordeel op
+   * naam van een collega vastleggen. In een compliance-dossier is dat precies
+   * de handtekening die moet kloppen (MCM2-CLAUDE.md §6: de identiteit komt uit
+   * de geverifieerde context).
+   */
+  async voegToe(
+    tenantId: string,
+    responseId: string,
+    reviewerUserId: string,
+    invoer: NieuweBeoordeling,
+  ): Promise<Beoordeling> {
+    return this.db.withTenant(
+      tenantId,
+      async (tx) => {
+        const respons = await this.eisBestaandeRespons(tx, responseId);
+
+        if (!respons.submitted_at) {
+          throw new BadRequestException(
+            'Deze respons is nog niet ingediend. Er valt pas iets te beoordelen zodra de leverancier heeft ingediend.',
+          );
+        }
+
+        const resultaat = await tx.execute<BeoordelingRij>(
+          sql`WITH nieuw AS (
+                INSERT INTO clm.survey_review
+                       (tenant_id, response_id, verdict, toelichting, reviewer_user_id)
+                VALUES (${tenantId}, ${responseId}, ${invoer.verdict},
+                        ${invoer.toelichting}, ${reviewerUserId})
+                RETURNING review_id, response_id, verdict, toelichting,
+                          reviewer_user_id, created_at
+              )
+              SELECT n.review_id,
+                     n.response_id,
+                     n.verdict,
+                     n.toelichting,
+                     n.reviewer_user_id,
+                     u.full_name AS reviewer_naam,
+                     n.created_at
+                FROM nieuw n
+                LEFT JOIN clm."user" u ON u.user_id = n.reviewer_user_id`,
+        );
+
+        const rij = resultaat.rows[0];
+        if (!rij) {
+          // Onbereikbaar in de praktijk: de INSERT gaf een rij terug of gooide.
+          // Toch expliciet, want stil `undefined` teruggeven zou het scherm een
+          // geslaagde beoordeling laten tonen die er niet is.
+          throw new BadRequestException(
+            'Het oordeel kon niet worden opgeslagen.',
+          );
+        }
+
+        return this.naarBeoordeling(rij);
+      },
+      'medewerker',
+    );
+  }
+
+  /**
+   * Controleert dat de respons bestaat binnen deze tenant.
+   *
+   * Zonder deze controle zou een oordeel op een verzonnen response_id een
+   * foreign-key-fout geven — een 500 met een constraintnaam in plaats van een
+   * 404 die zegt wat er aan de hand is.
+   */
+  private async eisBestaandeRespons(
+    tx: Parameters<Parameters<DatabaseService['withTenant']>[1]>[0],
+    responseId: string,
+  ): Promise<{ submitted_at: Date | string | null }> {
+    const gevonden = await tx.execute<{ submitted_at: Date | string | null }>(
+      sql`SELECT submitted_at FROM clm.survey_response
+           WHERE response_id = ${responseId}`,
+    );
+
+    const rij = gevonden.rows[0];
+    if (!rij) {
+      throw new NotFoundException('Deze respons bestaat niet.');
+    }
+
+    return rij;
+  }
+
+  private naarBeoordeling(r: BeoordelingRij): Beoordeling {
+    return {
+      reviewId: r.review_id,
+      responseId: r.response_id,
+      verdict: r.verdict,
+      toelichting: r.toelichting,
+      reviewerUserId: r.reviewer_user_id,
+      reviewerNaam: r.reviewer_naam,
+      createdAt: iso(r.created_at) ?? '',
+    };
+  }
+}

--- a/src/survey/ronde-invoer.ts
+++ b/src/survey/ronde-invoer.ts
@@ -277,3 +277,53 @@ export function leesStatus(body: unknown): string {
 export function mogelijkeOvergangen(van: string): readonly string[] {
   return OVERGANGEN[van] ?? [];
 }
+
+/** De drie oordelen uit migratie 0015. */
+const OORDELEN = ['goed', 'nadere_vragen', 'niet_goed'] as const;
+
+export interface NieuweBeoordelingInvoer {
+  verdict: (typeof OORDELEN)[number];
+  toelichting: string;
+}
+
+/**
+ * Leest de invoer voor een nieuw oordeel (fase C).
+ *
+ * De toelichting mag leeg zijn bij `goed` — daar valt vaak niets toe te
+ * lichten. Bij de andere twee is hij verplicht: "niet goed" zonder reden is
+ * voor de leverancier én voor een latere lezer onbruikbaar, en juist in een
+ * compliance-dossier is de onderbouwing het punt.
+ */
+export function leesNieuweBeoordeling(body: unknown): NieuweBeoordelingInvoer {
+  const invoer = leesObject(body);
+
+  if (
+    typeof invoer.verdict !== 'string' ||
+    !(OORDELEN as readonly string[]).includes(invoer.verdict)
+  ) {
+    throw new InvoerFout(
+      'verdict',
+      `Onbekend oordeel. Toegestaan: ${OORDELEN.join(', ')}.`,
+    );
+  }
+
+  const verdict = invoer.verdict as (typeof OORDELEN)[number];
+
+  if (
+    invoer.toelichting !== undefined &&
+    typeof invoer.toelichting !== 'string'
+  ) {
+    throw new InvoerFout('toelichting', 'De toelichting moet tekst zijn.');
+  }
+
+  const toelichting = (invoer.toelichting ?? '').trim();
+
+  if (verdict !== 'goed' && toelichting === '') {
+    throw new InvoerFout(
+      'toelichting',
+      'Licht toe waarom. Zonder onderbouwing is dit oordeel later niet te herleiden.',
+    );
+  }
+
+  return { verdict, toelichting };
+}

--- a/src/survey/survey.module.ts
+++ b/src/survey/survey.module.ts
@@ -9,6 +9,7 @@ import { SurveyTokenService } from './survey-token.service';
 import { AntwoordIndienService } from './antwoord-indienen.service';
 import { BestandOpslagService } from './bestand-opslag.service';
 import { BijlageService } from './bijlage.service';
+import { BeoordelingService } from './beoordeling.service';
 import { RondeBeheerService } from './ronde-beheer.service';
 import { VragenlijstBeheerController } from './vragenlijst-beheer.controller';
 import { VragenlijstBeheerService } from './vragenlijst-beheer.service';
@@ -43,6 +44,7 @@ import { VragenlijstLeesService } from './vragenlijst-lezen.service';
     SurveyTokenGuard,
     VragenlijstBeheerService,
     RondeBeheerService,
+    BeoordelingService,
     VragenlijstImportService,
     VragenlijstLeesService,
     AntwoordIndienService,
@@ -55,6 +57,7 @@ import { VragenlijstLeesService } from './vragenlijst-lezen.service';
     SurveyTokenGuard,
     VragenlijstBeheerService,
     RondeBeheerService,
+    BeoordelingService,
     VragenlijstImportService,
     VragenlijstLeesService,
     AntwoordIndienService,

--- a/src/survey/vragenlijst-beheer.controller.ts
+++ b/src/survey/vragenlijst-beheer.controller.ts
@@ -20,10 +20,13 @@ import {
 import { RondeBeheerService } from './ronde-beheer.service';
 import {
   InvoerFout,
+  leesNieuweBeoordeling,
+  type NieuweBeoordelingInvoer,
   leesNieuweRonde,
   leesStatus,
   leesUitnodigingen,
 } from './ronde-invoer';
+import { BeoordelingService } from './beoordeling.service';
 import { VragenlijstBeheerService } from './vragenlijst-beheer.service';
 
 /**
@@ -71,6 +74,8 @@ export class VragenlijstBeheerController {
     private readonly beheer: VragenlijstBeheerService,
     private readonly rondes: RondeBeheerService,
     private readonly verzender: UitnodigingVerzender,
+    // Onderstreept omdat `beoordelingen` al de naam van een routemethode is.
+    private readonly beoordelingen_: BeoordelingService,
   ) {}
 
   /** Alle vragenlijsten van deze tenant, met aantallen vragen en rondes. */
@@ -130,6 +135,61 @@ export class VragenlijstBeheerController {
     const sessie = request.sessie!;
 
     return this.beheer.antwoorden(sessie.tenantId, id);
+  }
+
+  /** Alle oordelen over één respons, nieuwste eerst. */
+  @Get('responses/:id/reviews')
+  async beoordelingen(
+    @Req() request: RequestMetSessie,
+    @Param('id') id: string,
+  ) {
+    const sessie = request.sessie!;
+
+    const beoordelingen = await this.beoordelingen_.lijst(sessie.tenantId, id);
+
+    return { beoordelingen };
+  }
+
+  /**
+   * Legt een nieuw oordeel vast over een ingediende respons.
+   *
+   * **Geen `@VereistRol('admin')`, en dat is een besluit** (plan §2a, eigenaar
+   * 2026-08-03). Beoordelen ís de rol van een reviewer; hem dat ontzeggen maakt
+   * de rol betekenisloos en de admin een flessenhals.
+   *
+   * Dat dit verantwoord is hangt aan één ding: elk oordeel staat met naam en
+   * datum vast en wordt nooit overschreven. Een reviewer kan dus niets
+   * stilletjes veranderen — alleen iets toevoegen dat zichtbaar van hem is.
+   * Zou de tabel updates toestaan, dan hoorde hier admin te staan.
+   *
+   * 201 met het oordeel erbij. 404 als de respons niet bestaat binnen deze
+   * tenant, 400 als er nog niet is ingediend of de invoer niet deugt.
+   */
+  @Post('responses/:id/reviews')
+  async beoordeel(
+    @Req() request: RequestMetSessie,
+    @Param('id') id: string,
+    @Body() body: unknown,
+  ) {
+    const sessie = request.sessie!;
+
+    let invoer: NieuweBeoordelingInvoer;
+    try {
+      invoer = leesNieuweBeoordeling(body);
+    } catch (err) {
+      throw this.naarHttpFout(err);
+    }
+
+    // De reviewer komt uit de sessie, nooit uit de body: anders kan iemand een
+    // oordeel op naam van een collega vastleggen (§6).
+    const beoordeling = await this.beoordelingen_.voegToe(
+      sessie.tenantId,
+      id,
+      sessie.userId,
+      invoer,
+    );
+
+    return { beoordeling };
   }
 
   // ── Fase B: schrijven ──────────────────────────────────────────────────────

--- a/test/beoordeling.e2e-spec.ts
+++ b/test/beoordeling.e2e-spec.ts
@@ -1,0 +1,415 @@
+import { INestApplication } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import cookieParser from 'cookie-parser';
+import { Client } from 'pg';
+import request from 'supertest';
+import type { App } from 'supertest/types';
+
+import { AppModule } from '../src/app.module';
+import { cookieInstellingen } from '../src/auth/sessie';
+import { SessieService } from '../src/auth/sessie.service';
+import { TEST_IDS } from './test-ids';
+
+/**
+ * Beoordelen van een ingediende respons (fase C2 van het surveybeheerplan).
+ *
+ * De makkelijke helft — "kan ik een oordeel opslaan" — is niet waar deze suite
+ * om draait. Vier dingen kunnen hier stuk zonder dat iemand het merkt:
+ *
+ *   1. Kan een LEVERANCIER het oordeel over zichzelf lezen? Dat mag nooit, en
+ *      het is de eerste tabel waar de tenantgrens daarvoor niet volstaat.
+ *   2. Kan tenant B een oordeel van A zien of eraan toevoegen?
+ *   3. Wordt een tweede oordeel toegevoegd of overschrijft het het eerste?
+ *   4. Kan er beoordeeld worden op iets dat nog niet is ingediend?
+ *
+ * De derde is de reden dat een reviewer dit mag zonder admin te zijn (plan
+ * §2a). Zou een oordeel het vorige overschrijven, dan hoorde daar admin te
+ * staan — dan kan iemand namelijk stilletjes de geschiedenis herschrijven.
+ */
+
+const {
+  tenantA,
+  tenantB,
+  adminA,
+  reviewerA,
+  templateA: TEMPLATE_A,
+  runA: RUN_A,
+  vendorA: VENDOR_A,
+  responseIngediend: RESPONSE_INGEDIEND,
+  responseOpen: RESPONSE_OPEN,
+  adminB,
+  vendorOpen: VENDOR_OPEN,
+} = TEST_IDS.beoordeling;
+
+const SUBJECT_ADMIN = `oid-bo-a-${Date.now()}`;
+const SUBJECT_REVIEWER = `oid-bo-r-${Date.now()}`;
+const SUBJECT_B = `oid-bo-b-${Date.now()}`;
+
+/** 64 hex-tekens, conform de CHECK op token_hash (migratie 0003). */
+const HASH_INGEDIEND = `${'1'.repeat(48)}aaaaaaaaaaaaaaaa`;
+const HASH_OPEN = `${'2'.repeat(48)}bbbbbbbbbbbbbbbb`;
+
+interface BeoordelingBody {
+  beoordeling: {
+    reviewId: string;
+    verdict: string;
+    toelichting: string;
+    reviewerUserId: string;
+    reviewerNaam: string | null;
+    createdAt: string;
+  };
+}
+
+interface LijstBody {
+  beoordelingen: Array<{
+    reviewId: string;
+    verdict: string;
+    toelichting: string;
+    reviewerNaam: string | null;
+  }>;
+}
+
+async function verwijderTestdata(client: Client) {
+  for (const tenant of [tenantA, tenantB]) {
+    await client.query('BEGIN');
+    await client.query(`SET LOCAL app.current_tenant_id = '${tenant}'`);
+    // De actor moet 'medewerker' zijn: zonder dat weigert de policy op
+    // survey_review élke rij, ook bij het opruimen. Dat is precies wat de
+    // policy hoort te doen.
+    await client.query(`SET LOCAL app.current_actor = 'medewerker'`);
+    for (const tabel of [
+      'clm.survey_review',
+      'clm.survey_answer',
+      'clm.survey_response',
+      'clm.survey_run',
+      'clm.survey_question',
+      'clm.survey_template',
+      'clm.vendor',
+      'clm.tenant_membership',
+      'clm."user"',
+      'clm.tenant',
+    ]) {
+      await client.query(`DELETE FROM ${tabel} WHERE tenant_id = $1`, [tenant]);
+    }
+    await client.query('COMMIT');
+  }
+}
+
+describe('Beoordelen van een respons (e2e)', () => {
+  // Met de generic erbij: zonder <App> geeft getHttpServer() `any` terug en
+  // slaat no-unsafe-assignment aan.
+  let app: INestApplication<App>;
+  let server: App;
+  let client: Client;
+  let cookieAdmin: string;
+  let cookieReviewer: string;
+  let cookieB: string;
+
+  beforeAll(async () => {
+    client = new Client({ connectionString: process.env.DATABASE_URL });
+    await client.connect();
+    await verwijderTestdata(client);
+
+    await client.query('BEGIN');
+    await client.query(`SET LOCAL app.current_tenant_id = '${tenantA}'`);
+    await client.query(`SET LOCAL app.current_actor = 'medewerker'`);
+
+    await client.query(
+      'INSERT INTO clm.tenant (tenant_id, name) VALUES ($1, $2)',
+      [tenantA, 'Tenant A (beoordeling)'],
+    );
+    for (const [userId, subject, naam, rol] of [
+      [adminA, SUBJECT_ADMIN, 'Admin van A', 'admin'],
+      [reviewerA, SUBJECT_REVIEWER, 'Reviewer van A', 'reviewer'],
+    ] as const) {
+      await client.query(
+        `INSERT INTO clm."user" (user_id, tenant_id, email, full_name, external_subject)
+         VALUES ($1, $2, $3, $4, $5)`,
+        [userId, tenantA, `${subject}@voorbeeld.nl`, naam, subject],
+      );
+      await client.query(
+        `INSERT INTO clm.tenant_membership (user_id, tenant_id, role)
+         VALUES ($1, $2, $3)`,
+        [userId, tenantA, rol],
+      );
+    }
+
+    await client.query(
+      `INSERT INTO clm.survey_template (template_id, tenant_id, name, version)
+       VALUES ($1, $2, 'beoordeel-test-lijst', 1)`,
+      [TEMPLATE_A, tenantA],
+    );
+    await client.query(
+      `INSERT INTO clm.survey_run
+         (run_id, tenant_id, template_id, status, survey_kind, is_test, started_at)
+       VALUES ($1, $2, $3, 'active', 'vendor_compliance', true, now())`,
+      [RUN_A, tenantA, TEMPLATE_A],
+    );
+    await client.query(
+      `INSERT INTO clm.vendor (vendor_id, tenant_id, name)
+       VALUES ($1, $2, 'Leverancier van A')`,
+      [VENDOR_A, tenantA],
+    );
+    // Tweede leverancier: survey_response_run_vendor_key staat maar één
+    // respons per vendor per ronde toe.
+    await client.query(
+      `INSERT INTO clm.vendor (vendor_id, tenant_id, name)
+       VALUES ($1, $2, 'Leverancier die nog moet')`,
+      [VENDOR_OPEN, tenantA],
+    );
+
+    // Eén ingediende respons en één die nog openstaat. Dat onderscheid is het
+    // hele punt van de controle "beoordelen mag pas na indienen".
+    await client.query(
+      `INSERT INTO clm.survey_response
+         (response_id, tenant_id, run_id, vendor_id, subject_vendor_id,
+          token_hash, status, expires_at, submitted_at)
+       VALUES ($1, $2, $3, $4, $4, $5, 'submitted',
+               now() + interval '30 days', now())`,
+      [RESPONSE_INGEDIEND, tenantA, RUN_A, VENDOR_A, HASH_INGEDIEND],
+    );
+    await client.query(
+      `INSERT INTO clm.survey_response
+         (response_id, tenant_id, run_id, vendor_id, subject_vendor_id,
+          token_hash, status, expires_at)
+       VALUES ($1, $2, $3, $4, $4, $5, 'pending', now() + interval '30 days')`,
+      [RESPONSE_OPEN, tenantA, RUN_A, VENDOR_OPEN, HASH_OPEN],
+    );
+    await client.query('COMMIT');
+
+    // Tenant B, zodat de tenantgrens iets te verbergen heeft.
+    await client.query('BEGIN');
+    await client.query(`SET LOCAL app.current_tenant_id = '${tenantB}'`);
+    await client.query(`SET LOCAL app.current_actor = 'medewerker'`);
+    await client.query(
+      'INSERT INTO clm.tenant (tenant_id, name) VALUES ($1, $2)',
+      [tenantB, 'Tenant B (beoordeling)'],
+    );
+    await client.query(
+      `INSERT INTO clm."user" (user_id, tenant_id, email, full_name, external_subject)
+       VALUES ($1, $2, $3, 'Admin van B', $4)`,
+      [adminB, tenantB, `${SUBJECT_B}@voorbeeld.nl`, SUBJECT_B],
+    );
+    await client.query(
+      `INSERT INTO clm.tenant_membership (user_id, tenant_id, role)
+       VALUES ($1, $2, 'admin')`,
+      [adminB, tenantB],
+    );
+    await client.query('COMMIT');
+
+    const moduleRef = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleRef.createNestApplication();
+    app.use(cookieParser());
+    await app.init();
+    server = app.getHttpServer();
+
+    const sessies = app.get(SessieService);
+    const naam = cookieInstellingen().naam;
+    for (const [subject, doel] of [
+      [SUBJECT_ADMIN, 'admin'],
+      [SUBJECT_REVIEWER, 'reviewer'],
+      [SUBJECT_B, 'b'],
+    ] as const) {
+      const sessie = await sessies.aanmaken(subject);
+
+      // Null betekent dat de gebruiker of het membership niet gevonden is;
+      // dan klopt de opzet hierboven niet en zijn alle tests hieronder
+      // betekenisloos. Hier stoppen is duidelijker dan een cookie 'undefined'.
+      expect(sessie).not.toBeNull();
+
+      const cookie = `${naam}=${sessie!.token}`;
+      if (doel === 'admin') cookieAdmin = cookie;
+      else if (doel === 'reviewer') cookieReviewer = cookie;
+      else cookieB = cookie;
+    }
+  }, 30000);
+
+  afterAll(async () => {
+    await app.close();
+    await verwijderTestdata(client);
+    await client.end();
+  }, 30000);
+
+  describe('een oordeel vastleggen', () => {
+    it('legt een oordeel vast met de naam van de beoordelaar', async () => {
+      const antwoord = await request(server)
+        .post(`/admin/survey/responses/${RESPONSE_INGEDIEND}/reviews`)
+        .set('Cookie', cookieAdmin)
+        .send({ verdict: 'goed', toelichting: 'Ziet er compleet uit.' })
+        .expect(201);
+
+      const body = antwoord.body as BeoordelingBody;
+
+      expect(body.beoordeling.verdict).toBe('goed');
+      expect(body.beoordeling.toelichting).toBe('Ziet er compleet uit.');
+      // De reviewer komt uit de sessie, niet uit de body.
+      expect(body.beoordeling.reviewerUserId).toBe(adminA);
+      expect(body.beoordeling.reviewerNaam).toBe('Admin van A');
+    });
+
+    it('laat een REVIEWER ook beoordelen — dat is zijn rol', async () => {
+      // Besluit eigenaar 2026-08-03. Hem dit ontzeggen maakt de rol
+      // betekenisloos en de admin een flessenhals.
+      await request(server)
+        .post(`/admin/survey/responses/${RESPONSE_INGEDIEND}/reviews`)
+        .set('Cookie', cookieReviewer)
+        .send({
+          verdict: 'nadere_vragen',
+          toelichting: 'Vraag 3 is onduidelijk.',
+        })
+        .expect(201);
+    });
+
+    // Dit is waarom een reviewer geen admin hoeft te zijn: hij kan niets
+    // stilletjes veranderen, alleen iets toevoegen dat van hem is.
+    it('voegt een tweede oordeel TOE in plaats van het eerste te overschrijven', async () => {
+      const antwoord = await request(server)
+        .get(`/admin/survey/responses/${RESPONSE_INGEDIEND}/reviews`)
+        .set('Cookie', cookieAdmin)
+        .expect(200);
+
+      const body = antwoord.body as LijstBody;
+
+      expect(body.beoordelingen).toHaveLength(2);
+      // Nieuwste eerst.
+      expect(body.beoordelingen[0].verdict).toBe('nadere_vragen');
+      expect(body.beoordelingen[1].verdict).toBe('goed');
+      expect(body.beoordelingen[0].reviewerNaam).toBe('Reviewer van A');
+    });
+
+    it('weigert een oordeel op een respons die nog niet is ingediend', async () => {
+      const antwoord = await request(server)
+        .post(`/admin/survey/responses/${RESPONSE_OPEN}/reviews`)
+        .set('Cookie', cookieAdmin)
+        .send({ verdict: 'goed', toelichting: '' })
+        .expect(400);
+
+      // De melding moet uitleggen waarom, niet alleen dat het niet mag —
+      // daarom een servicecontrole en geen CHECK-constraint.
+      expect(JSON.stringify(antwoord.body)).toContain('nog niet ingediend');
+    });
+
+    it('weigert een onbekend oordeel', async () => {
+      await request(server)
+        .post(`/admin/survey/responses/${RESPONSE_INGEDIEND}/reviews`)
+        .set('Cookie', cookieAdmin)
+        .send({ verdict: 'twijfelachtig', toelichting: 'iets' })
+        .expect(400);
+    });
+
+    it('eist een toelichting bij niet_goed', async () => {
+      const antwoord = await request(server)
+        .post(`/admin/survey/responses/${RESPONSE_INGEDIEND}/reviews`)
+        .set('Cookie', cookieAdmin)
+        .send({ verdict: 'niet_goed', toelichting: '   ' })
+        .expect(400);
+
+      expect(JSON.stringify(antwoord.body)).toContain('toelichting');
+    });
+
+    it('staat een lege toelichting toe bij goed', async () => {
+      await request(server)
+        .post(`/admin/survey/responses/${RESPONSE_INGEDIEND}/reviews`)
+        .set('Cookie', cookieAdmin)
+        .send({ verdict: 'goed' })
+        .expect(201);
+    });
+
+    it('geeft 404 op een respons die niet bestaat', async () => {
+      await request(server)
+        .post(
+          '/admin/survey/responses/00000000-0000-0000-0000-00000000dead/reviews',
+        )
+        .set('Cookie', cookieAdmin)
+        .send({ verdict: 'goed', toelichting: '' })
+        .expect(404);
+    });
+  });
+
+  describe('de tenantgrens', () => {
+    it('geeft tenant B een 404 op de respons van A', async () => {
+      await request(server)
+        .get(`/admin/survey/responses/${RESPONSE_INGEDIEND}/reviews`)
+        .set('Cookie', cookieB)
+        .expect(404);
+    });
+
+    it('laat tenant B geen oordeel toevoegen aan een respons van A', async () => {
+      await request(server)
+        .post(`/admin/survey/responses/${RESPONSE_INGEDIEND}/reviews`)
+        .set('Cookie', cookieB)
+        .send({ verdict: 'goed', toelichting: '' })
+        .expect(404);
+    });
+  });
+
+  /**
+   * De kern van migratie 0015, en de reden dat app.current_actor bestaat.
+   *
+   * Een leverancier zit in dezelfde tenant als de medewerker die hem
+   * beoordeelt. Elke andere tabel in dit project zegt "zelfde tenant = mag het
+   * zien". Hier niet — en dat verschil kon de database vóór migratie 0013 niet
+   * eens uitdrukken.
+   *
+   * Deze tests praten rechtstreeks met de database in plaats van via een route,
+   * want er ís geen route waarlangs een leverancier dit zou proberen. Dat is
+   * precies waarom de grens in de database moet liggen en niet in een guard:
+   * een toekomstige route die de actor vergeet, stuit hier alsnog op.
+   */
+  describe('een leverancier komt er niet bij', () => {
+    it('ziet geen enkel oordeel, ook niet over zichzelf', async () => {
+      await client.query('BEGIN');
+      await client.query(`SET LOCAL app.current_tenant_id = '${tenantA}'`);
+      await client.query(`SET LOCAL app.current_actor = 'leverancier'`);
+
+      const { rows } = await client.query(
+        'SELECT * FROM clm.survey_review WHERE response_id = $1',
+        [RESPONSE_INGEDIEND],
+      );
+
+      await client.query('COMMIT');
+
+      expect(rows).toHaveLength(0);
+    });
+
+    it('kan zelf geen oordeel wegschrijven', async () => {
+      await client.query('BEGIN');
+      await client.query(`SET LOCAL app.current_tenant_id = '${tenantA}'`);
+      await client.query(`SET LOCAL app.current_actor = 'leverancier'`);
+
+      // De actor-eis staat ook in WITH CHECK. Zonder dat zou een
+      // leverancierspad kunnen schrijven wat het niet kan lezen — een lek dat
+      // pas opvalt als de rij er al staat.
+      await expect(
+        client.query(
+          `INSERT INTO clm.survey_review
+             (tenant_id, response_id, verdict, toelichting, reviewer_user_id)
+           VALUES ($1, $2, 'goed', 'stiekem', $3)`,
+          [tenantA, RESPONSE_INGEDIEND, adminA],
+        ),
+      ).rejects.toThrow(/row-level security/i);
+
+      await client.query('ROLLBACK');
+    });
+
+    it('een medewerker ziet ze wél — de tests hierboven meten geen lege tabel', async () => {
+      // Zonder deze test zouden de twee hierboven ook slagen als de tabel
+      // gewoon leeg was, en dan bewijzen ze niets.
+      await client.query('BEGIN');
+      await client.query(`SET LOCAL app.current_tenant_id = '${tenantA}'`);
+      await client.query(`SET LOCAL app.current_actor = 'medewerker'`);
+
+      const { rows } = await client.query(
+        'SELECT * FROM clm.survey_review WHERE response_id = $1',
+        [RESPONSE_INGEDIEND],
+      );
+
+      await client.query('COMMIT');
+
+      expect(rows.length).toBeGreaterThan(0);
+    });
+  });
+});

--- a/test/test-ids.ts
+++ b/test/test-ids.ts
@@ -156,6 +156,28 @@ export const TEST_IDS = {
     vendorB: '00000000-0000-0000-0000-0000000000d4',
     vendorWeg: '00000000-0000-0000-0000-0000000000d5',
   },
+  // Fase C2 — beoordelen. Staarten d6 t/m db; da is al vergeven, vandaar de
+  // sprong. Gecontroleerd tegen alleTestIds(), niet gegokt.
+  beoordeling: {
+    tenantA: '00000000-0000-0000-0000-0000000000d6',
+    tenantB: '00000000-0000-0000-0000-0000000000d7',
+    adminA: '00000000-0000-0000-0000-0000000000d8',
+    reviewerA: '00000000-0000-0000-0000-0000000000d9',
+    templateA: '00000000-0000-0000-0000-0000000000db',
+    runA: '00000000-0000-0000-0000-0000000000dc',
+    vendorA: '00000000-0000-0000-0000-0000000000dd',
+    /** Ingediend — hierop mag beoordeeld worden. */
+    responseIngediend: '00000000-0000-0000-0000-0000000000de',
+    /** Nog niet ingediend — hierop juist niet. */
+    responseOpen: '00000000-0000-0000-0000-0000000000df',
+    adminB: '00000000-0000-0000-0000-0000000000e0',
+    /**
+     * Tweede leverancier. Nodig omdat survey_response_run_vendor_key één
+     * respons per vendor per ronde toestaat — de open en de ingediende respons
+     * kunnen dus niet dezelfde vendor hebben.
+     */
+    vendorOpen: '00000000-0000-0000-0000-0000000000e3',
+  },
 } as const;
 
 /** Alle uitgedeelde id's, plat. Gebruikt door de bewakingstest. */


### PR DESCRIPTION
Tweede van drie PR's voor fase C. **Gericht op `main`** — C1 (PR #94) staat er inmiddels in.

> Deze PR vervangt **#95**, die automatisch dichtklapte toen de basisbranch `feat/fase-c1-antwoorden-lezen` bij het mergen van #94 werd verwijderd. Er is niets gemerged en niets kwijt: dezelfde commit (`9f691eb`), plus een merge van `main` erbovenop. GitHub staat niet toe een gesloten PR te heropenen als zijn basisbranch weg is, vandaar een nieuw nummer.

## Wat erbij komt

Migratie **0015** met `clm.survey_review`, plus twee routes:

```
GET  /admin/survey/responses/:id/reviews
POST /admin/survey/responses/:id/reviews
```

## De eerste tabel waar de tenantgrens niet volstaat

Elke bestaande policy in dit project luidt `USING (tenant_id = clm.current_tenant_id())`. Dat klopt overal — behalve hier. Een leverancier zit in **dezelfde tenant** als de medewerker die hem beoordeelt, maar mag dat oordeel nooit lezen.

Daarvoor is `app.current_actor` gemaakt (migratie 0013). Dit is de eerste policy die hem gebruikt:

```sql
USING      (tenant_id = clm.current_tenant_id() AND clm.current_actor() = 'medewerker')
WITH CHECK (tenant_id = clm.current_tenant_id() AND clm.current_actor() = 'medewerker')
```

**De actor-eis staat ook in `WITH CHECK`.** Zonder dat zou een leverancierspad kunnen schrijven wat het niet kan lezen — een lek dat pas opvalt als de rij er al staat.

## Toevoegen, nooit overschrijven

Geen update, geen delete. Een herzien oordeel komt eronder te staan, niet eroverheen.

Dat is niet cosmetisch: het is precies waarom een **reviewer** dit mag zonder admin te zijn (plan §2a, besluit eigenaar 2026-08-03). Hij kan niets stilletjes veranderen, alleen iets toevoegen dat zichtbaar van hem is. Zou de tabel updates toestaan, dan hoorde daar `@VereistRol('admin')` te staan.

## Keuzes die uitleg verdienen

**De reviewer komt uit de sessie, nooit uit de body.** Anders kan iemand een oordeel op naam van een collega vastleggen — en in een compliance-dossier is dat de handtekening die moet kloppen (§6).

**"Alleen op een ingediende respons" is een servicecontrole, geen constraint.** De melding moet uitleggen wáárom het niet kan ("deze leverancier heeft nog niet ingediend"); een CHECK levert alleen een constraintnaam op.

**Toelichting verplicht bij `nadere_vragen` en `niet_goed`**, optioneel bij `goed`. "Niet goed" zonder reden is later niet te herleiden.

**`nadere_vragen` stuurt niets terug naar de leverancier.** Het oordeel wordt vastgelegd, de respons blijft dicht, de beheerder neemt zelf contact op. Terugsturen zou vier bewezen onderdelen raken (bevriezingstrigger, tokenguard, verlooplogica, audittrail). Het scherm moet dit straks zeggen — een knop die suggereert dat er iets verstuurd wordt terwijl dat niet gebeurt, is erger dan geen knop.

## Twee tegenproeven (§15b)

| Sabotage | Uitkomst |
|---|---|
| actor-eis uit de policy gehaald | precies de twee leveranciertests vielen om |
| indien-controle uitgeschakeld | precies die ene test viel om |

Beide hersteld, daarna weer 13 groen.

De eerste is de belangrijkste. Er staat ook een derde test — *"een medewerker ziet ze wél"* — juist omdat de twee leveranciertests anders óók zouden slagen op een lege tabel, en dan bewijzen ze niets.

## Migratie met de hand geschreven

`db:generate` is hier onbruikbaar: de snapshots in `drizzle/meta` lopen tot **0007** terwijl er 15 migraties zijn — 0008 t/m 0014 zijn destijds ook handmatig gemaakt. Het genereerde daardoor `sessie`, `tenant_membership` en een `user`-kolom opnieuw, wat op elke echte database zou stuklopen. Ik heb dat weggegooid en de migratie in dezelfde stijl als 0013 geschreven.

**Dat is een losse bevinding die aandacht verdient**, maar niet in deze PR thuishoort.

## Getoetst

- **341 e2e-tests groen** (was 328), 23 suites
- 266 unittests, lint/format/typecheck schoon
- **Migratieketen vanaf leeg bewezen** op een verse Postgres 18.2: 19 tabellen (was 18), RLS geforceerd, schema-conformiteit 17/17 en de RLS-isolatietest groen — dat is exact wat de `rls-isolation`-job in CI doet

De merge van `main` in deze branch verliep zonder conflicten; typecheck en lint zijn daarna opnieuw schoon gedraaid. CI draait nu wél (de Actions-storing van 06-08 is voorbij).
