### PR TITLE
fix(db): elke database is beschermd tot hij zich als wegwerp meldt (migratie 0019)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,6 +115,16 @@ jobs:
       - name: Migraties toepassen (via clm_migrator)
         run: npm run migrate:deploy
 
+      # De e2e-suites weigeren te draaien tegen een database die niet als
+      # wegwerp is gemarkeerd (migratie 0019, test/jest-e2e.setup.ts). Deze
+      # service-container leeft één job lang, dus dat is hij per definitie.
+      #
+      # Zonder deze stap loopt de RLS-isolatietest hierna vast met de melding
+      # dat de database beschermd is — de guard werkt dan, alleen tegen de
+      # verkeerde database.
+      - name: Database markeren als wegwerp
+        run: node scripts/markeer-wegwerp.js "CI — service-container"
+
       # Poort tegen een tenantgebonden tabel zonder RLS. drizzle-kit genereert
       # geen RLS (ADR-010), dus een nieuwe tabel met tenant_id krijgt niet
       # automatisch een policy. De verwachting komt uit src/db/schema.ts, niet

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,6 +35,13 @@ wegwerpcontainer op (`-p 127.0.0.1:55440:5432`, niet `0.0.0.0`) en overschrijf
 `MIGRATION_DATABASE_URL` / `DATABASE_URL` binnen het commando. Nooit `.env`
 aanpassen.
 
+**1b. Elke database is `beschermd` tot hij zich als wegwerp meldt.**
+Sinds migratie 0019 staat dat in `clm.omgeving`, en de e2e-suites weigeren te
+draaien tegen alles wat niet `wegwerp` is. Na het opzetten van je eigen
+container: `node scripts/markeer-wegwerp.js "waarvoor"`. **Markeer nooit de
+demo (poort 55450) of Supabase.** Aanleiding: op 2026-08-07 wisten de e2e-tests
+de demo-database leeg omdat `DATABASE_URL` naar 55450 wees.
+
 **2. Verzin nooit een commando.**
 Staat het niet in `package.json`, dan bestaat het niet:
 ```powershell

--- a/docs/runbooks/commandos-en-omgeving.md
+++ b/docs/runbooks/commandos-en-omgeving.md
@@ -66,6 +66,24 @@ hoort een beheerhandeling te zijn, geen iets wat de applicatie kan.
 `verify:volledig` en CI markeren hun eigen container automatisch — daar hoef je
 niets voor te doen.
 
+### Waar de controle overal geldt
+
+| Wat | Controle |
+|---|---|
+| e2e-suites (alle 27) | Weigeren te starten tegen `beschermd` |
+| `seed:demo -- --verwijder` | Weigert op `beschermd` |
+| `migrate:deploy` | Alleen de hostcontrole — migreren mág op productie |
+| `seed:vragenlijsten`, `seed:demo` (zonder `--verwijder`) | Alleen de hostcontrole — toevoegen mag |
+
+**Toevoegen mag op een beschermde database, verwijderen niet.** Dat onderscheid
+is opzet: anders kun je een demo-tenant in productie nooit inrichten. De eis
+geldt waar iets onherstelbaar is.
+
+`otap-doorloop.js` en `provider-migratietest.js` verwijderen ook, maar hebben de
+controle niet nodig: de eerste praat naar een vast adres binnen zijn eigen
+container, de tweede werkt in een eigen wegwerpschema dat hij zelf aanmaakt en
+weggooit.
+
 ---
 
 ## ⚠ Het belangrijkste: `.env` wijst naar Supabase

--- a/docs/runbooks/commandos-en-omgeving.md
+++ b/docs/runbooks/commandos-en-omgeving.md
@@ -31,6 +31,43 @@ Verzin nooit een commando. Staat het hier niet, dan bestaat het niet — kijk in
 
 ---
 
+## Twee soorten database, en de database zegt zelf welke
+
+Sinds migratie 0019 draagt elke database een markering in `clm.omgeving`:
+
+| Soort | Wat het betekent |
+|---|---|
+| `beschermd` | Met rust laten. Productie, de demo, of die van een collega. **Dit is de standaard.** |
+| `wegwerp` | Mag leeggegooid worden. Een container die je zelf opzet en weer weggooit. |
+
+**De e2e-suites weigeren te draaien tegen een beschermde database.** Ze maken
+tenants aan en voeren `DELETE` uit; dat is op alles behalve wegwerp
+gegevensverlies.
+
+**Waarom `beschermd` de standaard is:** een database die vergeet zich te
+benoemen wordt behandeld als productie. Andersom zou precies de database die
+niemand heeft ingericht — de nieuwe, de vergetene — vogelvrij zijn.
+
+**Aanleiding.** Op 2026-08-07 draaiden de e2e-suites tegen de demo-database
+(poort 55450 in plaats van 55440). De demo-tenant verdween, 400
+testleveranciers bleven achter. Er sloeg niets aan: de bestaande bescherming
+kijkt alleen of de host lokaal is, en binnen `localhost` was de demo niet te
+onderscheiden van een wegwerpcontainer.
+
+Een eigen wegwerpdatabase markeren, ná het draaien van de migraties:
+```powershell
+$env:MIGRATION_DATABASE_URL="postgresql://clm_migrator:pw@localhost:55440/postgres"
+node scripts/markeer-wegwerp.js "korte omschrijving"
+```
+
+Markeren gaat via `clm_migrator`, niet via de runtime-rol: een database omkatten
+hoort een beheerhandeling te zijn, geen iets wat de applicatie kan.
+
+`verify:volledig` en CI markeren hun eigen container automatisch — daar hoef je
+niets voor te doen.
+
+---
+
 ## ⚠ Het belangrijkste: `.env` wijst naar Supabase
 
 ```
@@ -217,6 +254,22 @@ MIGRATION_DATABASE_URL="postgresql://clm_migrator:pw@localhost:55440/postgres" n
 
 **Controleer de melding die het script afdrukt.** Hij noemt het doelwit. Staat
 daar `supabase.com`, dan is de variabele niet doorgekomen — stop.
+
+### Markeren als wegwerp (verplicht vóór de e2e-tests)
+
+```powershell
+node scripts/markeer-wegwerp.js "wegwerp voor <waar je aan werkt>"
+```
+
+Zonder deze stap weigeren de e2e-suites te draaien: elke database komt uit
+migratie 0019 als `beschermd`. Dat is opzet — zie de sectie bovenaan.
+
+De melding die je krijgt als je het vergeet noemt het doelwit, de status en dit
+commando, dus je kunt hem niet mislezen.
+
+> **Markeer nooit de demo-database (55450) of iets op Supabase als wegwerp.**
+> Het script weigert een niet-lokale host zonder `--extern`, maar tegen de demo
+> op localhost is er geen technische rem — alleen deze regel.
 
 Zie je twijfel over wat er nu gezet staat:
 ```powershell
@@ -412,6 +465,12 @@ npx jest --config test/jest-e2e.json <naam> --forceExit
 # 3. ALLE suites samen — dit is de stap die botsingen vindt
 npx jest --config test/jest-e2e.json --forceExit
 ```
+
+Krijg je bij stap 2 of 3 **"E2E GESTOPT — deze database is geen
+wegwerpdatabase"**, dan wijst `DATABASE_URL` naar iets dat met rust gelaten
+moet worden. Kijk naar het doelwit in die melding vóór je iets anders doet:
+staat daar poort 55450, dan is dat de demo, en dan moet je `DATABASE_URL`
+corrigeren — niet de demo markeren.
 
 **Stap 3 is niet optioneel.** Stap 2 groen zegt niets over botsingen; dat is
 precies wat het op 2026-08-07 twee runs lang verborg.

--- a/drizzle/0019_omgevingsmarkering.sql
+++ b/drizzle/0019_omgevingsmarkering.sql
@@ -1,0 +1,107 @@
+-- =============================================================================
+-- clm.omgeving — wat is dit voor database?
+--
+-- Aanleiding: op 2026-08-07 draaiden de e2e-tests tegen de demo-database. Ze
+-- maakten hun testtenants aan en ruimden op; de demo-tenant verdween, 400
+-- testleveranciers bleven achter. Geen enkele bescherming sloeg aan.
+--
+-- ── Waarom de bestaande bescherming dit niet ving ────────────────────────────
+--
+-- scripts/db-doelwit.js kent één criterium: is de host lokaal, ja of nee. Dat
+-- werkt voor productie (Supabase staat op aws-1-eu-west-1.pooler.supabase.com)
+-- maar binnen 'localhost' wordt niets onderscheiden. De demo op poort 55450 en
+-- een wegwerpcontainer op 55440 zijn daar identiek.
+--
+-- En die bescherming zit alleen in vier scripts. De e2e-tests hebben hem niet:
+-- test/jest-e2e.setup.ts bestond uit één regel, `import 'dotenv/config'`. Elke
+-- suite pakt DATABASE_URL en begint met DELETE FROM.
+--
+-- ── Waarom in de database en niet in een script ──────────────────────────────
+--
+-- Een poortnummer, een containernaam of een omgevingsvariabele zit náást de
+-- database: verhuist hij, dan klopt de markering niet meer. Een label op een
+-- Docker-container werkt bovendien niet voor Supabase, want daar is geen
+-- container.
+--
+-- Deze tabel reist mee met de database zelf. Een dump-en-restore neemt hem
+-- over, een verhuizing naar een andere poort verandert niets, en een kopie van
+-- productie draagt zichtbaar 'beschermd' met zich mee.
+--
+-- ── Waarom 'wegwerp' NIET de standaard is ────────────────────────────────────
+--
+-- De rij wordt bij deze migratie gezet op 'beschermd'. Dat is de veilige kant:
+-- een database die vergeet zich te benoemen, wordt behandeld als productie.
+-- Zou de standaard 'wegwerp' zijn, dan is precies de database die niemand heeft
+-- ingericht — de nieuwe, de vergeten, de per ongeluk aangemaakte — vogelvrij.
+--
+-- Een wegwerpdatabase moet zich dus expliciet als zodanig aanmelden. Dat doen
+-- scripts/verify-volledig.js en scripts/demo-omgeving.js na het opzetten.
+-- =============================================================================
+
+CREATE TABLE "clm"."omgeving" (
+	"id" boolean PRIMARY KEY DEFAULT true NOT NULL,
+	"soort" text NOT NULL,
+	"toelichting" text NOT NULL DEFAULT '',
+	"gemarkeerd_op" timestamp with time zone DEFAULT now() NOT NULL,
+	-- Eén rij, altijd. `id` is een boolean met DEFAULT true als primaire
+	-- sleutel: een tweede INSERT loopt op de sleutel stuk. Zonder deze truc kan
+	-- er een tweede rij ontstaan en is niet meer te zeggen welke geldt.
+	CONSTRAINT "omgeving_precies_een_rij_check" CHECK (id = true)
+);
+--> statement-breakpoint
+
+ALTER TABLE "clm"."omgeving"
+    ADD CONSTRAINT "omgeving_soort_check"
+    CHECK (soort IN ('wegwerp', 'beschermd'));--> statement-breakpoint
+
+-- Bewust 'beschermd': zie de kop. Een bestaande database — productie, demo,
+-- of die van een collega — komt hier als beschermd uit, en dat is de bedoeling.
+INSERT INTO "clm"."omgeving" (soort, toelichting)
+VALUES ('beschermd', 'Standaard bij migratie 0019. Een wegwerpdatabase meldt zich expliciet aan via scripts/markeer-wegwerp.js.');--> statement-breakpoint
+
+-- ── Row Level Security ──────────────────────────────────────────────────────
+--
+-- Geen tenant_id: dit gaat over de database als geheel, niet over een klant.
+-- Daarmee valt deze tabel buiten het patroon van alle andere tabellen, en dat
+-- is de reden dat hij hier expliciet wordt toegelicht in plaats van stil
+-- afwijkt.
+--
+-- Wel leesbaar voor de runtime-rol: de guard in de tests moet hem kunnen lezen
+-- zonder migratierechten. Niet schrijfbaar — een database omkatten van
+-- beschermd naar wegwerp hoort een bewuste beheerhandeling te zijn, via
+-- clm_migrator.
+
+ALTER TABLE clm.omgeving ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+ALTER TABLE clm.omgeving FORCE ROW LEVEL SECURITY;--> statement-breakpoint
+
+-- Iedereen binnen de database mag lezen. Dat moet, want de guard in de tests
+-- draait als clm_api_runtime en heeft geen migratierechten.
+CREATE POLICY omgeving_leesbaar ON clm.omgeving
+    FOR SELECT
+    USING (true);--> statement-breakpoint
+
+-- Alleen clm_migrator mag de markering wijzigen.
+--
+-- Twee lagen, en allebei nodig: het GRANT hieronder bepaalt wie het commando
+-- mag uitvoeren, deze policy welke rijen hij ziet. Met FORCE RLS geldt de
+-- policy óók voor de tabeleigenaar — zonder deze regel raakt een UPDATE als
+-- clm_migrator nul rijen en meldt het script "geen rij gevonden", een melding
+-- die naar de verkeerde oorzaak wijst. (Gemeten op 2026-08-07.)
+--
+-- De runtime-rol krijgt geen UPDATE-recht: een database omkatten van beschermd
+-- naar wegwerp hoort een bewuste beheerhandeling te zijn, niet iets wat de
+-- applicatie kan.
+CREATE POLICY omgeving_beheer ON clm.omgeving
+    FOR UPDATE
+    TO clm_migrator
+    USING (true)
+    WITH CHECK (true);--> statement-breakpoint
+
+COMMENT ON TABLE clm.omgeving IS
+    'Wat voor database is dit: wegwerp of beschermd. Eén rij. Gelezen door test/jest-e2e.setup.ts, die weigert te draaien tegen een beschermde database. Standaard beschermd — een database die zich niet meldt, wordt als productie behandeld.';--> statement-breakpoint
+
+GRANT SELECT ON clm.omgeving TO clm_api_runtime;--> statement-breakpoint
+
+-- clm_migrator is eigenaar en heeft daarmee al rechten; dit maakt expliciet
+-- wat de bedoeling is en overleeft een toekomstige eigenaarswissel.
+GRANT SELECT, UPDATE ON clm.omgeving TO clm_migrator;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -134,6 +134,13 @@
       "when": 1786449600000,
       "tag": "0018_response_note",
       "breakpoints": true
+    },
+    {
+      "idx": 19,
+      "version": "7",
+      "when": 1786464000000,
+      "tag": "0019_omgevingsmarkering",
+      "breakpoints": true
     }
   ]
 }

--- a/scripts/db-doelwit.js
+++ b/scripts/db-doelwit.js
@@ -13,6 +13,18 @@
 //
 // Dit bestand lost het eerste en tweede op. Het derde blijft: dotenv-gedrag
 // veranderen zou zijn eigen verrassingen opleveren (Issue #86, voorstel 3).
+//
+// ── Uitgebreid op 2026-08-07: de hostcontrole was niet genoeg ────────────────
+//
+// De lokaal/niet-lokaal-toets hierboven vangt Supabase af, maar binnen
+// 'localhost' onderscheidde hij niets. Daardoor wisten de e2e-suites de
+// demo-database (poort 55450) leeg terwijl een wegwerpcontainer (55440) bedoeld
+// was: allebei localhost, allebei goedgekeurd.
+//
+// `eisWegwerpdatabase()` hieronder leest daarom `clm.omgeving` (migratie 0019).
+// Die markering zit ín de database en niet in een poortnummer, containerlabel
+// of omgevingsvariabele — die zitten ernáást en kloppen niet meer zodra iets
+// verhuist.
 
 // Hosts die als "op deze machine" gelden. Alles daarbuiten is een echte
 // database die iemand anders ook gebruikt, ook als het geen productie is.
@@ -135,4 +147,93 @@ function eisToestemmingBuitenLokaal(url, { wat, vlag = '--extern' }) {
   return false;
 }
 
-module.exports = { ontleed, meldDoelwit, eisToestemmingBuitenLokaal };
+/**
+ * Weigert door te gaan tegen een database die niet als wegwerp is gemarkeerd.
+ *
+ * Voor scripts die gegevens verwijderen of overschrijven. Niet voor scripts die
+ * alleen toevoegen — daar is de hostcontrole hierboven genoeg, en zou deze eis
+ * betekenen dat je productie niet meer kunt seeden.
+ *
+ * ── Waarom dit náást eisToestemmingBuitenLokaal staat ───────────────────────
+ *
+ * Die kijkt naar de hostnaam en kent 'localhost' als veilig. Deze kijkt naar wat
+ * de database over zichzelf zegt. De demo-database is lokaal én beschermd:
+ * alleen de tweede controle houdt hem tegen.
+ *
+ * ── Waarom een ontbrekende tabel ook faalt ──────────────────────────────────
+ *
+ * Een database zonder `clm.omgeving` heeft migratie 0019 niet gehad. Dat kan
+ * een oude wegwerpcontainer zijn, maar net zo goed een kopie van productie van
+ * vóór die migratie. Doorgaan zou betekenen dat de bescherming zwijgt op
+ * precies het moment dat je hem nodig hebt.
+ *
+ * @param {string} url
+ * @param {{ wat: string, vlag?: string }} opties
+ * @returns {Promise<boolean>} false wanneer het script moet stoppen.
+ */
+async function eisWegwerpdatabase(url, { wat, vlag = '--ook-beschermd' }) {
+  const d = ontleed(url);
+
+  // Bewust hier vereist en niet bovenaan het bestand: db-doelwit.js wordt ook
+  // geladen door scripts die geen databaseverbinding maken, en die hoeven pg
+  // niet te laden.
+  const { Client } = require('pg');
+  const client = new Client({ connectionString: url });
+
+  let soort = null;
+  let reden = null;
+
+  try {
+    await client.connect();
+    const { rows } = await client.query('SELECT soort FROM clm.omgeving LIMIT 1');
+    soort = rows[0]?.soort ?? null;
+    if (!soort) reden = 'clm.omgeving is leeg';
+  } catch (err) {
+    const melding = err.message ?? String(err);
+
+    reden = /relation .*omgeving.* does not exist/i.test(melding)
+      ? 'clm.omgeving bestaat niet — migratie 0019 is niet toegepast'
+      : `verbinden mislukte: ${melding}`;
+  } finally {
+    await client.end().catch(() => {});
+  }
+
+  if (soort === 'wegwerp') return true;
+
+  // De uitweg staat ná de controle, niet ervoor: zo staat er altijd in de
+  // uitvoer wát er is overruled, ook als iemand de vlag gewoontegetrouw
+  // meegeeft.
+  const toegestaan =
+    process.argv.includes(vlag) || process.env.MCM2_OOK_BESCHERMD === 'ja';
+
+  const status = soort ? `gemarkeerd als '${soort}'` : reden;
+
+  if (toegestaan) {
+    console.log(
+      `LET OP: doelwit is ${status}, maar ${vlag} is meegegeven. Doorgaan.\n`,
+    );
+    return true;
+  }
+
+  console.error(
+    `\n${wat} GESTOPT — dit is geen wegwerpdatabase.\n\n` +
+      `  Doel:   ${d.beschrijving}\n` +
+      `  Status: ${status}\n\n` +
+      'Dit script verwijdert of overschrijft gegevens. Op een database die niet\n' +
+      'als wegwerp is gemarkeerd, is dat gegevensverlies.\n\n' +
+      'Op 2026-08-07 gebeurde dat met de demo-database: de demo-tenant verdween\n' +
+      'en er bleven 400 testleveranciers achter.\n\n' +
+      'Is dit wél een wegwerpdatabase:\n' +
+      '  node scripts/markeer-wegwerp.js "waarvoor"\n\n' +
+      `Alleen als je zeker weet wat je doet: ${vlag}\n`,
+  );
+  process.exitCode = 1;
+  return false;
+}
+
+module.exports = {
+  ontleed,
+  meldDoelwit,
+  eisToestemmingBuitenLokaal,
+  eisWegwerpdatabase,
+};

--- a/scripts/markeer-wegwerp.js
+++ b/scripts/markeer-wegwerp.js
@@ -1,0 +1,79 @@
+#!/usr/bin/env node
+// Markeert een database als wegwerp, zodat de e2e-tests er tegen mogen draaien.
+//
+// Aanleiding: op 2026-08-07 draaiden de e2e-suites tegen de demo-database en
+// wisten die leeg. Migratie 0019 zet elke database standaard op 'beschermd';
+// dit script is de enige manier om dat om te zetten.
+//
+// ── Waarom dit een apart script is en geen vlag ──────────────────────────────
+//
+// Omdat het een handeling moet zijn die je bewust doet en die je terugziet in
+// je terminalhistorie. Een omgevingsvariabele die 'wegwerp' afdwingt zou in een
+// .env belanden en daarna nooit meer opvallen — precies hoe MIGRATION_DATABASE_URL
+// stilzwijgend naar productie bleef wijzen (Issue #86).
+//
+// ── Wat het weigert ──────────────────────────────────────────────────────────
+//
+// Een niet-lokale host, tenzij --extern. Een database op Supabase als wegwerp
+// markeren is bijna altijd een vergissing, en als het dat niet is, hoort het
+// zichtbaar te zijn.
+require('dotenv').config();
+
+const { Client } = require('pg');
+
+const { meldDoelwit, eisToestemmingBuitenLokaal } = require('./db-doelwit.js');
+
+const url = process.env.MIGRATION_DATABASE_URL;
+
+if (!url) {
+  console.error(
+    'MIGRATION_DATABASE_URL ontbreekt. Markeren gaat via de clm_migrator-rol:\n' +
+      'clm_api_runtime mag clm.omgeving alleen lezen, en dat is opzet.',
+  );
+  process.exit(1);
+}
+
+meldDoelwit(url, 'Markeren als wegwerp');
+
+if (!eisToestemmingBuitenLokaal(url, { wat: 'Markeren als wegwerp' })) {
+  process.exit(1);
+}
+
+const toelichting = process.argv.slice(2).filter((a) => !a.startsWith('--'))[0];
+
+async function main() {
+  const client = new Client({ connectionString: url });
+  await client.connect();
+
+  try {
+    const { rows } = await client.query(
+      `UPDATE clm.omgeving
+          SET soort = 'wegwerp',
+              toelichting = $1,
+              gemarkeerd_op = now()
+        WHERE id = true
+      RETURNING soort, toelichting`,
+      [toelichting ?? `Gemarkeerd op ${new Date().toISOString()}`],
+    );
+
+    if (rows.length === 0) {
+      // Onbereikbaar zolang migratie 0019 is toegepast: die zet de rij neer.
+      // Toch expliciet, want een stille no-op zou "gemarkeerd" melden terwijl
+      // de tests daarna alsnog weigeren — met een melding die naar de
+      // verkeerde oorzaak wijst.
+      throw new Error(
+        'clm.omgeving heeft geen rij. Is migratie 0019 toegepast?',
+      );
+    }
+
+    console.log(`Gemarkeerd als '${rows[0].soort}'.`);
+    console.log('De e2e-tests mogen nu tegen deze database draaien.');
+  } finally {
+    await client.end();
+  }
+}
+
+main().catch((err) => {
+  console.error('Markeren mislukt:', err.message);
+  process.exit(1);
+});

--- a/scripts/seed-demo-tenant.js
+++ b/scripts/seed-demo-tenant.js
@@ -35,7 +35,11 @@ const { sql } = require('drizzle-orm');
 const { drizzle } = require('drizzle-orm/node-postgres');
 const { Pool } = require('pg');
 
-const { meldDoelwit, eisToestemmingBuitenLokaal } = require('./db-doelwit.js');
+const {
+  meldDoelwit,
+  eisToestemmingBuitenLokaal,
+  eisWegwerpdatabase,
+} = require('./db-doelwit.js');
 
 // Vast UUID, zodat het script idempotent is en `--verwijder` precies weet wat
 // het weghaalt. Bewust niet 1111.../2222..., die zijn in gebruik bij
@@ -600,6 +604,19 @@ async function main() {
   }
 
   const moetVerwijderen = process.argv.includes('--verwijder');
+
+  // Alleen bij --verwijder de wegwerpeis, en dat onderscheid is opzet.
+  //
+  // Seeden voegt toe: dat mag op een beschermde database, en moet ook — anders
+  // is een demo-tenant in productie niet in te richten. Verwijderen is
+  // onherstelbaar, en de hostcontrole hierboven kent 'localhost' als veilig
+  // terwijl juist de demo-database daar draait (2026-08-07).
+  if (
+    moetVerwijderen &&
+    !(await eisWegwerpdatabase(url, { wat: 'Opruimen demo-tenant' }))
+  ) {
+    process.exit(1);
+  }
   const pool = new Pool({ connectionString: url });
   const db = drizzle(pool);
 

--- a/scripts/verify-volledig.js
+++ b/scripts/verify-volledig.js
@@ -316,6 +316,24 @@ function startTestDatabase() {
         return { ok: false, reden: migraties.uitvoer.trim() };
       }
 
+      // Deze container is per definitie wegwerp: hij is hierboven aangemaakt
+      // en wordt in stap 6 weer weggegooid. Zonder deze markering weigeren de
+      // e2e-tests te draaien (migratie 0019, test/jest-e2e.setup.ts).
+      const markering = draai(
+        'node',
+        ['scripts/markeer-wegwerp.js', 'verify:volledig — wegwerpcontainer'],
+        {
+          stil: true,
+          env: {
+            MIGRATION_DATABASE_URL: `postgresql://clm_migrator:pw@localhost:${TESTDB_POORT}/postgres`,
+          },
+        },
+      );
+
+      if (!markering.ok) {
+        return { ok: false, reden: markering.uitvoer.trim() };
+      }
+
       return {
         ok: true,
         url: `postgresql://clm_api_runtime:pw@localhost:${TESTDB_POORT}/postgres`,

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -594,6 +594,37 @@ export const surveyReview = clm.table(
 );
 
 /**
+ * Wat voor database is dit (migratie 0019).
+ *
+ * ── De enige tabel zonder tenant_id, en dat is opzet ────────────────────────
+ *
+ * Dit gaat niet over een klant maar over de database als geheel: is hij
+ * wegwerp, of moet hij met rust gelaten worden. Eén rij, afgedwongen door een
+ * boolean als primaire sleutel.
+ *
+ * ── Waarom hier en niet in een script ───────────────────────────────────────
+ *
+ * Een poortnummer of containerlabel zit náást de database en klopt niet meer
+ * zodra iets verhuist. Dit reist mee: een dump neemt hem over, en een kopie van
+ * productie draagt zichtbaar 'beschermd' met zich mee.
+ *
+ * Gelezen door test/jest-e2e.setup.ts, die weigert te draaien tegen een
+ * beschermde database. Standaard is 'beschermd' — een database die zich niet
+ * meldt, wordt als productie behandeld.
+ */
+export const omgeving = clm.table('omgeving', {
+  // Boolean als primaire sleutel met DEFAULT true: een tweede INSERT loopt op
+  // de sleutel stuk, dus er is altijd precies één rij.
+  id: boolean('id').primaryKey().default(true),
+  // wegwerp | beschermd. CHECK in de database (migratie 0019).
+  soort: text('soort').notNull(),
+  toelichting: text('toelichting').notNull().default(''),
+  gemarkeerdOp: timestamp('gemarkeerd_op', { withTimezone: true })
+    .notNull()
+    .defaultNow(),
+});
+
+/**
  * Een notitie bij een inzending, voor collega's onderling (migratie 0018).
  *
  * ── Waarom dit geen survey_review is ────────────────────────────────────────

--- a/test/jest-e2e.guard.ts
+++ b/test/jest-e2e.guard.ts
@@ -1,0 +1,128 @@
+import { Client } from 'pg';
+
+/**
+ * Weigert de e2e-tests te draaien tegen een database die niet als wegwerp is
+ * gemarkeerd (migratie 0019).
+ *
+ * ── Waarom dit bestaat ──────────────────────────────────────────────────────
+ *
+ * Op 2026-08-07 draaiden deze suites tegen de demo-database. Ze maakten hun
+ * testtenants aan en ruimden op; de demo-tenant verdween en er bleven 400
+ * testleveranciers achter. Er sloeg niets aan, want de enige bescherming die
+ * dit project had (scripts/db-doelwit.js) kent één criterium — is de host
+ * lokaal — en zit bovendien alleen in vier scripts, niet in de tests.
+ *
+ * Binnen 'localhost' was een demo-database niet te onderscheiden van een
+ * wegwerpcontainer. Nu wel: de database zegt het zelf.
+ *
+ * ── Waarom in setupFilesAfterEnv en niet in setupFiles ──────────────────────
+ *
+ * `setupFiles` draait vóór het testframework: `beforeAll` bestaat daar nog
+ * niet. Dat leverde bij de eerste poging een `ReferenceError` op — de suite
+ * werd wel geblokkeerd, maar met een melding die niets uitlegde.
+ *
+ * ── Waarom dit hard faalt en niet waarschuwt ────────────────────────────────
+ *
+ * Een waarschuwing in een run van 27 suites leest niemand, en de schade is niet
+ * terug te draaien: als `verwijderTestdata` eenmaal heeft gelopen, is de data
+ * weg. De enige bruikbare bescherming komt vóór de schade.
+ *
+ * ── Waarom een ontbrekende tabel óók faalt ──────────────────────────────────
+ *
+ * Een database zonder `clm.omgeving` heeft migratie 0019 niet gehad. Dat kan
+ * een oude wegwerpcontainer zijn — maar net zo goed een kopie van productie van
+ * vóór die migratie. Doorgaan zou betekenen dat de bescherming zwijgt op
+ * precies het moment dat je hem nodig hebt.
+ */
+
+const UITWEG = 'MCM2_E2E_ONBESCHERMD';
+
+async function leesOmgevingssoort(url: string): Promise<{
+  soort: string | null;
+  reden: string | null;
+}> {
+  const client = new Client({ connectionString: url });
+
+  try {
+    await client.connect();
+
+    const { rows } = await client.query<{ soort: string }>(
+      'SELECT soort FROM clm.omgeving LIMIT 1',
+    );
+
+    if (rows.length === 0) {
+      return { soort: null, reden: 'clm.omgeving is leeg' };
+    }
+
+    return { soort: rows[0].soort, reden: null };
+  } catch (err) {
+    const melding = err instanceof Error ? err.message : String(err);
+
+    // Onderscheid tussen "tabel bestaat niet" en "kan niet verbinden": bij het
+    // eerste is de database te oud, bij het tweede staat hij niet aan. Die twee
+    // vragen om een ander antwoord van degene die dit leest.
+    if (/relation .*omgeving.* does not exist/i.test(melding)) {
+      return {
+        soort: null,
+        reden: 'clm.omgeving bestaat niet — migratie 0019 is niet toegepast',
+      };
+    }
+
+    return { soort: null, reden: `verbinden mislukte: ${melding}` };
+  } finally {
+    await client.end().catch(() => {
+      // Sluiten mag mislukken; het oordeel hierboven staat al vast.
+    });
+  }
+}
+
+/** Verbergt het wachtwoord, zodat de melding in een CI-log mag staan. */
+function zonderWachtwoord(url: string): string {
+  try {
+    const ontleed = new URL(url);
+    return `${ontleed.hostname}:${ontleed.port || '5432'}${ontleed.pathname}`;
+  } catch {
+    return '(onleesbare URL)';
+  }
+}
+
+beforeAll(async () => {
+  const url = process.env.DATABASE_URL;
+
+  if (!url) {
+    // Geen database: de suites die er een nodig hebben falen vanzelf met een
+    // duidelijke fout. Hier stoppen zou de read-only controles onterecht
+    // blokkeren.
+    return;
+  }
+
+  if (process.env[UITWEG] === 'ja') {
+    console.warn(
+      `\n${UITWEG}=ja — de omgevingscontrole is overgeslagen.\n` +
+        `Doelwit: ${zonderWachtwoord(url)}\n`,
+    );
+    return;
+  }
+
+  const { soort, reden } = await leesOmgevingssoort(url);
+
+  if (soort === 'wegwerp') return;
+
+  const wat = soort ? `gemarkeerd als '${soort}'` : (reden ?? 'onbekend');
+
+  throw new Error(
+    '\n\n' +
+      '  E2E GESTOPT — deze database is geen wegwerpdatabase.\n\n' +
+      `  Doelwit: ${zonderWachtwoord(url)}\n` +
+      `  Status:  ${wat}\n\n` +
+      '  Deze suites maken tenants aan en voeren DELETE uit. Op een database\n' +
+      '  die niet als wegwerp is gemarkeerd, is dat gegevensverlies.\n\n' +
+      '  Dit gebeurde op 2026-08-07 met de demo-database: de demo-tenant\n' +
+      '  verdween en er bleven 400 testleveranciers achter.\n\n' +
+      '  Een verse wegwerpdatabase opzetten:\n' +
+      '    zie docs/runbooks/commandos-en-omgeving.md\n\n' +
+      '  Is dit wel een wegwerpdatabase, markeer hem dan:\n' +
+      '    node scripts/markeer-wegwerp.js\n\n' +
+      `  Alleen als je zeker weet wat je doet: ${UITWEG}=ja\n`,
+  );
+}, 30000);

--- a/test/jest-e2e.json
+++ b/test/jest-e2e.json
@@ -4,6 +4,7 @@
   "testEnvironment": "node",
   "testRegex": ".e2e-spec.ts$",
   "setupFiles": ["<rootDir>/jest-e2e.setup.ts"],
+  "setupFilesAfterEnv": ["<rootDir>/jest-e2e.guard.ts"],
   "transform": {
     "^.+\\.(t|j)s$": "ts-jest"
   },

--- a/test/jest-e2e.setup.ts
+++ b/test/jest-e2e.setup.ts
@@ -1,1 +1,10 @@
 import 'dotenv/config';
+
+// De omgevingscontrole staat bewust NIET hier maar in jest-e2e.guard.ts.
+//
+// `setupFiles` draait vóór het testframework is geladen: `beforeAll` bestaat
+// hier nog niet. Dit bestand doet daarom alleen wat het altijd deed —
+// omgevingsvariabelen inlezen — en de guard hangt in `setupFilesAfterEnv`.
+//
+// Die volgorde is geen detail: dotenv moet vóór de guard draaien, anders leest
+// die een lege DATABASE_URL en slaat hij zichzelf over.

--- a/test/omgevingsmarkering.spec.ts
+++ b/test/omgevingsmarkering.spec.ts
@@ -75,6 +75,23 @@ describe('omgevingsmarkering: de guard staat aan', () => {
     expect(migratie).toMatch(/INSERT INTO "clm"\."omgeving"[\s\S]*'beschermd'/);
   });
 
+  it('eist een wegwerpdatabase voordat de demo-seed opruimt', () => {
+    const seed = lees('scripts/seed-demo-tenant.js');
+
+    // 13 DELETE-statements. De hostcontrole kent 'localhost' als veilig, en
+    // juist daar draait de demo-database.
+    expect(seed).toContain('eisWegwerpdatabase');
+  });
+
+  it('biedt eisWegwerpdatabase aan vanuit db-doelwit', () => {
+    const doelwit = lees('scripts/db-doelwit.js');
+
+    // Eén plek waar de controle staat: elk schrijvend script hoort dezelfde
+    // te gebruiken, niet zijn eigen variant.
+    expect(doelwit).toContain('async function eisWegwerpdatabase');
+    expect(doelwit).toMatch(/module\.exports[\s\S]*eisWegwerpdatabase/);
+  });
+
   it('staat de migratie in het journal', () => {
     const journal = JSON.parse(lees('drizzle/meta/_journal.json')) as {
       entries: { tag: string }[];

--- a/test/omgevingsmarkering.spec.ts
+++ b/test/omgevingsmarkering.spec.ts
@@ -1,0 +1,89 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+/**
+ * Bewaakt dat de omgevingsguard aan blijft staan.
+ *
+ * Een unittest, geen e2e: hij leest bestanden en heeft geen database nodig.
+ * Dat is met opzet — een guard die alleen door een e2e-test bewaakt wordt, is
+ * uitgeschakeld op precies het moment dat die e2e-test niet draait.
+ *
+ * ── Waarom dit bestaat ──────────────────────────────────────────────────────
+ *
+ * Op 2026-08-07 wisten de e2e-suites de demo-database leeg. De guard die dat
+ * voortaan voorkomt hangt aan drie dingen: het bestand zelf, de registratie in
+ * jest-e2e.json, en de markeerstap in verify-volledig.js. Valt er één weg, dan
+ * is de bescherming stil verdwenen — en dat merk je pas als er weer data weg
+ * is.
+ */
+
+const WORTEL = join(__dirname, '..');
+
+function lees(pad: string): string {
+  return readFileSync(join(WORTEL, pad), 'utf8');
+}
+
+describe('omgevingsmarkering: de guard staat aan', () => {
+  it('registreert de guard in de e2e-configuratie', () => {
+    const config = JSON.parse(lees('test/jest-e2e.json')) as {
+      setupFilesAfterEnv?: string[];
+    };
+
+    // setupFilesAfterEnv en niet setupFiles: het laatste draait vóór het
+    // testframework, en dan bestaat `beforeAll` nog niet.
+    expect(config.setupFilesAfterEnv).toContain('<rootDir>/jest-e2e.guard.ts');
+  });
+
+  it('laat de guard hard falen in plaats van waarschuwen', () => {
+    const guard = lees('test/jest-e2e.guard.ts');
+
+    // Een waarschuwing in een run van 27 suites leest niemand, en de schade is
+    // niet terug te draaien.
+    expect(guard).toContain('throw new Error');
+    expect(guard).toContain('E2E GESTOPT');
+  });
+
+  it('accepteert alleen de soort "wegwerp"', () => {
+    const guard = lees('test/jest-e2e.guard.ts');
+
+    // De vergelijking moet op de wáárde staan, niet op het bestaan van een
+    // rij. `soort !== null` zou elke gemarkeerde database doorlaten, ook een
+    // beschermde.
+    expect(guard).toMatch(/soort === 'wegwerp'/);
+  });
+
+  it('markeert de wegwerpcontainer in verify:volledig', () => {
+    const script = lees('scripts/verify-volledig.js');
+
+    // Zonder deze stap weigert de guard de eigen doorloop, en dan wordt hij
+    // uit frustratie uitgezet in plaats van gerepareerd.
+    expect(script).toContain('markeer-wegwerp.js');
+  });
+
+  it('markeert de service-container in CI', () => {
+    const workflow = lees('.github/workflows/ci.yml');
+
+    expect(workflow).toContain('markeer-wegwerp.js');
+  });
+
+  it('zet de migratie standaard op beschermd', () => {
+    const migratie = lees('drizzle/0019_omgevingsmarkering.sql');
+
+    // De veilige kant: een database die zich niet meldt, wordt behandeld als
+    // productie. Zou hier 'wegwerp' staan, dan is elke nieuwe database
+    // vogelvrij.
+    expect(migratie).toMatch(/INSERT INTO "clm"\."omgeving"[\s\S]*'beschermd'/);
+  });
+
+  it('staat de migratie in het journal', () => {
+    const journal = JSON.parse(lees('drizzle/meta/_journal.json')) as {
+      entries: { tag: string }[];
+    };
+
+    // Drizzle leest het journal, niet de map: een .sql zonder entry wordt
+    // stilzwijgend overgeslagen terwijl migrate:deploy "voltooid" meldt.
+    expect(journal.entries.map((e) => e.tag)).toContain(
+      '0019_omgevingsmarkering',
+    );
+  });
+});


### PR DESCRIPTION
## Wat er misging

Op 2026-08-07 draaiden de e2e-suites tegen de **demo-database**. `DATABASE_URL` wees naar poort 55450 in plaats van naar een wegwerpcontainer op 55440. De suites maakten hun testtenants aan en ruimden op: de demo-tenant verdween, 400 testleveranciers bleven achter.

**Er sloeg niets aan.** Dat is het echte probleem, niet de vergissing zelf.

## Waarom de bestaande bescherming dit niet ving

`scripts/db-doelwit.js` kent één criterium: **is de host lokaal, ja of nee.** Dat werkt voor productie — Supabase staat op `aws-1-eu-west-1.pooler.supabase.com`, dus daar slaat hij aan, precies zoals bedoeld na Issue #86.

Maar binnen `localhost` wordt niets onderscheiden. De demo-database en een wegwerpcontainer zijn voor die controle identiek.

En die bescherming zat alleen in vier scripts. **De e2e-tests hadden hem niet:** `test/jest-e2e.setup.ts` bestond uit één regel — `import 'dotenv/config'`. Zeventien suites pakken `DATABASE_URL` en beginnen met `DELETE FROM`, zonder enige controle.

> Was `DATABASE_URL` naar Supabase gewezen, dan hadden ze dáár gedraaid. RLS en de `WHERE tenant_id`-clausules zouden echte klantdata beschermen, maar er waren testtenants in productie ontstaan. Dat is één vergissing verwijderd van een echte ramp.

## De maatregel: de database zegt zelf wat hij is

Migratie **0019** zet `clm.omgeving` neer — één rij, met `wegwerp` of `beschermd`.

```sql
INSERT INTO clm.omgeving (soort, ...) VALUES ('beschermd', ...);
```

**Standaard `beschermd`, en dat is de kern.** Een database die vergeet zich te benoemen wordt behandeld als productie. Zou de standaard `wegwerp` zijn, dan is precies de database die niemand heeft ingericht — de nieuwe, de vergetene, de per ongeluk aangemaakte — vogelvrij.

### Waarom in de database en niet in een script

Een poortnummer, containernaam of omgevingsvariabele zit **náást** de database: verhuist hij, dan klopt de markering niet meer. Een Docker-label werkt bovendien niet voor Supabase — daar is geen container.

Deze markering reist mee met de database zelf. Een dump-en-restore neemt hem over, een verhuizing naar een andere poort verandert niets, en een kopie van productie draagt zichtbaar `beschermd` met zich mee. **Dat blijft gelden bij een migratie naar AWS RDS** — geen enkele regel hoeft dan opnieuw bedacht te worden.

## Twee lagen, en waarom allebei

| Controle | Kijkt naar | Vangt |
|---|---|---|
| `eisToestemmingBuitenLokaal` (bestond al) | de hostnaam | Supabase, andermans machine |
| `eisWegwerpdatabase` (nieuw) | wat de database over zichzelf zegt | de demo-database, die lokaal én beschermd is |

De demo is lokaal, dus alleen de tweede houdt hem tegen.

## Waar de eis geldt

| Wat | Controle |
|---|---|
| Alle 27 e2e-suites | Weigeren te starten tegen `beschermd` |
| `seed:demo -- --verwijder` | Weigert op `beschermd` |
| `migrate:deploy` | Alleen de hostcontrole — migreren mág op productie |
| Seeden zonder `--verwijder` | Alleen de hostcontrole — toevoegen mag |

**Toevoegen mag op een beschermde database, verwijderen niet.** Dat onderscheid is opzet: zou de eis ook voor seeden gelden, dan is een demo-tenant in productie nooit in te richten. De rem zit waar iets onherstelbaar is.

Nagelopen welke scripts nog meer verwijderen: `otap-doorloop.js` praat naar een vast adres binnen zijn eigen container, `provider-migratietest.js` werkt in een eigen schema dat het zelf aanmaakt en weggooit. Geen van beide kan naar productie wijzen.

## Hard falen, geen waarschuwing

```
E2E GESTOPT — deze database is geen wegwerpdatabase.

  Doelwit: localhost:55450/postgres
  Status:  gemarkeerd als 'beschermd'

  Deze suites maken tenants aan en voeren DELETE uit. Op een database
  die niet als wegwerp is gemarkeerd, is dat gegevensverlies.
  …
  Is dit wel een wegwerpdatabase, markeer hem dan:
    node scripts/markeer-wegwerp.js
```

Een waarschuwing in een run van 27 suites leest niemand, en na `verwijderTestdata` is de data weg. De enige bruikbare bescherming komt vóór de schade.

**Een ontbrekende `clm.omgeving` faalt ook.** Die database heeft migratie 0019 niet gehad — dat kan een oude wegwerpcontainer zijn, maar net zo goed een kopie van productie van vóór die migratie. Doorgaan zou betekenen dat de bescherming zwijgt op precies het moment dat je hem nodig hebt.

## Tegenproeven

| Sabotage | Uitkomst |
|---|---|
| `DATABASE_URL` naar 55450 — **exact de fout van 07-08** | geblokkeerd; nul tests gedraaid, demo-data ongewijzigd |
| `seed:demo --verwijder` op de demo | geweigerd met dezelfde melding |
| `seed:demo --verwijder` op een verse wegwerpdatabase | gaat gewoon door |
| guard uit `jest-e2e.json` gehaald | de nieuwe bewakingstest vangt het |

De laatste is er omdat een guard die niet bewaakt wordt, uitgeschakeld raakt op het moment dat hij in de weg zit. `test/omgevingsmarkering.spec.ts` (9 tests, geen database nodig) controleert dat de guard geregistreerd staat, hard faalt, alleen `wegwerp` accepteert, en dat CI én `verify:volledig` hun eigen container markeren.

## Eén ding dat onderweg misging en het ontwerp verbeterde

De eerste versie hing in `setupFiles`. Dat draait **vóór** het testframework, dus `beforeAll` bestond daar nog niet: de suite werd wel geblokkeerd, maar met een `ReferenceError` die niets uitlegde. Nu `setupFilesAfterEnv`, met `dotenv` nog in `setupFiles` — die volgorde is geen detail, want zonder dotenv leest de guard een lege `DATABASE_URL` en slaat hij zichzelf over.

Ook bleek de RLS-policy eerst alleen `FOR SELECT`, waardoor `markeer-wegwerp.js` nul rijen raakte en meldde "clm.omgeving heeft geen rij" — een melding die naar de verkeerde oorzaak wijst. Opgelost met een `FOR UPDATE`-policy voor `clm_migrator` alleen; de runtime-rol mag lezen maar niet omkatten.

## Getoetst

- **`npm run verify:volledig`: GROEN — de hele keten, van code tot browser**
- 316 unittests (was 307), 391 e2e, 47 browsertests
- lint / format / typecheck schoon
- Tabel, RLS, policy en rechten teruggelezen uit de database

## Wat dit niet oplost

De markering beschermt tegen de tests en tegen `--verwijder`. Een handmatige `DELETE` in psql kijkt er niet naar.

En dit is een vangnet, geen vereenvoudiging: er zijn nog steeds drie soorten database die op elkaar lijken (productie, de lokale demo, wegwerpcontainers). De echte vereenvoudiging is die tussencategorie laten verdwijnen — een DEMO-tenant ín productie voor acceptatie, en lokaal alleen nog wegwerp. Dat is een aparte stap, en deze bescherming blijft daarbij nodig.
