### PR TITLE
feat(survey): goedkeuren als vierde oordeel (migratie 0017) + commando-runbook

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,83 @@
+# MCM2 — instap bij iedere sessie
+
+> Dit bestand wordt door Claude Code **automatisch** geladen bij sessiestart.
+> `MCM2-CLAUDE.md` niet — die naam staat niet in de conventie, ook al staat er
+> bovenaan "lees dit bij iedere sessiestart". Vandaar dit bestand: het is de
+> haak die de rest binnenhaalt.
+
+---
+
+## Lees deze drie, in deze volgorde, vóór je iets doet
+
+| # | Bestand | Waarvoor |
+|---|---|---|
+| 1 | **`docs/runbooks/commandos-en-omgeving.md`** | Welk commando bestaat er echt, waar praat het naartoe, wat mag nooit |
+| 2 | `MCM2-CLAUDE.md` | Rol, werkmodus, architectuurregels, §14 sessiestartprotocol |
+| 3 | `docs/STATUS.md` | Waar het project nu staat |
+
+**Nummer 1 gaat vóór de rest**, en dat is een correctie op §14 van
+`MCM2-CLAUDE.md`. Reden: op 2026-08-07 werden in één sessie vier commando's
+aangeroepen die niet bestaan (`npm run migrate`, `migrate:status`,
+`verify:migratieketen`, `node scripts/db-doelwit.js`) en scheelde het weinig of
+er was een migratie tegen de Supabase-productiedatabase gedraaid. Dat komt
+doordat `.env` daarheen wijst. Architectuurregels lezen helpt niet als het
+eerste commando al het verkeerde doelwit raakt.
+
+---
+
+## De vier dingen die het vaakst misgaan
+
+Volledig uitgelegd in het runbook; hier alleen zodat je ze niet mist.
+
+**1. `.env` wijst naar Supabase — de echte database.**
+Elk databasecommando zonder overschreven variabele raakt productie. Zet een
+wegwerpcontainer op (`-p 127.0.0.1:55440:5432`, niet `0.0.0.0`) en overschrijf
+`MIGRATION_DATABASE_URL` / `DATABASE_URL` binnen het commando. Nooit `.env`
+aanpassen.
+
+**2. Verzin nooit een commando.**
+Staat het niet in `package.json`, dan bestaat het niet:
+```powershell
+(Get-Content package.json | ConvertFrom-Json).scripts
+```
+`psql` en de Supabase CLI staan **niet** op deze machine. psql loopt via
+`docker exec <container> psql …`.
+
+**3. Een handgeschreven migratie moet in `drizzle/meta/_journal.json`.**
+Anders slaat Drizzle hem over en meldt `migrate:deploy` alsnog "Migraties
+voltooid". `db:generate` is onbruikbaar (Issue #96) — migraties gaan met de
+hand, in de stijl van `drizzle/0015_survey_review.sql`.
+
+**4. Vertrouw geen enkele geruststellende melding.**
+Lees het resultaat terug uit de database. "Migraties voltooid" betekende op
+2026-08-07 dat er niets was gebeurd, en in Issue #86 dat het op de verkeerde
+database was gebeurd.
+
+---
+
+## Groen is alleen groen via verify
+
+```powershell
+npm run verify:volledig
+```
+
+Losse commando's bewijzen niets (§15a). Let op: `npm run lint` en
+`npm run format` **wijzigen** bestanden; CI draait `lint:check` en
+`format:check`.
+
+---
+
+## Bij conflicten
+
+```text
+Security en actuele blokkades
+  -> docs/runbooks/commandos-en-omgeving.md   (wat technisch kan en mag)
+    -> MCM2-CLAUDE.md                          (hoe we werken)
+      -> actuele ADR's en docs/STATUS.md
+        -> projectdocumentatie
+          -> oude plannen, pilots en sessiehistorie
+```
+
+Zolang we in deze architectuur werken — NestJS, Drizzle met handgeschreven
+migraties, Postgres met RLS, Supabase als productiedatabase — is het runbook
+leidend van ontwerp tot en met uitrol.

--- a/MCM2-CLAUDE.md
+++ b/MCM2-CLAUDE.md
@@ -407,6 +407,12 @@ Zet nooit een branchnaam, blocker-status of "aantoonbaar werkend"-claim in STATU
 
 Begin iedere nieuwe sessie als volgt:
 
+0. **Lees `docs/runbooks/commandos-en-omgeving.md`.** Welk commando bestaat er
+   werkelijk, waar praat het naartoe, en wat mag nooit. Dit gaat vóór dit
+   bestand: `.env` wijst naar de Supabase-productiedatabase, dus het eerste
+   verkeerde databasecommando is al raak. Toegevoegd 2026-08-07 nadat er in één
+   sessie vier niet-bestaande commando's waren aangeroepen en een migratie
+   bijna tegen productie liep.
 1. Lees dit bestand volledig.
 2. Lees `docs/STATUS.md`.
 3. Verifieer STATUS.md tegen de werkelijke repository-status vóórdat je erop vertrouwt: `git status`, `git branch -a`. Wijkt de vermelde branch of git-status af van de realiteit? Corrigeer STATUS.md direct en meld dit expliciet aan de gebruiker — ga niet stilzwijgend uit van het document.
@@ -426,10 +432,11 @@ Bij conflicten geldt deze prioriteit:
 
 ```text
 Security en expliciete actuele blokkades
-  -> dit MCM2-CLAUDE.md
-    -> actuele ADR's en STATUS.md
-      -> projectdocumentatie
-        -> oude plannen, pilots en sessiehistorie
+  -> docs/runbooks/commandos-en-omgeving.md   (wat technisch kan en mag)
+    -> dit MCM2-CLAUDE.md                      (hoe we werken)
+      -> actuele ADR's en STATUS.md
+        -> projectdocumentatie
+          -> oude plannen, pilots en sessiehistorie
 ```
 
 ---

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -286,6 +286,11 @@ Blijken ze over een half jaar nog steeds ongebruikt, dan kunnen ze weg — de ke
 
 ### Snel weer op gang komen
 
+> **Welk commando bestaat er, en waar praat het naartoe?**
+> `docs/runbooks/commandos-en-omgeving.md` — de volledige lijst, geverifieerd,
+> met de waarschuwing dat `.env` naar Supabase wijst. Lees dat eerst wanneer je
+> iets wilt draaien dat de database raakt.
+
 **De hele keten in één commando** (aanbevolen — sinds 2026-07-31):
 
 ```bash

--- a/docs/runbooks/commandos-en-omgeving.md
+++ b/docs/runbooks/commandos-en-omgeving.md
@@ -161,9 +161,19 @@ ongemoeid.
 
 ### Een verse wegwerpdatabase opzetten
 
+> **Bind op localhost, niet op alle interfaces.** `-p 55440:5432` luistert op
+> `0.0.0.0` — dan is de testdatabase bereikbaar vanaf het hele netwerk, met een
+> wachtwoord van twee letters. Op een kantoor- of hotelnetwerk is dat een open
+> database. Schrijf `-p 127.0.0.1:55440:5432`; alles hieronder werkt onveranderd,
+> want migraties en tests verbinden via `localhost`.
+>
+> Controleren waar hij luistert: `docker port <container>`. Staat er `0.0.0.0`,
+> dan is de binding te ruim.
+
 ```powershell
 # De containernaam moet minstens twee tekens hebben — Docker 29 weigert één teken.
-docker run -d --name mcm2test -e POSTGRES_PASSWORD=pw -p 55440:5432 postgres:17.6
+# 127.0.0.1 ervoor: anders luistert de database op alle netwerkinterfaces.
+docker run -d --name mcm2test -e POSTGRES_PASSWORD=pw -p 127.0.0.1:55440:5432 postgres:17.6
 
 # Wachten tot hij luistert; direct erna verbinden faalt met "the database system is starting up".
 docker exec mcm2test pg_isready -U postgres
@@ -188,16 +198,31 @@ PowerShell (deze machine):
 ```powershell
 $env:MIGRATION_DATABASE_URL="postgresql://clm_migrator:pw@localhost:55440/postgres"
 npm run migrate:deploy
-Remove-Item Env:\MIGRATION_DATABASE_URL
+Remove-Item Env:\MIGRATION_DATABASE_URL     # niet overslaan, zie hieronder
 ```
 
-Bash:
+Bash — veiliger, want de variabele geldt alleen voor dít commando:
 ```bash
 MIGRATION_DATABASE_URL="postgresql://clm_migrator:pw@localhost:55440/postgres" npm run migrate:deploy
 ```
 
+> **`Remove-Item` is geen opruimnetheid maar een veiligheidsmaatregel.**
+> In PowerShell blijft `$env:X` staan voor de hele sessie. Vergeet je hem, dan
+> draait een uur later een backup-, seed- of migratiescript stilzwijgend tegen
+> `localhost:55440` in plaats van tegen de database die je dan bedoelt — of
+> andersom, als je de variabele naar productie hebt gezet.
+>
+> Dit is dezelfde klasse fout als Issue #86, alleen met de omgekeerde richting.
+> Wil je dat risico helemaal niet: gebruik de bash-vorm.
+
 **Controleer de melding die het script afdrukt.** Hij noemt het doelwit. Staat
 daar `supabase.com`, dan is de variabele niet doorgekomen — stop.
+
+Zie je twijfel over wat er nu gezet staat:
+```powershell
+Get-ChildItem Env: | Where-Object Name -match 'DATABASE_URL' |
+  ForEach-Object { "{0} = {1}" -f $_.Name, ($_.Value -replace ':[^:@]+@',':***@') }
+```
 
 ### E2e-tests erop draaien
 
@@ -215,6 +240,44 @@ waardoor Jest anders blijft hangen zónder foutmelding.
 ```powershell
 docker rm -f mcm2test
 ```
+
+**Ruim de container op als je klaar bent.** Een blijvende testdatabase met
+wachtwoord `pw` is precies het soort ding dat maanden vergeten blijft draaien.
+`docker ps` laat zien wat er nog staat.
+
+---
+
+## Wat dit runbook bewust NIET verzwakt
+
+Nagelopen op 2026-08-07. Deze werkwijze mag geen enkele bestaande bescherming
+omzeilen, en doet dat ook niet:
+
+| Bescherming | Blijft gelden? |
+|---|---|
+| `migrate:deploy` weigert buiten lokaal zonder `--extern` of `MCM2_EXTERNE_DB=ja` | **Ja** — de wegwerpdatabase is lokaal, dus de bescherming hoeft nooit uitgezet |
+| `verify.js` weigert een niet-lokale `DATABASE_URL` | **Ja** — onaangeroerd |
+| Rolscheiding `clm_migrator` (DDL) / `clm_api_runtime` (runtime) / aparte backuprol | **Ja** — de opzet reproduceert alle drie via `bootstrap-roles.sql` |
+| Geen `BYPASSRLS`, geen superuser op de app-rollen | **Ja** — geverifieerd op de wegwerpdatabase: beide `f` |
+| `FORCE ROW LEVEL SECURITY` (migratie 0011) | **Ja** — komt mee via de migratieketen |
+| `.env` buiten git | **Ja** — staat in `.gitignore`, niet getrackt |
+
+**Drie dingen die nooit in dit runbook mogen sluipen:**
+
+1. **Geen `--extern` of `MCM2_EXTERNE_DB=ja` als standaardstap.** Die vlag hoort
+   een bewuste, zichtbare uitzondering te zijn — hij staat in de
+   terminalhistorie zodat later terug te zien is dat iemand het deed. Zet hem
+   nooit in een `.env`, script of alias.
+2. **Nooit een echte connectiestring in een commandovoorbeeld.** Voorbeelden
+   gebruiken `clm_migrator:pw@localhost`. Een commando met een echt wachtwoord
+   belandt in terminalhistorie, CI-logs en schermafdrukken.
+3. **Nooit `pw` buiten een wegwerpcontainer.** Het is een wegwerpwachtwoord voor
+   een database die je binnen een uur weggooit — geen patroon om elders te
+   hergebruiken.
+
+**Eén ding dat wél zwakker is dan productie, en dat mag:** de wegwerpdatabase
+heeft een triviaal wachtwoord en geen TLS. Dat is verdedigbaar omdat hij op
+`127.0.0.1` luistert, geen echte gegevens bevat en binnen een sessie verdwijnt.
+Zodra een van die drie niet meer klopt, is het geen wegwerpdatabase meer.
 
 ---
 

--- a/docs/runbooks/commandos-en-omgeving.md
+++ b/docs/runbooks/commandos-en-omgeving.md
@@ -6,6 +6,18 @@
 **Aanleiding:** te vaak begonnen met een commando dat niet bestaat, of dat tegen
 de verkeerde database zou hebben gedraaid.
 
+**Geverifieerd op deze machine, 2026-08-07:** Docker 29.6.2, gh 2.89.0,
+Node/npm-scripts uit `package.json`, `netstat`/`taskkill`/`findstr` in
+`C:\Windows\system32`, image `postgres:17.6` lokaal aanwezig.
+
+> **`psql` staat NIET op deze machine.** Er is geen PostgreSQL-client op de host
+> geïnstalleerd. Elke `psql`-aanroep hieronder loopt daarom via
+> `docker exec <container> psql …`. Een kaal `psql ...` faalt met
+> "The term 'psql' is not recognized".
+>
+> **De Supabase CLI staat er ook niet.** Supabase wordt in dit project alleen
+> benaderd via de connectiestrings in `.env` — er is geen `supabase`-commando.
+
 ---
 
 ## Waarvoor dit bestaat
@@ -81,10 +93,42 @@ CI draait `lint:check` en `format:check`. Gebruik nooit de schrijvende variant o
 | `npm run db:check` | — | Drizzle-consistentie, raakt geen database |
 
 **`npm run db:generate` is onbruikbaar** (Issue #96). De snapshots in
-`drizzle/meta` lopen tot `0007` terwijl er 16 migraties zijn; het genereert een
+`drizzle/meta` lopen tot `0007` terwijl er 17 migraties zijn; het genereert een
 migratie die `sessie`, `tenant_membership` en een `user`-kolom opnieuw wil
 aanmaken. **Schrijf migraties met de hand**, in de stijl van
 `drizzle/0015_survey_review.sql`.
+
+### ⚠ Een handgeschreven migratie moet in `_journal.json`
+
+Drizzle's `migrate()` leest **`drizzle/meta/_journal.json`**, niet de inhoud van
+de map. Een `.sql`-bestand zonder journal-entry bestaat voor het script niet — en
+`migrate:deploy` meldt dan gewoon **"Migraties voltooid"** zonder iets te doen.
+
+Dat is dezelfde valkuil als Issue #86: een geruststellende melding over iets dat
+niet gebeurd is. Overkwam ons op 2026-08-07 bij migratie 0017.
+
+Voeg na het schrijven van `NNNN_naam.sql` een entry toe, met `idx` gelijk aan het
+migratienummer:
+
+```json
+    {
+      "idx": 17,
+      "version": "7",
+      "when": 1786435200000,
+      "tag": "0017_goedkeuren",
+      "breakpoints": true
+    }
+```
+
+`tag` is de bestandsnaam **zonder** `.sql`. `when` is een epoch in milliseconden;
+hoger dan de vorige entry.
+
+**Controleer daarna in de database of het echt is gebeurd** — vertrouw de melding
+niet:
+
+```powershell
+docker exec <container> psql -U postgres -d postgres -t -c "SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conname = '<naam>';"
+```
 
 ### Demo-omgeving (om zelf te kijken)
 
@@ -120,8 +164,19 @@ ongemoeid.
 ```powershell
 # De containernaam moet minstens twee tekens hebben — Docker 29 weigert één teken.
 docker run -d --name mcm2test -e POSTGRES_PASSWORD=pw -p 55440:5432 postgres:17.6
-docker exec -i mcm2test psql -U postgres -q < db/roles/bootstrap-roles.sql
+
+# Wachten tot hij luistert; direct erna verbinden faalt met "the database system is starting up".
+docker exec mcm2test pg_isready -U postgres
+
+# LET OP: `< bestand.sql` werkt NIET in PowerShell. Gebruik een pipe.
+Get-Content db\roles\bootstrap-roles.sql | docker exec -i mcm2test psql -U postgres -q
+
 docker exec mcm2test psql -U postgres -d postgres -c "ALTER ROLE clm_migrator WITH PASSWORD 'pw'; ALTER ROLE clm_api_runtime WITH PASSWORD 'pw';"
+```
+
+In bash mag de redirect wél:
+```bash
+docker exec -i mcm2test psql -U postgres -q < db/roles/bootstrap-roles.sql
 ```
 
 `-d postgres` is niet optioneel: psql neemt anders de rolnaam als databasenaam
@@ -261,4 +316,27 @@ Select-String -Path .env -Pattern '^(MIGRATION_)?DATABASE_URL' |
 
 # Wat draait er nu in Docker?
 docker ps --format "{{.Names}} {{.Ports}}"
+
+# Bestaat een extern commando überhaupt op deze machine?
+Get-Command psql, supabase, gh, docker -ErrorAction SilentlyContinue |
+  Select-Object Name, Source
 ```
+
+---
+
+## Dit document actueel houden
+
+Elk commando hierin is **uitgevoerd of opgezocht**, niet uit het hoofd
+opgeschreven. Houd dat zo. Bij twijfel over een externe tool:
+
+| Vraag | Hoe je het vaststelt |
+|---|---|
+| Bestaat het npm-script? | `(Get-Content package.json \| ConvertFrom-Json).scripts` |
+| Bestaat de tool op deze machine? | `Get-Command <naam> -ErrorAction SilentlyContinue` |
+| Bestaat de vlag? | `<tool> --help` en zoek de vlag op |
+| Bestaat het script-argument? | `Select-String -Path scripts\<naam>.js -Pattern "'--<vlag>'"` |
+| Deed de migratie wat er staat? | terugleze uit de database, niet de melding geloven |
+
+Een commando dat plausibel klinkt maar niet bestaat, kost meer tijd dan het
+opzoeken ervan. `npm run migrate`, `migrate:status`, `verify:migratieketen` en
+`node scripts/db-doelwit.js` zijn alle vier zo ontstaan — geen ervan bestaat.

--- a/docs/runbooks/commandos-en-omgeving.md
+++ b/docs/runbooks/commandos-en-omgeving.md
@@ -1,0 +1,264 @@
+# Commando's en omgeving — wat draait waartegen
+
+**Type:** R — referentie
+**Eigenaar:** Kees Maling
+**Laatste update:** 2026-08-07
+**Aanleiding:** te vaak begonnen met een commando dat niet bestaat, of dat tegen
+de verkeerde database zou hebben gedraaid.
+
+---
+
+## Waarvoor dit bestaat
+
+Eén plek die zegt **welk commando er echt is**, **waar het naartoe praat**, en
+**wat je vooraf moet controleren**. Alles hieronder is geverifieerd tegen
+`package.json`, `scripts/` en `.github/workflows/ci.yml` op 2026-08-07.
+
+Verzin nooit een commando. Staat het hier niet, dan bestaat het niet — kijk in
+`package.json` voordat je iets typt.
+
+---
+
+## ⚠ Het belangrijkste: `.env` wijst naar Supabase
+
+```
+DATABASE_URL            → clm_api_runtime @ aws-1-eu-west-1.pooler.supabase.com
+MIGRATION_DATABASE_URL  → clm_migrator    @ aws-1-eu-west-1.pooler.supabase.com
+```
+
+**Dat is de echte database.** Elk commando dat deze variabelen gebruikt en dat je
+draait zónder ze te overschrijven, raakt Supabase.
+
+Dit is precies waar **Issue #86** op misging: `npm run migrate:deploy` draaide
+tegen productie terwijl een wegwerpcontainer de bedoeling was. Het script meldde
+"Migraties draaien als rol 'clm_migrator'" en daarna "Migraties voltooid" —
+beide waar, geen van beide verklapte het doelwit. Die rol heet lokaal precies zo.
+
+**Vóór elk commando dat de database schrijft:** stel vast waar het naartoe gaat.
+Sinds PR #93 noemen de schrijvende scripts hun doelwit zelf en weigeren ze
+buiten lokaal zonder bevestiging. Vertrouw daarop, maar lees de melding.
+
+---
+
+## De commando's die er zijn
+
+Volledige lijst uit `package.json`. Er is **geen** `npm run migrate`, **geen**
+`migrate:status`, **geen** `verify:migratieketen`, en **geen** `db:studio`.
+
+### Controleren (deze bewijzen iets)
+
+| Commando | Wat het doet | Database nodig? |
+|---|---|---|
+| `npm run verify:volledig` | **Het bewijs.** Vijf stappen: code, unittests, e2e tegen een wegwerpdatabase, beide productie-images, browsertests, opruimen. | Zet er zelf een op (poort 55441) |
+| `npm run verify` | Dezelfde poorten als CI, zonder de stack | Ja — `DATABASE_URL` |
+| `npm run verify:snel` | Idem, e2e overgeslagen (zegt dat er ook bij) | Nee |
+| `npm run verify:schema` | Schemaconformiteit: draait `test/schema-conformiteit.e2e-spec.ts` | Ja |
+
+`verify.js` **weigert** te draaien als `DATABASE_URL` niet naar een lokale host
+wijst. Die bescherming werkt; laat hem staan.
+
+### Losse poorten (deze bewijzen niets op zichzelf)
+
+```
+npm run format:check     prettier --check
+npm run lint:check       eslint --max-warnings=0
+npm run typecheck        tsc --noEmit
+npm test                 jest            (unittests, geen database)
+npm run test:e2e         jest --config ./test/jest-e2e.json   (database nodig)
+```
+
+**Let op het verschil:** `npm run lint` en `npm run format` *wijzigen* bestanden;
+CI draait `lint:check` en `format:check`. Gebruik nooit de schrijvende variant om
+"groen" vast te stellen — dat ging op 2026-07-31 mis (MCM2-CLAUDE.md §15a).
+
+### Database
+
+| Commando | Waartegen | Let op |
+|---|---|---|
+| `npm run migrate:deploy` | `MIGRATION_DATABASE_URL` | **Zonder overschrijven: Supabase.** |
+| `npm run seed:vragenlijsten -- <tenant-uuid>` | `DATABASE_URL` | Tenant moet bestaan |
+| `npm run seed:demo` | `DATABASE_URL` | Doet de vragenlijsten zelf ook |
+| `npm run db:check` | — | Drizzle-consistentie, raakt geen database |
+
+**`npm run db:generate` is onbruikbaar** (Issue #96). De snapshots in
+`drizzle/meta` lopen tot `0007` terwijl er 16 migraties zijn; het genereert een
+migratie die `sessie`, `tenant_membership` en een `user`-kolom opnieuw wil
+aanmaken. **Schrijf migraties met de hand**, in de stijl van
+`drizzle/0015_survey_review.sql`.
+
+### Demo-omgeving (om zelf te kijken)
+
+```
+npm run demo             database + backend + frontend + sessie, ~1 minuut
+npm run demo -- --vers   database eerst weggooien en opnieuw opbouwen
+npm run demo:status      draait het, en sinds wanneer?
+npm run demo:test        browsertests tegen de draaiende demo
+npm run demo:af          backend en frontend stoppen, database laten staan
+npm run demo:stop        ook de database weggooien
+```
+
+Container `mcm2demo` op poort **55450**, label `mcm2.rol=demo`. De data blijft
+staan tussen sessies. Zie `docs/runbooks/zelf-testen.md` voor het hele verhaal.
+
+### Overig
+
+```
+npm run backup:dump             draait dagelijks vanzelf om 07:00
+npm run backup:controle         controle op de laatste dump
+npm run mail:test               mailkanaal beproeven
+```
+
+---
+
+## Lokaal draaien zonder .env aan te raken
+
+**Dit is de manier.** Overschrijf de variabele binnen het commando; `.env` blijft
+ongemoeid.
+
+### Een verse wegwerpdatabase opzetten
+
+```powershell
+# De containernaam moet minstens twee tekens hebben — Docker 29 weigert één teken.
+docker run -d --name mcm2test -e POSTGRES_PASSWORD=pw -p 55440:5432 postgres:17.6
+docker exec -i mcm2test psql -U postgres -q < db/roles/bootstrap-roles.sql
+docker exec mcm2test psql -U postgres -d postgres -c "ALTER ROLE clm_migrator WITH PASSWORD 'pw'; ALTER ROLE clm_api_runtime WITH PASSWORD 'pw';"
+```
+
+`-d postgres` is niet optioneel: psql neemt anders de rolnaam als databasenaam
+en faalt met een melding die naar de verkeerde oorzaak wijst.
+
+### Migraties erop draaien
+
+PowerShell (deze machine):
+```powershell
+$env:MIGRATION_DATABASE_URL="postgresql://clm_migrator:pw@localhost:55440/postgres"
+npm run migrate:deploy
+Remove-Item Env:\MIGRATION_DATABASE_URL
+```
+
+Bash:
+```bash
+MIGRATION_DATABASE_URL="postgresql://clm_migrator:pw@localhost:55440/postgres" npm run migrate:deploy
+```
+
+**Controleer de melding die het script afdrukt.** Hij noemt het doelwit. Staat
+daar `supabase.com`, dan is de variabele niet doorgekomen — stop.
+
+### E2e-tests erop draaien
+
+```powershell
+$env:DATABASE_URL="postgresql://clm_api_runtime:pw@localhost:55440/postgres"
+npx jest --config test/jest-e2e.json --forceExit
+Remove-Item Env:\DATABASE_URL
+```
+
+`--forceExit` is nodig sinds de sessiesuite: die houdt een pg-verbinding open,
+waardoor Jest anders blijft hangen zónder foutmelding.
+
+### Opruimen
+
+```powershell
+docker rm -f mcm2test
+```
+
+---
+
+## Poorten — wie claimt wat
+
+| Poort | Wie | Wanneer |
+|---|---|---|
+| 55440 | handmatige wegwerpdatabase | als je hem zelf opzet (zie boven) |
+| 55441 | `verify:volledig` | tijdens stap 1 |
+| 55450 | `mcm2demo` | zolang de demo staat |
+| 5001 | API in de doorloopstack | tijdens `verify:volledig` en `npm run demo` |
+| 3000 | frontend | idem |
+
+**`verify:volledig` faalt op een bezette 55441** met "geen testdatabase kunnen
+starten" — een melding die naar de verkeerde oorzaak wijst. Draait daar nog iets
+van een vorige sessie: `docker rm -f <naam>`.
+
+**Het script sluit bewust niets zelf af.** Een dev-server op 3000 of 5001 kan van
+een ander project zijn. Zoeken wat het is:
+
+```powershell
+netstat -ano | findstr ":5001 "
+taskkill /PID <pid> /F
+```
+
+---
+
+## Wat CI werkelijk draait
+
+Drie jobs in `.github/workflows/ci.yml`:
+
+| Job | Stappen |
+|---|---|
+| Format, lint en typecheck | `npm ci`, `format:check`, `lint:check`, `typecheck`, `npm test` |
+| Docker productiebuild | `docker build -t mcm2-api:ci .`, daarna controleren dat het image het gecompileerde resultaat start |
+| RLS tenant-isolatietest | `npm ci`, migraties op een verse Postgres, e2e-suite |
+
+Sinds PR #92 is CI handmatig te starten:
+```powershell
+gh workflow run ci.yml --ref main
+```
+
+**Die trigger werkt alleen op branches die de commit van #92 al bevatten.**
+GitHub leest de handmatige triggers uit de workflow op de branch zelf. Op een
+oudere branch geeft dit een 422; `gh pr update-branch <nr>` haalt de trigger
+binnen en start CI meteen opnieuw.
+
+---
+
+## Waar de sleutels staan
+
+Alle variabelen staan in `.env` (niet in git) en zijn beschreven in
+`.env.example` (wel in git, met `PROJECT_REF` en `PASSWORD` als plaatshouders).
+
+| Variabele | Waarvoor |
+|---|---|
+| `DATABASE_URL` | runtime, rol `clm_api_runtime` |
+| `MIGRATION_DATABASE_URL` | migraties, rol `clm_migrator` |
+| `BACKUP_DATABASE_URL` | backups — aparte rol, want `FORCE RLS` breekt `pg_dump` als `clm_migrator` (#78) |
+| `OIDC_*` | Entra-inlogflow |
+| `RESEND_API_KEY`, `MAIL_AFZENDER_ADRES` | mailkanaal |
+| `PORTAAL_BASIS_URL` | de basis van de tokenlinks in uitnodigingen |
+| `TELEGRAM_*` | meldingen |
+| `FEATURE_VENDORS_ENABLED` | feature flag |
+
+**Nooit `.env` committen.** Nooit een sleutel in een commando dat in de
+terminalhistorie of een CI-log belandt.
+
+---
+
+## Drie dingen die dit project anders doet dan je verwacht
+
+1. **Migraties met de hand.** `db:generate` is kapot (Issue #96). Stijl:
+   `drizzle/0015_survey_review.sql` — met een kop die uitlegt wáárom, niet
+   alleen wat.
+
+2. **Test-id's staan centraal** in `test/test-ids.ts`, met een bewakingstest
+   erop. Verzin nooit een UUID in een testbestand. Hoogste vergeven staart per
+   2026-08-07: `ef`.
+
+3. **RLS eist een actor, niet alleen een tenant.** Databasetoegang loopt via
+   `db.withTenant(tenantId, fn, 'medewerker')`. Op `survey_review` staat
+   `clm.current_actor() = 'medewerker'` in zowel `USING` als `WITH CHECK` — een
+   leverancier zit in dezelfde tenant als zijn beoordelaar en mag het oordeel
+   niet zien.
+
+---
+
+## Bij twijfel
+
+```powershell
+# Welke commando's bestaan er echt?
+(Get-Content package.json | ConvertFrom-Json).scripts.PSObject.Properties |
+  ForEach-Object { "{0,-24} {1}" -f $_.Name, $_.Value }
+
+# Waar wijzen mijn database-variabelen naartoe? (zonder wachtwoord)
+Select-String -Path .env -Pattern '^(MIGRATION_)?DATABASE_URL' |
+  ForEach-Object { ($_.Line -replace ':[^:@]+@',':***@') }
+
+# Wat draait er nu in Docker?
+docker ps --format "{{.Names}} {{.Ports}}"
+```

--- a/docs/superpowers/plans/2026-08-07-migratie-0017-goedkeuren.md
+++ b/docs/superpowers/plans/2026-08-07-migratie-0017-goedkeuren.md
@@ -136,19 +136,29 @@ Deze migratie raakt alleen een CHECK-constraint en geen tabelstructuur, dus `src
 
 - [ ] **Stap 5: Bewijs dat de constraint echt vier waarden toestaat**
 
-Lees de constraint terug uit de database zelf, in plaats van te vertrouwen dat de migratie deed wat er staat:
+Lees de constraint terug uit de database zelf, in plaats van te vertrouwen dat de migratie deed wat er staat. **`psql` staat niet op deze machine** — het loopt via de container:
 
 ```powershell
-psql $env:MIGRATION_DATABASE_URL -c "SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conname = 'survey_review_verdict_check';"
+docker exec mcm2test0017 psql -U postgres -d postgres -t -c "SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conname = 'survey_review_verdict_check';"
 ```
 
-Expected: de definitie noemt alle vier de waarden, inclusief `goedgekeurd`.
+Expected: alle vier de waarden, inclusief `goedgekeurd`.
 
-Werkt `psql` niet vanaf de commandregel, gebruik dan het bestaande hulpscript:
-```powershell
-node scripts/db-doelwit.js
+**Staan er nog drie waarden, dan is de migratie overgeslagen** — ook al meldde `migrate:deploy` "Migraties voltooid". Drizzle leest `drizzle/meta/_journal.json`, niet de map. Voeg een entry toe (zie stap 2b) en draai opnieuw.
+
+- [ ] **Stap 2b: Registreer de migratie in het journal**
+
+Zonder deze stap bestaat het `.sql`-bestand niet voor Drizzle. Voeg toe aan `drizzle/meta/_journal.json`, ná de entry van `0016_template_reviewer`:
+
+```json
+    {
+      "idx": 17,
+      "version": "7",
+      "when": 1786435200000,
+      "tag": "0017_goedkeuren",
+      "breakpoints": true
+    }
 ```
-en voer de query via de daar getoonde verbinding uit.
 
 - [ ] **Stap 6: Commit**
 

--- a/docs/superpowers/plans/2026-08-07-migratie-0017-goedkeuren.md
+++ b/docs/superpowers/plans/2026-08-07-migratie-0017-goedkeuren.md
@@ -1,0 +1,697 @@
+# Goedkeuren als vierde oordeel — implementatieplan (migratie 0017)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `goedgekeurd` toevoegen als vierde `verdict` op `clm.survey_review`, zodat de laatste status uit de statusketen (§3 van `2026-08-07-statuswaarheid-per-vendor.md`) vastgelegd kan worden — met de identiteit van de goedkeurder gewaarborgd.
+
+**Architecture:** Geen nieuwe tabel. Goedkeuren is dezelfde soort uitspraak als de bestaande drie oordelen — genoemd persoon, genoemd moment, nooit overschreven — dus dezelfde tabel, dezelfde RLS-policy, dezelfde append-only-regel. De migratie vervangt alleen de CHECK-constraint. De backend krijgt één extra toegestane waarde plus één nieuwe route om in te trekken (V2).
+
+**Tech Stack:** NestJS, Drizzle (handgeschreven SQL-migraties), PostgreSQL met RLS, Jest + supertest voor e2e.
+
+---
+
+## Context die de uitvoerder moet kennen
+
+**Lees eerst** `docs/superpowers/plans/2026-08-07-statuswaarheid-per-vendor.md` §3.2 en §7. Dit plan voert daar stap 1 van uit.
+
+**Drie dingen die in dit project anders zijn dan je gewend bent:**
+
+1. **`db:generate` is onbruikbaar.** De Drizzle-snapshots in `drizzle/meta` lopen tot `0007` terwijl er 16 migraties zijn; het genereert een migratie die bestaande tabellen opnieuw wil aanmaken (Issue #96). **Schrijf de migratie met de hand**, in de stijl van `drizzle/0015_survey_review.sql`.
+
+2. **Test-id's zijn centraal vastgelegd** in `test/test-ids.ts` en er staat een bewakingstest op. Verzin nooit een UUID in een testbestand — voeg hem toe aan `test-ids.ts`. Hoogste vergeven staart is nu `ef`; dit plan gebruikt `f0` en verder.
+
+3. **De RLS-policy op `survey_review` eist actor `medewerker`**, niet alleen de tenant. Alle databasetoegang loopt via `db.withTenant(tenantId, fn, 'medewerker')`.
+
+**Draaien van tests:** e2e vereist een lopende Postgres. `npm run test:e2e -- <bestand>` voor één suite.
+
+---
+
+## Bestandsoverzicht
+
+| Bestand | Wat er verandert |
+|---|---|
+| `drizzle/0017_goedkeuren.sql` | **Nieuw.** CHECK vervangen door vier waarden. |
+| `src/survey/beoordeling.service.ts` | `OORDELEN` uitbreiden; `trekIn()` toevoegen. |
+| `src/survey/ronde-invoer.ts` | Toelichtingsregel voor `goedgekeurd` (zie Taak 3). |
+| `src/survey/vragenlijst-beheer.controller.ts` | Route `DELETE .../reviews/:reviewId`. |
+| `test/test-ids.ts` | Id's voor de nieuwe suite (`f0`–`f7`). |
+| `test/goedkeuren.e2e-spec.ts` | **Nieuw.** De suite voor dit alles. |
+
+`src/db/schema.ts` verandert **niet**: Drizzle legt CHECK-constraints daar niet vast, dus de vier waarden staan in de migratie en in `OORDELEN`.
+
+---
+
+## Taak 1: De migratie
+
+**Files:**
+- Create: `drizzle/0017_goedkeuren.sql`
+
+- [ ] **Stap 1: Zet een verse wegwerpdatabase op**
+
+**Lees eerst `docs/runbooks/commandos-en-omgeving.md`.** Kern: `.env` wijst naar Supabase. `npm run migrate:deploy` zonder overschreven variabele raakt de echte database — dat is Issue #86.
+
+```powershell
+docker run -d --name mcm2test0017 -e POSTGRES_PASSWORD=pw -p 55440:5432 postgres:17.6
+docker exec -i mcm2test0017 psql -U postgres -q < db/roles/bootstrap-roles.sql
+docker exec mcm2test0017 psql -U postgres -d postgres -c "ALTER ROLE clm_migrator WITH PASSWORD 'pw'; ALTER ROLE clm_api_runtime WITH PASSWORD 'pw';"
+```
+
+Bouw de keten op tot en met 0016:
+```powershell
+$env:MIGRATION_DATABASE_URL="postgresql://clm_migrator:pw@localhost:55440/postgres"
+npm run migrate:deploy
+```
+
+Expected: alle migraties t/m `0016_template_reviewer.sql` worden toegepast, en de melding noemt `localhost:55440` — **niet** `supabase.com`. Staat daar Supabase, dan is de variabele niet doorgekomen: stop.
+
+- [ ] **Stap 2: Schrijf de migratie**
+
+Create `drizzle/0017_goedkeuren.sql`:
+
+```sql
+-- =============================================================================
+-- Goedkeuren als vierde oordeel op clm.survey_review.
+--
+-- Aanleiding: docs/superpowers/plans/2026-08-07-statuswaarheid-per-vendor.md
+-- §3.2. De eigenaar wil dat de app de centrale waarheid is voor de status van
+-- een vragenlijst per leverancier. Drie van de vier statussen waren al af te
+-- leiden uit bestaande gegevens; "beoordeeld en goedgekeurd" was de enige die
+-- nergens bestond.
+--
+-- ── Waarom hier en niet in een eigen tabel ───────────────────────────────────
+--
+-- Goedkeuren is dezelfde soort uitspraak als de drie bestaande oordelen: van
+-- een genoemd persoon, op een genoemd moment, over één respons, en nooit
+-- overschreven. Een aparte tabel zou dezelfde kolommen, dezelfde policy en
+-- dezelfde append-only-regel dupliceren, plus een query opleveren die twee
+-- tabellen moet samenvoegen om "wat is de huidige status" te beantwoorden.
+--
+-- ── Waarom niet op survey_response ───────────────────────────────────────────
+--
+-- survey_response.status (migratie 0003) is de INVULstatus: waar staat de
+-- leverancier in zijn eigen proces (pending/submitted/revoked). Goedkeuring is
+-- een uitspraak van de ORGANISATIE over die inzending. Die twee in één kolom
+-- levert waarden op die elkaar ongemerkt uitsluiten — kan een 'revoked'
+-- respons goedgekeurd zijn?
+--
+-- ── Wat dit NIET verandert ───────────────────────────────────────────────────
+--
+-- De RLS-policy niet, de kolommen niet, de rechten niet. Alleen de verzameling
+-- toegestane waarden. Bestaande rijen blijven geldig: 'goedgekeurd' komt erbij,
+-- er gaat niets af.
+-- =============================================================================
+
+ALTER TABLE clm.survey_review
+    DROP CONSTRAINT survey_review_verdict_check;--> statement-breakpoint
+
+ALTER TABLE clm.survey_review
+    ADD CONSTRAINT survey_review_verdict_check
+    CHECK (verdict IN ('goed', 'nadere_vragen', 'niet_goed', 'goedgekeurd'));--> statement-breakpoint
+
+COMMENT ON CONSTRAINT survey_review_verdict_check ON clm.survey_review IS
+    'Vier oordelen. De eerste drie zijn inhoudelijk; goedgekeurd is een processtap die de inzending afsluit. Het scherm zet ze daarom niet als vier gelijkwaardige knoppen naast elkaar.';
+```
+
+- [ ] **Stap 3: Pas de migratie toe op de wegwerpdatabase**
+
+Met `MIGRATION_DATABASE_URL` nog gezet uit stap 1:
+```powershell
+npm run migrate:deploy
+```
+Expected: `0017_goedkeuren.sql` wordt toegepast zonder fout, doelwit `localhost:55440`.
+
+- [ ] **Stap 4: Controleer de schemaconformiteit**
+
+Run:
+```powershell
+$env:DATABASE_URL="postgresql://clm_api_runtime:pw@localhost:55440/postgres"
+npm run verify:schema
+```
+
+Expected: GOEDGEKEURD.
+
+**Er is bewust géén los verwachtingsbestand om bij te werken.** `scripts/verify-schema.js` draait `test/schema-conformiteit.e2e-spec.ts`, die de verwachting rechtstreeks uit het Drizzle-schema afleidt — een tweede lijst zou binnen één sprint gaan afwijken. Zakt deze stap, dan wijkt de database áf van `src/db/schema.ts`, niet van een lijstje.
+
+Deze migratie raakt alleen een CHECK-constraint en geen tabelstructuur, dus `src/db/schema.ts` hoeft niet mee te veranderen: Drizzle legt CHECK-constraints daar niet vast. De waarheid over de toegestane waarden staat op twee plekken — de migratie en `OORDELEN` in `beoordeling.service.ts` — en Taak 2 houdt die gelijk.
+
+- [ ] **Stap 5: Bewijs dat de constraint echt vier waarden toestaat**
+
+Lees de constraint terug uit de database zelf, in plaats van te vertrouwen dat de migratie deed wat er staat:
+
+```powershell
+psql $env:MIGRATION_DATABASE_URL -c "SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conname = 'survey_review_verdict_check';"
+```
+
+Expected: de definitie noemt alle vier de waarden, inclusief `goedgekeurd`.
+
+Werkt `psql` niet vanaf de commandregel, gebruik dan het bestaande hulpscript:
+```powershell
+node scripts/db-doelwit.js
+```
+en voer de query via de daar getoonde verbinding uit.
+
+- [ ] **Stap 6: Commit**
+
+```bash
+git add drizzle/0017_goedkeuren.sql
+git commit -m "feat(survey): goedgekeurd als vierde oordeel (migratie 0017)"
+```
+
+---
+
+## Taak 2: De backend accepteert `goedgekeurd`
+
+**Files:**
+- Modify: `src/survey/beoordeling.service.ts:42`
+- Test: `test/goedkeuren.e2e-spec.ts` (nieuw, opgezet in deze taak)
+
+- [ ] **Stap 1: Voeg de test-id's toe**
+
+Modify `test/test-ids.ts`. Voeg toe ná het blok `'beoordelaar-koppelen'`:
+
+```ts
+  // Goedkeuren (migratie 0017). Staarten f0 t/m f7; ef was de hoogste
+  // vergeven staart. Gecontroleerd tegen alleTestIds().
+  goedkeuren: {
+    tenantA: '00000000-0000-0000-0000-0000000000f0',
+    tenantB: '00000000-0000-0000-0000-0000000000f1',
+    adminA: '00000000-0000-0000-0000-0000000000f2',
+    /** Tweede medewerker in A: bewijst dat de identiteit uit de sessie komt. */
+    collegaA: '00000000-0000-0000-0000-0000000000f3',
+    templateA: '00000000-0000-0000-0000-0000000000f4',
+    runA: '00000000-0000-0000-0000-0000000000f5',
+    vendorA: '00000000-0000-0000-0000-0000000000f6',
+    /** Ingediend — hierop mag goedgekeurd worden. */
+    responseIngediend: '00000000-0000-0000-0000-0000000000f7',
+  },
+```
+
+- [ ] **Stap 2: Draai de bewakingstest op test-id's**
+
+Run:
+```powershell
+npm test -- test-ids
+```
+Expected: PASS. Zakt dit op een dubbele id, kies dan de eerstvolgende vrije staart en werk het commentaar bij.
+
+- [ ] **Stap 3: Schrijf de falende test**
+
+Create `test/goedkeuren.e2e-spec.ts`. Neem de opzet (app opstarten, sessiecookie, seed) letterlijk over uit `test/beoordeling.e2e-spec.ts` — dezelfde imports, dezelfde `beforeAll`-structuur — en vervang de id's door `TEST_IDS.goedkeuren`. De eerste test:
+
+```ts
+it('legt een goedkeuring vast op een ingediende respons', async () => {
+  const antwoord = await request(app.getHttpServer() as App)
+    .post(`/admin/survey/responses/${RESPONSE_INGEDIEND}/reviews`)
+    .set('Cookie', cookieAdminA)
+    .send({ verdict: 'goedgekeurd', toelichting: 'Akkoord namens IT.' })
+    .expect(201);
+
+  const body = antwoord.body as BeoordelingBody;
+  expect(body.beoordeling.verdict).toBe('goedgekeurd');
+  expect(body.beoordeling.reviewerUserId).toBe(ADMIN_A);
+});
+```
+
+- [ ] **Stap 4: Draai de test en zie hem falen**
+
+Run:
+```powershell
+npm run test:e2e -- goedkeuren
+```
+Expected: FAIL met status 400 en de melding `Onbekend oordeel. Toegestaan: goed, nadere_vragen, niet_goed.` — de validatie in `ronde-invoer.ts` kent de nieuwe waarde nog niet.
+
+- [ ] **Stap 5: Voeg de waarde toe**
+
+Modify `src/survey/beoordeling.service.ts` regel 41-43:
+
+```ts
+/**
+ * De vier toegestane oordelen. Gelijk aan de CHECK uit migratie 0017.
+ *
+ * De eerste drie zijn inhoudelijk: wat vindt de beoordelaar van de inzending.
+ * `goedgekeurd` is een processtap die de inzending afsluit — dezelfde vorm
+ * (naam, datum, nooit overschreven), maar een andere betekenis. Het scherm zet
+ * ze daarom niet als vier gelijkwaardige knoppen naast elkaar.
+ */
+export const OORDELEN = [
+  'goed',
+  'nadere_vragen',
+  'niet_goed',
+  'goedgekeurd',
+] as const;
+```
+
+- [ ] **Stap 6: Draai de test en zie hem slagen**
+
+Run:
+```powershell
+npm run test:e2e -- goedkeuren
+```
+Expected: PASS.
+
+- [ ] **Stap 7: Commit**
+
+```bash
+git add src/survey/beoordeling.service.ts test/test-ids.ts test/goedkeuren.e2e-spec.ts
+git commit -m "feat(survey): goedkeuren als oordeel accepteren"
+```
+
+---
+
+## Taak 3: Toelichting bij goedkeuren is optioneel
+
+De bestaande regel (`ronde-invoer.ts:321`) luidt: alles behalve `goed` vereist een toelichting. Zonder wijziging zou `goedgekeurd` dus een verplichte toelichting krijgen.
+
+**Dat is niet wat we willen.** De onderbouwingseis bestaat omdat *"niet goed" zonder reden later niet te herleiden is*. Een goedkeuring is de bevestiging dat het akkoord is; daar is de handtekening de inhoud, niet de uitleg.
+
+**Files:**
+- Modify: `src/survey/ronde-invoer.ts:321-326`
+- Test: `test/goedkeuren.e2e-spec.ts`
+
+- [ ] **Stap 1: Schrijf de falende test**
+
+Voeg toe aan `test/goedkeuren.e2e-spec.ts`:
+
+```ts
+it('staat goedkeuren zonder toelichting toe', async () => {
+  await request(app.getHttpServer() as App)
+    .post(`/admin/survey/responses/${RESPONSE_INGEDIEND}/reviews`)
+    .set('Cookie', cookieAdminA)
+    .send({ verdict: 'goedgekeurd' })
+    .expect(201);
+});
+
+it('blijft een toelichting eisen bij niet_goed', async () => {
+  const antwoord = await request(app.getHttpServer() as App)
+    .post(`/admin/survey/responses/${RESPONSE_INGEDIEND}/reviews`)
+    .set('Cookie', cookieAdminA)
+    .send({ verdict: 'niet_goed' })
+    .expect(400);
+
+  expect((antwoord.body as { message: string }).message).toContain('Licht toe');
+});
+```
+
+De tweede test is er niet voor de sier: hij bewaakt dat het versoepelen voor `goedgekeurd` de eis bij de andere oordelen niet stilletjes opheft.
+
+- [ ] **Stap 2: Draai en zie de eerste falen**
+
+Run:
+```powershell
+npm run test:e2e -- goedkeuren
+```
+Expected: de eerste test FAIL met 400 (`Licht toe waarom...`), de tweede PASS.
+
+- [ ] **Stap 3: Pas de regel aan**
+
+Modify `src/survey/ronde-invoer.ts`, vervang regels 321-326:
+
+```ts
+  // Een toelichting is verplicht bij de inhoudelijke afwijzingen, niet bij
+  // 'goed' en niet bij 'goedgekeurd'. Reden: "niet goed" zonder reden is later
+  // niet te herleiden. Bij een goedkeuring is de handtekening de inhoud — wie
+  // en wanneer, en dat legt de tabel zelf vast.
+  const vereistToelichting = verdict === 'nadere_vragen' || verdict === 'niet_goed';
+
+  if (vereistToelichting && toelichting === '') {
+    throw new InvoerFout(
+      'toelichting',
+      'Licht toe waarom. Zonder onderbouwing is dit oordeel later niet te herleiden.',
+    );
+  }
+```
+
+- [ ] **Stap 4: Draai en zie beide slagen**
+
+Run:
+```powershell
+npm run test:e2e -- goedkeuren
+```
+Expected: PASS, beide.
+
+- [ ] **Stap 5: Commit**
+
+```bash
+git add src/survey/ronde-invoer.ts test/goedkeuren.e2e-spec.ts
+git commit -m "feat(survey): toelichting optioneel bij goedkeuren"
+```
+
+---
+
+## Taak 4: De identiteit komt uit de sessie (V1)
+
+Dit is de voorwaarde die de eigenaar aan V1 verbond: *iedereen mag goedkeuren, mits de identiteit van de keurder vastligt.* De code doet dit al (`beoordeling.service.ts:130-135` neemt `reviewerUserId` als parameter, de controller vult hem uit `sessie.userId`). **Deze taak bewijst het en bewaakt het.**
+
+**Files:**
+- Test: `test/goedkeuren.e2e-spec.ts`
+
+- [ ] **Stap 1: Schrijf de tegenproef**
+
+```ts
+it('negeert een reviewerUserId uit de body en gebruikt de sessie', async () => {
+  const antwoord = await request(app.getHttpServer() as App)
+    .post(`/admin/survey/responses/${RESPONSE_INGEDIEND}/reviews`)
+    .set('Cookie', cookieAdminA)
+    .send({
+      verdict: 'goedgekeurd',
+      toelichting: 'Akkoord.',
+      // Een poging om de goedkeuring op naam van een collega te zetten.
+      reviewerUserId: COLLEGA_A,
+    })
+    .expect(201);
+
+  const body = antwoord.body as BeoordelingBody;
+  expect(body.beoordeling.reviewerUserId).toBe(ADMIN_A);
+  expect(body.beoordeling.reviewerUserId).not.toBe(COLLEGA_A);
+});
+```
+
+- [ ] **Stap 2: Draai de test**
+
+Run:
+```powershell
+npm run test:e2e -- goedkeuren
+```
+Expected: PASS meteen — de code doet dit al goed.
+
+- [ ] **Stap 3: Bewijs dat de test iets meet (§15b tegenproef)**
+
+Deze test slaagt zonder codewijziging, dus moet je aantonen dat hij zou falen als de bescherming wegviel. Wijzig **tijdelijk** in `vragenlijst-beheer.controller.ts` de aanroep:
+
+```ts
+    const beoordeling = await this.beoordelingen_.voegToe(
+      sessie.tenantId,
+      id,
+      (body as { reviewerUserId?: string }).reviewerUserId ?? sessie.userId,
+      invoer,
+    );
+```
+
+Run:
+```powershell
+npm run test:e2e -- goedkeuren
+```
+Expected: **precies deze ene test FAIL**, de andere PASS.
+
+**Draai de wijziging daarna volledig terug** met:
+```bash
+git checkout src/survey/vragenlijst-beheer.controller.ts
+```
+en draai de suite opnieuw — alles PASS. Noteer de uitkomst in de PR-body.
+
+- [ ] **Stap 4: Commit**
+
+```bash
+git add test/goedkeuren.e2e-spec.ts
+git commit -m "test(survey): de goedkeurder komt uit de sessie, nooit uit de body"
+```
+
+---
+
+## Taak 5: Een goedkeuring intrekken (V2)
+
+**Files:**
+- Modify: `src/survey/beoordeling.service.ts` (methode `trekIn`)
+- Modify: `src/survey/vragenlijst-beheer.controller.ts` (route)
+- Test: `test/goedkeuren.e2e-spec.ts`
+
+- [ ] **Stap 1: Schrijf de falende tests**
+
+```ts
+it('trekt een oordeel in en laat het uit de lijst verdwijnen', async () => {
+  const gemaakt = await request(app.getHttpServer() as App)
+    .post(`/admin/survey/responses/${RESPONSE_INGEDIEND}/reviews`)
+    .set('Cookie', cookieAdminA)
+    .send({ verdict: 'goedgekeurd', toelichting: 'Akkoord.' })
+    .expect(201);
+
+  const reviewId = (gemaakt.body as BeoordelingBody).beoordeling.reviewId;
+
+  await request(app.getHttpServer() as App)
+    .delete(`/admin/survey/responses/${RESPONSE_INGEDIEND}/reviews/${reviewId}`)
+    .set('Cookie', cookieAdminA)
+    .expect(204);
+
+  const lijst = await request(app.getHttpServer() as App)
+    .get(`/admin/survey/responses/${RESPONSE_INGEDIEND}/reviews`)
+    .set('Cookie', cookieAdminA)
+    .expect(200);
+
+  const ids = (lijst.body as { beoordelingen: { reviewId: string }[] })
+    .beoordelingen.map((b) => b.reviewId);
+  expect(ids).not.toContain(reviewId);
+});
+
+it('bewaart een ingetrokken oordeel in de database', async () => {
+  const gemaakt = await request(app.getHttpServer() as App)
+    .post(`/admin/survey/responses/${RESPONSE_INGEDIEND}/reviews`)
+    .set('Cookie', cookieAdminA)
+    .send({ verdict: 'goedgekeurd', toelichting: 'Akkoord.' })
+    .expect(201);
+
+  const reviewId = (gemaakt.body as BeoordelingBody).beoordeling.reviewId;
+
+  await request(app.getHttpServer() as App)
+    .delete(`/admin/survey/responses/${RESPONSE_INGEDIEND}/reviews/${reviewId}`)
+    .set('Cookie', cookieAdminA)
+    .expect(204);
+
+  // Wissen zou de historie kapotmaken die deze tabel juist bewaart.
+  const rij = await db.query(
+    `SELECT deleted_at FROM clm.survey_review WHERE review_id = $1`,
+    [reviewId],
+  );
+  expect(rij.rows).toHaveLength(1);
+  expect(rij.rows[0].deleted_at).not.toBeNull();
+});
+
+it('geeft 404 bij het intrekken van een onbekend oordeel', async () => {
+  await request(app.getHttpServer() as App)
+    .delete(
+      `/admin/survey/responses/${RESPONSE_INGEDIEND}/reviews/00000000-0000-0000-0000-00000000ffff`,
+    )
+    .set('Cookie', cookieAdminA)
+    .expect(404);
+});
+```
+
+De tweede test is de belangrijkste: hij bewijst dat intrekken een `deleted_at` zet en geen `DELETE` uitvoert. Gebruik dezelfde `Client`-opzet als `beoordeling.e2e-spec.ts` voor de directe databasecontrole.
+
+- [ ] **Stap 2: Draai en zie ze falen**
+
+Run:
+```powershell
+npm run test:e2e -- goedkeuren
+```
+Expected: FAIL met 404 op de DELETE-route (bestaat nog niet).
+
+- [ ] **Stap 3: Voeg de servicemethode toe**
+
+Modify `src/survey/beoordeling.service.ts`, ná `voegToe`:
+
+```ts
+  /**
+   * Trekt een oordeel in.
+   *
+   * Zet `deleted_at` en verwijdert niets. De tabel is append-only: wissen zou
+   * de historie kapotmaken die deze tabel juist bewaart, en een goedkeuring die
+   * spoorloos kan verdampen maakt de status onbetrouwbaar.
+   *
+   * Wie mag intrekken is niet beperkt, consequent met beoordelen zelf (plan
+   * §2a): elke handeling ligt met naam en datum vast, dus niemand kan iets
+   * stilletjes doen.
+   */
+  async trekIn(
+    tenantId: string,
+    responseId: string,
+    reviewId: string,
+  ): Promise<void> {
+    return this.db.withTenant(
+      tenantId,
+      async (tx) => {
+        const geraakt = await tx.execute(
+          sql`UPDATE clm.survey_review
+                 SET deleted_at = now()
+               WHERE review_id = ${reviewId}
+                 AND response_id = ${responseId}
+                 AND deleted_at IS NULL`,
+        );
+
+        if (geraakt.rowCount === 0) {
+          throw new NotFoundException(
+            'Dit oordeel bestaat niet, of is al ingetrokken.',
+          );
+        }
+      },
+      'medewerker',
+    );
+  }
+```
+
+- [ ] **Stap 4: Voeg de route toe**
+
+Modify `src/survey/vragenlijst-beheer.controller.ts`, ná de `@Post('responses/:id/reviews')`-methode:
+
+```ts
+  /**
+   * Trekt een oordeel in.
+   *
+   * Geen `@VereistRol('admin')`, consequent met beoordelen zelf: elke handeling
+   * ligt met naam en datum vast. 204 bij succes, 404 als het oordeel niet
+   * bestaat binnen deze tenant of al is ingetrokken.
+   */
+  @Delete('responses/:id/reviews/:reviewId')
+  @HttpCode(204)
+  async trekBeoordelingIn(
+    @Req() request: RequestMetSessie,
+    @Param('id') id: string,
+    @Param('reviewId') reviewId: string,
+  ): Promise<void> {
+    const sessie = request.sessie!;
+
+    await this.beoordelingen_.trekIn(sessie.tenantId, id, reviewId);
+  }
+```
+
+Controleer dat `Delete` en `HttpCode` in de import uit `@nestjs/common` staan; `Delete` staat er al (regel 269 gebruikt hem), `HttpCode` mogelijk nog niet.
+
+- [ ] **Stap 5: Draai en zie ze slagen**
+
+Run:
+```powershell
+npm run test:e2e -- goedkeuren
+```
+Expected: PASS, alle tests in de suite.
+
+- [ ] **Stap 6: Commit**
+
+```bash
+git add src/survey/beoordeling.service.ts src/survey/vragenlijst-beheer.controller.ts test/goedkeuren.e2e-spec.ts
+git commit -m "feat(survey): een oordeel intrekken zonder de historie te wissen"
+```
+
+---
+
+## Taak 6: Tenantisolatie en leverancierafscherming
+
+De policy verandert niet, maar een nieuwe route verdient een eigen bewijs. Zonder deze taak is er geen test die aantoont dat tenant B niet kan intrekken bij A.
+
+**Files:**
+- Test: `test/goedkeuren.e2e-spec.ts`
+
+- [ ] **Stap 1: Schrijf de tests**
+
+```ts
+it('laat tenant B niet goedkeuren op een respons van tenant A', async () => {
+  await request(app.getHttpServer() as App)
+    .post(`/admin/survey/responses/${RESPONSE_INGEDIEND}/reviews`)
+    .set('Cookie', cookieAdminB)
+    .send({ verdict: 'goedgekeurd', toelichting: 'Akkoord.' })
+    .expect(404);
+});
+
+it('laat tenant B geen oordeel van tenant A intrekken', async () => {
+  const gemaakt = await request(app.getHttpServer() as App)
+    .post(`/admin/survey/responses/${RESPONSE_INGEDIEND}/reviews`)
+    .set('Cookie', cookieAdminA)
+    .send({ verdict: 'goedgekeurd', toelichting: 'Akkoord.' })
+    .expect(201);
+
+  const reviewId = (gemaakt.body as BeoordelingBody).beoordeling.reviewId;
+
+  await request(app.getHttpServer() as App)
+    .delete(`/admin/survey/responses/${RESPONSE_INGEDIEND}/reviews/${reviewId}`)
+    .set('Cookie', cookieAdminB)
+    .expect(404);
+});
+```
+
+404 en niet 403: het verschil tussen "bestaat niet" en "mag je niet zien" hoort niet naar buiten te lekken (zie de toelichting bij `responses/:id/answers`).
+
+- [ ] **Stap 2: Draai de tests**
+
+Run:
+```powershell
+npm run test:e2e -- goedkeuren
+```
+Expected: PASS — RLS regelt dit.
+
+- [ ] **Stap 3: Tegenproef op de isolatie (§15b)**
+
+Wijzig **tijdelijk** in `beoordeling.service.ts` de `trekIn`-aanroep van `'medewerker'` naar `'leverancier'`:
+
+Run:
+```powershell
+npm run test:e2e -- goedkeuren
+```
+Expected: de intrek-tests FAIL — de policy eist actor `medewerker`.
+
+Draai terug met `git checkout src/survey/beoordeling.service.ts`, draai opnieuw, alles PASS. Noteer in de PR-body.
+
+- [ ] **Stap 4: Commit**
+
+```bash
+git add test/goedkeuren.e2e-spec.ts
+git commit -m "test(survey): tenantisolatie op goedkeuren en intrekken"
+```
+
+---
+
+## Taak 7: Volledige controle en PR
+
+- [ ] **Stap 1: Draai alles**
+
+Run:
+```powershell
+npm run lint:check
+npm run typecheck
+npm test
+npm run test:e2e
+```
+Expected: alles groen. Noteer het aantal e2e-tests — dat was 358 vóór dit werk.
+
+- [ ] **Stap 2: Bewijs de migratieketen vanaf leeg**
+
+Run:
+```powershell
+npm run verify:volledig
+```
+
+Dit is het zwaarste controlescript (`scripts/verify-volledig.js`) en het dichtst bij wat CI doet. Expected: schemaconformiteit GOEDGEKEURD, RLS geforceerd, alle suites groen.
+
+**Waarom dit niet overgeslagen mag worden bij een migratie:** de vorige stap bewijst dat 0017 werkt op *jouw* database, die al 0016 had. Dit bewijst dat de hele keten vanaf leeg klopt — precies wat de `rls-isolation`-job in CI controleert, en waar op 2026-08-06 twee migraties ongecontroleerd op stapelden.
+
+- [ ] **Stap 3: Push en maak de PR**
+
+```bash
+git push -u origin feat/goedkeuren-migratie-0017
+```
+
+PR-body moet bevatten:
+- Wat erbij komt (één CHECK-constraint, één route, één waarde)
+- **Waarom geen aparte tabel** (§3.2 van de uitwerking, kort samengevat)
+- **Waarom toelichting optioneel is bij goedkeuren** maar niet bij `niet_goed`
+- **De twee tegenproeven uit Taak 4 stap 3 en Taak 6 stap 3**, met wat er precies omviel
+- Aantal e2e-tests voor en na
+
+- [ ] **Stap 4: Wacht op groene CI en meld het**
+
+Run:
+```powershell
+gh pr checks --watch
+```
+
+Merge niet zonder overleg met de eigenaar.
+
+---
+
+## Zelfcontrole op dit plan
+
+**Dekking van de uitwerking:** §3.2 (goedgekeurd als vierde verdict) → Taak 1+2. §7 V1 (identiteit vastgelegd) → Taak 4. §7 V2 (intrekken zichtbaar) → Taak 5. §7 V3 (laatste oordeel telt) → **niet hier**: dat is de statusberekening en hoort bij stap 3 van de uitwerking, niet bij deze migratie.
+
+**Wat dit plan bewust niet doet:** de statusberekening (§3.3), `response_note` (migratie 0018), de werkvoorraad van de contractmanager, en alle schermen. Elk daarvan krijgt een eigen plan. Dit plan levert één migratie plus de routes die hem bruikbaar maken.
+
+**Alle commando's in dit plan zijn geverifieerd tegen `package.json` en `scripts/`** op 2026-08-07. Let op twee valkuilen die tijdens het schrijven naar boven kwamen:
+
+- Er is **geen** `npm run migrate` en **geen** `migrate:status`. Migraties draaien met `npm run migrate:deploy`, via `MIGRATION_DATABASE_URL` (rol `clm_migrator`), niet via `DATABASE_URL`. Dat verschil is precies waar Issue #86 op misging: het script meldde "Migraties voltooid" tegen de verkeerde database.
+- Er is **geen** los bestand met verwachte schemadefinities. `verify:schema` leidt de verwachting af uit het Drizzle-schema.

--- a/docs/superpowers/plans/2026-08-07-statuswaarheid-per-vendor.md
+++ b/docs/superpowers/plans/2026-08-07-statuswaarheid-per-vendor.md
@@ -1,0 +1,369 @@
+# Statuswaarheid per vendor — uitwerking
+
+> **Dit document beschrijft wat en waarom, nog niet stap voor stap hoe.**
+> De drie openstaande vragen zijn beantwoord door de eigenaar op 2026-08-07
+> (§7). Volgende stap: omzetten in taken met teststappen, te beginnen bij
+> migratie 0017.
+
+**Doel:** de app wordt de centrale waarheid voor de status van elke vragenlijst
+per leverancier, zodat een klein team dat elkaar toch al spreekt, niet meer hoeft
+te vragen "hoe staat het met X".
+
+**Aanleiding:** eigenaar, 2026-08-07. Bij het bespreken van de schermen voor fase
+C bleek de behoefte anders te liggen dan het oorspronkelijke plan aannam. Niet
+een beoordeelmachine met rollen en grenzen, maar een statusoverzicht dat de
+organisatie helpt.
+
+---
+
+## 1. Wat de eigenaar vroeg, in zijn eigen ordening
+
+> "De app moet vooral de hele organisatie helpen door de centrale waarheid te
+> zijn voor de status van de survey per vendor: opgestuurd en nog niet terug,
+> terug maar nog niet beoordeeld, beoordeeld maar nog niet goedgekeurd,
+> beoordeeld en goedgekeurd."
+
+Daarnaast, in dezelfde toelichting:
+
+1. **Toegankelijk voor de collega's** — contractmanagers en beoordelaars zitten
+   in hetzelfde gebouw en vinden elkaar op tien manieren. De app hoeft ze niet
+   uit elkaar te houden.
+2. **Notities bij een beoordeling**, bedoeld voor collega's.
+3. **Hulp bij het versturen van de juiste survey naar de juiste vendor** — met
+   nadruk op een goed mailadres.
+4. **Hulp bij een heads-up wegens tijdsoverschrijding.**
+5. **Uitdrukkelijk geen "totaal geautomatiseerde fabriek".**
+
+Punt 5 is een ontwerpinstructie en geen bijzin. Het is de reden dat dit document
+op meerdere plekken kiest voor tonen boven afdwingen.
+
+---
+
+## 2. Wat dit vervangt uit het oorspronkelijke plan
+
+`docs/superpowers/plans/2026-08-03-surveybeheer.md` §Fase C "Frontend" beschrijft
+drie schermen: voortgang per ronde, antwoorden lezen met beoordeelblok, en twee
+werkvoorraden met een schakelaar "van mij" / "hele organisatie".
+
+**Wat blijft:** de drie schermen, en de twee werkvoorraden als aparte lijsten
+(ADR-013 besluit 3 — één lijst met een filter bedient allebei half).
+
+**Wat verandert:** de statusketen wordt het ordenende principe in plaats van de
+rondevoortgang. En er komt een vierde status bij, `goedgekeurd`, die nog nergens
+bestaat.
+
+**Wat verviel tijdens het gesprek:** een vrijgavestap waarbij de contractmanager
+een respons vrijgeeft voordat een beoordelaar eraan mag. Dat is in de bespreking
+van 2026-08-07 uitdrukkelijk losgelaten als te ingewikkeld voor de omvang van
+het team. Zie §6 — het is bewust geen harde grens geworden, en dat heeft gevolgen
+die vastgelegd moeten blijven.
+
+---
+
+## 3. De statusketen
+
+### 3.1 De vier statussen en waar ze vandaan komen
+
+| Status | Afleidbaar uit wat er nu is? |
+|---|---|
+| Opgestuurd, nog niet terug | **Ja** — `survey_response.submitted_at IS NULL` |
+| Terug, nog niet beoordeeld | **Ja** — `submitted_at` gevuld, geen rij in `survey_review` |
+| Beoordeeld, nog niet goedgekeurd | **Ja** — minstens één `survey_review` |
+| Beoordeeld en goedgekeurd | **Nee — bestaat niet** |
+
+Drie van de vier zijn af te leiden uit bestaande gegevens. Alleen de laatste is
+nieuw.
+
+Er is een vijfde toestand die de eigenaar niet noemde maar die het scherm moet
+tonen, omdat hij anders onzichtbaar in "opgestuurd, nog niet terug" verdwijnt:
+
+| Extra | Afleidbaar uit |
+|---|---|
+| Te laat | `submitted_at IS NULL` en `closes_at < now()` bij een `active` ronde |
+
+Dat is dezelfde regel die wens 4 (heads-up bij overschrijding) nodig heeft, dus
+hij hoort hier thuis en niet in een apart hoekje.
+
+### 3.2 Waarom goedkeuring geen kolom op `survey_response` wordt
+
+`survey_response.status` bestaat al, met een CHECK op `pending / submitted /
+revoked` (migratie 0003). Dat is de **invulstatus**: waar staat de leverancier
+in zijn eigen proces.
+
+Goedkeuring is een oordeel van de *organisatie* over die inzending. Die twee
+door elkaar halen levert een kolom op die twee dingen tegelijk betekent, en
+statuswaarden die elkaar uitsluiten zonder dat iemand dat bedoeld heeft — kan
+een `revoked` respons goedgekeurd zijn?
+
+Bovendien is de reden die in migratie 0015 staat om `survey_review` een eigen
+tabel te geven, hier onverkort van toepassing:
+
+> Omdat er meerdere oordelen mogen zijn en geen enkele wordt overschreven. Elk
+> oordeel staat met naam en datum vast. Een kolom op survey_response zou het
+> vorige oordeel wissen (…) en juist in een compliance-dossier is "wat vond men
+> er eerder van" de vraag die je later stelt.
+
+Datzelfde geldt voor goedkeuring, en sterker nog: een goedkeuring die later
+wordt ingetrokken is precies het geval waarin je wilt kunnen zien dát het is
+ingetrokken en door wie.
+
+**Voorstel:** goedkeuring wordt een `verdict`-waarde erbij op `survey_review`,
+niet een nieuwe tabel en niet een kolom.
+
+```sql
+-- migratie 0017
+ALTER TABLE clm.survey_review DROP CONSTRAINT survey_review_verdict_check;
+ALTER TABLE clm.survey_review
+    ADD CONSTRAINT survey_review_verdict_check
+    CHECK (verdict IN ('goed', 'nadere_vragen', 'niet_goed', 'goedgekeurd'));
+```
+
+Waarom dat past: goedkeuren is óók een uitspraak van een genoemd persoon op een
+genoemd moment over één respons, die nooit overschreven wordt. Dezelfde vorm,
+dezelfde RLS-policy, dezelfde append-only-redenering. Een aparte tabel zou die
+regels dupliceren zonder verschil te maken.
+
+Waarom het toch aandacht vraagt: `goedgekeurd` is geen *inhoudelijk* oordeel
+zoals de andere drie, maar een procesbevestiging. Het scherm moet ze dus niet
+als vier gelijkwaardige knoppen naast elkaar zetten. Zie §4.2.
+
+**Alternatief dat is overwogen en afgevallen:** een aparte tabel
+`survey_approval`. Netter in theorie — goedkeuring is een ander soort uitspraak —
+maar het levert een tweede tabel op met exact dezelfde kolommen, dezelfde policy
+en dezelfde append-only-regel, plus een query die twee tabellen moet samenvoegen
+om "wat is de huidige status" te beantwoorden. Dat is meer bouwwerk voor
+hetzelfde resultaat.
+
+### 3.3 De status is afgeleid, niet opgeslagen
+
+De statusketen wordt **berekend**, niet als veld bijgehouden. Eén functie in de
+backend die per respons de status bepaalt, en één plek waar die regel staat.
+
+Dat is belangrijk omdat een opgeslagen status onvermijdelijk uit de pas gaat
+lopen met de onderliggende feiten — er is dan een rij die zegt "beoordeeld"
+terwijl er geen oordeel staat, en dan is de centrale waarheid juist geen
+waarheid meer.
+
+---
+
+## 4. Wat er gebouwd wordt
+
+### 4.1 Backend (repo `MCM2`)
+
+| # | Wat | Migratie |
+|---|---|---|
+| B1 | `verdict` uitbreiden met `goedgekeurd` | 0017 |
+| B2 | `clm.response_note` — losse notities | 0018 |
+| B3 | Statusberekening op één plek, meegeleverd in de bestaande responsroutes | — |
+| B4 | Werkvoorraad contractmanager: rondes op vendors met `owner_user_id` = ik | — |
+| B5 | Overzichtsroute per vendor: alle rondes met hun status | — |
+
+**B2 — waarom notities een eigen tabel worden.** De eigenaar vroeg om een
+notitie voor collega's die géén beoordeling is ("gebeld, komt volgende week").
+Die in `survey_review` persen zou een `verdict` afdwingen die er niet is, of een
+vierde nepwaarde introduceren. Een eigen tabel is hier het eenvoudigst:
+
+```sql
+-- migratie 0018
+CREATE TABLE clm.response_note (
+    note_id     uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+    tenant_id   uuid NOT NULL REFERENCES clm.tenant(tenant_id) ON DELETE restrict,
+    response_id uuid NOT NULL REFERENCES clm.survey_response(response_id) ON DELETE restrict,
+    tekst       text NOT NULL,
+    author_user_id uuid NOT NULL REFERENCES clm."user"(user_id) ON DELETE restrict,
+    created_at  timestamptz NOT NULL DEFAULT now(),
+    deleted_at  timestamptz
+);
+```
+
+Met **dezelfde policy als `survey_review`**, inclusief de actor-eis in zowel
+`USING` als `WITH CHECK`:
+
+```sql
+CREATE POLICY response_note_isolation ON clm.response_note
+    USING       (tenant_id = clm.current_tenant_id() AND clm.current_actor() = 'medewerker')
+    WITH CHECK  (tenant_id = clm.current_tenant_id() AND clm.current_actor() = 'medewerker');
+```
+
+Dat is geen kopieerwerk maar noodzaak: een notitie over een leverancier is voor
+collega's, en de leverancier zit in dezelfde tenant. Zonder de actor-eis leest
+hij mee. Dit is exact de situatie waar migratie 0015 voor gebouwd is.
+
+**B4 — de contractmanager-werkvoorraad.** `vendor.owner_user_id` bestaat in het
+schema (`src/db/schema.ts:153`) maar wordt door **geen enkele route gebruikt** —
+geverifieerd, twee treffers in de hele `src/`, beide in het schema zelf. De
+werkvoorraad van de contractmanager moet dus vanaf nul, in tegenstelling tot die
+van de beoordelaar (`GET /admin/survey/mijn-beoordelingen`, bestaat al).
+
+### 4.2 Frontend (repo `MCM2-frontend`)
+
+Drie schermen, zoals in het oorspronkelijke plan, maar geordend op status.
+
+**S1 — Statusoverzicht per vendor.** Het scherm dat de eigenaar eigenlijk vroeg.
+Eén regel per leverancier per ronde, met de status uit §3.1 en het laatste
+oordeel erbij. Dit is waar iemand kijkt die wil weten "hoe staat het ervoor".
+
+**S2 — Respons lezen, beoordelen, notitie plaatsen.** De antwoorden, daaronder
+de oordelen op datum, de notities, en de invoervelden. Drie inhoudelijke knoppen
+(Goed / Nadere vragen / Niet goed) plus **apart daarvan** een goedkeuringsactie —
+visueel gescheiden, want het is een processtap en geen vierde mening (§3.2).
+
+Toelichting verplicht bij *nadere vragen* en *niet goed*; dat is bestaande
+backendlogica en het scherm moet het vooraf zeggen in plaats van achteraf een
+foutmelding tonen.
+
+Bij *nadere vragen* een expliciete zin: **de leverancier merkt hier niets van, u
+neemt zelf contact op.** Dit staat al in het oorspronkelijke plan en blijft
+staan — een knop die suggereert dat er iets verstuurd wordt terwijl dat niet
+gebeurt, is erger dan geen knop.
+
+**S3 — Twee werkvoorraden.** Contractmanager (B4) en beoordelaar (bestaand), als
+aparte lijsten. Schakelaar "van mij" / "hele organisatie", **standaard op "van
+mij"** (besluit eigenaar 2026-08-07).
+
+### 4.3 Wens 3 en 4 — apart, en waarom
+
+**Hulp bij het juiste mailadres.** Dat `vendor_contact.email` nullable is, is
+geen gat maar opzet: een leverancier heeft meerdere contactpersonen en lang niet
+elk daarvan hoeft een mailadres te hebben. Alleen degene die de survey krijgt
+moet er een hebben, en **dat vangt de backend al af**
+(`src/survey/ronde-beheer.service.ts:351-365`):
+
+```sql
+LEFT JOIN LATERAL (
+       SELECT email FROM clm.vendor_contact
+        WHERE vendor_id = v.vendor_id
+          AND deleted_at IS NULL
+          AND email IS NOT NULL          -- alleen wie te mailen is
+        ORDER BY is_primary DESC, created_at ASC
+        LIMIT 1
+     ) c ON true
+```
+
+De keuze is voorspelbaar (primaire contactpersoon eerst, daarna de oudste) en de
+`LEFT JOIN` is bewust: een leverancier zonder mailbaar contact blijft in de
+lijst staan, het token wordt aangemaakt, en alleen het versturen mislukt — wat
+de verzender gemeld krijgt.
+
+**Wat er dan nog te winnen valt, is zichtbaarheid vooraf.** Nu merk je pas bij
+het versturen dat er niemand te mailen is. Een leverancier zonder mailbaar
+contact zou al in het uitnodigingsscherm herkenbaar moeten zijn, vóór je op
+verzenden drukt.
+
+Er is bovendien een bevinding die hier tegenaan ligt: *"een geldig gevormd maar
+niet-bestaand mailadres levert Geslaagd op"* (STATUS.md, 2026-08-06) — het bewijs
+dat de bounce-webhook nodig is. Een adres kán immers ingevuld en toch verkeerd
+zijn, en dát is het overgebleven risico.
+
+**Heads-up bij tijdsoverschrijding.** De berekening (`closes_at < now()` bij
+`active`) hoort in de statusketen en zit daarom in §3.1. Maar *een seintje
+sturen* is iets anders dan *het zichtbaar maken*, en hangt aan e-mail (fase D)
+en Issue #16.
+
+**Voorstel:** beide worden eigen stappen ná de statusketen. Het zichtbare deel
+van "te laat" komt wel meteen mee, want dat is dezelfde regel.
+
+---
+
+## 5. Volgorde
+
+De statusketen eerst en compleet, omdat de rest eraan hangt.
+
+| Stap | Wat | Waar |
+|---|---|---|
+| 1 | Migratie 0017 (`goedgekeurd`) + statusberekening + tests | MCM2 |
+| 2 | Migratie 0018 (`response_note`) + routes + tests | MCM2 |
+| 3 | B4 en B5: werkvoorraad contractmanager, overzicht per vendor | MCM2 |
+| 4 | S1: statusoverzicht per vendor | MCM2-frontend |
+| 5 | S2: lezen, beoordelen, notitie | MCM2-frontend |
+| 6 | S3: twee werkvoorraden | MCM2-frontend |
+| — | *Daarna:* mailadres-hulp (wens 3), heads-up (wens 4) | beide |
+
+Stap 1 t/m 3 zijn backend en gaan in aparte PR's per migratie — dat is de
+werkwijze die bij fase C ook is aangehouden en die bij het mergen op 2026-08-07
+zijn nut bewees.
+
+**Let op bij het ketenen van PR's:** richt een PR die op een andere branch staat
+op `main` **vóórdat** de onderliggende gemerged wordt. Anders klapt hij dicht
+zoals #95 op 2026-08-07 — heropenen kan dan niet meer.
+
+---
+
+## 6. Eén ding dat vastgelegd moet blijven
+
+Tijdens de bespreking is een vrijgavestap overwogen (contractmanager geeft vrij,
+daarna mag de beoordelaar) en daarna losgelaten omdat het team klein is en
+elkaar toch spreekt.
+
+**Dat is de juiste keuze voor deze organisatie, en hij botst niet met ADR-013 —
+juist doordat hij is losgelaten.** `src/survey/beoordelaar.service.ts` zegt in
+zoveel woorden:
+
+> **Voor wie hier later iets bouwt:** gebruik `template_reviewer` nooit om een
+> beoordeling te blokkeren. Een harde grens legt het proces stil zodra de
+> gekoppelde beoordelaar ziek is, en dan wijzigt iemand met databasetoegang de
+> koppeling — een noodgreep buiten de app om, zonder spoor.
+
+Een vrijgave die beoordelen blokkeert zou precies zo'n harde grens zijn geweest.
+Wordt de wens later opnieuw gesteld, dan is dat een aanpassing van ADR-013 en
+geen detail — met dezelfde vraag erbij: wat gebeurt er als degene die moet
+vrijgeven twee weken weg is.
+
+De statusketen doet wat de vrijgave zou moeten doen, zonder iemand tegen te
+houden: je ziet dát er nog niet beoordeeld is.
+
+---
+
+## 7. Besloten (eigenaar, 2026-08-07)
+
+**V1 — Wie mag goedkeuren? → Iedereen, mits de identiteit vastligt.**
+
+Geen `@VereistRol('admin')`, consequent met beoordelen. De voorwaarde die de
+eigenaar erbij stelde is precies de onderbouwing die er al lag: elk oordeel
+staat met naam en datum vast en wordt nooit overschreven (plan §2a).
+
+**Die voorwaarde is een bouwopdracht, geen bijzin.** Concreet betekent het:
+
+- De goedkeurder komt **uit de sessie, nooit uit de body** — dezelfde regel als
+  bij beoordelen (`vragenlijst-beheer.controller.ts:187-194`). Anders kan iemand
+  goedkeuren op naam van een collega, en in een compliance-dossier is dat de
+  handtekening die moet kloppen.
+- `reviewer_user_id` is `NOT NULL` met `ON DELETE restrict` (migratie 0015,
+  *"een oordeel zonder naam is waardeloos in een compliance-dossier"*). Dat geldt
+  onverkort voor een goedkeuring.
+- Het scherm toont bij elke goedkeuring **wie** en **wanneer**, niet alleen dát
+  het is goedgekeurd.
+
+Er komt een tegenproef die dit bewijst: een poging om goed te keuren met een
+andere `userId` in de body legt de goedkeuring vast op naam van de ingelogde
+gebruiker, niet die van de body.
+
+**V2 — Mag een goedkeuring ingetrokken worden? → Ja, met zichtbare intrekking.**
+
+Via `deleted_at`, zoals de tabel al werkt. Het scherm toont dát er is
+ingetrokken en door wie; de intrekking verdwijnt niet stilletjes uit beeld. Een
+goedkeuring die spoorloos kan verdampen is geen centrale waarheid.
+
+**V3 — Twee tegenstrijdige oordelen? → Het laatste telt, maar het meningsverschil
+blijft zichtbaar.**
+
+De statusberekening neemt het laatste oordeel (`ORDER BY created_at DESC
+LIMIT 1`, zoals de bestaande werkvoorraadquery). Maar het overzicht toont
+daarnaast dat er méér oordelen zijn — anders verdwijnt een meningsverschil uit
+beeld, en dat is juist wat je wilt zien.
+
+`WerkvoorraadItem` levert `aantalOordelen` daar nu al voor
+(`beoordelaar.service.ts:48`); dat veld gaat mee naar het statusoverzicht.
+
+---
+
+## 8. Wat af is wanneer
+
+Je opent één scherm en ziet per leverancier waar zijn vragenlijst staat:
+opgestuurd, terug, beoordeeld, goedgekeurd — of te laat. Je kunt een inzending
+openen, lezen, beoordelen en er een notitie voor een collega bij zetten. Een
+tweede oordeel wist het eerste niet. En je ziet je eigen stapel, met één klik de
+hele organisatie erbij.
+
+Niet af, bewust: automatische herinneringen, bouncedetectie, en alles wat de
+eigenaar met "geen totaal geautomatiseerde fabriek" heeft afgegrensd.

--- a/drizzle/0017_goedkeuren.sql
+++ b/drizzle/0017_goedkeuren.sql
@@ -1,0 +1,51 @@
+-- =============================================================================
+-- Goedkeuren als vierde oordeel op clm.survey_review.
+--
+-- Aanleiding: docs/superpowers/plans/2026-08-07-statuswaarheid-per-vendor.md
+-- §3.2. De eigenaar wil dat de app de centrale waarheid is voor de status van
+-- een vragenlijst per leverancier: opgestuurd en nog niet terug, terug maar nog
+-- niet beoordeeld, beoordeeld maar nog niet goedgekeurd, beoordeeld en
+-- goedgekeurd.
+--
+-- Drie van die vier waren al af te leiden uit bestaande gegevens
+-- (submitted_at, en het bestaan van een survey_review-rij). "Beoordeeld en
+-- goedgekeurd" was de enige die nergens bestond.
+--
+-- ── Waarom hier en niet in een eigen tabel ───────────────────────────────────
+--
+-- Goedkeuren is dezelfde soort uitspraak als de drie bestaande oordelen: van
+-- een genoemd persoon, op een genoemd moment, over één respons, en nooit
+-- overschreven. Een aparte tabel zou dezelfde kolommen, dezelfde policy en
+-- dezelfde append-only-regel dupliceren, plus een query opleveren die twee
+-- tabellen moet samenvoegen om "wat is de huidige status" te beantwoorden.
+--
+-- ── Waarom niet op survey_response ───────────────────────────────────────────
+--
+-- survey_response.status (migratie 0003) is de INVULstatus: waar staat de
+-- leverancier in zijn eigen proces (pending/submitted/revoked). Goedkeuring is
+-- een uitspraak van de ORGANISATIE over die inzending. Die twee in één kolom
+-- levert waarden op die elkaar ongemerkt uitsluiten — kan een 'revoked'
+-- respons goedgekeurd zijn?
+--
+-- ── Waarom een verdict en geen kolom is_goedgekeurd ──────────────────────────
+--
+-- Een boolean op survey_review zou zeggen "dit oordeel is óók een goedkeuring",
+-- terwijl het een eigen uitspraak is die los van een inhoudelijk oordeel kan
+-- staan: een collega mag goedkeuren zonder eerst 'goed' te hebben gezegd.
+--
+-- ── Wat dit NIET verandert ───────────────────────────────────────────────────
+--
+-- De RLS-policy niet, de kolommen niet, de rechten niet. Alleen de verzameling
+-- toegestane waarden. Bestaande rijen blijven geldig: 'goedgekeurd' komt erbij,
+-- er gaat niets af. Daarom is deze migratie ook veilig op een gevulde database.
+-- =============================================================================
+
+ALTER TABLE clm.survey_review
+    DROP CONSTRAINT survey_review_verdict_check;--> statement-breakpoint
+
+ALTER TABLE clm.survey_review
+    ADD CONSTRAINT survey_review_verdict_check
+    CHECK (verdict IN ('goed', 'nadere_vragen', 'niet_goed', 'goedgekeurd'));--> statement-breakpoint
+
+COMMENT ON CONSTRAINT survey_review_verdict_check ON clm.survey_review IS
+    'Vier oordelen. De eerste drie zijn inhoudelijk: wat vindt de beoordelaar van de inzending. Goedgekeurd is een processtap die de inzending afsluit — dezelfde vorm (naam, datum, nooit overschreven), andere betekenis. Het scherm zet ze daarom niet als vier gelijkwaardige knoppen naast elkaar.';

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -120,6 +120,13 @@
       "when": 1786046641509,
       "tag": "0016_template_reviewer",
       "breakpoints": true
+    },
+    {
+      "idx": 17,
+      "version": "7",
+      "when": 1786435200000,
+      "tag": "0017_goedkeuren",
+      "breakpoints": true
     }
   ]
 }

--- a/src/survey/beoordeling.service.ts
+++ b/src/survey/beoordeling.service.ts
@@ -38,9 +38,33 @@ import { DatabaseService } from '../db/database.service';
  * erger dan geen knop.
  */
 
-/** De drie toegestane oordelen. Gelijk aan de CHECK uit migratie 0015. */
-export const OORDELEN = ['goed', 'nadere_vragen', 'niet_goed'] as const;
+/**
+ * De vier toegestane oordelen. Gelijk aan de CHECK uit migratie 0017.
+ *
+ * De eerste drie zijn inhoudelijk: wat vindt de beoordelaar van de inzending.
+ * `goedgekeurd` is een processtap die de inzending afsluit — dezelfde vorm
+ * (naam, datum, nooit overschreven), maar een andere betekenis. Het scherm zet
+ * ze daarom niet als vier gelijkwaardige knoppen naast elkaar.
+ */
+export const OORDELEN = [
+  'goed',
+  'nadere_vragen',
+  'niet_goed',
+  'goedgekeurd',
+] as const;
 export type Oordeel = (typeof OORDELEN)[number];
+
+/**
+ * Oordelen die een onderbouwing vereisen.
+ *
+ * `goed` en `goedgekeurd` niet: bij een goedkeuring is de handtekening de
+ * inhoud — wie en wanneer, en dat legt de tabel zelf vast. De eis bestaat
+ * omdat "niet goed" zonder reden later niet te herleiden is.
+ */
+export const OORDELEN_MET_TOELICHTING: readonly Oordeel[] = [
+  'nadere_vragen',
+  'niet_goed',
+];
 
 export interface NieuweBeoordeling {
   verdict: Oordeel;
@@ -175,6 +199,50 @@ export class BeoordelingService {
         }
 
         return this.naarBeoordeling(rij);
+      },
+      'medewerker',
+    );
+  }
+
+  /**
+   * Trekt een oordeel in.
+   *
+   * Zet `deleted_at` en verwijdert niets. De tabel is append-only: wissen zou
+   * de historie kapotmaken die deze tabel juist bewaart, en een goedkeuring die
+   * spoorloos kan verdampen maakt de status onbetrouwbaar (besluit eigenaar
+   * 2026-08-07, V2).
+   *
+   * Wie mag intrekken is niet beperkt, consequent met beoordelen zelf: elke
+   * handeling ligt met naam en datum vast, dus niemand kan iets stilletjes
+   * doen. Wél zichtbaar in het scherm dát er is ingetrokken.
+   *
+   * De `response_id` in de WHERE is geen overbodige controle: zonder die eis
+   * zou een geldig review-id uit een ándere respons van dezelfde tenant hier
+   * ingetrokken kunnen worden via een verzonnen pad.
+   */
+  async trekIn(
+    tenantId: string,
+    responseId: string,
+    reviewId: string,
+  ): Promise<void> {
+    return this.db.withTenant(
+      tenantId,
+      async (tx) => {
+        await this.eisBestaandeRespons(tx, responseId);
+
+        const geraakt = await tx.execute(
+          sql`UPDATE clm.survey_review
+                 SET deleted_at = now()
+               WHERE review_id = ${reviewId}
+                 AND response_id = ${responseId}
+                 AND deleted_at IS NULL`,
+        );
+
+        if (geraakt.rowCount === 0) {
+          throw new NotFoundException(
+            'Dit oordeel bestaat niet, of is al ingetrokken.',
+          );
+        }
       },
       'medewerker',
     );

--- a/src/survey/ronde-invoer.ts
+++ b/src/survey/ronde-invoer.ts
@@ -278,8 +278,28 @@ export function mogelijkeOvergangen(van: string): readonly string[] {
   return OVERGANGEN[van] ?? [];
 }
 
-/** De drie oordelen uit migratie 0015. */
-const OORDELEN = ['goed', 'nadere_vragen', 'niet_goed'] as const;
+/**
+ * De vier oordelen uit migratie 0017.
+ *
+ * Bewust hier herhaald en niet geïmporteerd: dit bestand valideert wat een
+ * browser opstuurt en staat daarvoor los van de servicelaag, net als
+ * `vendor-invoer.ts`. De koppeling met `beoordeling.service.ts` is een
+ * typecontrole verderop in dit bestand — lopen de twee lijsten uiteen, dan
+ * faalt de build en niet pas een test.
+ */
+const OORDELEN = ['goed', 'nadere_vragen', 'niet_goed', 'goedgekeurd'] as const;
+
+/**
+ * Oordelen die een onderbouwing vereisen.
+ *
+ * Expliciet opgesomd en niet als "alles behalve goed": bij het toevoegen van
+ * `goedgekeurd` (migratie 0017) zou die uitzonderingsvorm er stilzwijgend een
+ * verplichte toelichting van hebben gemaakt.
+ */
+const VEREIST_TOELICHTING: readonly (typeof OORDELEN)[number][] = [
+  'nadere_vragen',
+  'niet_goed',
+];
 
 export interface NieuweBeoordelingInvoer {
   verdict: (typeof OORDELEN)[number];
@@ -289,10 +309,12 @@ export interface NieuweBeoordelingInvoer {
 /**
  * Leest de invoer voor een nieuw oordeel (fase C).
  *
- * De toelichting mag leeg zijn bij `goed` — daar valt vaak niets toe te
- * lichten. Bij de andere twee is hij verplicht: "niet goed" zonder reden is
- * voor de leverancier én voor een latere lezer onbruikbaar, en juist in een
- * compliance-dossier is de onderbouwing het punt.
+ * De toelichting is verplicht bij `nadere_vragen` en `niet_goed`: zonder reden
+ * is zo'n oordeel voor de leverancier én voor een latere lezer onbruikbaar, en
+ * juist in een compliance-dossier is de onderbouwing het punt.
+ *
+ * Bij `goed` valt er vaak niets toe te lichten, en bij `goedgekeurd` is de
+ * handtekening de inhoud — wie en wanneer, en dat legt de tabel zelf vast.
  */
 export function leesNieuweBeoordeling(body: unknown): NieuweBeoordelingInvoer {
   const invoer = leesObject(body);
@@ -318,7 +340,11 @@ export function leesNieuweBeoordeling(body: unknown): NieuweBeoordelingInvoer {
 
   const toelichting = (invoer.toelichting ?? '').trim();
 
-  if (verdict !== 'goed' && toelichting === '') {
+  // Alleen de inhoudelijke afwijzingen. Zou hier `verdict !== 'goed'` staan,
+  // dan zou een goedkeuring een verplichte onderbouwing krijgen — en dat is
+  // precies de reden dat deze lijst expliciet is en niet als uitzondering
+  // geschreven.
+  if (VEREIST_TOELICHTING.includes(verdict) && toelichting === '') {
     throw new InvoerFout(
       'toelichting',
       'Licht toe waarom. Zonder onderbouwing is dit oordeel later niet te herleiden.',

--- a/src/survey/vragenlijst-beheer.controller.ts
+++ b/src/survey/vragenlijst-beheer.controller.ts
@@ -197,6 +197,32 @@ export class VragenlijstBeheerController {
   }
 
   /**
+   * Trekt een oordeel in.
+   *
+   * Zet `deleted_at`; de rij blijft staan (besluit eigenaar 2026-08-07, V2).
+   * Een goedkeuring die spoorloos kan verdampen maakt de status onbetrouwbaar,
+   * en dit is juist de tabel waar "wat vond men er eerder van" de vraag is die
+   * je later stelt.
+   *
+   * **Geen `@VereistRol('admin')`, consequent met beoordelen zelf.** Elke
+   * handeling ligt met naam en datum vast; niemand kan iets stilletjes doen.
+   *
+   * 204 bij succes. 404 als de respons of het oordeel niet bestaat binnen deze
+   * tenant, of als het oordeel al is ingetrokken.
+   */
+  @Delete('responses/:id/reviews/:reviewId')
+  @HttpCode(204)
+  async trekBeoordelingIn(
+    @Req() request: RequestMetSessie,
+    @Param('id') id: string,
+    @Param('reviewId') reviewId: string,
+  ): Promise<void> {
+    const sessie = request.sessie!;
+
+    await this.beoordelingen_.trekIn(sessie.tenantId, id, reviewId);
+  }
+
+  /**
    * Wat er op de ingelogde gebruiker wacht: ingediende responses op
    * vragenlijsten waaraan hij als beoordelaar gekoppeld is.
    *

--- a/test/goedkeuren.e2e-spec.ts
+++ b/test/goedkeuren.e2e-spec.ts
@@ -1,0 +1,391 @@
+import { INestApplication } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import cookieParser from 'cookie-parser';
+import { Client } from 'pg';
+import request from 'supertest';
+import type { App } from 'supertest/types';
+
+import { AppModule } from '../src/app.module';
+import { cookieInstellingen } from '../src/auth/sessie';
+import { SessieService } from '../src/auth/sessie.service';
+import { TEST_IDS } from './test-ids';
+
+/**
+ * Goedkeuren als vierde oordeel (migratie 0017).
+ *
+ * Zie docs/superpowers/plans/2026-08-07-statuswaarheid-per-vendor.md §3.2 en §7.
+ *
+ * "Kan ik een goedkeuring opslaan" is de makkelijke helft. Vier dingen kunnen
+ * hier stuk zonder dat iemand het merkt:
+ *
+ *   1. Legt de goedkeuring vast op naam van iemand ánders dan de ingelogde
+ *      gebruiker? Dat is de voorwaarde die de eigenaar aan V1 verbond:
+ *      iedereen mag goedkeuren, MITS de identiteit van de keurder vastligt.
+ *   2. Eist goedkeuren een toelichting? Dat hoort niet — bij een goedkeuring is
+ *      de handtekening de inhoud. Maar de eis bij niet_goed moet blijven staan.
+ *   3. Wist intrekken de rij, in plaats van deleted_at te zetten? Dan is de
+ *      historie weg die deze tabel juist bewaart.
+ *   4. Kan tenant B goedkeuren of intrekken bij tenant A?
+ */
+
+const {
+  tenantA,
+  tenantB,
+  adminA: ADMIN_A,
+  collegaA: COLLEGA_A,
+  templateA: TEMPLATE_A,
+  runA: RUN_A,
+  vendorA: VENDOR_A,
+  responseIngediend: RESPONSE_INGEDIEND,
+  adminB,
+  reviewBestaatNiet: REVIEW_BESTAAT_NIET,
+} = TEST_IDS.goedkeuren;
+
+const SUBJECT_ADMIN = `oid-gk-a-${Date.now()}`;
+const SUBJECT_COLLEGA = `oid-gk-c-${Date.now()}`;
+const SUBJECT_B = `oid-gk-b-${Date.now()}`;
+
+/** 64 hex-tekens, conform de CHECK op token_hash (migratie 0003). */
+const HASH_INGEDIEND = `${'3'.repeat(48)}cccccccccccccccc`;
+
+interface BeoordelingBody {
+  beoordeling: {
+    reviewId: string;
+    verdict: string;
+    toelichting: string;
+    reviewerUserId: string;
+    reviewerNaam: string | null;
+    createdAt: string;
+  };
+}
+
+interface LijstBody {
+  beoordelingen: Array<{
+    reviewId: string;
+    verdict: string;
+    toelichting: string;
+    reviewerNaam: string | null;
+  }>;
+}
+
+async function verwijderTestdata(client: Client) {
+  for (const tenant of [tenantA, tenantB]) {
+    await client.query('BEGIN');
+    await client.query(`SET LOCAL app.current_tenant_id = '${tenant}'`);
+    // Actor 'medewerker' is nodig: zonder dat weigert de policy op
+    // survey_review élke rij, ook bij het opruimen.
+    await client.query(`SET LOCAL app.current_actor = 'medewerker'`);
+    for (const tabel of [
+      'clm.survey_review',
+      'clm.survey_answer',
+      'clm.survey_response',
+      'clm.survey_run',
+      'clm.survey_question',
+      'clm.survey_template',
+      'clm.vendor',
+      'clm.tenant_membership',
+      'clm."user"',
+      'clm.tenant',
+    ]) {
+      await client.query(`DELETE FROM ${tabel} WHERE tenant_id = $1`, [tenant]);
+    }
+    await client.query('COMMIT');
+  }
+}
+
+describe('Goedkeuren van een respons (e2e)', () => {
+  let app: INestApplication<App>;
+  let server: App;
+  let client: Client;
+  let cookieAdminA: string;
+  let cookieB: string;
+
+  beforeAll(async () => {
+    client = new Client({ connectionString: process.env.DATABASE_URL });
+    await client.connect();
+    await verwijderTestdata(client);
+
+    await client.query('BEGIN');
+    await client.query(`SET LOCAL app.current_tenant_id = '${tenantA}'`);
+    await client.query(`SET LOCAL app.current_actor = 'medewerker'`);
+
+    await client.query(
+      'INSERT INTO clm.tenant (tenant_id, name) VALUES ($1, $2)',
+      [tenantA, 'Tenant A (goedkeuren)'],
+    );
+    for (const [userId, subject, naam, rol] of [
+      [ADMIN_A, SUBJECT_ADMIN, 'Admin van A', 'admin'],
+      [COLLEGA_A, SUBJECT_COLLEGA, 'Collega van A', 'reviewer'],
+    ] as const) {
+      await client.query(
+        `INSERT INTO clm."user" (user_id, tenant_id, email, full_name, external_subject)
+         VALUES ($1, $2, $3, $4, $5)`,
+        [userId, tenantA, `${subject}@voorbeeld.nl`, naam, subject],
+      );
+      await client.query(
+        `INSERT INTO clm.tenant_membership (user_id, tenant_id, role)
+         VALUES ($1, $2, $3)`,
+        [userId, tenantA, rol],
+      );
+    }
+
+    await client.query(
+      `INSERT INTO clm.survey_template (template_id, tenant_id, name, version)
+       VALUES ($1, $2, 'goedkeur-test-lijst', 1)`,
+      [TEMPLATE_A, tenantA],
+    );
+    await client.query(
+      `INSERT INTO clm.survey_run
+         (run_id, tenant_id, template_id, status, survey_kind, is_test, started_at)
+       VALUES ($1, $2, $3, 'active', 'vendor_compliance', true, now())`,
+      [RUN_A, tenantA, TEMPLATE_A],
+    );
+    await client.query(
+      `INSERT INTO clm.vendor (vendor_id, tenant_id, name)
+       VALUES ($1, $2, 'Leverancier van A')`,
+      [VENDOR_A, tenantA],
+    );
+    await client.query(
+      `INSERT INTO clm.survey_response
+         (response_id, tenant_id, run_id, vendor_id, subject_vendor_id,
+          token_hash, status, expires_at, submitted_at)
+       VALUES ($1, $2, $3, $4, $4, $5, 'submitted',
+               now() + interval '30 days', now())`,
+      [RESPONSE_INGEDIEND, tenantA, RUN_A, VENDOR_A, HASH_INGEDIEND],
+    );
+    await client.query('COMMIT');
+
+    // Tenant B, zodat de tenantgrens iets te verbergen heeft.
+    await client.query('BEGIN');
+    await client.query(`SET LOCAL app.current_tenant_id = '${tenantB}'`);
+    await client.query(`SET LOCAL app.current_actor = 'medewerker'`);
+    await client.query(
+      'INSERT INTO clm.tenant (tenant_id, name) VALUES ($1, $2)',
+      [tenantB, 'Tenant B (goedkeuren)'],
+    );
+    await client.query(
+      `INSERT INTO clm."user" (user_id, tenant_id, email, full_name, external_subject)
+       VALUES ($1, $2, $3, 'Admin van B', $4)`,
+      [adminB, tenantB, `${SUBJECT_B}@voorbeeld.nl`, SUBJECT_B],
+    );
+    await client.query(
+      `INSERT INTO clm.tenant_membership (user_id, tenant_id, role)
+       VALUES ($1, $2, 'admin')`,
+      [adminB, tenantB],
+    );
+    await client.query('COMMIT');
+
+    const moduleRef = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleRef.createNestApplication();
+    app.use(cookieParser());
+    await app.init();
+    server = app.getHttpServer();
+
+    const sessies = app.get(SessieService);
+    const naam = cookieInstellingen().naam;
+    for (const [subject, doel] of [
+      [SUBJECT_ADMIN, 'a'],
+      [SUBJECT_B, 'b'],
+    ] as const) {
+      const sessie = await sessies.aanmaken(subject);
+      expect(sessie).not.toBeNull();
+
+      const cookie = `${naam}=${sessie!.token}`;
+      if (doel === 'a') cookieAdminA = cookie;
+      else cookieB = cookie;
+    }
+  }, 30000);
+
+  afterAll(async () => {
+    await app.close();
+    await verwijderTestdata(client);
+    await client.end();
+  }, 30000);
+
+  /** Legt een goedkeuring vast en geeft het review-id terug. */
+  async function keurGoed(cookie: string): Promise<string> {
+    const antwoord = await request(server)
+      .post(`/admin/survey/responses/${RESPONSE_INGEDIEND}/reviews`)
+      .set('Cookie', cookie)
+      .send({ verdict: 'goedgekeurd', toelichting: 'Akkoord namens IT.' })
+      .expect(201);
+
+    return (antwoord.body as BeoordelingBody).beoordeling.reviewId;
+  }
+
+  describe('een goedkeuring vastleggen', () => {
+    it('legt een goedkeuring vast op een ingediende respons', async () => {
+      const antwoord = await request(server)
+        .post(`/admin/survey/responses/${RESPONSE_INGEDIEND}/reviews`)
+        .set('Cookie', cookieAdminA)
+        .send({ verdict: 'goedgekeurd', toelichting: 'Akkoord namens IT.' })
+        .expect(201);
+
+      const body = antwoord.body as BeoordelingBody;
+
+      expect(body.beoordeling.verdict).toBe('goedgekeurd');
+      expect(body.beoordeling.reviewerUserId).toBe(ADMIN_A);
+      expect(body.beoordeling.reviewerNaam).toBe('Admin van A');
+    });
+
+    it('staat goedkeuren zonder toelichting toe', async () => {
+      // Bij een goedkeuring is de handtekening de inhoud — wie en wanneer, en
+      // dat legt de tabel zelf vast. De onderbouwingseis bestaat omdat
+      // "niet goed" zonder reden later niet te herleiden is.
+      await request(server)
+        .post(`/admin/survey/responses/${RESPONSE_INGEDIEND}/reviews`)
+        .set('Cookie', cookieAdminA)
+        .send({ verdict: 'goedgekeurd' })
+        .expect(201);
+    });
+
+    it('blijft een toelichting eisen bij niet_goed', async () => {
+      // De keerzijde van de test hierboven: het versoepelen voor goedgekeurd
+      // mag de eis bij de inhoudelijke afwijzingen niet stilletjes opheffen.
+      const antwoord = await request(server)
+        .post(`/admin/survey/responses/${RESPONSE_INGEDIEND}/reviews`)
+        .set('Cookie', cookieAdminA)
+        .send({ verdict: 'niet_goed' })
+        .expect(400);
+
+      expect((antwoord.body as { message: string }).message).toContain(
+        'Licht toe',
+      );
+    });
+
+    it('blijft een toelichting eisen bij nadere_vragen', async () => {
+      await request(server)
+        .post(`/admin/survey/responses/${RESPONSE_INGEDIEND}/reviews`)
+        .set('Cookie', cookieAdminA)
+        .send({ verdict: 'nadere_vragen' })
+        .expect(400);
+    });
+  });
+
+  describe('de identiteit van de keurder (V1)', () => {
+    // "Iedereen mag goedkeuren, mits de identiteit van de keurder vastligt"
+    // (eigenaar 2026-08-07). Zonder deze test is die voorwaarde een belofte.
+    it('negeert een reviewerUserId uit de body en gebruikt de sessie', async () => {
+      const antwoord = await request(server)
+        .post(`/admin/survey/responses/${RESPONSE_INGEDIEND}/reviews`)
+        .set('Cookie', cookieAdminA)
+        .send({
+          verdict: 'goedgekeurd',
+          toelichting: 'Akkoord.',
+          // Een poging om de goedkeuring op naam van een collega te zetten.
+          reviewerUserId: COLLEGA_A,
+        })
+        .expect(201);
+
+      const body = antwoord.body as BeoordelingBody;
+
+      expect(body.beoordeling.reviewerUserId).toBe(ADMIN_A);
+      expect(body.beoordeling.reviewerUserId).not.toBe(COLLEGA_A);
+      expect(body.beoordeling.reviewerNaam).toBe('Admin van A');
+    });
+  });
+
+  describe('een oordeel intrekken (V2)', () => {
+    it('trekt een oordeel in en laat het uit de lijst verdwijnen', async () => {
+      const reviewId = await keurGoed(cookieAdminA);
+
+      await request(server)
+        .delete(
+          `/admin/survey/responses/${RESPONSE_INGEDIEND}/reviews/${reviewId}`,
+        )
+        .set('Cookie', cookieAdminA)
+        .expect(204);
+
+      const lijst = await request(server)
+        .get(`/admin/survey/responses/${RESPONSE_INGEDIEND}/reviews`)
+        .set('Cookie', cookieAdminA)
+        .expect(200);
+
+      const ids = (lijst.body as LijstBody).beoordelingen.map(
+        (b) => b.reviewId,
+      );
+      expect(ids).not.toContain(reviewId);
+    });
+
+    it('bewaart een ingetrokken oordeel in de database', async () => {
+      // De belangrijkste test van dit blok: intrekken zet deleted_at en
+      // verwijdert niets. Wissen zou de historie kapotmaken die deze tabel
+      // juist bewaart — en een goedkeuring die spoorloos kan verdampen maakt
+      // de status onbetrouwbaar.
+      const reviewId = await keurGoed(cookieAdminA);
+
+      await request(server)
+        .delete(
+          `/admin/survey/responses/${RESPONSE_INGEDIEND}/reviews/${reviewId}`,
+        )
+        .set('Cookie', cookieAdminA)
+        .expect(204);
+
+      await client.query('BEGIN');
+      await client.query(`SET LOCAL app.current_tenant_id = '${tenantA}'`);
+      await client.query(`SET LOCAL app.current_actor = 'medewerker'`);
+      const rij = await client.query<{ deleted_at: Date | null }>(
+        'SELECT deleted_at FROM clm.survey_review WHERE review_id = $1',
+        [reviewId],
+      );
+      await client.query('COMMIT');
+
+      expect(rij.rows).toHaveLength(1);
+      expect(rij.rows[0].deleted_at).not.toBeNull();
+    });
+
+    it('geeft 404 bij een tweede poging tot intrekken', async () => {
+      const reviewId = await keurGoed(cookieAdminA);
+      const pad = `/admin/survey/responses/${RESPONSE_INGEDIEND}/reviews/${reviewId}`;
+
+      await request(server).delete(pad).set('Cookie', cookieAdminA).expect(204);
+      await request(server).delete(pad).set('Cookie', cookieAdminA).expect(404);
+    });
+
+    it('geeft 404 bij het intrekken van een onbekend oordeel', async () => {
+      await request(server)
+        .delete(
+          `/admin/survey/responses/${RESPONSE_INGEDIEND}/reviews/${REVIEW_BESTAAT_NIET}`,
+        )
+        .set('Cookie', cookieAdminA)
+        .expect(404);
+    });
+  });
+
+  describe('de tenantgrens', () => {
+    // 404 en niet 403: het verschil tussen "bestaat niet" en "mag je niet
+    // zien" hoort niet naar buiten te lekken.
+    it('laat tenant B niet goedkeuren op een respons van tenant A', async () => {
+      await request(server)
+        .post(`/admin/survey/responses/${RESPONSE_INGEDIEND}/reviews`)
+        .set('Cookie', cookieB)
+        .send({ verdict: 'goedgekeurd', toelichting: 'Akkoord.' })
+        .expect(404);
+    });
+
+    it('laat tenant B geen oordeel van tenant A intrekken', async () => {
+      const reviewId = await keurGoed(cookieAdminA);
+
+      await request(server)
+        .delete(
+          `/admin/survey/responses/${RESPONSE_INGEDIEND}/reviews/${reviewId}`,
+        )
+        .set('Cookie', cookieB)
+        .expect(404);
+
+      // En het oordeel staat er nog: een mislukte poging mag niets wijzigen.
+      const lijst = await request(server)
+        .get(`/admin/survey/responses/${RESPONSE_INGEDIEND}/reviews`)
+        .set('Cookie', cookieAdminA)
+        .expect(200);
+
+      const ids = (lijst.body as LijstBody).beoordelingen.map(
+        (b) => b.reviewId,
+      );
+      expect(ids).toContain(reviewId);
+    });
+  });
+});

--- a/test/test-ids.ts
+++ b/test/test-ids.ts
@@ -204,6 +204,41 @@ export const TEST_IDS = {
      */
     bestaatNiet: '00000000-0000-0000-0000-00000000dead',
   },
+  // Goedkeuren (migratie 0017). Staarten f9 t/m ff, plus 90 en 91.
+  //
+  // Let op bij het kiezen van vrije staarten: ze worden in dit bestand op TWEE
+  // manieren uitgedeeld — letterlijk zoals hieronder, én via de id()-helper
+  // bovenaan. Zoek je alleen op de letterlijke vorm, dan lijken f0-f8 vrij
+  // terwijl ze via id() al vergeven zijn. Beide vormen tellen:
+  //
+  //   Select-String test\test-ids.ts -Pattern "id\('([0-9a-f]{2})'\)"
+  //   Select-String test\test-ids.ts -Pattern "'0{20}([0-9a-f]{2})'"
+  //
+  // De f-reeks was bijna op (f8 was de hoogste), vandaar de sprong naar 90.
+  goedkeuren: {
+    tenantA: '00000000-0000-0000-0000-0000000000f9',
+    tenantB: '00000000-0000-0000-0000-0000000000fa',
+    adminA: '00000000-0000-0000-0000-0000000000fb',
+    /**
+     * Tweede medewerker in A. Bestaat alleen om te bewijzen dat een
+     * reviewerUserId uit de body genegeerd wordt: zonder een tweede echte
+     * gebruiker zou die test ook slagen op een niet-bestaand id, en dan
+     * bewijst hij niets.
+     */
+    collegaA: '00000000-0000-0000-0000-0000000000fc',
+    templateA: '00000000-0000-0000-0000-0000000000fd',
+    runA: '00000000-0000-0000-0000-0000000000fe',
+    vendorA: '00000000-0000-0000-0000-0000000000ff',
+    /** Ingediend — hierop mag goedgekeurd worden. */
+    responseIngediend: '00000000-0000-0000-0000-000000000090',
+    adminB: '00000000-0000-0000-0000-000000000091',
+    /**
+     * Bestaat met opzet NIET — voor de 404 bij intrekken. Eigen waarde en niet
+     * de `dead` uit beoordelaar-koppelen: twee suites die dezelfde id delen is
+     * precies de faalvorm die de bewakingstest hierboven afvangt.
+     */
+    reviewBestaatNiet: '00000000-0000-0000-0000-000000000bad',
+  },
 } as const;
 
 /** Alle uitgedeelde id's, plat. Gebruikt door de bewakingstest. */


### PR DESCRIPTION
Eerste stap van de statusketen uit `docs/superpowers/plans/2026-08-07-statuswaarheid-per-vendor.md`. Plus een runbook dat had moeten bestaan.

## Wat de eigenaar vroeg

> "De app moet vooral de hele organisatie helpen door de centrale waarheid te zijn voor de status van de survey per vendor: opgestuurd en nog niet terug, terug maar nog niet beoordeeld, beoordeeld maar nog niet goedgekeurd, beoordeeld en goedgekeurd."

Drie van die vier waren al af te leiden uit bestaande gegevens. **Alleen "goedgekeurd" bestond nergens.** Dat is wat deze PR toevoegt.

## Migratie 0017 — geen nieuwe tabel

```sql
CHECK (verdict IN ('goed', 'nadere_vragen', 'niet_goed', 'goedgekeurd'))
```

Goedkeuren is dezelfde soort uitspraak als de drie bestaande oordelen: van een genoemd persoon, op een genoemd moment, over één respons, nooit overschreven. Een aparte tabel zou dezelfde kolommen, dezelfde RLS-policy en dezelfde append-only-regel dupliceren, plus een query opleveren die twee tabellen moet samenvoegen om "wat is de huidige status" te beantwoorden.

**Niet op `survey_response`**, want `status` daar (migratie 0003) is de *invul*status van de leverancier: `pending`/`submitted`/`revoked`. Goedkeuring is een uitspraak van de *organisatie*. Die twee in één kolom levert waarden op die elkaar ongemerkt uitsluiten — kan een `revoked` respons goedgekeurd zijn?

Bestaande rijen blijven geldig: er komt iets bij, er gaat niets af.

## De drie besluiten van de eigenaar (2026-08-07)

**V1 — iedereen mag goedkeuren, mits de identiteit vastligt.** Geen `@VereistRol('admin')`, consequent met beoordelen. Die voorwaarde is als bouwopdracht opgevat, niet als bijzin: de goedkeurder komt uit de sessie en nooit uit de body, `reviewer_user_id` blijft `NOT NULL` met `ON DELETE restrict`.

**V2 — een goedkeuring mag ingetrokken worden, zichtbaar.** Nieuwe route `DELETE /admin/survey/responses/:id/reviews/:reviewId`, die `deleted_at` zet en niets wist. Een goedkeuring die spoorloos kan verdampen maakt de status onbetrouwbaar.

**V3 — bij tegenstrijdige oordelen telt het laatste**, maar het scherm toont dat er meer zijn. Dat is de statusberekening en zit **niet** in deze PR; `aantalOordelen` bestaat al in `beoordelaar.service.ts`.

## Toelichting: van uitzondering naar opsomming

De regel luidde "alles behalve `goed` vereist een toelichting". Ongewijzigd zou `goedgekeurd` daarmee stilzwijgend een verplichte onderbouwing hebben gekregen.

```ts
const VEREIST_TOELICHTING = ['nadere_vragen', 'niet_goed'];
```

Expliciet opgesomd, juist omdat de uitzonderingsvorm dit soort fouten maakt bij elke volgende waarde. De eis bestaat omdat *"niet goed" zonder reden later niet te herleiden is*; bij een goedkeuring is de handtekening de inhoud.

Er staat een test op beide kanten: goedkeuren zonder toelichting slaagt, `niet_goed` zonder toelichting geeft nog steeds 400.

## Twee tegenproeven (§15b)

| Sabotage | Uitkomst |
|---|---|
| `reviewerUserId` uit de body laten winnen van de sessie | **precies** de identiteitstest viel om |
| actor `'leverancier'` op `trekIn` | **precies** de drie intrek-tests vielen om |

Beide volledig teruggedraaid, daarna weer 11/11 groen. De eerste is de belangrijkste: zonder die test is V1 een belofte in plaats van een eigenschap.

## Eén detail in `trekIn` dat geen detail is

```sql
WHERE review_id = ... AND response_id = ... AND deleted_at IS NULL
```

De `response_id` staat er niet voor de sier. Zonder die eis kan een geldig review-id uit een *andere* respons van dezelfde tenant worden ingetrokken via een verzonnen pad.

## Het runbook — `docs/runbooks/commandos-en-omgeving.md`

Nieuw, en de aanleiding is ongemakkelijk: in één sessie zijn vier commando's aangeroepen die niet bestaan (`npm run migrate`, `migrate:status`, `verify:migratieketen`, `node scripts/db-doelwit.js`), en scheelde het weinig of `migrate:deploy` was tegen de **Supabase-productiedatabase** gedraaid — `.env` wijst daarheen.

Het runbook legt vast welk commando er echt is, waar het naartoe praat, en wat nooit mag. Alles erin is uitgevoerd of opgezocht, niet uit het hoofd geschreven.

**Twee beveiligingsbevindingen tijdens het nalopen ervan:**

- `-p 55440:5432` bindt op `0.0.0.0` — de testdatabase was bereikbaar vanaf het hele netwerk met wachtwoord `pw`. Nu `-p 127.0.0.1:55440:5432`, opnieuw opgezet en de hele keten erop bewezen.
- In PowerShell blijft `$env:X` staan voor de hele sessie. `Remove-Item` erna is geen netheid maar voorkomt dat een later script tegen de verkeerde database praat.

Er staat een paragraaf in met wat het runbook bewust **niet** verzwakt — rolscheiding, FORCE RLS, geen `BYPASSRLS`, de `--extern`-drempel — elk geverifieerd tegen de wegwerpdatabase.

## `CLAUDE.md` — de haak die ontbrak

`MCM2-CLAUDE.md` zegt bovenaan *"lees dit bestand volledig bij iedere sessiestart"* en heeft in §14 een compleet startprotocol. Maar Claude Code laadt alleen een bestand dat exact `CLAUDE.md` heet — die naam bestond hier niet. Het document vroeg dus om iets dat technisch niet gebeurde.

`CLAUDE.md` verwijst nu in volgorde naar het runbook, `MCM2-CLAUDE.md` en `STATUS.md`. Het runbook staat bewust vóór de architectuurregels: die lezen helpt niet als het eerste databasecommando al het verkeerde doelwit raakt.

## Een valkuil die dit werk zelf blootlegde

`migrate:deploy` meldde **"Migraties voltooid"** terwijl de constraint onveranderd bleef. Drizzle leest `drizzle/meta/_journal.json`, niet de map — een `.sql`-bestand zonder journal-entry bestaat voor het script niet.

Gevonden doordat het plan voorschreef de constraint *terug te lezen uit de database* in plaats van de melding te geloven. Zonder die stap was hier een lege migratie gemerged. Staat nu in het runbook.

## Getoetst

- **369 e2e-tests groen** (was 358), 25 suites — 11 nieuwe in `test/goedkeuren.e2e-spec.ts`
- 289 unittests, lint/format/typecheck schoon
- **`npm run verify:volledig`: GROEN — de hele keten, van code tot browser**
- Constraint teruggelezen uit de database: vier waarden
- Schemaconformiteit 17/17 op een verse container, migratieketen vanaf leeg

> De doorloop meldt daarnaast dat de productiedatabase achterloopt. Dat is juist en verwacht: migratie 0017 gaat pas mee bij uitrol.
