### PR TITLE
feat(survey): werkvoorraad contractmanager met berekende status

### DIFF
--- a/src/survey/contractmanager.service.ts
+++ b/src/survey/contractmanager.service.ts
@@ -1,0 +1,190 @@
+import { Injectable } from '@nestjs/common';
+import { sql } from 'drizzle-orm';
+
+import { DatabaseService } from '../db/database.service';
+import { bepaalStatus, type ResponsStatus } from './respons-status';
+
+/**
+ * De werkvoorraad van de contractmanager, en het statusoverzicht per vendor.
+ *
+ * Zie docs/superpowers/plans/2026-08-07-statuswaarheid-per-vendor.md §4.1 (B4,
+ * B5). Dit is de tegenhanger van BeoordelaarService.werkvoorraad().
+ *
+ * ── Waarom twee lijsten en niet één met een filter ──────────────────────────
+ *
+ * ADR-013: "wat wacht er op mij" betekent voor de twee rollen iets wezenlijk
+ * anders. De CISO wil niet zien wie er nog moet invullen — daar gaat hij niet
+ * over. De contractmanager wil niet de beoordeelstapel van de hele
+ * organisatie. Eén lijst met een filter bedient allebei half.
+ *
+ * ── De koppeling is een hulpmiddel, geen grens ──────────────────────────────
+ *
+ * `vendor.owner_user_id` bepaalt wat je standaard ziet, niet wat je mag. Deze
+ * service kent daarom geen enkele methode die iets weigert: `alles()` toont de
+ * hele organisatie, en dat is opzet (ADR-013 besluit 3). Wie hier later iets
+ * bouwt dat op eigenaarschap wéigert, gaat daartegen in — en legt het proces
+ * stil zodra een contractmanager op vakantie is.
+ *
+ * ── owner_user_id mag leeg zijn ─────────────────────────────────────────────
+ *
+ * De kolom is nullable met ON DELETE set null: een vendor zonder
+ * contractmanager is geldig, en na het vertrek van een collega ontstaat die
+ * situatie vanzelf. Zulke vendors horen in het organisatiebrede overzicht
+ * zichtbaar te blijven — anders verdwijnt precies datgene waar niemand naar
+ * omkijkt.
+ */
+
+/** Eén respons in het statusoverzicht. */
+export interface StatusItem {
+  responseId: string;
+  runId: string;
+  templateId: string;
+  templateNaam: string;
+  vendorId: string | null;
+  vendorNaam: string | null;
+  /** De contractmanager van deze vendor; null wanneer er geen is. */
+  eigenaarUserId: string | null;
+  eigenaarNaam: string | null;
+  submittedAt: string | null;
+  closesAt: string | null;
+  /** De berekende status — de centrale waarheid uit respons-status.ts. */
+  status: ResponsStatus;
+  /** Het laatste oordeel, of null wanneer er nog geen is. */
+  laatsteOordeel: string | null;
+  /**
+   * Hoeveel oordelen er staan. Hoort in het scherm: bij tegenstrijdige
+   * oordelen telt het laatste voor de status, maar dan moet wél zichtbaar
+   * blijven dát er meer zijn (besluit eigenaar 2026-08-07, V3).
+   */
+  aantalOordelen: number;
+  /** Hoeveel notities erbij staan. Nul is een geldige uitkomst. */
+  aantalNotities: number;
+}
+
+interface StatusRij extends Record<string, unknown> {
+  response_id: string;
+  run_id: string;
+  template_id: string;
+  template_naam: string;
+  vendor_id: string | null;
+  vendor_naam: string | null;
+  eigenaar_user_id: string | null;
+  eigenaar_naam: string | null;
+  submitted_at: Date | string | null;
+  closes_at: Date | string | null;
+  ronde_status: string;
+  laatste_oordeel: string | null;
+  aantal_oordelen: string | number;
+  aantal_notities: string | number;
+}
+
+function iso(waarde: Date | string | null): string | null {
+  if (waarde === null) return null;
+  return waarde instanceof Date ? waarde.toISOString() : String(waarde);
+}
+
+@Injectable()
+export class ContractmanagerService {
+  constructor(private readonly db: DatabaseService) {}
+
+  /**
+   * Rondes op vendors die deze gebruiker beheert.
+   *
+   * Anders dan de beoordeelstapel bevat deze lijst óók responses die nog niet
+   * zijn ingediend — dat is juist wat een contractmanager wil weten: wie moet
+   * er nog invullen, en wie is te laat.
+   */
+  async vanMij(tenantId: string, userId: string): Promise<StatusItem[]> {
+    return this.haal(tenantId, userId);
+  }
+
+  /**
+   * Alles binnen de tenant, ongeacht wie de vendor beheert.
+   *
+   * De schakelaar "van mij / hele organisatie" uit het plan. Standaard toont
+   * het scherm de eigen lijst, maar de rest blijft één klik weg: de koppeling
+   * is een hulpmiddel en geen grens (ADR-013 besluit 3).
+   */
+  async alles(tenantId: string): Promise<StatusItem[]> {
+    return this.haal(tenantId, null);
+  }
+
+  /**
+   * @param eigenaarUserId Beperk tot vendors van deze gebruiker, of null voor
+   *   de hele tenant.
+   */
+  private async haal(
+    tenantId: string,
+    eigenaarUserId: string | null,
+  ): Promise<StatusItem[]> {
+    return this.db.withTenant(
+      tenantId,
+      async (tx) => {
+        // LEFT JOIN op vendor: bij UC2 is vendor_id leeg (dan vult een collega
+        // in over een leverancier). Een INNER JOIN zou die responses stil laten
+        // verdwijnen uit het overzicht dat de centrale waarheid moet zijn.
+        const resultaat = await tx.execute<StatusRij>(
+          sql`SELECT s.response_id,
+                     s.run_id,
+                     r.template_id,
+                     t.name          AS template_naam,
+                     s.vendor_id,
+                     v.name          AS vendor_naam,
+                     v.owner_user_id AS eigenaar_user_id,
+                     o.full_name     AS eigenaar_naam,
+                     s.submitted_at,
+                     r.closes_at,
+                     r.status        AS ronde_status,
+                     (SELECT rv.verdict
+                        FROM clm.survey_review rv
+                       WHERE rv.response_id = s.response_id
+                         AND rv.deleted_at IS NULL
+                       ORDER BY rv.created_at DESC
+                       LIMIT 1)                       AS laatste_oordeel,
+                     (SELECT count(*)
+                        FROM clm.survey_review rv
+                       WHERE rv.response_id = s.response_id
+                         AND rv.deleted_at IS NULL)   AS aantal_oordelen,
+                     (SELECT count(*)
+                        FROM clm.response_note n
+                       WHERE n.response_id = s.response_id
+                         AND n.deleted_at IS NULL)    AS aantal_notities
+                FROM clm.survey_response s
+                JOIN clm.survey_run r      ON r.run_id = s.run_id
+                JOIN clm.survey_template t ON t.template_id = r.template_id
+                LEFT JOIN clm.vendor v     ON v.vendor_id = s.vendor_id
+                LEFT JOIN clm."user" o     ON o.user_id = v.owner_user_id
+               WHERE (${eigenaarUserId}::uuid IS NULL
+                      OR v.owner_user_id = ${eigenaarUserId}::uuid)
+               ORDER BY s.submitted_at DESC NULLS FIRST, v.name`,
+        );
+
+        return resultaat.rows.map((r) => ({
+          responseId: r.response_id,
+          runId: r.run_id,
+          templateId: r.template_id,
+          templateNaam: r.template_naam,
+          vendorId: r.vendor_id,
+          vendorNaam: r.vendor_naam,
+          eigenaarUserId: r.eigenaar_user_id,
+          eigenaarNaam: r.eigenaar_naam,
+          submittedAt: iso(r.submitted_at),
+          closesAt: iso(r.closes_at),
+          // Eén plek waar de status wordt bepaald: dezelfde functie die de
+          // unittests toetsen. Zou deze query zijn eigen CASE-expressie
+          // hebben, dan zijn er binnen een sprint twee waarheden.
+          status: bepaalStatus({
+            submittedAt: r.submitted_at,
+            closesAt: r.closes_at,
+            rondeStatus: r.ronde_status,
+            laatsteOordeel: r.laatste_oordeel,
+          }),
+          laatsteOordeel: r.laatste_oordeel,
+          aantalOordelen: Number(r.aantal_oordelen),
+          aantalNotities: Number(r.aantal_notities),
+        }));
+      },
+      'medewerker',
+    );
+  }
+}

--- a/src/survey/survey.module.ts
+++ b/src/survey/survey.module.ts
@@ -11,6 +11,7 @@ import { BestandOpslagService } from './bestand-opslag.service';
 import { BijlageService } from './bijlage.service';
 import { BeoordelaarService } from './beoordelaar.service';
 import { BeoordelingService } from './beoordeling.service';
+import { ContractmanagerService } from './contractmanager.service';
 import { NotitieService } from './notitie.service';
 import { RondeBeheerService } from './ronde-beheer.service';
 import { VragenlijstBeheerController } from './vragenlijst-beheer.controller';
@@ -49,6 +50,7 @@ import { VragenlijstLeesService } from './vragenlijst-lezen.service';
     BeoordelingService,
     BeoordelaarService,
     NotitieService,
+    ContractmanagerService,
     VragenlijstImportService,
     VragenlijstLeesService,
     AntwoordIndienService,
@@ -64,6 +66,7 @@ import { VragenlijstLeesService } from './vragenlijst-lezen.service';
     BeoordelingService,
     BeoordelaarService,
     NotitieService,
+    ContractmanagerService,
     VragenlijstImportService,
     VragenlijstLeesService,
     AntwoordIndienService,

--- a/src/survey/vragenlijst-beheer.controller.ts
+++ b/src/survey/vragenlijst-beheer.controller.ts
@@ -8,6 +8,7 @@ import {
   Param,
   Patch,
   Post,
+  Query,
   Req,
   UseGuards,
 } from '@nestjs/common';
@@ -18,6 +19,7 @@ import {
   TenantContextGuard,
   type RequestMetSessie,
 } from '../auth/tenant-context.guard';
+import { ContractmanagerService } from './contractmanager.service';
 import { NotitieService } from './notitie.service';
 import { RondeBeheerService } from './ronde-beheer.service';
 import {
@@ -84,6 +86,7 @@ export class VragenlijstBeheerController {
     private readonly beoordelaars: BeoordelaarService,
     // Onderstreept om dezelfde reden als beoordelingen_.
     private readonly notities_: NotitieService,
+    private readonly contractmanagers: ContractmanagerService,
   ) {}
 
   /** Alle vragenlijsten van deze tenant, met aantallen vragen en rondes. */
@@ -314,6 +317,39 @@ export class VragenlijstBeheerController {
     );
 
     return { werkvoorraad };
+  }
+
+  /**
+   * De werkvoorraad van de contractmanager: rondes op vendors die hij beheert.
+   *
+   * Bewust een andere lijst dan `mijn-beoordelingen` en geen filter erop
+   * (ADR-013). De contractmanager wil weten wie er nog moet invullen en wie te
+   * laat is; de beoordelaar wil dat juist niet zien. Deze lijst bevat daarom
+   * óók responses die nog niet zijn ingediend.
+   *
+   * `?scope=organisatie` toont alles binnen de tenant. Dat is de schakelaar
+   * "van mij / hele organisatie": de koppeling stuurt wat je standaard ziet,
+   * niet wat je mag (ADR-013 besluit 3). Zonder die uitweg ligt het proces
+   * stil zodra een contractmanager op vakantie is.
+   *
+   * Geen `@VereistRol`: iedereen mag zijn eigen werkvoorraad zien, en beheert
+   * hij geen enkele vendor dan is de lijst leeg — een geldig antwoord, geen
+   * fout.
+   */
+  @Get('mijn-vendors')
+  async mijnVendors(
+    @Req() request: RequestMetSessie,
+    @Query('scope') scope?: string,
+  ) {
+    const sessie = request.sessie!;
+
+    const heleOrganisatie = scope === 'organisatie';
+
+    const werkvoorraad = heleOrganisatie
+      ? await this.contractmanagers.alles(sessie.tenantId)
+      : await this.contractmanagers.vanMij(sessie.tenantId, sessie.userId);
+
+    return { werkvoorraad, scope: heleOrganisatie ? 'organisatie' : 'mij' };
   }
 
   /** Wie er aan deze vragenlijst gekoppeld zijn als beoordelaar. */

--- a/test/test-ids.ts
+++ b/test/test-ids.ts
@@ -267,6 +267,40 @@ export const TEST_IDS = {
     /** Bestaat met opzet NIET — voor de 404 bij intrekken. */
     notitieBestaatNiet: '00000000-0000-0000-0000-000000000fee',
   },
+  // Werkvoorraad contractmanager. Staarten 10 t/m 1b, aaneengesloten.
+  //
+  // Bewust laag in het bereik: de a0–bf-zone is grotendeels vergeven, en een
+  // eerste poging daar leverde drie botsingen op (ac, b1, b2) die de
+  // bewakingstest hieronder ving. Onder 0x20 is nog alles vrij.
+  //
+  // Zie docs/runbooks/commandos-en-omgeving.md, §"Een nieuwe e2e-suite
+  // schrijven" — en let op dat staarten op TWEE manieren worden uitgedeeld:
+  // letterlijk zoals hier, én via de id()-helper bovenaan.
+  'werkvoorraad-contractmanager': {
+    tenantA: '00000000-0000-0000-0000-000000000010',
+    tenantB: '00000000-0000-0000-0000-000000000011',
+    /** Contractmanager van vendorVanMij. */
+    managerA: '00000000-0000-0000-0000-000000000012',
+    /** Collega-contractmanager: beheert een andere vendor. */
+    collegaA: '00000000-0000-0000-0000-000000000013',
+    templateA: '00000000-0000-0000-0000-000000000014',
+    runA: '00000000-0000-0000-0000-000000000015',
+    /** Vendor van managerA — ingediend. */
+    vendorVanMij: '00000000-0000-0000-0000-000000000016',
+    /** Vendor van collegaA — hoort niet in 'van mij'. */
+    vendorVanCollega: '00000000-0000-0000-0000-000000000017',
+    /**
+     * Vendor zónder contractmanager. owner_user_id is nullable met ON DELETE
+     * set null, dus die situatie ontstaat vanzelf na het vertrek van een
+     * collega — en dan moet hij juist zichtbaar blijven in het organisatiebrede
+     * overzicht.
+     */
+    vendorZonderEigenaar: '00000000-0000-0000-0000-000000000018',
+    responseVanMij: '00000000-0000-0000-0000-000000000019',
+    responseVanCollega: '00000000-0000-0000-0000-00000000001a',
+    responseZonderEigenaar: '00000000-0000-0000-0000-00000000001b',
+    adminB: '00000000-0000-0000-0000-00000000001c',
+  },
 } as const;
 
 /** Alle uitgedeelde id's, plat. Gebruikt door de bewakingstest. */

--- a/test/werkvoorraad-contractmanager.e2e-spec.ts
+++ b/test/werkvoorraad-contractmanager.e2e-spec.ts
@@ -1,0 +1,402 @@
+import { INestApplication } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import cookieParser from 'cookie-parser';
+import { Client } from 'pg';
+import request from 'supertest';
+import type { App } from 'supertest/types';
+
+import { AppModule } from '../src/app.module';
+import { cookieInstellingen } from '../src/auth/sessie';
+import { SessieService } from '../src/auth/sessie.service';
+import { TEST_IDS } from './test-ids';
+
+/**
+ * De werkvoorraad van de contractmanager (plan 2026-08-07, §4.1 B4).
+ *
+ * Vier dingen kunnen hier stuk zonder dat iemand het merkt:
+ *
+ *   1. Toont "van mij" ook vendors van een collega? Dan is de lijst
+ *      betekenisloos en kan de contractmanager hem net zo goed niet gebruiken.
+ *   2. Verdwijnt een vendor ZONDER contractmanager uit beeld? Juist die vendor
+ *      is degene waar niemand naar omkijkt.
+ *   3. Blokkeert de schakelaar "hele organisatie"? Dat mag niet — de koppeling
+ *      is een hulpmiddel en geen grens (ADR-013 besluit 3).
+ *   4. Berekent deze route zijn eigen status in plaats van respons-status.ts
+ *      te gebruiken? Dan zijn er twee waarheden.
+ *
+ * De statuslogica zelf staat in test/respons-status.spec.ts — dat zijn
+ * unittests zonder database. Hier wordt alleen bewezen dat de route hem
+ * gebruikt en de juiste feiten aanlevert.
+ */
+
+const {
+  tenantA,
+  tenantB,
+  managerA: MANAGER_A,
+  collegaA: COLLEGA_A,
+  templateA: TEMPLATE_A,
+  runA: RUN_A,
+  vendorVanMij: VENDOR_VAN_MIJ,
+  vendorVanCollega: VENDOR_VAN_COLLEGA,
+  vendorZonderEigenaar: VENDOR_ZONDER_EIGENAAR,
+  responseVanMij: RESPONSE_VAN_MIJ,
+  responseVanCollega: RESPONSE_VAN_COLLEGA,
+  responseZonderEigenaar: RESPONSE_ZONDER_EIGENAAR,
+  adminB,
+} = TEST_IDS['werkvoorraad-contractmanager'];
+
+const SUBJECT_MANAGER = `oid-wv-m-${Date.now()}`;
+const SUBJECT_COLLEGA = `oid-wv-c-${Date.now()}`;
+const SUBJECT_B = `oid-wv-b-${Date.now()}`;
+
+/**
+ * 64 hex-tekens. Het herhaalde teken moet uniek zijn over ALLE suites heen:
+ * survey_response_token_hash_key kent geen tenant_id. Bezet waren 0 t/m 6.
+ */
+const HASH_VAN_MIJ = `${'7'.repeat(48)}7a11e70000000001`;
+const HASH_VAN_COLLEGA = `${'7'.repeat(48)}7a11e70000000002`;
+const HASH_ZONDER = `${'7'.repeat(48)}7a11e70000000003`;
+
+interface WerkvoorraadBody {
+  scope: string;
+  werkvoorraad: Array<{
+    responseId: string;
+    vendorId: string | null;
+    vendorNaam: string | null;
+    eigenaarUserId: string | null;
+    eigenaarNaam: string | null;
+    status: string;
+    laatsteOordeel: string | null;
+    aantalOordelen: number;
+    aantalNotities: number;
+  }>;
+}
+
+async function verwijderTestdata(client: Client) {
+  for (const tenant of [tenantA, tenantB]) {
+    await client.query('BEGIN');
+    await client.query(`SET LOCAL app.current_tenant_id = '${tenant}'`);
+    await client.query(`SET LOCAL app.current_actor = 'medewerker'`);
+    for (const tabel of [
+      'clm.response_note',
+      'clm.survey_review',
+      'clm.survey_answer',
+      'clm.survey_response',
+      'clm.survey_run',
+      'clm.survey_question',
+      'clm.survey_template',
+      'clm.vendor',
+      'clm.tenant_membership',
+      'clm."user"',
+      'clm.tenant',
+    ]) {
+      await client.query(`DELETE FROM ${tabel} WHERE tenant_id = $1`, [tenant]);
+    }
+    await client.query('COMMIT');
+  }
+}
+
+describe('Werkvoorraad contractmanager (e2e)', () => {
+  let app: INestApplication<App>;
+  let server: App;
+  let client: Client;
+  let cookieManager: string;
+  let cookieB: string;
+
+  beforeAll(async () => {
+    client = new Client({ connectionString: process.env.DATABASE_URL });
+    await client.connect();
+    await verwijderTestdata(client);
+
+    await client.query('BEGIN');
+    await client.query(`SET LOCAL app.current_tenant_id = '${tenantA}'`);
+    await client.query(`SET LOCAL app.current_actor = 'medewerker'`);
+
+    await client.query(
+      'INSERT INTO clm.tenant (tenant_id, name) VALUES ($1, $2)',
+      [tenantA, 'Tenant A (werkvoorraad)'],
+    );
+    for (const [userId, subject, naam] of [
+      [MANAGER_A, SUBJECT_MANAGER, 'Manager van A'],
+      [COLLEGA_A, SUBJECT_COLLEGA, 'Collega van A'],
+    ] as const) {
+      await client.query(
+        `INSERT INTO clm."user" (user_id, tenant_id, email, full_name, external_subject)
+         VALUES ($1, $2, $3, $4, $5)`,
+        [userId, tenantA, `${subject}@voorbeeld.nl`, naam, subject],
+      );
+      await client.query(
+        `INSERT INTO clm.tenant_membership (user_id, tenant_id, role)
+         VALUES ($1, $2, 'admin')`,
+        [userId, tenantA],
+      );
+    }
+
+    await client.query(
+      `INSERT INTO clm.survey_template (template_id, tenant_id, name, version)
+       VALUES ($1, $2, 'werkvoorraad-test-lijst', 1)`,
+      [TEMPLATE_A, tenantA],
+    );
+    // closes_at in de toekomst: anders zou 'te_laat' de statustests
+    // onvoorspelbaar maken. De 'te_laat'-tak wordt in de unittests gedekt.
+    await client.query(
+      `INSERT INTO clm.survey_run
+         (run_id, tenant_id, template_id, status, survey_kind, is_test,
+          started_at, closes_at)
+       VALUES ($1, $2, $3, 'active', 'vendor_compliance', true, now(),
+               now() + interval '30 days')`,
+      [RUN_A, tenantA, TEMPLATE_A],
+    );
+
+    // Drie vendors: van mij, van een collega, en één zonder contractmanager.
+    for (const [vendorId, naam, eigenaar] of [
+      [VENDOR_VAN_MIJ, 'Leverancier van mij', MANAGER_A],
+      [VENDOR_VAN_COLLEGA, 'Leverancier van collega', COLLEGA_A],
+      [VENDOR_ZONDER_EIGENAAR, 'Leverancier zonder beheerder', null],
+    ] as const) {
+      await client.query(
+        `INSERT INTO clm.vendor (vendor_id, tenant_id, name, owner_user_id)
+         VALUES ($1, $2, $3, $4)`,
+        [vendorId, tenantA, naam, eigenaar],
+      );
+    }
+
+    // Eén ingediende respons en twee die nog openstaan. Dat de contractmanager
+    // óók de openstaande ziet is het verschil met de beoordeelstapel.
+    await client.query(
+      `INSERT INTO clm.survey_response
+         (response_id, tenant_id, run_id, vendor_id, subject_vendor_id,
+          token_hash, status, expires_at, submitted_at)
+       VALUES ($1, $2, $3, $4, $4, $5, 'submitted',
+               now() + interval '30 days', now())`,
+      [RESPONSE_VAN_MIJ, tenantA, RUN_A, VENDOR_VAN_MIJ, HASH_VAN_MIJ],
+    );
+    for (const [responseId, vendorId, hash] of [
+      [RESPONSE_VAN_COLLEGA, VENDOR_VAN_COLLEGA, HASH_VAN_COLLEGA],
+      [RESPONSE_ZONDER_EIGENAAR, VENDOR_ZONDER_EIGENAAR, HASH_ZONDER],
+    ] as const) {
+      await client.query(
+        `INSERT INTO clm.survey_response
+           (response_id, tenant_id, run_id, vendor_id, subject_vendor_id,
+            token_hash, status, expires_at)
+         VALUES ($1, $2, $3, $4, $4, $5, 'pending', now() + interval '30 days')`,
+        [responseId, tenantA, RUN_A, vendorId, hash],
+      );
+    }
+    await client.query('COMMIT');
+
+    await client.query('BEGIN');
+    await client.query(`SET LOCAL app.current_tenant_id = '${tenantB}'`);
+    await client.query(`SET LOCAL app.current_actor = 'medewerker'`);
+    await client.query(
+      'INSERT INTO clm.tenant (tenant_id, name) VALUES ($1, $2)',
+      [tenantB, 'Tenant B (werkvoorraad)'],
+    );
+    await client.query(
+      `INSERT INTO clm."user" (user_id, tenant_id, email, full_name, external_subject)
+       VALUES ($1, $2, $3, 'Admin van B', $4)`,
+      [adminB, tenantB, `${SUBJECT_B}@voorbeeld.nl`, SUBJECT_B],
+    );
+    await client.query(
+      `INSERT INTO clm.tenant_membership (user_id, tenant_id, role)
+       VALUES ($1, $2, 'admin')`,
+      [adminB, tenantB],
+    );
+    await client.query('COMMIT');
+
+    const moduleRef = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleRef.createNestApplication();
+    app.use(cookieParser());
+    await app.init();
+    server = app.getHttpServer();
+
+    const sessies = app.get(SessieService);
+    const naam = cookieInstellingen().naam;
+    for (const [subject, doel] of [
+      [SUBJECT_MANAGER, 'm'],
+      [SUBJECT_B, 'b'],
+    ] as const) {
+      const sessie = await sessies.aanmaken(subject);
+      expect(sessie).not.toBeNull();
+
+      const cookie = `${naam}=${sessie!.token}`;
+      if (doel === 'm') cookieManager = cookie;
+      else cookieB = cookie;
+    }
+  }, 30000);
+
+  afterAll(async () => {
+    await app.close();
+    await verwijderTestdata(client);
+    await client.end();
+  }, 30000);
+
+  async function haal(scope?: string): Promise<WerkvoorraadBody> {
+    const pad = scope
+      ? `/admin/survey/mijn-vendors?scope=${scope}`
+      : '/admin/survey/mijn-vendors';
+
+    const antwoord = await request(server)
+      .get(pad)
+      .set('Cookie', cookieManager)
+      .expect(200);
+
+    return antwoord.body as WerkvoorraadBody;
+  }
+
+  describe('van mij', () => {
+    it('toont alleen vendors die ik beheer', async () => {
+      const { werkvoorraad, scope } = await haal();
+
+      expect(scope).toBe('mij');
+
+      const ids = werkvoorraad.map((w) => w.responseId);
+      expect(ids).toContain(RESPONSE_VAN_MIJ);
+      // Dit is de kern: zou dit falen, dan is de lijst betekenisloos.
+      expect(ids).not.toContain(RESPONSE_VAN_COLLEGA);
+      expect(ids).not.toContain(RESPONSE_ZONDER_EIGENAAR);
+    });
+
+    it('noemt de contractmanager bij naam', async () => {
+      const { werkvoorraad } = await haal();
+      const mijne = werkvoorraad.find((w) => w.responseId === RESPONSE_VAN_MIJ);
+
+      expect(mijne?.eigenaarUserId).toBe(MANAGER_A);
+      expect(mijne?.eigenaarNaam).toBe('Manager van A');
+      expect(mijne?.vendorNaam).toBe('Leverancier van mij');
+    });
+  });
+
+  describe('hele organisatie', () => {
+    it('toont ook de vendors van een collega', async () => {
+      const { werkvoorraad, scope } = await haal('organisatie');
+
+      expect(scope).toBe('organisatie');
+
+      const ids = werkvoorraad.map((w) => w.responseId);
+      expect(ids).toContain(RESPONSE_VAN_MIJ);
+      expect(ids).toContain(RESPONSE_VAN_COLLEGA);
+    });
+
+    // Een vendor zonder contractmanager is degene waar niemand naar omkijkt.
+    // Verdwijnt hij ook uit het organisatiebrede overzicht, dan is hij
+    // onzichtbaar geworden — precies het tegenovergestelde van een centrale
+    // waarheid.
+    it('toont een vendor zonder contractmanager', async () => {
+      const { werkvoorraad } = await haal('organisatie');
+      const wees = werkvoorraad.find(
+        (w) => w.responseId === RESPONSE_ZONDER_EIGENAAR,
+      );
+
+      expect(wees).toBeDefined();
+      expect(wees?.eigenaarUserId).toBeNull();
+      expect(wees?.eigenaarNaam).toBeNull();
+      expect(wees?.vendorNaam).toBe('Leverancier zonder beheerder');
+    });
+
+    it('valt terug op "van mij" bij een onbekende scope', async () => {
+      const { werkvoorraad, scope } = await haal('onzin');
+
+      expect(scope).toBe('mij');
+      expect(werkvoorraad.map((w) => w.responseId)).not.toContain(
+        RESPONSE_VAN_COLLEGA,
+      );
+    });
+  });
+
+  describe('de status komt uit respons-status.ts', () => {
+    it('toont een openstaande respons als opgestuurd', async () => {
+      const { werkvoorraad } = await haal('organisatie');
+      const open = werkvoorraad.find(
+        (w) => w.responseId === RESPONSE_VAN_COLLEGA,
+      );
+
+      expect(open?.status).toBe('opgestuurd');
+    });
+
+    it('toont een ingediende respons zonder oordeel als terug', async () => {
+      const { werkvoorraad } = await haal();
+      const mijne = werkvoorraad.find((w) => w.responseId === RESPONSE_VAN_MIJ);
+
+      expect(mijne?.status).toBe('terug');
+      expect(mijne?.aantalOordelen).toBe(0);
+    });
+
+    it('verschuift naar beoordeeld en dan naar goedgekeurd', async () => {
+      await request(server)
+        .post(`/admin/survey/responses/${RESPONSE_VAN_MIJ}/reviews`)
+        .set('Cookie', cookieManager)
+        .send({ verdict: 'goed', toelichting: 'Compleet.' })
+        .expect(201);
+
+      let mijne = (await haal()).werkvoorraad.find(
+        (w) => w.responseId === RESPONSE_VAN_MIJ,
+      );
+      expect(mijne?.status).toBe('beoordeeld');
+      expect(mijne?.laatsteOordeel).toBe('goed');
+
+      await request(server)
+        .post(`/admin/survey/responses/${RESPONSE_VAN_MIJ}/reviews`)
+        .set('Cookie', cookieManager)
+        .send({ verdict: 'goedgekeurd' })
+        .expect(201);
+
+      mijne = (await haal()).werkvoorraad.find(
+        (w) => w.responseId === RESPONSE_VAN_MIJ,
+      );
+      expect(mijne?.status).toBe('goedgekeurd');
+      // Het meningsverschil moet zichtbaar blijven: twee oordelen, niet één.
+      expect(mijne?.aantalOordelen).toBe(2);
+    });
+
+    // Besluit eigenaar 2026-08-07: het laatste oordeel telt, ook als dat een
+    // goedkeuring ongedaan maakt. Een goedkeuring die blijft staan terwijl er
+    // een afwijzing onder hangt is niet herstelbaar zonder dat iemand het merkt.
+    it('valt terug op beoordeeld als er na goedkeuring een afwijzing komt', async () => {
+      await request(server)
+        .post(`/admin/survey/responses/${RESPONSE_VAN_MIJ}/reviews`)
+        .set('Cookie', cookieManager)
+        .send({ verdict: 'niet_goed', toelichting: 'Toch een probleem.' })
+        .expect(201);
+
+      const mijne = (await haal()).werkvoorraad.find(
+        (w) => w.responseId === RESPONSE_VAN_MIJ,
+      );
+
+      expect(mijne?.status).toBe('beoordeeld');
+      expect(mijne?.laatsteOordeel).toBe('niet_goed');
+    });
+
+    it('telt de notities mee', async () => {
+      await request(server)
+        .post(`/admin/survey/responses/${RESPONSE_VAN_MIJ}/notes`)
+        .set('Cookie', cookieManager)
+        .send({ tekst: 'Gebeld, komt volgende week.' })
+        .expect(201);
+
+      const mijne = (await haal()).werkvoorraad.find(
+        (w) => w.responseId === RESPONSE_VAN_MIJ,
+      );
+
+      expect(mijne?.aantalNotities).toBe(1);
+    });
+  });
+
+  describe('de tenantgrens', () => {
+    it('toont tenant B niets van tenant A', async () => {
+      const antwoord = await request(server)
+        .get('/admin/survey/mijn-vendors?scope=organisatie')
+        .set('Cookie', cookieB)
+        .expect(200);
+
+      const { werkvoorraad } = antwoord.body as WerkvoorraadBody;
+      const ids = werkvoorraad.map((w) => w.responseId);
+
+      expect(ids).not.toContain(RESPONSE_VAN_MIJ);
+      expect(ids).not.toContain(RESPONSE_VAN_COLLEGA);
+    });
+  });
+});


### PR DESCRIPTION
Derde en laatste backendstap van de statusketen uit `docs/superpowers/plans/2026-08-07-statuswaarheid-per-vendor.md` (§4.1, B4). Hierna volgen de schermen.

## Wat erbij komt

```
GET /admin/survey/mijn-vendors
GET /admin/survey/mijn-vendors?scope=organisatie
```

De tegenhanger van `mijn-beoordelingen`. Deze route gebruikt **`vendor.owner_user_id`** — een kolom die in het schema stond maar door geen enkele route werd aangeroepen (geverifieerd: twee treffers in de hele `src/`, beide in het schema zelf).

## Twee lijsten, geen filter op één lijst

ADR-013: *"wat wacht er op mij"* betekent voor de twee rollen iets wezenlijk anders. De CISO wil niet zien wie er nog moet invullen — daar gaat hij niet over. De contractmanager wil niet de beoordeelstapel van de hele organisatie.

Concreet verschil: **deze lijst bevat óók responses die nog niet zijn ingediend.** Dat is precies wat een contractmanager wil weten — wie moet er nog invullen, en wie is te laat. De beoordeelstapel toont die juist niet, want daar valt niets te beoordelen.

## De schakelaar is geen grens

`?scope=organisatie` toont alles binnen de tenant. Dat is ADR-013 besluit 3: de koppeling stuurt wat je standaard ziet, niet wat je mag. Zonder die uitweg ligt het proces stil zodra een contractmanager op vakantie is, en dan wijzigt iemand met databasetoegang de eigenaar — een noodgreep buiten de app om, zonder spoor.

`ContractmanagerService` kent daarom **geen enkele methode die iets weigert**, en dat staat er als waarschuwing bij voor wie er later iets bouwt.

## Een vendor zonder contractmanager blijft zichtbaar

`owner_user_id` is nullable met `ON DELETE set null`: na het vertrek van een collega ontstaat die situatie vanzelf. Zo'n vendor is juist degene waar niemand naar omkijkt — verdwijnt hij ook uit het organisatiebrede overzicht, dan is hij onzichtbaar geworden. Precies het tegenovergestelde van een centrale waarheid.

Er staat een eigen test op, met een vendor die bewust geen eigenaar heeft.

## De status komt uit één plek

De query berekent de status niet zelf met een `CASE`, maar geeft de feiten door aan `bepaalStatus()` uit `src/survey/respons-status.ts` — dezelfde functie die de 17 unittests toetsen.

Zou deze query zijn eigen versie hebben, dan zijn er binnen een sprint twee waarheden over wanneer iets "beoordeeld" is. Dat is exact wat de eigenaar met "centrale waarheid" wilde vermijden.

Meegeleverd per regel: `aantalOordelen` en `aantalNotities`. Het eerste omdat bij tegenstrijdige oordelen het laatste telt voor de status, maar dan wél zichtbaar moet blijven dát er meer zijn (V3).

## Twee tegenproeven

| Sabotage | Uitkomst |
|---|---|
| eigenaarsfilter altijd waar (`OR true`) | **precies** de twee "van mij"-tests vielen om |
| `laatsteOordeel` hardcoded op `null` | **precies** de twee statustests vielen om |

Beide teruggedraaid, daarna weer 11/11 groen.

## Het runbook bewees zichzelf

Dit is de eerste suite die is geschreven met §"Een nieuwe e2e-suite schrijven" erbij (toegevoegd in #101). Twee dingen die het opleverde:

- **Het herhaalde teken voor `token_hash`**: 0 t/m 6 bleken bezet, dus deze suite claimt `7`. Zonder die controle was dit de derde botsing geweest.
- **De test-id's gingen alsnog mis**, en dat is goed nieuws: mijn eerste keuze (`ac`, `b1`, `b2`) botste, en de bewakingstest ving het meteen — vóór de e2e-run, in een seconde. Opgelost door naar `10`–`1c` te gaan; onder `0x20` is nog alles vrij.

De volledige e2e-run daarna: 27 suites in één keer groen, geen `duplicate key`.

## Getoetst

- **391 e2e-tests groen** (was 380), 27 suites — 11 nieuwe
- 307 unittests, lint / format / typecheck schoon
- **`npm run verify:volledig`: GROEN — de hele keten, van code tot browser**

> De doorloop meldt dat de productiedatabase achterloopt. Verwacht: 0017 en 0018 gaan pas mee bij uitrol.

## Hierna

De backend van de statusketen is hiermee compleet. Wat rest zijn de schermen, te beginnen met het **statusoverzicht per vendor** — het eerste moment waarop de eigenaar zelf kan klikken.
