### PR TITLE
feat(survey): notities bij een inzending (migratie 0018) + statusberekening

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,6 +53,12 @@ Lees het resultaat terug uit de database. "Migraties voltooid" betekende op
 2026-08-07 dat er niets was gebeurd, en in Issue #86 dat het op de verkeerde
 database was gebeurd.
 
+**5. Schrijf je een e2e-suite? Lees dan eerst §"Een nieuwe e2e-suite schrijven".**
+Alle suites delen één database. Vier unieke sleutels hebben géén `tenant_id`
+erin — je eigen tenant beschermt je dus niet. Een suite die los groen draait
+kan de volledige run alsnog rood maken, en welke suite dan omvalt hangt af van
+de volgorde. Draai altijd `npx jest test-ids` én de volledige e2e-run.
+
 ---
 
 ## Groen is alleen groen via verify

--- a/docs/runbooks/commandos-en-omgeving.md
+++ b/docs/runbooks/commandos-en-omgeving.md
@@ -305,6 +305,128 @@ taskkill /PID <pid> /F
 
 ---
 
+## Een nieuwe e2e-suite schrijven
+
+Alle e2e-suites delen één database. Een suite die los groen draait kan de
+volledige run alsnog rood maken — en welke suite dan omvalt, hangt af van de
+volgorde. Dat is de vervelendste faalvorm in dit project: hij ziet eruit als
+toeval en is het niet.
+
+### Vier waarden moeten uniek zijn over ALLE suites heen
+
+Deze unieke sleutels hebben **geen `tenant_id` erin**. Je eigen tenant beschermt
+je dus niet:
+
+| Sleutel | Op | Hoe je het oplost |
+|---|---|---|
+| `survey_response_token_hash_key` | `survey_response.token_hash` | Eigen herhaald teken per suite |
+| `tenant_name_key` | `tenant.name` | Suitenaam in de tenantnaam |
+| `user_external_subject_key` | `user.external_subject` | Suiteprefix **plus** `Date.now()` |
+| `survey_attachment_storage_key_key` | `survey_attachment.storage_key` | Eigen prefix per suite |
+| `sessie_token_hash_key` | `sessie.token_hash` | Komt uit `SessieService`, dus vanzelf uniek |
+
+**De beproefde vormen**, zoals de bestaande suites het doen:
+
+```ts
+// token_hash — 64 hex-tekens (CHECK uit migratie 0003).
+// Het herhaalde teken is je claim; kies er een die nog vrij is.
+const HASH_INGEDIEND = `${'6'.repeat(48)}60ed6e0e60ed6e0e`;
+
+// external_subject — prefix én tijdstempel. Dubbel beveiligd, want twee
+// suites met dezelfde prefix zouden nog steeds botsen.
+const SUBJECT_ADMIN = `oid-gk-a-${Date.now()}`;
+
+// tenantnaam — noem de suite erin.
+'Tenant A (goedkeuren)'
+```
+
+Welke tekens al vergeven zijn:
+```powershell
+Select-String -Path test\*.e2e-spec.ts -Pattern "repeat\(48\)"
+```
+
+**Er staat een bewakingstest op** (`test/test-ids.spec.ts`): die vangt een
+botsende `token_hash` en noemt beide suites bij naam. Draai hem vóór je een
+volledige e2e-run start — hij kost een seconde en heeft geen database nodig:
+
+```powershell
+npx jest test-ids
+```
+
+### Test-id's: kijk naar BEIDE uitdeelvormen
+
+`test/test-ids.ts` deelt UUID's op twee manieren uit: letterlijk, én via de
+`id()`-helper bovenaan. Zoek je alleen op de letterlijke vorm, dan lijken
+staarten vrij die het niet zijn.
+
+```powershell
+# Beide vormen, samengevoegd. Schrijf de UUID voluit — met koppeltekens.
+# Een verkort patroon als '0{20}([0-9a-f]{2})' vindt NUL treffers en ziet er
+# toch uit alsof het werkt; het geeft dan een lijst vrije staarten die allemaal
+# bezet zijn.
+$viaId = Select-String -Path test\test-ids.ts -Pattern "id\('([0-9a-f]{2})'\)" -AllMatches |
+  ForEach-Object { $_.Matches } | ForEach-Object { $_.Groups[1].Value }
+$letterlijk = Select-String -Path test\test-ids.ts -Pattern "'00000000-0000-0000-0000-0000000000([0-9a-f]{2})'" -AllMatches |
+  ForEach-Object { $_.Matches } | ForEach-Object { $_.Groups[1].Value }
+$vergeven = ($viaId + $letterlijk) | Sort-Object -Unique
+"$($vergeven.Count) vergeven"
+
+# Wat is er vrij in een bereik?
+0x92..0xa4 | ForEach-Object { $h='{0:x2}' -f $_; if ($vergeven -notcontains $h) { $h } }
+```
+
+**Controleer de uitkomst op plausibiliteit.** Krijg je opeens veel minder
+vergeven staarten dan de vorige keer, dan matcht je patroon niet — niet dat er
+ruimte is vrijgekomen.
+
+Verzin nooit een UUID in een testbestand: er staat een bewakingstest op die elke
+letterlijke test-UUID in het register wil zien.
+
+### Geef elke test die een script start een timeout mee
+
+Jest hanteert standaard **5 seconden**. Een test die `draaiSeed()` of een ander
+Node-proces start haalt dat alleen op een verder onbelaste machine. In de
+volledige run valt hij dan om — niet omdat er iets stuk is, maar omdat het even
+duurde.
+
+```ts
+it('vult een lege database…', async () => {
+  draaiSeed();
+  // …
+}, 20_000);
+```
+
+Dit is twee keer misgegaan: op 2026-08-04 en, in de tests die toen waren
+overgeslagen, opnieuw op 2026-08-07.
+
+### Voordat je een suite als klaar beschouwt
+
+```powershell
+# 1. Bewakingstests (snel, geen database)
+npx jest test-ids
+
+# 2. Je eigen suite
+$env:DATABASE_URL="postgresql://clm_api_runtime:pw@localhost:55440/postgres"
+npx jest --config test/jest-e2e.json <naam> --forceExit
+
+# 3. ALLE suites samen — dit is de stap die botsingen vindt
+npx jest --config test/jest-e2e.json --forceExit
+```
+
+**Stap 3 is niet optioneel.** Stap 2 groen zegt niets over botsingen; dat is
+precies wat het op 2026-08-07 twee runs lang verborg.
+
+Zakt er iets, zoek dan eerst naar de databasefout in plaats van naar de
+falende assertie:
+```powershell
+npx jest --config test/jest-e2e.json --forceExit 2>&1 |
+  Select-String -Pattern "duplicate key|violates|deadlock|Exceeded timeout"
+```
+`duplicate key` betekent een botsing tussen suites, `Exceeded timeout` een
+ontbrekende timeout. Beide staan hierboven.
+
+---
+
 ## Wat CI werkelijk draait
 
 Drie jobs in `.github/workflows/ci.yml`:

--- a/drizzle/0018_response_note.sql
+++ b/drizzle/0018_response_note.sql
@@ -1,0 +1,105 @@
+-- =============================================================================
+-- clm.response_note — een notitie bij een inzending, voor collega's.
+--
+-- Aanleiding: docs/superpowers/plans/2026-08-07-statuswaarheid-per-vendor.md
+-- §4.1 (B2), besluit eigenaar 2026-08-07. Het contractmanagementteam is klein
+-- en zit bij elkaar; de app hoeft ze niet uit elkaar te houden, maar moet wél
+-- de plek zijn waar staat wat er speelt.
+--
+-- ── Waarom dit geen survey_review is ─────────────────────────────────────────
+--
+-- Een notitie is géén oordeel. "Gebeld, komt volgende week" past niet in
+-- 'goed', 'nadere_vragen', 'niet_goed' of 'goedgekeurd'. Hem daar toch in
+-- persen zou een verdict afdwingen dat er niet is, of een vijfde nepwaarde
+-- introduceren die de statusberekening moet leren negeren.
+--
+-- Het verschil is niet cosmetisch: een oordeel bepaalt de status van de
+-- inzending, een notitie niet. Zouden ze in één tabel staan, dan moet elke
+-- query die "wat is de huidige status" beantwoordt de notities eruit filteren
+-- — en die filter vergeten is een stille fout.
+--
+-- ── Wat het WEL van survey_review overneemt ──────────────────────────────────
+--
+-- De policy, letterlijk. Een notitie over een leverancier is voor collega's,
+-- en de leverancier zit in dezelfde tenant. Zonder de actor-eis leest hij mee
+-- wat er over hem geschreven wordt — en dat is precies de situatie waarvoor
+-- clm.current_actor() in migratie 0013 is gemaakt.
+--
+-- Ook append-only, om dezelfde reden: intrekken gaat via deleted_at. Een
+-- notitie die spoorloos kan verdwijnen maakt het dossier onbetrouwbaar.
+--
+-- ── Geen titel, geen categorie, geen @-vermeldingen ──────────────────────────
+--
+-- Bewust één tekstveld. De eigenaar was expliciet: "het hoeft niet een totaal
+-- geautomatiseerde fabriek te worden." Wie een notitie aan iemand wil richten,
+-- schrijft dat op — het team spreekt elkaar toch.
+-- =============================================================================
+
+CREATE TABLE "clm"."response_note" (
+	"note_id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"tenant_id" uuid NOT NULL,
+	"response_id" uuid NOT NULL,
+	"tekst" text NOT NULL,
+	"author_user_id" uuid NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"deleted_at" timestamp with time zone
+);
+--> statement-breakpoint
+
+ALTER TABLE "clm"."response_note"
+    ADD CONSTRAINT "response_note_tenant_id_tenant_tenant_id_fk"
+    FOREIGN KEY ("tenant_id") REFERENCES "clm"."tenant"("tenant_id")
+    ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+
+ALTER TABLE "clm"."response_note"
+    ADD CONSTRAINT "response_note_response_id_survey_response_response_id_fk"
+    FOREIGN KEY ("response_id") REFERENCES "clm"."survey_response"("response_id")
+    ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+
+-- ON DELETE restrict, zoals survey_review.reviewer_user_id en anders dan
+-- template_reviewer: een notitie zonder afzender is in een dossier waardeloos.
+-- "Gebeld, komt volgende week" — door wie?
+ALTER TABLE "clm"."response_note"
+    ADD CONSTRAINT "response_note_author_user_id_user_user_id_fk"
+    FOREIGN KEY ("author_user_id") REFERENCES "clm"."user"("user_id")
+    ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+
+-- Een lege notitie is geen notitie. In de service staat de bruikbare melding;
+-- dit vangt af wat daar langs zou komen (bijvoorbeeld via een toekomstig
+-- importpad) en houdt de tabel schoon.
+ALTER TABLE "clm"."response_note"
+    ADD CONSTRAINT "response_note_tekst_niet_leeg_check"
+    CHECK (length(btrim(tekst)) > 0);--> statement-breakpoint
+
+CREATE INDEX "response_note_tenant_id_idx"
+    ON "clm"."response_note" USING btree ("tenant_id");--> statement-breakpoint
+
+-- Op response_id: notities worden altijd per inzending opgehaald.
+CREATE INDEX "response_note_response_id_idx"
+    ON "clm"."response_note" USING btree ("response_id");--> statement-breakpoint
+
+-- ── Row Level Security ──────────────────────────────────────────────────────
+
+ALTER TABLE clm.response_note ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+
+-- FORCE conform migratie 0011: RLS geldt ook voor de eigenaar van de tabel.
+ALTER TABLE clm.response_note FORCE ROW LEVEL SECURITY;--> statement-breakpoint
+
+-- Zelfde vorm als survey_review (0015) en template_reviewer (0016): tenant én
+-- actor, in USING én WITH CHECK. Zonder de actor-eis in WITH CHECK zou een
+-- leverancierspad kunnen schrijven wat het niet kan lezen.
+CREATE POLICY response_note_isolation ON clm.response_note
+    USING (
+        tenant_id = clm.current_tenant_id()
+        AND clm.current_actor() = 'medewerker'
+    )
+    WITH CHECK (
+        tenant_id = clm.current_tenant_id()
+        AND clm.current_actor() = 'medewerker'
+    );--> statement-breakpoint
+
+COMMENT ON TABLE clm.response_note IS
+    'Notities bij een inzending, voor collega''s onderling. Geen oordeel: raakt de status van de inzending niet. Append-only, intrekken via deleted_at. Alleen leesbaar en schrijfbaar door actor medewerker — de leverancier zit in dezelfde tenant en mag niet meelezen wat er over hem geschreven wordt.';--> statement-breakpoint
+
+-- Geen DELETE: intrekken gaat via een UPDATE op deleted_at.
+GRANT SELECT, INSERT, UPDATE ON clm.response_note TO clm_api_runtime;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -127,6 +127,13 @@
       "when": 1786435200000,
       "tag": "0017_goedkeuren",
       "breakpoints": true
+    },
+    {
+      "idx": 18,
+      "version": "7",
+      "when": 1786449600000,
+      "tag": "0018_response_note",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -568,8 +568,10 @@ export const surveyReview = clm.table(
     responseId: uuid('response_id')
       .notNull()
       .references(() => surveyResponse.responseId, { onDelete: 'restrict' }),
-    // goed | nadere_vragen | niet_goed. Als CHECK in de database, zodat een
-    // typefout in code een databasefout wordt en geen rij met onzin.
+    // goed | nadere_vragen | niet_goed | goedgekeurd (migratie 0017). Als CHECK
+    // in de database, zodat een typefout in code een databasefout wordt en geen
+    // rij met onzin. De eerste drie zijn inhoudelijk; goedgekeurd is een
+    // processtap die de inzending afsluit.
     verdict: text('verdict').notNull(),
     // NOT NULL met '' als lege waarde, net als survey_question.body: dan hoeft
     // de aanroeper nergens onderscheid te maken tussen null en leeg.
@@ -588,6 +590,53 @@ export const surveyReview = clm.table(
   (t) => [
     index('survey_review_tenant_id_idx').on(t.tenantId),
     index('survey_review_response_id_idx').on(t.responseId),
+  ],
+);
+
+/**
+ * Een notitie bij een inzending, voor collega's onderling (migratie 0018).
+ *
+ * ── Waarom dit geen survey_review is ────────────────────────────────────────
+ *
+ * Een notitie is géén oordeel. "Gebeld, komt volgende week" past in geen van de
+ * vier verdicts, en hem daar toch in persen zou een verdict afdwingen dat er
+ * niet is.
+ *
+ * Het verschil is niet cosmetisch: een oordeel bepaalt de status van de
+ * inzending, een notitie niet. In één tabel zou elke statusquery de notities
+ * eruit moeten filteren — en die filter vergeten is een stille fout.
+ *
+ * De policy is wél letterlijk dezelfde: de leverancier zit in dezelfde tenant
+ * en mag niet meelezen wat er over hem geschreven wordt.
+ */
+export const responseNote = clm.table(
+  'response_note',
+  {
+    noteId: uuid('note_id').primaryKey().defaultRandom(),
+    tenantId: uuid('tenant_id')
+      .notNull()
+      .references(() => tenant.tenantId, { onDelete: 'restrict' }),
+    responseId: uuid('response_id')
+      .notNull()
+      .references(() => surveyResponse.responseId, { onDelete: 'restrict' }),
+    // Eén tekstveld, geen titel of categorie. De eigenaar was expliciet: het
+    // hoeft geen geautomatiseerde fabriek te worden. Een CHECK in de database
+    // weigert een lege notitie.
+    tekst: text('tekst').notNull(),
+    // ON DELETE restrict, zoals survey_review.reviewer_user_id: een notitie
+    // zonder afzender is in een dossier waardeloos. "Gebeld" — door wie?
+    authorUserId: uuid('author_user_id')
+      .notNull()
+      .references(() => user.userId, { onDelete: 'restrict' }),
+    createdAt: timestamp('created_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    // Intrekken kan wel, wissen niet — net als bij een oordeel.
+    deletedAt: timestamp('deleted_at', { withTimezone: true }),
+  },
+  (t) => [
+    index('response_note_tenant_id_idx').on(t.tenantId),
+    index('response_note_response_id_idx').on(t.responseId),
   ],
 );
 

--- a/src/survey/notitie.service.ts
+++ b/src/survey/notitie.service.ts
@@ -1,0 +1,205 @@
+import {
+  BadRequestException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { sql } from 'drizzle-orm';
+
+import { DatabaseService } from '../db/database.service';
+
+/**
+ * Notities bij een inzending, voor collega's onderling (migratie 0018).
+ *
+ * ── Een notitie is geen oordeel ─────────────────────────────────────────────
+ *
+ * "Gebeld, komt volgende week" past in geen van de vier verdicts. Daarom een
+ * eigen tabel: een notitie raakt de status van de inzending niet, een oordeel
+ * wel. Zaten ze in één tabel, dan zou elke statusquery de notities eruit
+ * moeten filteren — en die filter vergeten is een stille fout.
+ *
+ * ── Mag ook vóór het indienen ───────────────────────────────────────────────
+ *
+ * Anders dan bij beoordelen (besluit eigenaar 2026-08-07). "Gebeld, komt
+ * volgende week" gaat juist over een leverancier die nog niét heeft ingediend;
+ * de regel van BeoordelingService zou hier het meest bruikbare geval
+ * uitsluiten.
+ *
+ * ── Wie en wanneer horen erbij ──────────────────────────────────────────────
+ *
+ * De datum staat in de tabel én in het antwoord, samen met de naam van de
+ * schrijver. Een notitie zonder afzender en tijdstip is in een dossier
+ * waardeloos: "gebeld" — door wie, en hoe lang geleden?
+ */
+
+export interface Notitie {
+  noteId: string;
+  responseId: string;
+  tekst: string;
+  authorUserId: string;
+  /** Null wanneer de gebruiker geen naam heeft — dan toont het scherm het adres. */
+  authorNaam: string | null;
+  /** Wanneer de notitie is geschreven. ISO-8601, altijd gevuld. */
+  createdAt: string;
+}
+
+interface NotitieRij extends Record<string, unknown> {
+  note_id: string;
+  response_id: string;
+  tekst: string;
+  author_user_id: string;
+  author_naam: string | null;
+  created_at: Date | string;
+}
+
+function iso(waarde: Date | string | null): string | null {
+  if (waarde === null) return null;
+  return waarde instanceof Date ? waarde.toISOString() : String(waarde);
+}
+
+@Injectable()
+export class NotitieService {
+  constructor(private readonly db: DatabaseService) {}
+
+  /**
+   * Alle notities bij één respons, nieuwste eerst.
+   *
+   * Ingetrokken notities blijven buiten beschouwing maar staan nog in de
+   * database — wissen zou de historie kapotmaken die deze tabel bewaart.
+   */
+  async lijst(tenantId: string, responseId: string): Promise<Notitie[]> {
+    return this.db.withTenant(
+      tenantId,
+      async (tx) => {
+        await this.eisBestaandeRespons(tx, responseId);
+
+        const resultaat = await tx.execute<NotitieRij>(
+          sql`SELECT n.note_id,
+                     n.response_id,
+                     n.tekst,
+                     n.author_user_id,
+                     u.full_name AS author_naam,
+                     n.created_at
+                FROM clm.response_note n
+                LEFT JOIN clm."user" u ON u.user_id = n.author_user_id
+               WHERE n.response_id = ${responseId}
+                 AND n.deleted_at IS NULL
+               ORDER BY n.created_at DESC`,
+        );
+
+        return resultaat.rows.map((r) => this.naarNotitie(r));
+      },
+      'medewerker',
+    );
+  }
+
+  /**
+   * Voegt een notitie toe.
+   *
+   * De schrijver komt uit de sessie, nooit uit de invoer — dezelfde regel als
+   * bij een oordeel (MCM2-CLAUDE.md §6). Anders kan iemand een notitie op naam
+   * van een collega achterlaten.
+   */
+  async voegToe(
+    tenantId: string,
+    responseId: string,
+    authorUserId: string,
+    tekst: string,
+  ): Promise<Notitie> {
+    return this.db.withTenant(
+      tenantId,
+      async (tx) => {
+        await this.eisBestaandeRespons(tx, responseId);
+
+        const resultaat = await tx.execute<NotitieRij>(
+          sql`WITH nieuw AS (
+                INSERT INTO clm.response_note
+                       (tenant_id, response_id, tekst, author_user_id)
+                VALUES (${tenantId}, ${responseId}, ${tekst}, ${authorUserId})
+                RETURNING note_id, response_id, tekst, author_user_id, created_at
+              )
+              SELECT n.note_id,
+                     n.response_id,
+                     n.tekst,
+                     n.author_user_id,
+                     u.full_name AS author_naam,
+                     n.created_at
+                FROM nieuw n
+                LEFT JOIN clm."user" u ON u.user_id = n.author_user_id`,
+        );
+
+        const rij = resultaat.rows[0];
+        if (!rij) {
+          // Onbereikbaar: de INSERT gaf een rij terug of gooide. Toch
+          // expliciet, want stil `undefined` teruggeven zou het scherm een
+          // opgeslagen notitie laten tonen die er niet is.
+          throw new BadRequestException(
+            'De notitie kon niet worden opgeslagen.',
+          );
+        }
+
+        return this.naarNotitie(rij);
+      },
+      'medewerker',
+    );
+  }
+
+  /**
+   * Trekt een notitie in.
+   *
+   * Zet `deleted_at` en verwijdert niets, net als bij een oordeel. De
+   * `response_id` in de WHERE is geen overbodige controle: zonder die eis zou
+   * een geldig note-id uit een ándere respons van dezelfde tenant hier
+   * ingetrokken kunnen worden via een verzonnen pad.
+   */
+  async trekIn(
+    tenantId: string,
+    responseId: string,
+    noteId: string,
+  ): Promise<void> {
+    return this.db.withTenant(
+      tenantId,
+      async (tx) => {
+        await this.eisBestaandeRespons(tx, responseId);
+
+        const geraakt = await tx.execute(
+          sql`UPDATE clm.response_note
+                 SET deleted_at = now()
+               WHERE note_id = ${noteId}
+                 AND response_id = ${responseId}
+                 AND deleted_at IS NULL`,
+        );
+
+        if (geraakt.rowCount === 0) {
+          throw new NotFoundException(
+            'Deze notitie bestaat niet, of is al ingetrokken.',
+          );
+        }
+      },
+      'medewerker',
+    );
+  }
+
+  private async eisBestaandeRespons(
+    tx: Parameters<Parameters<DatabaseService['withTenant']>[1]>[0],
+    responseId: string,
+  ): Promise<void> {
+    const gevonden = await tx.execute(
+      sql`SELECT 1 FROM clm.survey_response WHERE response_id = ${responseId}`,
+    );
+
+    if (gevonden.rows.length === 0) {
+      throw new NotFoundException('Deze respons bestaat niet.');
+    }
+  }
+
+  private naarNotitie(r: NotitieRij): Notitie {
+    return {
+      noteId: r.note_id,
+      responseId: r.response_id,
+      tekst: r.tekst,
+      authorUserId: r.author_user_id,
+      authorNaam: r.author_naam,
+      createdAt: iso(r.created_at) ?? '',
+    };
+  }
+}

--- a/src/survey/respons-status.ts
+++ b/src/survey/respons-status.ts
@@ -1,0 +1,133 @@
+/**
+ * De status van één inzending — de centrale waarheid per leverancier.
+ *
+ * Zie docs/superpowers/plans/2026-08-07-statuswaarheid-per-vendor.md §3.
+ *
+ * ── Waarom dit één bestand is ───────────────────────────────────────────────
+ *
+ * De eigenaar vroeg om één plek waar staat hoe elke leverancier ervoor staat.
+ * Zou elk scherm en elke route zijn eigen versie van "wanneer is iets
+ * beoordeeld" berekenen, dan zijn er binnen een sprint twee waarheden — en
+ * dan is het geen centrale waarheid meer.
+ *
+ * ── Berekend, niet opgeslagen ───────────────────────────────────────────────
+ *
+ * Er is bewust geen statuskolom. Een opgeslagen status loopt onvermijdelijk
+ * uit de pas met de onderliggende feiten: dan staat er "beoordeeld" terwijl er
+ * geen oordeel is, en dan liegt juist het veld waar iedereen op vaart.
+ *
+ * Alles hieronder is af te leiden uit gegevens die er al zijn: submitted_at,
+ * closes_at, de ronde-status en het laatste oordeel.
+ */
+
+/** De vier statussen die de eigenaar noemde, plus 'te_laat'. */
+export const RESPONS_STATUSSEN = [
+  'opgestuurd',
+  'te_laat',
+  'terug',
+  'beoordeeld',
+  'goedgekeurd',
+] as const;
+
+export type ResponsStatus = (typeof RESPONS_STATUSSEN)[number];
+
+/** Wat het scherm toont. Nederlands, want dit is wat de gebruiker leest. */
+export const STATUS_LABEL: Record<ResponsStatus, string> = {
+  opgestuurd: 'Opgestuurd, nog niet terug',
+  te_laat: 'Te laat',
+  terug: 'Terug, nog niet beoordeeld',
+  beoordeeld: 'Beoordeeld, nog niet goedgekeurd',
+  goedgekeurd: 'Beoordeeld en goedgekeurd',
+};
+
+/** De feiten waaruit de status volgt. Alles wat de query oplevert. */
+export interface StatusFeiten {
+  /** Null zolang de leverancier niet heeft ingediend. */
+  submittedAt: Date | string | null;
+  /** Sluitdatum van de ronde. Null betekent: geen deadline. */
+  closesAt: Date | string | null;
+  /** Status van de ronde: alleen bij 'active' telt een overschrijding. */
+  rondeStatus: string;
+  /** Het laatste niet-ingetrokken oordeel, of null wanneer er geen is. */
+  laatsteOordeel: string | null;
+}
+
+function tijd(waarde: Date | string | null): number | null {
+  if (waarde === null) return null;
+  const d = waarde instanceof Date ? waarde : new Date(waarde);
+  return Number.isNaN(d.getTime()) ? null : d.getTime();
+}
+
+/**
+ * Bepaalt de status van één inzending.
+ *
+ * ── De volgorde van de vragen is het ontwerp ────────────────────────────────
+ *
+ * Eerst indienen, dan pas oordelen. Een respons die nog niet terug is kán geen
+ * oordeel hebben (BeoordelingService weigert dat), dus die tak komt eerst en
+ * hoeft daarna niet meer gecontroleerd te worden.
+ *
+ * ── 'te_laat' is geen aparte kolom maar een rekensom ────────────────────────
+ *
+ * `closes_at < now()` bij een `active` ronde (plan §2b). De eigenaar noemde
+ * deze status niet, maar zonder hem verdwijnt een overschrijding in
+ * "opgestuurd, nog niet terug" — en dat is juist wat je wél wilt zien.
+ *
+ * Alleen bij `active`: een ronde in `draft` is nog niet uitgestuurd, en bij
+ * `finished` of `archived` is de deadline niet meer interessant.
+ *
+ * ── Het laatste oordeel telt, ook als dat een goedkeuring ongedaan maakt ────
+ *
+ * Besluit eigenaar 2026-08-07 (V3, en de vervolgvraag daarop). Schrijft iemand
+ * na een goedkeuring alsnog 'niet_goed', dan staat de inzending weer op
+ * 'beoordeeld'. Dat is zichtbaar en herstelbaar; een goedkeuring die blijft
+ * staan terwijl er een afwijzing onder hangt, is dat niet.
+ *
+ * Het aantal oordelen hoort daarnaast in het scherm — anders verdwijnt een
+ * meningsverschil uit beeld.
+ */
+export function bepaalStatus(feiten: StatusFeiten): ResponsStatus {
+  const ingediend = tijd(feiten.submittedAt);
+
+  if (ingediend === null) {
+    const sluit = tijd(feiten.closesAt);
+
+    if (
+      feiten.rondeStatus === 'active' &&
+      sluit !== null &&
+      sluit < Date.now()
+    ) {
+      return 'te_laat';
+    }
+
+    return 'opgestuurd';
+  }
+
+  if (feiten.laatsteOordeel === null) {
+    return 'terug';
+  }
+
+  // Alleen een goedkeuring als LAATSTE oordeel sluit de inzending af. Een
+  // eerdere goedkeuring met daarna een inhoudelijk oordeel telt niet meer.
+  if (feiten.laatsteOordeel === 'goedgekeurd') {
+    return 'goedgekeurd';
+  }
+
+  return 'beoordeeld';
+}
+
+/**
+ * Het SQL-fragment dat het laatste oordeel oplevert.
+ *
+ * Hier neergezet zodat elke query die de status nodig heeft dezelfde definitie
+ * gebruikt van "het laatste oordeel": nieuwste eerst, ingetrokken oordelen
+ * buiten beschouwing. Twee queries met een net iets andere ORDER BY leveren
+ * twee waarheden op.
+ */
+export const LAATSTE_OORDEEL_SQL = `
+  (SELECT rv.verdict
+     FROM clm.survey_review rv
+    WHERE rv.response_id = s.response_id
+      AND rv.deleted_at IS NULL
+    ORDER BY rv.created_at DESC
+    LIMIT 1)`;

--- a/src/survey/ronde-invoer.ts
+++ b/src/survey/ronde-invoer.ts
@@ -365,3 +365,42 @@ export function leesBeoordelaar(body: unknown): string {
 
   return leesUuid(invoer.userId, 'userId');
 }
+
+/**
+ * Hoe lang een notitie mag zijn.
+ *
+ * Ruim: het gaat om "gebeld, komt volgende week", niet om een rapport. De
+ * grens bestaat om te voorkomen dat iemand per ongeluk een heel document in
+ * een notitieveld plakt — dan is de lijst onleesbaar en hoort de inhoud
+ * ergens anders thuis.
+ */
+export const NOTITIE_MAX_TEKENS = 4000;
+
+/**
+ * Leest de tekst van een notitie (migratie 0018).
+ *
+ * Alleen de tekst. De schrijver komt uit de sessie en de respons uit het pad —
+ * die horen niet in een body waar een client ze kan verzinnen (§6).
+ */
+export function leesNotitie(body: unknown): string {
+  const invoer = leesObject(body);
+
+  if (typeof invoer.tekst !== 'string') {
+    throw new InvoerFout('tekst', 'De notitie moet tekst zijn.');
+  }
+
+  const tekst = invoer.tekst.trim();
+
+  if (tekst === '') {
+    throw new InvoerFout('tekst', 'Een lege notitie heeft geen zin.');
+  }
+
+  if (tekst.length > NOTITIE_MAX_TEKENS) {
+    throw new InvoerFout(
+      'tekst',
+      `Een notitie is maximaal ${NOTITIE_MAX_TEKENS} tekens. Hoort dit ergens anders thuis?`,
+    );
+  }
+
+  return tekst;
+}

--- a/src/survey/survey.module.ts
+++ b/src/survey/survey.module.ts
@@ -11,6 +11,7 @@ import { BestandOpslagService } from './bestand-opslag.service';
 import { BijlageService } from './bijlage.service';
 import { BeoordelaarService } from './beoordelaar.service';
 import { BeoordelingService } from './beoordeling.service';
+import { NotitieService } from './notitie.service';
 import { RondeBeheerService } from './ronde-beheer.service';
 import { VragenlijstBeheerController } from './vragenlijst-beheer.controller';
 import { VragenlijstBeheerService } from './vragenlijst-beheer.service';
@@ -47,6 +48,7 @@ import { VragenlijstLeesService } from './vragenlijst-lezen.service';
     RondeBeheerService,
     BeoordelingService,
     BeoordelaarService,
+    NotitieService,
     VragenlijstImportService,
     VragenlijstLeesService,
     AntwoordIndienService,
@@ -61,6 +63,7 @@ import { VragenlijstLeesService } from './vragenlijst-lezen.service';
     RondeBeheerService,
     BeoordelingService,
     BeoordelaarService,
+    NotitieService,
     VragenlijstImportService,
     VragenlijstLeesService,
     AntwoordIndienService,

--- a/src/survey/vragenlijst-beheer.controller.ts
+++ b/src/survey/vragenlijst-beheer.controller.ts
@@ -18,11 +18,13 @@ import {
   TenantContextGuard,
   type RequestMetSessie,
 } from '../auth/tenant-context.guard';
+import { NotitieService } from './notitie.service';
 import { RondeBeheerService } from './ronde-beheer.service';
 import {
   InvoerFout,
   leesBeoordelaar,
   leesNieuweBeoordeling,
+  leesNotitie,
   type NieuweBeoordelingInvoer,
   leesNieuweRonde,
   leesStatus,
@@ -80,6 +82,8 @@ export class VragenlijstBeheerController {
     // Onderstreept omdat `beoordelingen` al de naam van een routemethode is.
     private readonly beoordelingen_: BeoordelingService,
     private readonly beoordelaars: BeoordelaarService,
+    // Onderstreept om dezelfde reden als beoordelingen_.
+    private readonly notities_: NotitieService,
   ) {}
 
   /** Alle vragenlijsten van deze tenant, met aantallen vragen en rondes. */
@@ -220,6 +224,71 @@ export class VragenlijstBeheerController {
     const sessie = request.sessie!;
 
     await this.beoordelingen_.trekIn(sessie.tenantId, id, reviewId);
+  }
+
+  /** Alle notities bij één respons, nieuwste eerst. */
+  @Get('responses/:id/notes')
+  async notities(@Req() request: RequestMetSessie, @Param('id') id: string) {
+    const sessie = request.sessie!;
+
+    const notities = await this.notities_.lijst(sessie.tenantId, id);
+
+    return { notities };
+  }
+
+  /**
+   * Plaatst een notitie bij een respons.
+   *
+   * **Ook vóór het indienen toegestaan**, anders dan bij beoordelen (besluit
+   * eigenaar 2026-08-07). "Gebeld, komt volgende week" gaat juist over een
+   * leverancier die nog niet heeft ingediend.
+   *
+   * De schrijver komt uit de sessie, nooit uit de body (§6). 201 met de
+   * notitie erbij, inclusief naam en datum — een notitie zonder afzender en
+   * tijdstip is in een dossier waardeloos.
+   */
+  @Post('responses/:id/notes')
+  async plaatsNotitie(
+    @Req() request: RequestMetSessie,
+    @Param('id') id: string,
+    @Body() body: unknown,
+  ) {
+    const sessie = request.sessie!;
+
+    let tekst: string;
+    try {
+      tekst = leesNotitie(body);
+    } catch (err) {
+      throw this.naarHttpFout(err);
+    }
+
+    const notitie = await this.notities_.voegToe(
+      sessie.tenantId,
+      id,
+      sessie.userId,
+      tekst,
+    );
+
+    return { notitie };
+  }
+
+  /**
+   * Trekt een notitie in.
+   *
+   * Zet `deleted_at`; de rij blijft staan, net als bij een oordeel. 204 bij
+   * succes, 404 als de notitie niet bestaat binnen deze tenant of al is
+   * ingetrokken.
+   */
+  @Delete('responses/:id/notes/:noteId')
+  @HttpCode(204)
+  async trekNotitieIn(
+    @Req() request: RequestMetSessie,
+    @Param('id') id: string,
+    @Param('noteId') noteId: string,
+  ): Promise<void> {
+    const sessie = request.sessie!;
+
+    await this.notities_.trekIn(sessie.tenantId, id, noteId);
   }
 
   /**

--- a/test/demo-seed.e2e-spec.ts
+++ b/test/demo-seed.e2e-spec.ts
@@ -146,7 +146,11 @@ describe('Demo-seed (e2e)', () => {
     expect(stand.rondes).toBe(1);
     expect(stand.responses).toBe(3);
     expect(stand.antwoorden).toBeGreaterThan(0);
-  });
+    // Zelfde limiet en dezelfde reden als de test hieronder: deze start het
+    // seedscript als apart Node-proces. Bij die reparatie (2026-08-04) is
+    // uitgerekend deze eerste test overgeslagen, waardoor hij op 2026-08-07
+    // alsnog omviel in de volledige e2e-run — los bleef hij groen.
+  }, 20_000);
 
   it('geeft bij een tweede run exact dezelfde stand', async () => {
     const voor = await tel();
@@ -366,5 +370,7 @@ describe('Demo-seed (e2e)', () => {
     // afterAll draait --verwijder nog een keer en dat moet op een lege
     // tenant net zo goed werken.
     draaiSeed();
-  });
+    // Twee scriptaanroepen (--verwijder plus deze), dus dezelfde limiet als de
+    // andere tests die het seedscript starten.
+  }, 20_000);
 });

--- a/test/goedkeuren.e2e-spec.ts
+++ b/test/goedkeuren.e2e-spec.ts
@@ -45,8 +45,19 @@ const SUBJECT_ADMIN = `oid-gk-a-${Date.now()}`;
 const SUBJECT_COLLEGA = `oid-gk-c-${Date.now()}`;
 const SUBJECT_B = `oid-gk-b-${Date.now()}`;
 
-/** 64 hex-tekens, conform de CHECK op token_hash (migratie 0003). */
-const HASH_INGEDIEND = `${'3'.repeat(48)}cccccccccccccccc`;
+/**
+ * 64 hex-tekens, conform de CHECK op token_hash (migratie 0003).
+ *
+ * **Moet uniek zijn over ALLE suites heen.** `survey_response_token_hash_key`
+ * is een unieke index zonder tenant_id erin — twee suites met dezelfde hash
+ * botsen dus, ook al zitten ze in verschillende tenants. Dat gebeurde op
+ * 2026-08-07: deze suite deelde zijn hash met beoordelaar-koppelen, wat een
+ * onregelmatig falende run opleverde die eerst onverklaarbaar leek.
+ *
+ * Bezet: 0=vragenlijst-beheer-routes, 1+2=beoordeling, 3=beoordelaar-koppelen,
+ * 4+5=notities, 6=hier.
+ */
+const HASH_INGEDIEND = `${'6'.repeat(48)}60ed6e0e60ed6e0e`;
 
 interface BeoordelingBody {
   beoordeling: {

--- a/test/notities.e2e-spec.ts
+++ b/test/notities.e2e-spec.ts
@@ -1,0 +1,377 @@
+import { INestApplication } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import cookieParser from 'cookie-parser';
+import { Client } from 'pg';
+import request from 'supertest';
+import type { App } from 'supertest/types';
+
+import { AppModule } from '../src/app.module';
+import { cookieInstellingen } from '../src/auth/sessie';
+import { SessieService } from '../src/auth/sessie.service';
+import { TEST_IDS } from './test-ids';
+
+/**
+ * Notities bij een inzending (migratie 0018).
+ *
+ * Vier dingen kunnen hier stuk zonder dat iemand het merkt:
+ *
+ *   1. Kan een LEVERANCIER meelezen wat er over hem geschreven wordt? Hij zit
+ *      in dezelfde tenant, dus de tenantgrens alleen volstaat niet.
+ *   2. Wordt de datum en de naam van de schrijver meegegeven? Zonder die twee
+ *      is een notitie in een dossier waardeloos: "gebeld" — door wie, wanneer?
+ *   3. Kan er een notitie geplaatst worden vóór het indienen? Dat MOET kunnen,
+ *      anders is het meest bruikbare geval uitgesloten.
+ *   4. Wist intrekken de rij in plaats van deleted_at te zetten?
+ */
+
+const {
+  tenantA,
+  tenantB,
+  adminA: ADMIN_A,
+  templateA: TEMPLATE_A,
+  runA: RUN_A,
+  vendorA: VENDOR_A,
+  responseIngediend: RESPONSE_INGEDIEND,
+  responseOpen: RESPONSE_OPEN,
+  vendorOpen: VENDOR_OPEN,
+  adminB,
+  notitieBestaatNiet: NOTITIE_BESTAAT_NIET,
+} = TEST_IDS.notities;
+
+const SUBJECT_ADMIN = `oid-nt-a-${Date.now()}`;
+const SUBJECT_B = `oid-nt-b-${Date.now()}`;
+
+/** 64 hex-tekens, conform de CHECK op token_hash (migratie 0003). */
+const HASH_INGEDIEND = `${'4'.repeat(48)}dddddddddddddddd`;
+const HASH_OPEN = `${'5'.repeat(48)}eeeeeeeeeeeeeeee`;
+
+interface NotitieBody {
+  notitie: {
+    noteId: string;
+    tekst: string;
+    authorUserId: string;
+    authorNaam: string | null;
+    createdAt: string;
+  };
+}
+
+interface LijstBody {
+  notities: Array<{
+    noteId: string;
+    tekst: string;
+    authorNaam: string | null;
+    createdAt: string;
+  }>;
+}
+
+async function verwijderTestdata(client: Client) {
+  for (const tenant of [tenantA, tenantB]) {
+    await client.query('BEGIN');
+    await client.query(`SET LOCAL app.current_tenant_id = '${tenant}'`);
+    await client.query(`SET LOCAL app.current_actor = 'medewerker'`);
+    for (const tabel of [
+      'clm.response_note',
+      'clm.survey_review',
+      'clm.survey_answer',
+      'clm.survey_response',
+      'clm.survey_run',
+      'clm.survey_question',
+      'clm.survey_template',
+      'clm.vendor',
+      'clm.tenant_membership',
+      'clm."user"',
+      'clm.tenant',
+    ]) {
+      await client.query(`DELETE FROM ${tabel} WHERE tenant_id = $1`, [tenant]);
+    }
+    await client.query('COMMIT');
+  }
+}
+
+describe('Notities bij een inzending (e2e)', () => {
+  let app: INestApplication<App>;
+  let server: App;
+  let client: Client;
+  let cookieAdminA: string;
+  let cookieB: string;
+
+  beforeAll(async () => {
+    client = new Client({ connectionString: process.env.DATABASE_URL });
+    await client.connect();
+    await verwijderTestdata(client);
+
+    await client.query('BEGIN');
+    await client.query(`SET LOCAL app.current_tenant_id = '${tenantA}'`);
+    await client.query(`SET LOCAL app.current_actor = 'medewerker'`);
+
+    await client.query(
+      'INSERT INTO clm.tenant (tenant_id, name) VALUES ($1, $2)',
+      [tenantA, 'Tenant A (notities)'],
+    );
+    await client.query(
+      `INSERT INTO clm."user" (user_id, tenant_id, email, full_name, external_subject)
+       VALUES ($1, $2, $3, 'Admin van A', $4)`,
+      [ADMIN_A, tenantA, `${SUBJECT_ADMIN}@voorbeeld.nl`, SUBJECT_ADMIN],
+    );
+    await client.query(
+      `INSERT INTO clm.tenant_membership (user_id, tenant_id, role)
+       VALUES ($1, $2, 'admin')`,
+      [ADMIN_A, tenantA],
+    );
+    await client.query(
+      `INSERT INTO clm.survey_template (template_id, tenant_id, name, version)
+       VALUES ($1, $2, 'notitie-test-lijst', 1)`,
+      [TEMPLATE_A, tenantA],
+    );
+    await client.query(
+      `INSERT INTO clm.survey_run
+         (run_id, tenant_id, template_id, status, survey_kind, is_test, started_at)
+       VALUES ($1, $2, $3, 'active', 'vendor_compliance', true, now())`,
+      [RUN_A, tenantA, TEMPLATE_A],
+    );
+    for (const [vendorId, naam] of [
+      [VENDOR_A, 'Leverancier van A'],
+      [VENDOR_OPEN, 'Leverancier die nog moet'],
+    ] as const) {
+      await client.query(
+        `INSERT INTO clm.vendor (vendor_id, tenant_id, name) VALUES ($1, $2, $3)`,
+        [vendorId, tenantA, naam],
+      );
+    }
+    await client.query(
+      `INSERT INTO clm.survey_response
+         (response_id, tenant_id, run_id, vendor_id, subject_vendor_id,
+          token_hash, status, expires_at, submitted_at)
+       VALUES ($1, $2, $3, $4, $4, $5, 'submitted',
+               now() + interval '30 days', now())`,
+      [RESPONSE_INGEDIEND, tenantA, RUN_A, VENDOR_A, HASH_INGEDIEND],
+    );
+    await client.query(
+      `INSERT INTO clm.survey_response
+         (response_id, tenant_id, run_id, vendor_id, subject_vendor_id,
+          token_hash, status, expires_at)
+       VALUES ($1, $2, $3, $4, $4, $5, 'pending', now() + interval '30 days')`,
+      [RESPONSE_OPEN, tenantA, RUN_A, VENDOR_OPEN, HASH_OPEN],
+    );
+    await client.query('COMMIT');
+
+    await client.query('BEGIN');
+    await client.query(`SET LOCAL app.current_tenant_id = '${tenantB}'`);
+    await client.query(`SET LOCAL app.current_actor = 'medewerker'`);
+    await client.query(
+      'INSERT INTO clm.tenant (tenant_id, name) VALUES ($1, $2)',
+      [tenantB, 'Tenant B (notities)'],
+    );
+    await client.query(
+      `INSERT INTO clm."user" (user_id, tenant_id, email, full_name, external_subject)
+       VALUES ($1, $2, $3, 'Admin van B', $4)`,
+      [adminB, tenantB, `${SUBJECT_B}@voorbeeld.nl`, SUBJECT_B],
+    );
+    await client.query(
+      `INSERT INTO clm.tenant_membership (user_id, tenant_id, role)
+       VALUES ($1, $2, 'admin')`,
+      [adminB, tenantB],
+    );
+    await client.query('COMMIT');
+
+    const moduleRef = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleRef.createNestApplication();
+    app.use(cookieParser());
+    await app.init();
+    server = app.getHttpServer();
+
+    const sessies = app.get(SessieService);
+    const naam = cookieInstellingen().naam;
+    for (const [subject, doel] of [
+      [SUBJECT_ADMIN, 'a'],
+      [SUBJECT_B, 'b'],
+    ] as const) {
+      const sessie = await sessies.aanmaken(subject);
+      expect(sessie).not.toBeNull();
+
+      const cookie = `${naam}=${sessie!.token}`;
+      if (doel === 'a') cookieAdminA = cookie;
+      else cookieB = cookie;
+    }
+  }, 30000);
+
+  afterAll(async () => {
+    await app.close();
+    await verwijderTestdata(client);
+    await client.end();
+  }, 30000);
+
+  async function plaats(responseId: string, tekst: string): Promise<string> {
+    const antwoord = await request(server)
+      .post(`/admin/survey/responses/${responseId}/notes`)
+      .set('Cookie', cookieAdminA)
+      .send({ tekst })
+      .expect(201);
+
+    return (antwoord.body as NotitieBody).notitie.noteId;
+  }
+
+  describe('een notitie plaatsen', () => {
+    it('geeft de naam van de schrijver en de datum terug', async () => {
+      const voor = Date.now();
+
+      const antwoord = await request(server)
+        .post(`/admin/survey/responses/${RESPONSE_INGEDIEND}/notes`)
+        .set('Cookie', cookieAdminA)
+        .send({ tekst: 'Gebeld met de leverancier, komt volgende week.' })
+        .expect(201);
+
+      const { notitie } = antwoord.body as NotitieBody;
+
+      expect(notitie.tekst).toBe(
+        'Gebeld met de leverancier, komt volgende week.',
+      );
+      // Zonder naam en datum is een notitie in een dossier waardeloos.
+      expect(notitie.authorUserId).toBe(ADMIN_A);
+      expect(notitie.authorNaam).toBe('Admin van A');
+      expect(notitie.createdAt).toBeTruthy();
+
+      const geschrevenOp = new Date(notitie.createdAt).getTime();
+      expect(Number.isNaN(geschrevenOp)).toBe(false);
+      // Ruime marge; het gaat erom dat het een echt tijdstip is en geen
+      // lege string of epoch 0.
+      expect(geschrevenOp).toBeGreaterThanOrEqual(voor - 60_000);
+      expect(geschrevenOp).toBeLessThanOrEqual(Date.now() + 60_000);
+    });
+
+    // Dit is het geval waar de eigenaar om vroeg: notities gaan juist óók over
+    // leveranciers die nog niet hebben ingediend.
+    it('mag ook op een respons die nog niet is ingediend', async () => {
+      await request(server)
+        .post(`/admin/survey/responses/${RESPONSE_OPEN}/notes`)
+        .set('Cookie', cookieAdminA)
+        .send({ tekst: 'Nog niets ontvangen, morgen nabellen.' })
+        .expect(201);
+    });
+
+    it('weigert een lege notitie', async () => {
+      await request(server)
+        .post(`/admin/survey/responses/${RESPONSE_INGEDIEND}/notes`)
+        .set('Cookie', cookieAdminA)
+        .send({ tekst: '   ' })
+        .expect(400);
+    });
+
+    it('negeert een authorUserId uit de body en gebruikt de sessie', async () => {
+      const antwoord = await request(server)
+        .post(`/admin/survey/responses/${RESPONSE_INGEDIEND}/notes`)
+        .set('Cookie', cookieAdminA)
+        .send({ tekst: 'Op naam van een ander?', authorUserId: adminB })
+        .expect(201);
+
+      expect((antwoord.body as NotitieBody).notitie.authorUserId).toBe(ADMIN_A);
+    });
+
+    it('geeft 404 op een respons die niet bestaat', async () => {
+      await request(server)
+        .post(`/admin/survey/responses/${NOTITIE_BESTAAT_NIET}/notes`)
+        .set('Cookie', cookieAdminA)
+        .send({ tekst: 'Bestaat niet.' })
+        .expect(404);
+    });
+  });
+
+  describe('notities lezen', () => {
+    it('toont de nieuwste eerst, met naam en datum', async () => {
+      await plaats(RESPONSE_INGEDIEND, 'Eerste notitie.');
+      await plaats(RESPONSE_INGEDIEND, 'Tweede notitie.');
+
+      const antwoord = await request(server)
+        .get(`/admin/survey/responses/${RESPONSE_INGEDIEND}/notes`)
+        .set('Cookie', cookieAdminA)
+        .expect(200);
+
+      const { notities } = antwoord.body as LijstBody;
+
+      expect(notities.length).toBeGreaterThanOrEqual(2);
+      for (const n of notities) {
+        expect(n.authorNaam).toBe('Admin van A');
+        expect(n.createdAt).toBeTruthy();
+      }
+    });
+  });
+
+  describe('een notitie intrekken', () => {
+    it('haalt hem uit de lijst maar bewaart de rij', async () => {
+      const noteId = await plaats(RESPONSE_INGEDIEND, 'Deze gaat weg.');
+
+      await request(server)
+        .delete(`/admin/survey/responses/${RESPONSE_INGEDIEND}/notes/${noteId}`)
+        .set('Cookie', cookieAdminA)
+        .expect(204);
+
+      const lijst = await request(server)
+        .get(`/admin/survey/responses/${RESPONSE_INGEDIEND}/notes`)
+        .set('Cookie', cookieAdminA)
+        .expect(200);
+
+      const ids = (lijst.body as LijstBody).notities.map((n) => n.noteId);
+      expect(ids).not.toContain(noteId);
+
+      // Wissen zou de historie kapotmaken die deze tabel bewaart.
+      await client.query('BEGIN');
+      await client.query(`SET LOCAL app.current_tenant_id = '${tenantA}'`);
+      await client.query(`SET LOCAL app.current_actor = 'medewerker'`);
+      const rij = await client.query<{ deleted_at: Date | null }>(
+        'SELECT deleted_at FROM clm.response_note WHERE note_id = $1',
+        [noteId],
+      );
+      await client.query('COMMIT');
+
+      expect(rij.rows).toHaveLength(1);
+      expect(rij.rows[0].deleted_at).not.toBeNull();
+    });
+
+    it('geeft 404 bij een tweede poging', async () => {
+      const noteId = await plaats(RESPONSE_INGEDIEND, 'Eenmalig.');
+      const pad = `/admin/survey/responses/${RESPONSE_INGEDIEND}/notes/${noteId}`;
+
+      await request(server).delete(pad).set('Cookie', cookieAdminA).expect(204);
+      await request(server).delete(pad).set('Cookie', cookieAdminA).expect(404);
+    });
+  });
+
+  describe('de tenantgrens', () => {
+    it('laat tenant B geen notitie plaatsen bij tenant A', async () => {
+      await request(server)
+        .post(`/admin/survey/responses/${RESPONSE_INGEDIEND}/notes`)
+        .set('Cookie', cookieB)
+        .send({ tekst: 'Meekijken?' })
+        .expect(404);
+    });
+
+    it('laat tenant B de notities van tenant A niet lezen', async () => {
+      await plaats(RESPONSE_INGEDIEND, 'Vertrouwelijk voor A.');
+
+      await request(server)
+        .get(`/admin/survey/responses/${RESPONSE_INGEDIEND}/notes`)
+        .set('Cookie', cookieB)
+        .expect(404);
+    });
+
+    it('laat tenant B een notitie van tenant A niet intrekken', async () => {
+      const noteId = await plaats(RESPONSE_INGEDIEND, 'Blijft staan.');
+
+      await request(server)
+        .delete(`/admin/survey/responses/${RESPONSE_INGEDIEND}/notes/${noteId}`)
+        .set('Cookie', cookieB)
+        .expect(404);
+
+      const lijst = await request(server)
+        .get(`/admin/survey/responses/${RESPONSE_INGEDIEND}/notes`)
+        .set('Cookie', cookieAdminA)
+        .expect(200);
+
+      const ids = (lijst.body as LijstBody).notities.map((n) => n.noteId);
+      expect(ids).toContain(noteId);
+    });
+  });
+});

--- a/test/respons-status.spec.ts
+++ b/test/respons-status.spec.ts
@@ -1,0 +1,137 @@
+import {
+  bepaalStatus,
+  STATUS_LABEL,
+  RESPONS_STATUSSEN,
+  type StatusFeiten,
+} from '../src/survey/respons-status';
+
+/**
+ * De statusberekening (plan 2026-08-07, §3).
+ *
+ * Unittests en geen e2e: hier zit geen database of RLS bij, alleen de regel
+ * zelf. Die regel is de centrale waarheid van de app, dus elke tak verdient
+ * een eigen test — inclusief de gevallen die de eigenaar expliciet noemde.
+ */
+
+const DAG = 24 * 60 * 60 * 1000;
+
+function feiten(overschrijf: Partial<StatusFeiten> = {}): StatusFeiten {
+  return {
+    submittedAt: null,
+    closesAt: null,
+    rondeStatus: 'active',
+    laatsteOordeel: null,
+    ...overschrijf,
+  };
+}
+
+describe('bepaalStatus', () => {
+  describe('nog niet ingediend', () => {
+    it('is opgestuurd zonder sluitdatum', () => {
+      expect(bepaalStatus(feiten())).toBe('opgestuurd');
+    });
+
+    it('is opgestuurd zolang de sluitdatum niet is gepasseerd', () => {
+      expect(
+        bepaalStatus(feiten({ closesAt: new Date(Date.now() + 7 * DAG) })),
+      ).toBe('opgestuurd');
+    });
+
+    it('is te laat zodra de sluitdatum is gepasseerd', () => {
+      expect(
+        bepaalStatus(feiten({ closesAt: new Date(Date.now() - 1 * DAG) })),
+      ).toBe('te_laat');
+    });
+
+    // Een ronde in draft is nog niet uitgestuurd; dan is er niets te laat.
+    it.each(['draft', 'finished', 'archived'])(
+      'is niet te laat bij een ronde met status %s',
+      (rondeStatus) => {
+        expect(
+          bepaalStatus(
+            feiten({ closesAt: new Date(Date.now() - 1 * DAG), rondeStatus }),
+          ),
+        ).toBe('opgestuurd');
+      },
+    );
+
+    it('accepteert een ISO-string net zo goed als een Date', () => {
+      const verleden = new Date(Date.now() - 1 * DAG).toISOString();
+
+      expect(bepaalStatus(feiten({ closesAt: verleden }))).toBe('te_laat');
+    });
+  });
+
+  describe('ingediend', () => {
+    const ingediend = { submittedAt: new Date(Date.now() - 2 * DAG) };
+
+    it('is terug zolang er geen oordeel is', () => {
+      expect(bepaalStatus(feiten(ingediend))).toBe('terug');
+    });
+
+    // Een gepasseerde sluitdatum doet er niet meer toe zodra er is ingediend.
+    it('is terug, ook als de sluitdatum is gepasseerd', () => {
+      expect(
+        bepaalStatus(
+          feiten({ ...ingediend, closesAt: new Date(Date.now() - 1 * DAG) }),
+        ),
+      ).toBe('terug');
+    });
+
+    it.each(['goed', 'nadere_vragen', 'niet_goed'])(
+      'is beoordeeld bij het inhoudelijke oordeel %s',
+      (laatsteOordeel) => {
+        expect(bepaalStatus(feiten({ ...ingediend, laatsteOordeel }))).toBe(
+          'beoordeeld',
+        );
+      },
+    );
+
+    it('is goedgekeurd wanneer het laatste oordeel goedgekeurd is', () => {
+      expect(
+        bepaalStatus(feiten({ ...ingediend, laatsteOordeel: 'goedgekeurd' })),
+      ).toBe('goedgekeurd');
+    });
+  });
+
+  describe('het laatste oordeel telt (besluit eigenaar 2026-08-07)', () => {
+    const ingediend = { submittedAt: new Date(Date.now() - 2 * DAG) };
+
+    // Dit is de vervolgvraag op V3, en het minst vanzelfsprekende geval:
+    // schrijft iemand ná een goedkeuring alsnog 'niet_goed', dan staat de
+    // inzending weer op 'beoordeeld'. Een goedkeuring die blijft staan terwijl
+    // er een afwijzing onder hangt, is niet herstelbaar zonder dat iemand het
+    // merkt.
+    it('valt terug op beoordeeld als er na goedkeuring een afwijzing komt', () => {
+      expect(
+        bepaalStatus(feiten({ ...ingediend, laatsteOordeel: 'niet_goed' })),
+      ).toBe('beoordeeld');
+    });
+
+    // De keerzijde: een ingetrokken goedkeuring hoort niet meer te tellen. Dat
+    // regelt de query (deleted_at IS NULL); hier bewijst de test dat de functie
+    // niets anders doet dan naar het meegegeven laatste oordeel kijken.
+    it('kijkt alleen naar het meegegeven laatste oordeel', () => {
+      expect(bepaalStatus(feiten({ ...ingediend, laatsteOordeel: null }))).toBe(
+        'terug',
+      );
+    });
+  });
+
+  describe('labels', () => {
+    it('heeft voor elke status een Nederlands label', () => {
+      for (const status of RESPONS_STATUSSEN) {
+        expect(STATUS_LABEL[status]).toBeTruthy();
+      }
+    });
+
+    // De labels zijn wat de gebruiker leest; ze horen letterlijk bij de
+    // formulering van de eigenaar te blijven.
+    it('noemt de vier statussen zoals de eigenaar ze formuleerde', () => {
+      expect(STATUS_LABEL.opgestuurd).toBe('Opgestuurd, nog niet terug');
+      expect(STATUS_LABEL.terug).toBe('Terug, nog niet beoordeeld');
+      expect(STATUS_LABEL.beoordeeld).toBe('Beoordeeld, nog niet goedgekeurd');
+      expect(STATUS_LABEL.goedgekeurd).toBe('Beoordeeld en goedgekeurd');
+    });
+  });
+});

--- a/test/test-ids.spec.ts
+++ b/test/test-ids.spec.ts
@@ -64,4 +64,38 @@ describe("test-ids: geen botsende UUID's tussen suites", () => {
 
     expect(overtredingen).toEqual([]);
   });
+
+  it('deelt geen enkele token_hash tussen suites', () => {
+    // `survey_response_token_hash_key` (migratie 0003) is uniek over ALLE
+    // tenants heen — er zit geen tenant_id in. Twee suites met dezelfde hash
+    // botsen dus, ook al zitten ze keurig in hun eigen tenant.
+    //
+    // Dat is een gemene faalvorm: los draait elke suite groen, en pas in de
+    // volledige run valt er een om — welke hangt af van de volgorde. Op
+    // 2026-08-07 kostte dat twee onverklaarbare rode runs voordat de oorzaak
+    // boven kwam.
+    const testMap = __dirname;
+    // Vangt de vorm `${'3'.repeat(48)}cccccccccccccccc` die alle suites
+    // gebruiken: het herhaalde teken plus de staart.
+    const patroon = /\$\{'([0-9a-f])'\.repeat\(48\)\}([0-9a-f]{16})/g;
+
+    const perHash = new Map<string, string[]>();
+
+    for (const naam of readdirSync(testMap)) {
+      if (!naam.endsWith('.e2e-spec.ts')) continue;
+
+      const inhoud = readFileSync(join(testMap, naam), 'utf8');
+
+      for (const treffer of inhoud.matchAll(patroon)) {
+        const hash = treffer[1].repeat(48) + treffer[2];
+        perHash.set(hash, [...(perHash.get(hash) ?? []), naam]);
+      }
+    }
+
+    const botsingen = [...perHash.entries()]
+      .filter(([, suites]) => new Set(suites).size > 1)
+      .map(([hash, suites]) => `${hash.slice(0, 8)}…: ${suites.join(', ')}`);
+
+    expect(botsingen).toEqual([]);
+  });
 });

--- a/test/test-ids.ts
+++ b/test/test-ids.ts
@@ -239,6 +239,34 @@ export const TEST_IDS = {
      */
     reviewBestaatNiet: '00000000-0000-0000-0000-000000000bad',
   },
+  // Notities (migratie 0018). Staarten 92 t/m 99; de f-reeks was op.
+  // Gecontroleerd tegen BEIDE uitdeelvormen — zie de opmerking bij
+  // `goedkeuren` hierboven.
+  notities: {
+    tenantA: '00000000-0000-0000-0000-000000000092',
+    tenantB: '00000000-0000-0000-0000-000000000093',
+    adminA: '00000000-0000-0000-0000-000000000094',
+    templateA: '00000000-0000-0000-0000-000000000095',
+    runA: '00000000-0000-0000-0000-000000000096',
+    vendorA: '00000000-0000-0000-0000-000000000097',
+    /** Ingediend. */
+    responseIngediend: '00000000-0000-0000-0000-000000000098',
+    /**
+     * Nog niet ingediend. Hierop mag WEL een notitie — anders dan bij
+     * beoordelen (besluit eigenaar 2026-08-07): "gebeld, komt volgende week"
+     * gaat juist over een leverancier die nog niet heeft ingediend.
+     */
+    responseOpen: '00000000-0000-0000-0000-000000000099',
+    /**
+     * Tweede leverancier: survey_response_run_vendor_key staat één respons per
+     * vendor per ronde toe, dus de open en de ingediende respons kunnen niet
+     * dezelfde vendor hebben.
+     */
+    vendorOpen: '00000000-0000-0000-0000-00000000009f',
+    adminB: '00000000-0000-0000-0000-0000000000a0',
+    /** Bestaat met opzet NIET — voor de 404 bij intrekken. */
+    notitieBestaatNiet: '00000000-0000-0000-0000-000000000fee',
+  },
 } as const;
 
 /** Alle uitgedeelde id's, plat. Gebruikt door de bewakingstest. */


### PR DESCRIPTION
Tweede stap van de statusketen uit `docs/superpowers/plans/2026-08-07-statuswaarheid-per-vendor.md`. Plus twee onregelmatige falers die er niets mee te maken hadden, maar wel de runs rood maakten.

## Notities — migratie 0018

Een eigen tabel `clm.response_note`, geen vijfde `verdict`.

**Waarom geen oordeel:** "gebeld, komt volgende week" past in geen van de vier verdicts. Hem daar toch in persen zou een verdict afdwingen dat er niet is. Het verschil is niet cosmetisch — een oordeel bepaalt de status van de inzending, een notitie niet. In één tabel zou elke statusquery de notities eruit moeten filteren, en die filter vergeten is een stille fout.

**De policy is wél letterlijk overgenomen** van `survey_review`: tenant én actor, in `USING` én `WITH CHECK`. Een notitie over een leverancier is voor collega's, en de leverancier zit in dezelfde tenant. Zonder de actor-eis leest hij mee wat er over hem geschreven wordt.

Drie routes:
```
GET    /admin/survey/responses/:id/notes
POST   /admin/survey/responses/:id/notes
DELETE /admin/survey/responses/:id/notes/:noteId
```

**Naam en datum staan in het antwoord**, niet alleen in de tabel. Een notitie zonder afzender en tijdstip is in een dossier waardeloos: "gebeld" — door wie, en hoe lang geleden?

**Mag ook vóór het indienen** (besluit eigenaar 2026-08-07), anders dan bij beoordelen. "Gebeld, komt volgende week" gaat juist over een leverancier die nog niét heeft ingediend; de regel van `BeoordelingService` zou hier het meest bruikbare geval uitsluiten.

## De statusberekening

`src/survey/respons-status.ts` — één plek, berekend en niet opgeslagen.

Een opgeslagen status loopt onvermijdelijk uit de pas met de onderliggende feiten: dan staat er "beoordeeld" terwijl er geen oordeel is, en dan liegt juist het veld waar iedereen op vaart.

| Status | Volgt uit |
|---|---|
| Opgestuurd, nog niet terug | `submitted_at IS NULL` |
| Te laat | idem, plus `closes_at < now()` bij een `active` ronde |
| Terug, nog niet beoordeeld | ingediend, geen oordeel |
| Beoordeeld, nog niet goedgekeurd | laatste oordeel is inhoudelijk |
| Beoordeeld en goedgekeurd | laatste oordeel is `goedgekeurd` |

**"Te laat" noemde de eigenaar niet**, maar zonder die status verdwijnt een overschrijding in "opgestuurd, nog niet terug" — en dat is juist wat je wél wilt zien. Alleen bij een `active` ronde: in `draft` is er nog niets uitgestuurd.

**Het laatste oordeel telt, ook als dat een goedkeuring ongedaan maakt** (besluit eigenaar 2026-08-07). Schrijft iemand na een goedkeuring alsnog `niet_goed`, dan staat de inzending weer op "beoordeeld". Dat is zichtbaar en herstelbaar; een goedkeuring die blijft staan terwijl er een afwijzing onder hangt, is dat niet.

De berekening wordt in deze PR **nog nergens aangeroepen** — dat is de volgende stap (werkvoorraad en statusoverzicht). Hij staat er nu zodat er één definitie is voordat er twee schermen hun eigen versie verzinnen.

## Twee onregelmatige falers, opgelost

Beide maakten de e2e-run rood zonder dat er iets stuk was. Dit is de vervelendste faalvorm in dit project: het ziet eruit als toeval en is het niet.

**1. Een botsende `token_hash`.** De `goedkeuren`-suite gebruikte exact dezelfde waarde als `beoordelaar-koppelen`. `survey_response_token_hash_key` is uniek over **alle** tenants heen — er zit geen `tenant_id` in — dus de tenantscheiding hielp niet. Los draaide elke suite groen; alleen in de volledige run viel er willekeurig een om.

> Dit was ook de oorzaak van de "onverklaarbare" rode run bij PR #100, die toen als toeval is afgedaan. Dat was te snel geconcludeerd.

Er staat nu een bewakingstest op in `test/test-ids.spec.ts` die de botsing vangt en beide suites bij naam noemt. Tegenproef: de oude waarde teruggezet → de test faalt met `33333333…: beoordelaar-koppelen, goedkeuren`.

**2. Twee tests in `demo-seed` zonder timeout.** Die starten het seedscript als apart Node-proces maar vielen terug op Jests standaard van 5 seconden. Opvallend: bij de reparatie van 2026-08-04 zijn precies deze twee overgeslagen — de andere drie hadden hun `20_000` wel, met een commentaar dat het probleem woordelijk beschrijft.

## Runbook — hoe dit voortaan wordt voorkomen

Nieuwe sectie in `docs/runbooks/commandos-en-omgeving.md`: **"Een nieuwe e2e-suite schrijven"**.

Bij het uitzoeken bleek het om **vier** unieke sleutels te gaan zonder `tenant_id`, niet één: `token_hash`, `tenant.name`, `external_subject` en `storage_key`. Bij drie daarvan deden de bestaande suites al iets slims — de tenantnaam bevat de suitenaam, en `external_subject` gebruikt een suiteprefix *plus* een tijdstempel. Alleen bij `token_hash` was die gewoonte nergens vastgelegd.

Alle vier staan nu in een tabel met de beproefde vorm ernaast, plus:
- Het commando om te zien welke tekens al vergeven zijn
- De twee uitdeelvormen van test-id's (letterlijk én via `id()`) — kijk je maar naar één, dan lijken staarten vrij die het niet zijn
- Timeouts voor tests die een script starten
- **Draai altijd de volledige e2e-run**; een groene losse suite zegt niets over botsingen
- Een foutzoeker die `duplicate key` en `Exceeded timeout` uit de uitvoer vist

Bij het schrijven van die sectie ging hetzelfde soort fout nog een keer mis: het verkorte zoekpatroon `'0{20}([0-9a-f]{2})'` vindt **nul** treffers omdat de UUID koppeltekens heeft, en levert dan een lijst "vrije" staarten op die allemaal bezet zijn. Opgemerkt doordat het aantal vergeven staarten van 93 naar 49 zakte. Staat er nu als waarschuwing bij, met de plausibiliteitscontrole erbij.

## Getoetst

- **380 e2e-tests groen** (was 369), 26 suites — 11 nieuwe voor notities
- **307 unittests** (was 289) — 17 daarvan voor de statusberekening, zonder database
- lint / format / typecheck schoon
- **`npm run verify:volledig`: GROEN — de hele keten, van code tot browser**, inclusief 42 browsertests
- `verify:schema` 17/17 op een verse container; tabel, RLS, policy en rechten teruggelezen uit de database

**Drie tegenproeven:**

| Sabotage | Uitkomst |
|---|---|
| actor `'leverancier'` op de notitieroutes | precies de leestests vielen om |
| elk oordeel als goedkeuring tellen | precies vier statustests vielen om |
| de oude botsende `token_hash` teruggezet | de nieuwe bewakingstest vangt hem, met beide suitenamen |

> De doorloop meldt dat de productiedatabase achterloopt. Dat is juist en verwacht: 0017 en 0018 gaan pas mee bij uitrol.
