### PR TITLE
feat(demo): seed toont elke status + documentatie bij de werkwijze van vandaag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,6 @@ report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json
 
 # Werkmap van de demo-stack (logs, PID's) — zie scripts/demo-stack.js
 .demo/
+
+# Schermafdrukken uit browsersessies — werkmateriaal, geen broncode.
+/*.png

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,7 +1,25 @@
 # MCM2 — actuele status
 
 ## Laatst bijgewerkt
-2026-08-07, ochtend (**de PR-stapel is weggewerkt en fase C is backend-compleet in `main`.** De Actions-storing van 06-08 is voorbij; alle PR's zijn met groene CI gemerged. Daarmee staat de hele beoordeelketen in `main`: antwoorden lezen, oordelen vastleggen, beoordelaars koppelen. **Er is nog geen enkel scherm** — dat is het werk dat nu volgt.)
+2026-08-07, avond (**de statusketen is backend-compleet en het eerste scherm staat er.** Vier PR's gemerged: goedkeuren (0017), notities (0018), werkvoorraad contractmanager, en een bescherming die voorkomt dat de tests een database leegmaken die niet wegwerp is (0019). Het statusoverzicht per vendor is gebouwd en met echte data bekeken. **Het responsscherm ontbreekt nog** — oordelen en notities zijn wel te tellen, niet te lezen.)
+
+> ### ⚠ Wat er op 2026-08-07 misging, en wat eraan is gedaan
+>
+> De e2e-suites draaiden tegen de **demo-database**: `DATABASE_URL` wees naar
+> poort 55450 in plaats van naar een wegwerpcontainer op 55440. De demo-tenant
+> verdween, 400 testleveranciers bleven achter. Er sloeg niets aan.
+>
+> De bestaande bescherming (`scripts/db-doelwit.js`) kent één criterium — is de
+> host lokaal — en zat bovendien alleen in vier scripts. Binnen `localhost` was
+> de demo niet te onderscheiden van een wegwerpcontainer.
+>
+> **Migratie 0019** zet `clm.omgeving` neer: elke database is `beschermd` tot
+> hij zichzelf als `wegwerp` meldt. De e2e-suites weigeren te starten tegen
+> alles wat niet wegwerp is, en `seed:demo --verwijder` ook. Zie
+> `docs/runbooks/commandos-en-omgeving.md`.
+>
+> Productie is niet geraakt: die loopt zelfs achter (0017–0019 staan er nog
+> niet op).
 
 ---
 
@@ -28,14 +46,19 @@ Alle vijf zijn gemerged, elk met een groene CI-run — de Actions-storing was vo
 
 ---
 
-**Nu aan de beurt: de frontend van fase C.** De backend is compleet en getest; er is nog geen enkel
-scherm. Drie stuks volgens het plan (§Fase C, "Frontend"):
+**Nu aan de beurt: de frontend van fase C.** De backend is compleet en getest. Van de drie
+schermen uit het plan (§Fase C, "Frontend") staat er één:
 
-1. **Voortgang per ronde** — ingediend / open / verlopen
+1. ~~**Voortgang per ronde**~~ — vervangen door het **statusoverzicht per vendor**
+   (`/beheer/status`), gebouwd 2026-08-07. Toont de vijf statussen uit
+   `docs/superpowers/plans/2026-08-07-statuswaarheid-per-vendor.md`, met de schakelaar
+   "van mij" / "hele organisatie" erin verwerkt. Daarmee dekt dit scherm ook punt 3.
 2. **Antwoorden lezen** per respons, met het beoordeelblok eronder: drie knoppen plus een
-   toelichtingsveld, en daaronder de eerdere oordelen op datum
-3. **Twee werkvoorraden**, geen twee filters op dezelfde lijst (ADR-013) — met een schakelaar
-   "van mij" / "hele organisatie"
+   toelichtingsveld, en daaronder de eerdere oordelen op datum — **ontbreekt nog, en dat is
+   het grootste gat.** Het statusoverzicht telt oordelen en notities, maar je kunt ze nergens
+   lézen: de toelichting bij een oordeel en de notities van collega's zijn onbereikbaar.
+3. **Twee werkvoorraden** (ADR-013) — de contractmanagerkant zit in het statusoverzicht;
+   `GET /admin/survey/mijn-beoordelingen` heeft nog geen eigen scherm.
 
 Twee dingen die daarbij geen detail zijn:
 - **Het huidige oordeel hoort in de voortgangslijst**, niet alleen op het detailscherm. Anders
@@ -95,10 +118,20 @@ Drie dingen daaruit die het onthouden waard zijn:
 |---|---|
 | **Een tegenproef die niets bewees.** Een heredoc at de backslashes op; sabotage nooit toegepast, 22 tests groen tegen ónveranderde code. Sabotage gaat nu via een bestand en faalt hard als het patroon ontbreekt | werkwijze |
 | `migrate:deploy` gedraaid met alleen `DATABASE_URL` gezet; het script leest `MIGRATION_DATABASE_URL` en die wees naar **productie**. Meldde "Migraties voltooid" tegen de verkeerde database. Geen schade (no-op) → **Issue #86**, opgelost in #93 | `scripts/` |
-| **`db:generate` is onbruikbaar** — snapshots lopen tot 0007 terwijl er 16 migraties zijn. Het genereerde een migratie die `sessie`, `tenant_membership` en een `user`-kolom opnieuw wilde aanmaken → **Issue #96** | `drizzle/meta/` |
+| **`db:generate` is onbruikbaar** — snapshots lopen tot 0007 terwijl er 19 migraties zijn. Het genereerde een migratie die `sessie`, `tenant_membership` en een `user`-kolom opnieuw wilde aanmaken → **Issue #96** | `drizzle/meta/` |
 | De bewakingstest op test-id's kijkt alleen naar UUID's tussen **enkele** aanhalingstekens; dezelfde waarde binnen een template-string glipt erdoor. Nog geen issue | `test/test-ids.spec.ts` |
 | Verouderde context uit een automatisch geladen skill stelde dat Bizaline naar Azure migreert; als feit overgenomen in een architectuurdocument. Bron opgespoord, vier bestanden geactualiseerd met een gedateerd "Stand per"-kopje | buiten dit project |
 | Een geldig gevormd maar niet-bestaand mailadres levert "Geslaagd" op. Geen fout, wel het bewijs dat de bounce-webhook nodig is | mailkanaal |
+
+### Wat er op 2026-08-07 boven kwam
+
+| Bevinding | Waar |
+|---|---|
+| **De e2e-suites wisten de demo-database leeg.** Geen enkele bescherming sloeg aan: de hostcontrole kent `localhost` als veilig, en de tests hadden hem sowieso niet. Opgelost met migratie 0019 (`clm.omgeving`) | `test/`, `scripts/` |
+| **Een handgeschreven migratie wordt stil overgeslagen** als hij niet in `drizzle/meta/_journal.json` staat — `migrate:deploy` meldt dan gewoon "Migraties voltooid". Gevonden doordat het plan voorschreef de constraint terug te lezen uit de database | `drizzle/` |
+| **Twee suites deelden dezelfde `token_hash`.** `survey_response_token_hash_key` is uniek over álle tenants heen, dus de tenantscheiding hielp niet. Los draaide elke suite groen; alleen in de volledige run viel er willekeurig een om. Bewakingstest toegevoegd | `test/test-ids.spec.ts` |
+| Twee tests in `demo-seed` startten een script zonder timeout en vielen terug op Jests 5s. Bij de reparatie van 2026-08-04 waren juist deze twee overgeslagen | `test/demo-seed.e2e-spec.ts` |
+| De opruimstap van `seed:demo --verwijder` kende `survey_review` en `response_note` niet, en zette geen actor `medewerker` — waardoor de policy elke rij weigerde en de fout naar een foreign key wees | `scripts/` |
 
 <details>
 <summary>Vorige stand (2026-08-04, avond)</summary>

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,7 +1,47 @@
 # MCM2 — actuele status
 
 ## Laatst bijgewerkt
-2026-08-07, avond (**de statusketen is backend-compleet en het eerste scherm staat er.** Vier PR's gemerged: goedkeuren (0017), notities (0018), werkvoorraad contractmanager, en een bescherming die voorkomt dat de tests een database leegmaken die niet wegwerp is (0019). Het statusoverzicht per vendor is gebouwd en met echte data bekeken. **Het responsscherm ontbreekt nog** — oordelen en notities zijn wel te tellen, niet te lezen.)
+2026-08-07, avond (**de statusketen werkt van database tot scherm.** Vier PR's gemerged — goedkeuren (0017), notities (0018), werkvoorraad contractmanager, en de wegwerpmarkering (0019). Beide schermen zijn gebouwd en met echte data bekeken. **Twee PR's staan open, allebei groen, en die zijn het startpunt voor morgen.**)
+
+## 🔵 MORGEN BEGINNEN: twee open PR's, in deze volgorde
+
+Allebei groen op CI, allebei wachtend op akkoord van de eigenaar.
+
+| Volgorde | PR | Repo | Wat |
+|---|---|---|---|
+| 1 | **#104** | `MCM2` | Demo-seed toont élke status, plus de documentatie van 07-08 |
+| 2 | **#8** | `MCM2-frontend` | Statusoverzicht + beoordeelscherm |
+
+> **De volgorde is niet vrijblijvend.** #104 bevat de seed die de schermen data
+> geeft. Merge je #8 eerst, dan staat het beoordeelscherm leeg bij een demo:
+> het toont alleen afwijkingen, en zonder die seed is alles bevestigd.
+
+Na het mergen:
+
+```powershell
+gh workflow run ci.yml --ref main          # in MCM2
+npm run demo -- --vers                     # verse demo met alle statussen
+```
+
+Daarna is `/beheer/status` het scherm om te bekijken.
+
+> ### ⚠ Wat er op 2026-08-07 misging, en wat eraan is gedaan
+>
+> De e2e-suites draaiden tegen de **demo-database**: `DATABASE_URL` wees naar
+> poort 55450 in plaats van naar een wegwerpcontainer op 55440. De demo-tenant
+> verdween, 400 testleveranciers bleven achter. Er sloeg niets aan.
+>
+> De bestaande bescherming (`scripts/db-doelwit.js`) kent één criterium — is de
+> host lokaal — en zat bovendien alleen in vier scripts. Binnen `localhost` was
+> de demo niet te onderscheiden van een wegwerpcontainer.
+>
+> **Migratie 0019** zet `clm.omgeving` neer: elke database is `beschermd` tot
+> hij zichzelf als `wegwerp` meldt. De e2e-suites weigeren te starten tegen
+> alles wat niet wegwerp is, en `seed:demo --verwijder` ook. Zie
+> `docs/runbooks/commandos-en-omgeving.md` en **ADR-014**.
+>
+> Productie is niet geraakt: die loopt zelfs achter (0017–0019 staan er nog
+> niet op).
 
 > ### ⚠ Wat er op 2026-08-07 misging, en wat eraan is gedaan
 >
@@ -46,26 +86,51 @@ Alle vijf zijn gemerged, elk met een groene CI-run — de Actions-storing was vo
 
 ---
 
-**Nu aan de beurt: de frontend van fase C.** De backend is compleet en getest. Van de drie
-schermen uit het plan (§Fase C, "Frontend") staat er één:
+**De frontend van fase C.** Twee van de drie schermen uit het plan (§Fase C, "Frontend")
+staan er; beide zitten in **MCM2-frontend PR #8**.
 
-1. ~~**Voortgang per ronde**~~ — vervangen door het **statusoverzicht per vendor**
-   (`/beheer/status`), gebouwd 2026-08-07. Toont de vijf statussen uit
-   `docs/superpowers/plans/2026-08-07-statuswaarheid-per-vendor.md`, met de schakelaar
-   "van mij" / "hele organisatie" erin verwerkt. Daarmee dekt dit scherm ook punt 3.
-2. **Antwoorden lezen** per respons, met het beoordeelblok eronder: drie knoppen plus een
-   toelichtingsveld, en daaronder de eerdere oordelen op datum — **ontbreekt nog, en dat is
-   het grootste gat.** Het statusoverzicht telt oordelen en notities, maar je kunt ze nergens
-   lézen: de toelichting bij een oordeel en de notities van collega's zijn onbereikbaar.
-3. **Twee werkvoorraden** (ADR-013) — de contractmanagerkant zit in het statusoverzicht;
-   `GET /admin/survey/mijn-beoordelingen` heeft nog geen eigen scherm.
+1. ~~**Voortgang per ronde**~~ → **statusoverzicht per vendor** (`/beheer/status`).
+   De vijf statussen uit `docs/superpowers/plans/2026-08-07-statuswaarheid-per-vendor.md`,
+   een samenvatting bovenaan, en de tijdlijn *uitgestuurd → terug ontvangen → sluit op*.
+   Met de schakelaar "van mij" / "hele organisatie", standaard de eigen stapel.
+2. **De inzending zelf** (`/beheer/status/[responseId]`). **Opent op de afwijkingen**, niet
+   op alle antwoorden — acht keer "Bevestigd" lezen is verspilde aandacht (besluit eigenaar
+   2026-08-07). De bevestigde vragen zitten achter een schakelaar. Notities staan boven de
+   eerdere oordelen: ze gaan meestal over de afwijking. Goedkeuren staat apart van de drie
+   oordelen.
+3. **Werkvoorraad van de beoordelaar** — **ontbreekt nog.** De contractmanagerkant zit in
+   het statusoverzicht; `GET /admin/survey/mijn-beoordelingen` bestaat maar heeft geen eigen
+   scherm. Dat is een aparte lijst en geen filter (ADR-013).
 
-Twee dingen die daarbij geen detail zijn:
-- **Het huidige oordeel hoort in de voortgangslijst**, niet alleen op het detailscherm. Anders
-  moet je zeventien schermen openen om te zien wie er nog openstaat.
-- **`nadere_vragen` leest als een openstaande actie, geen eindoordeel.** Het scherm moet zeggen
-  dat de leverancier hier niets van merkt en dat de beheerder zelf contact opneemt. Een knop die
-  suggereert dat er iets verstuurd wordt terwijl dat niet gebeurt, is erger dan geen knop.
+**Wat een "afwijking" is, is geen nieuwe definitie.** De database eist al een toelichting van
+minstens tien tekens bij alles behalve `confirmed`
+(`survey_answer_comment_required_check`, migratie 0005). Die regel bestond; hij was alleen
+nergens zichtbaar. Een onbeantwoorde verplichte vraag telt óók mee.
+
+Twee dingen die daarbij geen detail waren, en die nu gebouwd zijn:
+- ✅ **Het huidige oordeel staat in de lijst**, met "(van 2)" wanneer er meer oordelen zijn —
+  anders verdwijnt een meningsverschil uit beeld.
+- ✅ **`nadere_vragen` leest als een openstaande actie.** Onder de knoppen staat expliciet dat
+  de leverancier hier niets van merkt en dat u zelf contact opneemt.
+
+---
+
+## Wat er ná de twee open PR's ligt
+
+**Voor de eigenaar, in volgorde van wat het meest oplevert:**
+
+1. **De DEMO-tenant in productie.** Voorstel van de eigenaar (2026-08-07): een tenant náást
+   de echte klanten, waar hij zelf admin is, om ná uitrol te toetsen. Dat maakt de lokale
+   demo als tussencategorie overbodig — en die tussencategorie is waar het vandaag misging.
+   De seed kan het al (`--echte-tokens`), maar **inloggen vraagt een echte Entra-koppeling**,
+   en dat pad is nog niet volledig doorlopen. Waarschijnlijk het meeste werk van wat er ligt.
+2. **Werkvoorraad van de beoordelaar** — het derde scherm.
+3. **Hulp bij het juiste mailadres.** De backend kiest al bewust een contactpersoon *met*
+   adres (`ronde-beheer.service.ts`), maar je merkt pas bij het verzenden dat er niemand te
+   mailen is. Dat hoort in het uitnodigingsscherm zichtbaar te zijn vóór je op verzenden
+   drukt. Restrisico blijft een adres dat is ingevuld maar verkeerd → bounce-webhook.
+4. **Heads-up bij tijdsoverschrijding.** Het zichtbare deel is er ("Te laat" in het
+   overzicht); een seintje sturen hangt aan e-mail (fase D) en Issue #16.
 
 Ook nog open: het **vragenlijst-overzichtscherm** ("levert nu nauwelijks zinvolle informatie",
 eigenaar 2026-08-06).

--- a/docs/adr/ADR-009-migration-role-en-ci-database.md
+++ b/docs/adr/ADR-009-migration-role-en-ci-database.md
@@ -41,6 +41,31 @@ Twee opties zijn overwogen om deze test automatisch te laten draaien:
 - CI faalt nu zichtbaar als een toekomstige codewijziging de tenant-isolatie breekt (bijv. een per ongeluk verwijderde policy of ingetrokken grant) — dit was vóór deze ADR niet het geval.
 - `test/jest-e2e.setup.ts` (`import 'dotenv/config'`) toegevoegd aan `test/jest-e2e.json` zodat `.env` ook voor e2e-tests wordt geladen — dit ontbrak volledig, ook voor de al bestaande tests.
 
+## Bijgewerkt 2026-08-07 — twee dingen uit deze ADR zijn achterhaald
+
+De ADR zelf blijft staan zoals hij is: hij legt het besluit vast zoals het toen
+genomen werd. Twee verwijzingen kloppen inmiddels niet meer.
+
+**`prisma/roles/bootstrap-roles.sql` heet nu `db/roles/bootstrap-roles.sql`.**
+De ORM-keuze viel op Drizzle (ADR-010) en het migratiecommando is
+`npm run migrate:deploy`, niet `prisma migrate deploy`. Het script zelf en zijn
+rol als enige bron van waarheid voor de databaserollen zijn onveranderd.
+
+**`test/jest-e2e.setup.ts` doet meer dan dotenv laden.** De regel hierboven —
+"`import 'dotenv/config'` toegevoegd" — beschreef de hele inhoud van dat
+bestand. Sinds migratie 0019 hangt daarnaast `test/jest-e2e.guard.ts` in
+`setupFilesAfterEnv`: die weigert de suites te draaien tegen een database die
+niet als wegwerp is gemarkeerd.
+
+Aanleiding: op 2026-08-07 draaiden de e2e-suites tegen de demo-database en
+wisten die leeg. De bescherming uit déze ADR ving dat niet — die gaat over
+rollen en rechten binnen een database, niet over de vraag *welke* database.
+Beide zijn nodig. Zie `docs/runbooks/commandos-en-omgeving.md`.
+
+**Gevolg voor CI:** de `rls-isolation`-job heeft een extra stap gekregen die de
+service-container als wegwerp markeert. Zonder die stap blokkeert de guard zijn
+eigen tests.
+
 ## Openstaand controlepunt
 
 - De `quality`- en `rls-isolation`-jobs zijn niet verplicht gesteld via branch-protection (zie `docs/STATUS.md` — branch-protection is geblokkeerd door het GitHub-plan van de organisatie, niet door deze wijziging).

--- a/docs/adr/ADR-014-wegwerp-of-beschermde-database.md
+++ b/docs/adr/ADR-014-wegwerp-of-beschermde-database.md
@@ -1,0 +1,162 @@
+# ADR-014 — Elke database zegt zelf of hij wegwerp is
+
+- **Status:** aanvaard — gebouwd en gemerged (PR #103, migratie 0019).
+- **Datum:** 2026-08-07
+- **Aanleiding:** de e2e-suites draaiden tegen de demo-database en wisten die leeg. Geen enkele bestaande bescherming sloeg aan.
+- **Relatie:** ADR-009 (migratierol en CI-database), Issue #86, `docs/runbooks/commandos-en-omgeving.md`
+
+---
+
+## Context
+
+Op 2026-08-07 wees `DATABASE_URL` naar poort **55450** — de demo-database —
+terwijl een wegwerpcontainer op 55440 bedoeld was. De e2e-suites maakten hun
+testtenants aan en ruimden op. De demo-tenant verdween; 400 testleveranciers
+bleven achter.
+
+Er sloeg niets aan, en dat is het eigenlijke probleem.
+
+### Wat er wél was, en waarom het niet hielp
+
+`scripts/db-doelwit.js` (Issue #86) kent **één criterium: is de host lokaal.**
+Vijf hostnamen gelden als "op deze machine"; alles daarbuiten wordt geweigerd
+zonder `--extern`.
+
+Dat werkt voor productie — Supabase staat op
+`aws-1-eu-west-1.pooler.supabase.com` — maar binnen `localhost` onderscheidt
+het niets. De demo-database en een wegwerpcontainer zijn voor die controle
+identiek.
+
+En die bescherming zat **alleen in vier scripts**. De e2e-tests hadden hem
+niet: `test/jest-e2e.setup.ts` bestond uit één regel, `import 'dotenv/config'`.
+Zeventien suites lezen `DATABASE_URL` en beginnen met `DELETE FROM`.
+
+### Waarom dit meer is dan een vergissing
+
+Had `DATABASE_URL` naar Supabase gewezen, dan hadden de suites dáár gedraaid.
+RLS en de `WHERE tenant_id`-clausules beschermen echte klantdata, maar er waren
+testtenants in productie ontstaan. Dat is één vergissing verwijderd van iets
+onherstelbaars.
+
+De fout was bovendien **gedragsmatig, niet technisch**: een omgevingsvariabele
+gezet en vergeten terug te zetten. Dat kan iedereen overkomen, dus een
+werkafspraak is geen oplossing.
+
+---
+
+## Besluit
+
+**Elke database draagt een markering die zegt wat hij is.** Migratie 0019 zet
+`clm.omgeving` neer: één rij, met `wegwerp` of `beschermd`.
+
+De standaard is **`beschermd`**. Een database die vergeet zich te benoemen
+wordt behandeld als productie. Andersom zou precies de database die niemand
+heeft ingericht — de nieuwe, de vergetene, de per ongeluk aangemaakte —
+vogelvrij zijn.
+
+Een wegwerpdatabase meldt zich expliciet aan:
+```
+node scripts/markeer-wegwerp.js "waarvoor"
+```
+
+### Twee lagen die verschillende dingen doen
+
+| Controle | Kijkt naar | Vangt |
+|---|---|---|
+| `eisToestemmingBuitenLokaal` (ADR-009, Issue #86) | de hostnaam | Supabase, andermans machine |
+| `eisWegwerpdatabase` (deze ADR) | wat de database over zichzelf zegt | de demo-database, die lokaal én beschermd is |
+
+De demo is lokaal, dus alleen de tweede houdt hem tegen. Beide blijven bestaan.
+
+### Waar de eis geldt
+
+| Wat | Controle |
+|---|---|
+| Alle e2e-suites | Weigeren te starten tegen `beschermd` |
+| `seed:demo -- --verwijder` | Weigert op `beschermd` |
+| `migrate:deploy` | Alleen de hostcontrole — migreren mág op productie |
+| Seeden zonder `--verwijder` | Alleen de hostcontrole — toevoegen mag |
+
+**Toevoegen mag op een beschermde database, verwijderen niet.** Anders is een
+demo-tenant in productie nooit in te richten. De rem zit waar iets
+onherstelbaar is.
+
+---
+
+## Overwogen alternatieven
+
+**Poort 55450 verbieden in de tests.** Simpel en meteen effectief, maar breekt
+zodra de demo op een andere poort draait, en zegt niets over een database op
+een andere machine. Een poortnummer is geen eigenschap van de database.
+
+**Het Docker-label `mcm2.rol=demo` uitlezen.** Bestaat al voor de
+demo-container. Werkt alleen als de database in Docker draait op dezelfde
+machine — dus niet voor Supabase, en niet na een migratie naar AWS RDS.
+
+**Een omgevingsvariabele.** Zou in een `.env` belanden en daarna nooit meer
+opvallen — precies hoe `MIGRATION_DATABASE_URL` stilzwijgend naar productie
+bleef wijzen (Issue #86).
+
+**Waarschuwen in plaats van weigeren.** Een melding in een run van 27 suites
+leest niemand, en na `verwijderTestdata` is de data weg. De enige bruikbare
+bescherming komt vóór de schade.
+
+---
+
+## Gevolgen
+
+**De markering reist mee met de database.** Een dump-en-restore neemt hem over,
+een verhuizing naar een andere poort verandert niets, en een kopie van
+productie draagt zichtbaar `beschermd` met zich mee. **Dat blijft gelden bij
+een migratie naar AWS RDS** — geen enkele regel hoeft opnieuw bedacht te worden.
+
+**CI en `verify:volledig` markeren hun eigen container.** Beide zetten een
+wegwerpdatabase op die één run leeft; zonder die stap blokkeert de guard zijn
+eigen tests. De stap staat in `.github/workflows/ci.yml` en in
+`scripts/verify-volledig.js`.
+
+**Een database zonder `clm.omgeving` faalt ook.** Die heeft migratie 0019 niet
+gehad — dat kan een oude wegwerpcontainer zijn, maar net zo goed een kopie van
+productie van vóór die migratie. Doorgaan zou betekenen dat de bescherming
+zwijgt op het moment dat je hem nodig hebt.
+
+**Er is een uitweg, en die is zichtbaar.** `MCM2_E2E_ONBESCHERMD=ja` voor de
+tests, `--ook-beschermd` voor de scripts. Beide staan in de terminalhistorie, zodat
+later terug te zien is dat iemand het bewust deed — dezelfde redenering als bij
+`--extern` in ADR-009.
+
+**Een bewakingstest houdt de guard aan.** `test/omgevingsmarkering.spec.ts`
+(9 tests, geen database nodig) controleert dat de guard geregistreerd staat,
+hard faalt, alleen `wegwerp` accepteert, en dat CI én `verify:volledig` hun
+container markeren. Zonder die test raakt de guard uitgeschakeld op het moment
+dat hij in de weg zit.
+
+---
+
+## Wat dit niet oplost
+
+**Een handmatige `DELETE` in psql kijkt er niet naar.** De markering beschermt
+de tests en de schrijvende scripts, niet iemand die zelf een query typt.
+
+**Het is een vangnet, geen vereenvoudiging.** Er zijn nog steeds drie soorten
+database die op elkaar lijken: productie, de lokale demo, en wegwerpcontainers.
+De demo is het verwarrende geval — lokaal zoals wegwerp, met data die je wilt
+houden zoals productie.
+
+De echte vereenvoudiging is die tussencategorie laten verdwijnen: een
+DEMO-tenant ín productie voor acceptatie, en lokaal alleen nog wegwerp. Dan
+blijft over: *wat blijft bestaan is heilig, wat je net zelf hebt aangemaakt mag
+stuk.* Deze bescherming blijft daarbij nodig, maar hoeft dan niet meer het
+verschil te maken tussen drie dingen die op elkaar lijken.
+
+---
+
+## Reviewmoment
+
+Bij het opzetten van de DEMO-tenant in productie, en bij een migratie naar AWS
+RDS — dan moet blijken of de markering inderdaad zonder aanpassing meereist.
+
+## Bronnen
+
+Issue #86; ADR-009; PR #103; `docs/runbooks/commandos-en-omgeving.md`;
+`drizzle/0019_omgevingsmarkering.sql`

--- a/docs/runbooks/commandos-en-omgeving.md
+++ b/docs/runbooks/commandos-en-omgeving.md
@@ -54,6 +54,9 @@ testleveranciers bleven achter. Er sloeg niets aan: de bestaande bescherming
 kijkt alleen of de host lokaal is, en binnen `localhost` was de demo niet te
 onderscheiden van een wegwerpcontainer.
 
+Het besluit erachter — inclusief de afgevallen alternatieven en wat dit níét
+oplost — staat in **ADR-014**.
+
 Een eigen wegwerpdatabase markeren, ná het draaien van de migraties:
 ```powershell
 $env:MIGRATION_DATABASE_URL="postgresql://clm_migrator:pw@localhost:55440/postgres"

--- a/docs/runbooks/zelf-testen.md
+++ b/docs/runbooks/zelf-testen.md
@@ -2,7 +2,7 @@
 
 **Type:** D — routineoperatie
 **Eigenaar:** Kees Maling
-**Laatste update:** 2026-08-04
+**Laatste update:** 2026-08-07
 **Vereiste toegang:** Docker Desktop draaiend, deze repository, `MCM2-frontend` als buurmap
 
 ---
@@ -96,15 +96,41 @@ of er een backend is. In zowel demo als productie staat daar LIVE.
 
 ```
 21 leveranciers    uit MVM_V2, eenmalig geëxtraheerd
- 4 gebruikers      1 admin (Sophie van der Berg), de rest reviewer
+ 3 gebruikers      1 admin (Sophie van der Berg), de rest reviewer
  2 vragenlijsten   transdev-annual-vendor-it-risk (8 vragen + 1 instructie)
                    transdev-leveranciersbeoordeling (29 vragen, interne UC2)
- 1 ronde           3 deelnemers: open, half ingevuld, ingediend
+ 2 rondes          één lopende, één met een gepasseerde sluitdatum
+ 6 responses       samen élke status uit het overzicht
 ```
 
 De tweede vragenlijst is de interne beoordelingslijst die nog niet gebouwd is.
 Hij staat in de demo omdat `seed-demo-tenant.js` alles uit `db/seeds/` inleest;
 `verify:volledig` seedt bewust alleen de eerste.
+
+### De zes responses, en waarom het er zes zijn
+
+| Leverancier | Status op `/beheer/status` |
+|---|---|
+| Alstom | Nog niet terug |
+| Siemens | Nog niet terug |
+| Thales | **Te laat** — plus één notitie |
+| Capgemini | Wacht op beoordeling |
+| Strukton | Beoordeeld — twee tegenstrijdige oordelen, twee notities |
+| Microsoft | Goedgekeurd |
+
+Bijgewerkt op 2026-08-07. Daarvóór waren het er drie, en dan toonde het
+statusoverzicht maar twee van de vijf statussen: de rest was visueel nooit
+beoordeeld.
+
+Twee dingen die daarbij bewust zo zijn:
+
+- **De tweede ronde heeft een sluitdatum in het verleden.** "Te laat" is
+  `closes_at < now()` bij een actieve ronde, en één ronde kan niet tegelijk
+  open en verlopen zijn.
+- **De uitnodigingen liggen 5 tot 40 dagen terug.** Stonden ze allemaal op
+  vandaag, dan zegt de kolom "Uitgestuurd" niets — het verschil tussen
+  gisteren en zes weken geleden is juist wat een lege "terug ontvangen"
+  betekenis geeft.
 
 ---
 
@@ -117,6 +143,31 @@ npm run demo:test        de browsertests tegen de draaiende demo
 npm run demo:af          backend en frontend stoppen, database laten staan
 npm run demo:stop        ook de database weggooien
 ```
+
+### Deze data in een echte omgeving zetten
+
+De seed draait ongewijzigd tegen een andere database — de enige invoer is
+`DATABASE_URL`. Eén ding moet dan anders:
+
+```
+DATABASE_URL=... node scripts/seed-demo-tenant.js --echte-tokens
+```
+
+Zonder die vlag krijgen de zes responses vaste tokens die **in de broncode
+staan**. Op een wegwerpdatabase is dat prima — de link moet ná het seeden nog
+bruikbaar zijn om een scherm te tonen. In een echte omgeving betekent het dat
+iedereen die het script leest die surveys kan openen; ook al wijzen ze naar
+verzonnen data, dat is een verschil met een klant dat er niet hoort te zijn.
+
+Met `--echte-tokens` worden ze gegenereerd zoals bij een echte uitnodiging en
+**één keer afgedrukt**. Daarna bestaan ze alleen nog als hash: er is geen route
+die een token opnieuw kan tonen. Bewaar wat je nodig hebt.
+
+> **Inloggen vraagt nog een handeling.** De demo-gebruikers krijgen een
+> herkenbaar nep-identiteitskenmerk (`demo:…`), juist om te voorkomen dat een
+> verzonnen account botst met een echte Entra-identiteit — `external_subject`
+> is uniek. Om zelf in te loggen moet een echte `oid` aan één van die
+> gebruikers gekoppeld worden; zie `docs/STATUS.md`, "Demo-tenant".
 
 `demo:test` draait dezelfde Playwright-suites als de doorloop, maar tegen
 `next dev` en tegen de gevulde demo-database. Nuttig wanneer je iets met de hand

--- a/scripts/seed-demo-tenant.js
+++ b/scripts/seed-demo-tenant.js
@@ -508,6 +508,16 @@ async function rondeAanmaken(db, vendors) {
           oordelen: [],
           dagenGeleden: 9,
           ingediendDagenGeleden: 2,
+          // Eén afwijking, zodat het beoordeelscherm iets te tonen heeft: dat
+          // toont standaard alléén wat afwijkt. Alles bevestigd betekent daar
+          // een leeg scherm.
+          afwijkingen: {
+            2: {
+              code: 'cannot_upload',
+              toelichting:
+                'Certificaat verloopt volgende maand; hercertificering loopt. Nieuw certificaat volgt in september.',
+            },
+          },
         },
         {
           // Status 'te laat': niet ingediend, en de ronde is gesloten. Krijgt
@@ -547,6 +557,20 @@ async function rondeAanmaken(db, vendors) {
             'Mail gestuurd met de vraag over onderaannemers. Nog geen antwoord.',
             'Gesproken op de kwartaalmeeting; sturen deze week aanvulling.',
           ],
+          // Twee afwijkingen: dit is het geval waar de notities en het
+          // meningsverschil over gaan.
+          afwijkingen: {
+            5: {
+              code: 'not_confirmed',
+              toelichting:
+                'In maart is er een phishingincident geweest. Gemeld op dag 4 in plaats van binnen 48 uur; procedure is inmiddels aangepast.',
+            },
+            9: {
+              code: 'not_confirmed',
+              toelichting:
+                'Eén onderaannemer voldoet nog niet aan alle eisen; contract wordt dit kwartaal herzien.',
+            },
+          },
         },
         {
           sleutel: 'goedgekeurd',
@@ -606,7 +630,15 @@ async function rondeAanmaken(db, vendors) {
             continue;
           }
 
-          const antwoord = antwoordVoor(vraag.answer_type, vraag.config);
+          // Afwijkingen zijn per positie opgegeven; `position` telt vanaf 1 en
+          // is wat de leverancier als vraagnummer ziet.
+          const afwijking = stadium.afwijkingen?.[vraag.position];
+
+          const antwoord = antwoordVoor(
+            vraag.answer_type,
+            vraag.config,
+            afwijking?.code,
+          );
 
           // Geen plausibel antwoord te maken (keuzevraag zonder opties in de
           // config): overslaan in plaats van iets verzinnen dat de
@@ -620,9 +652,13 @@ async function rondeAanmaken(db, vendors) {
           // survey_answer_comment_required_check). Bij 'confirmed' mag het
           // leeg blijven, en dat houden we ook zo — anders toont de demo een
           // toelichting waar een echte invuller er geen hoeft te geven.
-          const toelichting =
-            vraag.answer_type === 'confirmation' &&
-            antwoord.code === 'confirmed'
+          const toelichting = afwijking
+            ? // Bij een afwijking is de toelichting het antwoord op "waarom",
+              // en dus het enige wat de beoordelaar echt leest. Een generieke
+              // zin zou het scherm vullen zonder iets te zeggen.
+              afwijking.toelichting
+            : vraag.answer_type === 'confirmation' &&
+                antwoord.code === 'confirmed'
               ? null
               : 'Voorbeeldantwoord uit de demo-seed.';
 
@@ -732,14 +768,20 @@ async function rondeAanmaken(db, vendors) {
  * vormconstraint (die alleen NOT NULL eist) maar levert een demo op met
  * antwoorden die in geen enkele keuzelijst voorkomen.
  */
-function antwoordVoor(type, config) {
+/**
+ * @param afwijkendeCode Alternatief voor 'confirmed' bij een bevestigingsvraag.
+ *   Bedoeld om een inzending mét afwijking te kunnen tonen: het beoordeelscherm
+ *   laat standaard alléén de afwijkingen zien, en zonder deze mogelijkheid was
+ *   dat scherm altijd leeg.
+ */
+function antwoordVoor(type, config, afwijkendeCode) {
   const opties = (config?.options ?? config?.choices ?? [])
     .map((optie) => (typeof optie === 'string' ? optie : optie?.code))
     .filter(Boolean);
 
   switch (type) {
     case 'confirmation':
-      return { code: 'confirmed' };
+      return { code: afwijkendeCode ?? 'confirmed' };
     case 'yes_no':
       return { code: 'yes' };
     case 'single_choice':

--- a/scripts/seed-demo-tenant.js
+++ b/scripts/seed-demo-tenant.js
@@ -10,6 +10,11 @@
 // Gebruik:
 //   DATABASE_URL=... node scripts/seed-demo-tenant.js
 //   DATABASE_URL=... node scripts/seed-demo-tenant.js --verwijder
+//   DATABASE_URL=... node scripts/seed-demo-tenant.js --echte-tokens
+//
+// `--echte-tokens` genereert willekeurige tokens in plaats van de vaste uit
+// dit bestand, en drukt ze één keer af. Bedoeld voor een echte omgeving: daar
+// hoort een demo-tenant niet te verschillen van een klant. Zie ECHTE_TOKENS.
 //
 // ── Drie dingen die dit script bewust NIET doet ──────────────────────────────
 //
@@ -102,11 +107,56 @@ function demoToken(naam) {
   return token;
 }
 
-const DEMO_TOKENS = {
-  open: demoToken('open'),
-  concept: demoToken('concept'),
-  ingediend: demoToken('ingediend'),
-};
+/**
+ * Een echt, willekeurig token — dezelfde weg als een echte uitnodiging.
+ *
+ * `randomBytes` is de veilige generator van Node, gelijk aan genereerToken()
+ * in src/survey/survey-token.ts. base64url omdat het token in een URL komt.
+ */
+function echtToken() {
+  return crypto.randomBytes(32).toString('base64url');
+}
+
+/**
+ * Met `--echte-tokens` krijgt elke respons een willekeurig token in plaats van
+ * de vaste demo-waarde.
+ *
+ * ── Waarom die keuze bestaat ────────────────────────────────────────────────
+ *
+ * De vaste tokens hieronder staan in de broncode, zodat een demo-link ná het
+ * seeden nog te gebruiken is om een scherm te tonen. Op een wegwerpdatabase is
+ * dat prima: ze geven toegang tot verzonnen data die binnen een uur weg is.
+ *
+ * In een echte omgeving ligt dat anders. Ook al wijzen ze naar nepdata, iedereen
+ * die het script leest kan die surveys openen — en dan is er een verschil met
+ * een echte klant dat er niet hoort te zijn.
+ *
+ * Met deze vlag is dat verschil weg: de tokens worden gegenereerd zoals bij een
+ * echte uitnodiging, en het script drukt ze één keer af. Daarna bestaan ze
+ * alleen nog als hash, precies zoals het ontwerp voorschrijft.
+ */
+const ECHTE_TOKENS = process.argv.includes('--echte-tokens');
+
+const DEMO_TOKENS = ECHTE_TOKENS
+  ? {
+      open: echtToken(),
+      concept: echtToken(),
+      ingediend: echtToken(),
+      telaat: echtToken(),
+      beoordeeld: echtToken(),
+      goedgekeurd: echtToken(),
+    }
+  : {
+      open: demoToken('open'),
+      concept: demoToken('concept'),
+      ingediend: demoToken('ingediend'),
+      // De laatste drie vullen het statusoverzicht (plan 2026-08-07). Zonder
+      // deze toonde het scherm alleen 'nog niet terug' en 'wacht op
+      // beoordeling' — de helft van de statussen was visueel nooit beoordeeld.
+      telaat: demoToken('telaat'),
+      beoordeeld: demoToken('beoordeeld'),
+      goedgekeurd: demoToken('goedgekeurd'),
+    };
 
 function hashToken(token) {
   return crypto.createHash('sha256').update(token, 'utf8').digest('hex');
@@ -316,13 +366,31 @@ function vragenlijstenLaden() {
 }
 
 /**
- * Eén actieve ronde op de Transdev-vragenlijst, met drie responses die samen
- * de statusweergave vullen.
+ * Twee rondes op de Transdev-vragenlijst, met zes responses die samen élke
+ * status in het overzicht laten zien.
  *
- * De drie stadia zijn wat het datamodel kent, niet meer: status is
- * 'pending' | 'submitted' | 'revoked' (CHECK-constraint, migratie 0003). Een
- * "concept" is daarin een pending response die al enkele antwoorden heeft —
- * geen aparte status. Dat is bewust het model volgen in plaats van uitbreiden.
+ * ── Twee soorten status, en dat onderscheid is het ontwerp ──────────────────
+ *
+ * `survey_response.status` is de INVULstatus: 'pending' | 'submitted' |
+ * 'revoked' (migratie 0003). Een "concept" is daarin een pending response met
+ * enkele antwoorden — geen aparte waarde.
+ *
+ * Wat het scherm toont is iets anders: de berekende status uit
+ * src/survey/respons-status.ts, die daarnaast kijkt naar de sluitdatum en het
+ * laatste oordeel. Die twee lopen bewust niet gelijk.
+ *
+ * ── Waarom een tweede, verlopen ronde ───────────────────────────────────────
+ *
+ * 'te laat' is `closes_at < now()` bij een actieve ronde. Eén ronde kan niet
+ * tegelijk open en verlopen zijn, dus krijgt dat stadium een eigen ronde met
+ * een sluitdatum vijf dagen terug.
+ *
+ * ── Waarom oordelen in de seed ──────────────────────────────────────────────
+ *
+ * Zonder oordelen toonde het statusoverzicht alleen 'nog niet terug' en 'wacht
+ * op beoordeling': de helft van de statussen was visueel nooit beoordeeld.
+ * Eén response krijgt twee tegenstrijdige oordelen, zodat zichtbaar is dat het
+ * laatste telt én dat er meer zijn.
  */
 async function rondeAanmaken(db, vendors) {
   return db.transaction(async (tx) =>
@@ -360,6 +428,36 @@ async function rondeAanmaken(db, vendors) {
       );
 
       const runId = ronde.rows[0].run_id;
+
+      // Een tweede ronde die al gesloten is, voor de status 'te laat'.
+      // Dezelfde ronde kan niet tegelijk open en verlopen zijn, en de
+      // statusberekening kijkt naar closes_at bij een 'active' ronde
+      // (src/survey/respons-status.ts).
+      const verlopen = await tx.execute(
+        sql`INSERT INTO clm.survey_run
+                (tenant_id, template_id, survey_kind, status, closes_at)
+            VALUES (${DEMO_TENANT_ID}, ${templateId}, 'vendor_compliance',
+                    'active', now() - interval '10 days')
+            RETURNING run_id`,
+      );
+
+      const verlopenRunId = verlopen.rows[0].run_id;
+
+      // Wie de oordelen op zijn naam krijgt. De eerste gebruiker is admin, de
+      // rest reviewer; een oordeel van een reviewer laat zien dat die rol dat
+      // mag zonder admin te zijn (plan §2a).
+      const beoordelaars = await tx.execute(
+        sql`SELECT u.user_id
+              FROM clm."user" u
+              JOIN clm.tenant_membership m ON m.user_id = u.user_id
+             WHERE u.tenant_id = ${DEMO_TENANT_ID}
+               AND m.role = 'reviewer'
+             ORDER BY u.full_name
+             LIMIT 1`,
+      );
+
+      const beoordelaarId = beoordelaars.rows[0]?.user_id ?? null;
+
       const vragen = await tx.execute(
         sql`SELECT question_id, answer_type, position, config
              FROM clm.survey_question
@@ -368,24 +466,99 @@ async function rondeAanmaken(db, vendors) {
              ORDER BY position`,
       );
 
+      // Zes responses: drie invulstadia plus drie beoordeelstadia.
+      //
+      // De eerste drie waren er al en volgen het datamodel: status is
+      // 'pending' | 'submitted' | 'revoked' (migratie 0003). Een "concept" is
+      // daarin een pending response met enkele antwoorden — geen aparte status.
+      //
+      // De laatste drie bestaan voor het statusoverzicht (plan 2026-08-07).
+      // `oordelen` bepaalt wat er ná het indienen wordt vastgelegd; de
+      // berekende status volgt daaruit vanzelf, want die kijkt naar het
+      // laatste oordeel (src/survey/respons-status.ts).
+      // `dagenGeleden` zet de uitnodiging terug in de tijd.
+      //
+      // Zonder dat staan alle uitnodigingen op vandaag, en dan zegt de kolom
+      // "Uitgestuurd" niets: het verschil tussen gisteren verstuurd en zes
+      // weken geleden verstuurd is juist wat een lege "terug ontvangen"
+      // betekenis geeft. Bij de verlopen ronde was het zelfs tegenstrijdig —
+      // uitgestuurd ná de sluitdatum.
       const stadia = [
         {
           sleutel: 'open',
           mockId: vendors[0],
           status: 'pending',
           antwoorden: 0,
+          oordelen: [],
+          dagenGeleden: 5,
         },
         {
           sleutel: 'concept',
           mockId: vendors[1],
           status: 'pending',
           antwoorden: 3,
+          oordelen: [],
+          dagenGeleden: 12,
         },
         {
           sleutel: 'ingediend',
           mockId: vendors[2],
           status: 'submitted',
           antwoorden: vragen.rows.length,
+          oordelen: [],
+          dagenGeleden: 9,
+          ingediendDagenGeleden: 2,
+        },
+        {
+          // Status 'te laat': niet ingediend, en de ronde is gesloten. Krijgt
+          // hieronder een eigen ronde met een sluitdatum in het verleden —
+          // dezelfde ronde kan niet tegelijk open en verlopen zijn.
+          sleutel: 'telaat',
+          mockId: vendors[3],
+          status: 'pending',
+          antwoorden: 1,
+          oordelen: [],
+          verlopenRonde: true,
+          // Ruim vóór de sluitdatum van die ronde (5 dagen terug), anders zou
+          // de uitnodiging ná het sluiten zijn uitgegaan.
+          dagenGeleden: 40,
+          notities: [
+            'Twee keer gebeld, contactpersoon met vakantie. Collega zou het oppakken.',
+          ],
+        },
+        {
+          // Twee oordelen die elkaar tegenspreken. Het laatste telt voor de
+          // status, maar het scherm toont "(van 2)" — anders verdwijnt een
+          // meningsverschil uit beeld (besluit eigenaar, V3).
+          sleutel: 'beoordeeld',
+          mockId: vendors[4],
+          status: 'submitted',
+          antwoorden: vragen.rows.length,
+          oordelen: [
+            { verdict: 'goed', toelichting: 'Ziet er compleet uit.' },
+            {
+              verdict: 'nadere_vragen',
+              toelichting: 'Toch een vraag over het onderaannemersbeleid.',
+            },
+          ],
+          dagenGeleden: 21,
+          ingediendDagenGeleden: 14,
+          notities: [
+            'Mail gestuurd met de vraag over onderaannemers. Nog geen antwoord.',
+            'Gesproken op de kwartaalmeeting; sturen deze week aanvulling.',
+          ],
+        },
+        {
+          sleutel: 'goedgekeurd',
+          mockId: vendors[5],
+          status: 'submitted',
+          antwoorden: vragen.rows.length,
+          oordelen: [
+            { verdict: 'goed', toelichting: 'Alles aangeleverd.' },
+            { verdict: 'goedgekeurd', toelichting: '' },
+          ],
+          dagenGeleden: 28,
+          ingediendDagenGeleden: 20,
         },
       ];
 
@@ -402,13 +575,26 @@ async function rondeAanmaken(db, vendors) {
           sql`INSERT INTO clm.survey_response
                   (tenant_id, run_id, vendor_id, subject_vendor_id, token_hash,
                    status, expires_at)
-              VALUES (${DEMO_TENANT_ID}, ${runId}, ${stadium.mockId},
+              VALUES (${DEMO_TENANT_ID},
+                      ${stadium.verlopenRonde ? verlopenRunId : runId},
+                      ${stadium.mockId},
                       ${stadium.mockId},
                       ${hashToken(DEMO_TOKENS[stadium.sleutel])},
                       'pending',
                       ${vervalOverDagen(30).toISOString()})
               RETURNING response_id`,
         );
+
+        // created_at is de uitnodigingsdatum in het statusoverzicht. De kolom
+        // heeft DEFAULT now(), dus terugzetten gebeurt hier in plaats van in
+        // de INSERT — dat houdt de INSERT gelijk aan wat de applicatie doet.
+        if (stadium.dagenGeleden) {
+          await tx.execute(
+            sql`UPDATE clm.survey_response
+                   SET created_at = now() - (${stadium.dagenGeleden} * interval '1 day')
+                 WHERE response_id = ${respons.rows[0].response_id}`,
+          );
+        }
 
         const responseId = respons.rows[0].response_id;
 
@@ -471,9 +657,60 @@ async function rondeAanmaken(db, vendors) {
         if (stadium.status === 'submitted') {
           await tx.execute(
             sql`UPDATE clm.survey_response
-                   SET status = 'submitted', submitted_at = now()
+                   SET status = 'submitted',
+                       submitted_at = now() -
+                         (${stadium.ingediendDagenGeleden ?? 0} * interval '1 day')
                  WHERE response_id = ${responseId}
                    AND tenant_id = ${DEMO_TENANT_ID}`,
+          );
+        }
+
+        // Oordelen ná het indienen, in volgorde: het láátste bepaalt de
+        // status. Elk oordeel krijgt een created_at die een uur later ligt dan
+        // het vorige, want binnen één transactie geeft now() steeds hetzelfde
+        // tijdstip — en dan is "het laatste oordeel" niet te bepalen.
+        // De policy op survey_review eist naast de tenant ook actor
+        // 'medewerker' (migratie 0015): een leverancier zit in dezelfde tenant
+        // als zijn beoordelaar en mag het oordeel niet zien. metTenantContext
+        // zet alleen de tenant, dus zonder deze regel weigert RLS elke INSERT
+        // — met een foutmelding die de constraint niet noemt.
+        const teOordelen = beoordelaarId ? (stadium.oordelen ?? []) : [];
+        const teNoteren = beoordelaarId ? (stadium.notities ?? []) : [];
+
+        if (teOordelen.length > 0 || teNoteren.length > 0) {
+          await tx.execute(
+            sql`SELECT set_config('app.current_actor', 'medewerker', true)`,
+          );
+        }
+
+        // Notities van collega's onderling (migratie 0018). Ze raken de status
+        // niet — het scherm toont alleen dát ze er zijn. Zonder deze regels
+        // bleef dat deel van het overzicht visueel ongetest.
+        let notitieDagen = stadium.dagenGeleden ?? 0;
+        for (const tekst of teNoteren) {
+          notitieDagen = Math.max(0, notitieDagen - 3);
+          await tx.execute(
+            sql`INSERT INTO clm.response_note
+                    (tenant_id, response_id, tekst, author_user_id, created_at)
+                VALUES (${DEMO_TENANT_ID}, ${responseId}, ${tekst},
+                        ${beoordelaarId},
+                        now() - (${notitieDagen} * interval '1 day'))`,
+          );
+        }
+
+        // Ná het indienen, elk oordeel een dag later dan het vorige. Binnen één
+        // transactie geeft now() steeds hetzelfde tijdstip, en dan is "het
+        // laatste oordeel" niet te bepalen — juist dat bepaalt de status.
+        let oordeelDagen = stadium.ingediendDagenGeleden ?? 0;
+        for (const oordeel of teOordelen) {
+          oordeelDagen = Math.max(0, oordeelDagen - 1);
+          await tx.execute(
+            sql`INSERT INTO clm.survey_review
+                    (tenant_id, response_id, verdict, toelichting,
+                     reviewer_user_id, created_at)
+                VALUES (${DEMO_TENANT_ID}, ${responseId}, ${oordeel.verdict},
+                        ${oordeel.toelichting}, ${beoordelaarId},
+                        now() - (${oordeelDagen} * interval '1 day'))`,
           );
         }
       }
@@ -528,7 +765,15 @@ function antwoordVoor(type, config) {
 async function verwijderen(db) {
   // Volgorde volgt de foreign keys: antwoorden en bijlagen vóór responses,
   // responses vóór rondes, rondes vóór templates.
+  //
+  // Oordelen en notities staan bovenaan om dezelfde reden. Beide verwijzen met
+  // ON DELETE restrict naar survey_response — bewust, want een oordeel is
+  // bewijsmateriaal en mag niet stilzwijgend meeverdwijnen. Vergeet je ze hier,
+  // dan strandt het opruimen op een foreign key. Gebeurde op 2026-08-07 bij het
+  // toevoegen van notities aan de seed.
   const stappen = [
+    sql`DELETE FROM clm.response_note WHERE tenant_id = ${DEMO_TENANT_ID}`,
+    sql`DELETE FROM clm.survey_review WHERE tenant_id = ${DEMO_TENANT_ID}`,
     sql`DELETE FROM clm.survey_answer WHERE tenant_id = ${DEMO_TENANT_ID}`,
     sql`DELETE FROM clm.survey_attachment WHERE tenant_id = ${DEMO_TENANT_ID}`,
     sql`DELETE FROM clm.survey_response WHERE tenant_id = ${DEMO_TENANT_ID}`,
@@ -545,6 +790,16 @@ async function verwijderen(db) {
 
   await db.transaction(async (tx) =>
     metTenantContext(tx, async () => {
+      // survey_review en response_note eisen naast de tenant ook actor
+      // 'medewerker' (migraties 0015 en 0018): een leverancier zit in dezelfde
+      // tenant als zijn beoordelaar en mag niet meelezen. Zonder deze regel
+      // weigert de policy élke rij — ook bij het opruimen, en dan strandt de
+      // DELETE op survey_response met een foreign-keyfout die naar de
+      // verkeerde oorzaak wijst.
+      await tx.execute(
+        sql`SELECT set_config('app.current_actor', 'medewerker', true)`,
+      );
+
       for (const stap of stappen) {
         await tx.execute(stap);
       }
@@ -682,9 +937,31 @@ async function main() {
     console.table(await tellen(db));
 
     if (!ronde.overgeslagen) {
-      console.log('\nDemo-links (alleen deze tenant, alleen verzonnen data):');
+      if (ECHTE_TOKENS) {
+        // Deze uitvoer is eenmalig: de database bewaart alleen een hash, en er
+        // is geen route die een token opnieuw kan tonen. Wie hem nu niet
+        // bewaart, kan die survey nooit meer openen — dat is het ontwerp, geen
+        // omissie.
+        console.log(
+          '\nUitnodigingslinks — DEZE UITVOER IS EENMALIG.\n' +
+            'De database bewaart alleen een hash. Bewaar wat je nodig hebt;\n' +
+            'daarna is er geen enkele manier om deze links terug te halen.',
+        );
+      } else {
+        console.log(
+          '\nDemo-links (alleen deze tenant, alleen verzonnen data):',
+        );
+      }
+
       for (const [stadium, token] of Object.entries(DEMO_TOKENS)) {
-        console.log(`  ${stadium.padEnd(10)} /portal/survey/${token}`);
+        console.log(`  ${stadium.padEnd(12)} /portal/survey/${token}`);
+      }
+
+      if (!ECHTE_TOKENS) {
+        console.log(
+          '\nDeze tokens staan in de broncode. Voor een echte omgeving:\n' +
+            '  node scripts/seed-demo-tenant.js --echte-tokens',
+        );
       }
     }
 

--- a/src/survey/contractmanager.service.ts
+++ b/src/survey/contractmanager.service.ts
@@ -45,6 +45,15 @@ export interface StatusItem {
   /** De contractmanager van deze vendor; null wanneer er geen is. */
   eigenaarUserId: string | null;
   eigenaarNaam: string | null;
+  /**
+   * Wanneer de uitnodiging is uitgegeven.
+   *
+   * Hoort naast `submittedAt` in beeld: een leverancier die nog niet heeft
+   * ingediend zegt weinig, tenzij je weet of de uitnodiging drie dagen of zes
+   * weken oud is (besluit eigenaar 2026-08-07).
+   */
+  uitgestuurdOp: string | null;
+  /** Wanneer de leverancier heeft ingediend. Daarna staat zijn antwoord vast. */
   submittedAt: string | null;
   closesAt: string | null;
   /** De berekende status — de centrale waarheid uit respons-status.ts. */
@@ -70,6 +79,7 @@ interface StatusRij extends Record<string, unknown> {
   vendor_naam: string | null;
   eigenaar_user_id: string | null;
   eigenaar_naam: string | null;
+  uitgestuurd_op: Date | string | null;
   submitted_at: Date | string | null;
   closes_at: Date | string | null;
   ronde_status: string;
@@ -132,6 +142,9 @@ export class ContractmanagerService {
                      v.name          AS vendor_naam,
                      v.owner_user_id AS eigenaar_user_id,
                      o.full_name     AS eigenaar_naam,
+                     -- Het moment waarop het token is uitgegeven; dat is wat
+                     -- de leverancier als uitnodiging in zijn mailbox kreeg.
+                     s.created_at    AS uitgestuurd_op,
                      s.submitted_at,
                      r.closes_at,
                      r.status        AS ronde_status,
@@ -168,6 +181,7 @@ export class ContractmanagerService {
           vendorNaam: r.vendor_naam,
           eigenaarUserId: r.eigenaar_user_id,
           eigenaarNaam: r.eigenaar_naam,
+          uitgestuurdOp: iso(r.uitgestuurd_op),
           submittedAt: iso(r.submitted_at),
           closesAt: iso(r.closes_at),
           // Eén plek waar de status wordt bepaald: dezelfde functie die de

--- a/test/demo-seed.e2e-spec.ts
+++ b/test/demo-seed.e2e-spec.ts
@@ -68,9 +68,17 @@ interface Telling {
 function leesDemoTokens(): string[] {
   const TOKEN_LENGTE = 43;
 
-  return ['open', 'concept', 'ingediend'].map((naam) =>
-    `demo-${naam}`.padEnd(TOKEN_LENGTE, 'x'),
-  );
+  // Zes stadia sinds 2026-08-07: de laatste drie bestaan zodat het
+  // statusoverzicht élke status kan tonen. Verandert deze lijst in het script,
+  // dan valt deze test om — en dat is de bedoeling.
+  return [
+    'open',
+    'concept',
+    'ingediend',
+    'telaat',
+    'beoordeeld',
+    'goedgekeurd',
+  ].map((naam) => `demo-${naam}`.padEnd(TOKEN_LENGTE, 'x'));
 }
 
 function draaiSeed(argumenten: string[] = []): string {
@@ -143,8 +151,13 @@ describe('Demo-seed (e2e)', () => {
     // niemand om een survey naartoe te sturen.
     expect(stand.contactpersonen).toBe(stand.leveranciers);
 
-    expect(stand.rondes).toBe(1);
-    expect(stand.responses).toBe(3);
+    // Twee rondes: één lopende en één met een gepasseerde sluitdatum. Die
+    // tweede bestaat voor de status 'te laat' — dezelfde ronde kan niet
+    // tegelijk open en verlopen zijn (statusoverzicht, 2026-08-07).
+    expect(stand.rondes).toBe(2);
+    // Zes responses die samen élke status in het overzicht laten zien. Waren
+    // het er drie, dan toonde dat scherm maar twee van de vijf statussen.
+    expect(stand.responses).toBe(6);
     expect(stand.antwoorden).toBeGreaterThan(0);
     // Zelfde limiet en dezelfde reden als de test hieronder: deze start het
     // seedscript als apart Node-proces. Bij die reparatie (2026-08-04) is
@@ -173,9 +186,9 @@ describe('Demo-seed (e2e)', () => {
     // suite, en die op 2026-08-04 opnieuw toesloeg.
   }, 20_000);
 
-  // ── De drie stadia ────────────────────────────────────────────────────────
+  // ── De invulstadia ────────────────────────────────────────────────────────
 
-  it('levert responses in drie verschillende stadia', async () => {
+  it('levert responses in elk invulstadium', async () => {
     await client.query('SELECT set_config($1, $2, false)', [
       'app.current_tenant_id',
       DEMO_TENANT_ID,
@@ -193,22 +206,81 @@ describe('Demo-seed (e2e)', () => {
        ORDER BY antwoorden
     `);
 
-    expect(rows).toHaveLength(3);
+    expect(rows).toHaveLength(6);
 
     // Open: nog niets ingevuld.
     expect(rows[0].status).toBe('pending');
     expect(rows[0].antwoorden).toBe(0);
 
-    // Concept: deels ingevuld, nog niet ingediend. Geen aparte status in het
-    // model — 'concept' is een pending response mét antwoorden.
-    expect(rows[1].status).toBe('pending');
-    expect(rows[1].antwoorden).toBeGreaterThan(0);
+    // Er is minstens één respons die deels is ingevuld maar niet ingediend.
+    // 'concept' is geen aparte status in het model — het is een pending
+    // response mét antwoorden.
+    const concepten = rows.filter(
+      (r) => r.status === 'pending' && r.antwoorden > 0,
+    );
+    expect(concepten.length).toBeGreaterThan(0);
 
     // Ingediend: submitted_at is gevuld, afgedwongen door
     // survey_response_submitted_consistent_check.
-    expect(rows[2].status).toBe('submitted');
-    expect(rows[2].submitted_at).not.toBeNull();
-    expect(rows[2].antwoorden).toBeGreaterThan(rows[1].antwoorden);
+    const ingediend = rows.filter((r) => r.status === 'submitted');
+    expect(ingediend.length).toBeGreaterThan(0);
+    for (const r of ingediend) {
+      expect(r.submitted_at).not.toBeNull();
+    }
+  });
+
+  // ── De statusketen ────────────────────────────────────────────────────────
+
+  it('dekt élke status uit het overzicht', async () => {
+    // Zonder deze test kan de seed stilzwijgend terugvallen naar één ronde met
+    // alleen bevestigde antwoorden, en dan toont het statusoverzicht nog maar
+    // twee van de vijf statussen — precies de situatie van vóór 2026-08-07.
+    await client.query('SELECT set_config($1, $2, false)', [
+      'app.current_tenant_id',
+      DEMO_TENANT_ID,
+    ]);
+    await client.query('SELECT set_config($1, $2, false)', [
+      'app.current_actor',
+      'medewerker',
+    ]);
+
+    const { rows } = await client.query<{
+      te_laat: number;
+      beoordeeld: number;
+      goedgekeurd: number;
+      met_notities: number;
+      afwijkende_antwoorden: number;
+    }>(`
+      SELECT
+        (SELECT count(*)::int
+           FROM clm.survey_response s
+           JOIN clm.survey_run u ON u.run_id = s.run_id
+          WHERE s.submitted_at IS NULL
+            AND u.status = 'active'
+            AND u.closes_at < now())                        AS te_laat,
+        (SELECT count(DISTINCT response_id)::int
+           FROM clm.survey_review
+          WHERE deleted_at IS NULL)                          AS beoordeeld,
+        (SELECT count(*)::int FROM clm.survey_review
+          WHERE verdict = 'goedgekeurd' AND deleted_at IS NULL) AS goedgekeurd,
+        (SELECT count(DISTINCT response_id)::int
+           FROM clm.response_note
+          WHERE deleted_at IS NULL)                          AS met_notities,
+        (SELECT count(*)::int FROM clm.survey_answer
+          WHERE answer_type = 'confirmation'
+            AND answer_code <> 'confirmed')                  AS afwijkende_antwoorden
+    `);
+
+    const stand = rows[0];
+
+    expect(stand.te_laat).toBeGreaterThan(0);
+    expect(stand.beoordeeld).toBeGreaterThan(0);
+    expect(stand.goedgekeurd).toBeGreaterThan(0);
+    expect(stand.met_notities).toBeGreaterThan(0);
+
+    // Het beoordeelscherm toont standaard alléén de afwijkingen. Zonder
+    // afwijkende antwoorden is dat scherm leeg en valt er niets te beoordelen.
+    expect(stand.afwijkende_antwoorden).toBeGreaterThan(0);
   });
 
   // ── Tokens ────────────────────────────────────────────────────────────────
@@ -231,7 +303,7 @@ describe('Demo-seed (e2e)', () => {
     // links en viel om op iets dat niets met hashing te maken had.
     const tokens = leesDemoTokens();
 
-    expect(tokens).toHaveLength(3);
+    expect(tokens).toHaveLength(6);
 
     // Vanaf niets, zodat de hashes bij déze tokens horen en niet bij een
     // eerdere seed met andere waarden.
@@ -294,7 +366,7 @@ describe('Demo-seed (e2e)', () => {
       (match) => match[1],
     );
 
-    expect(links).toHaveLength(3);
+    expect(links).toHaveLength(6);
 
     for (const token of links) {
       expect(token).toMatch(TOKEN_PATROON);

--- a/test/ronde-beheer-routes.e2e-spec.ts
+++ b/test/ronde-beheer-routes.e2e-spec.ts
@@ -107,6 +107,16 @@ async function verwijderTestdata(client: Client): Promise<void> {
 }
 
 describe('Ronde-beheerroutes (e2e)', () => {
+  // Eén limiet voor de hele suite in plaats van 32 losse regels.
+  //
+  // Elke test hier doet minstens één HTTP-verzoek tegen een echte database, en
+  // sommige twee (een ronde aanmaken, dan iets ermee doen). Binnen Jests
+  // standaard van 5 seconden past dat alleen op een verder onbelaste machine;
+  // in de volledige e2e-run viel er daardoor onregelmatig één om — welke hing
+  // af van de volgorde. Zelfde faalvorm als in demo-seed (2026-08-04 en
+  // 2026-08-07).
+  jest.setTimeout(20_000);
+
   let app: INestApplication<App>;
   let server: App;
   let client: Client;


### PR DESCRIPTION
Ondersteunt de twee schermen uit **MCM2-frontend PR (statusoverzicht + beoordeelscherm)**, en werkt de documentatie bij op alles wat er vandaag is veranderd.

## De demo-seed toont nu élke status

Vóór vandaag: één ronde, drie responses. Het statusoverzicht toonde daarmee **twee van de vijf statussen** — de rest was visueel nooit beoordeeld.

Nu twee rondes en zes responses:

| Leverancier | Status |
|---|---|
| Alstom, Siemens | Nog niet terug |
| Thales | **Te laat** — plus één notitie |
| Capgemini | Wacht op beoordeling |
| Strukton | Beoordeeld — twee tegenstrijdige oordelen, twee notities |
| Microsoft | Goedgekeurd |

**Waarom een tweede ronde:** "te laat" is `closes_at < now()` bij een actieve ronde. Eén ronde kan niet tegelijk open en verlopen zijn.

## Drie dingen die het beeld pas bruikbaar maakten

**De datums stonden allemaal op vandaag.** Dan zegt de kolom "Uitgestuurd" niets — het verschil tussen gisteren en zes weken geleden is juist wat een lege "terug ontvangen" betekenis geeft. Bij de verlopen ronde was het zelfs tegenstrijdig: uitgestuurd ná de sluitdatum. Elk stadium heeft nu een eigen `dagenGeleden`.

**Alles was `confirmed`.** Het beoordeelscherm toont standaard alleen afwijkingen; met deze data was dat scherm leeg. Twee inzendingen hebben nu een afwijking, mét de toelichting die de database daar toch al eist (`survey_answer_comment_required_check`, migratie 0005).

**Er stonden geen notities.** Dat deel van het scherm was daardoor visueel ongetest.

## `--echte-tokens` voor gebruik in een echte omgeving

De seed draait ongewijzigd tegen een andere database — de enige invoer is `DATABASE_URL`. Eén ding moest anders om hem in de DEMO-tenant op Supabase te kunnen gebruiken.

Zonder vlag krijgen de zes responses **vaste tokens die in de broncode staan**. Op een wegwerpdatabase is dat juist handig: de link moet ná het seeden nog bruikbaar zijn om een scherm te tonen. In een echte omgeving kan iedereen die het script leest die surveys openen — ook al wijzen ze naar verzonnen data, dat is een verschil met een klant dat er niet hoort te zijn.

Met `--echte-tokens` worden ze gegenereerd via dezelfde weg als een echte uitnodiging (`randomBytes(32)`, base64url) en **één keer afgedrukt**, met de waarschuwing dat de database alleen een hash bewaart.

## Een nieuwe test die de dekking bewaakt

`dekt élke status uit het overzicht` controleert dat er minstens één respons is die te laat is, één met een oordeel, één goedgekeurd, één met notities, en één met een afwijkend antwoord.

Zonder die test kan de seed stilzwijgend terugvallen naar de oude situatie, en dan staat het statusoverzicht er weer half bij zonder dat iets daarop wijst.

## Twee bugs opgelost

**`seed:demo --verwijder` strandde.** `survey_review` en `response_note` ontbraken in de opruimvolgorde — beide verwijzen met `ON DELETE restrict` naar `survey_response`, bewust, want een oordeel is bewijsmateriaal. En het opruimen zette geen actor `medewerker`, waardoor de policy élke rij weigerde en de fout naar een foreign key wees in plaats van naar de oorzaak.

**`ronde-beheer-routes` had 32 tests zonder timeout** en viel onregelmatig om op Jests standaard van 5 seconden. Nu een suitebrede limiet van 20s. Dezelfde faalvorm als eerder bij `demo-seed` (2026-08-04 en 2026-08-07).

## Documentatie nagelopen

Vier bevindingen, waarvan één ontbrak.

**ADR-014 (nieuw)** — *Elke database is beschermd tot hij zich als wegwerp meldt.* Legt het besluit achter migratie 0019 vast, met de afgevallen alternatieven: poortnummer, Docker-label, omgevingsvariabele, waarschuwen in plaats van weigeren. Bij elk staat waarom het niet meereist naar AWS. Ook expliciet wat het **niet** oplost.

**ADR-009** had twee achterhaalde verwijzingen: `prisma/roles/bootstrap-roles.sql` (heet nu `db/roles/`) en de bewering dat `jest-e2e.setup.ts` alleen dotenv laadt. De ADR zelf is **ongewijzigd** gelaten — die legt het besluit van toen vast; een gedateerd blok eronder corrigeert wat er inmiddels anders is.

**STATUS.md** stond op de ochtendstand en zei "er is nog geen enkel scherm". Nu de avondstand, met het incident van de demo-database als waarschuwing bovenaan en vijf bevindingen van vandaag in de tabel.

**`zelf-testen.md`** beschreef nog "3 deelnemers: open, half ingevuld, ingediend". Nu zes responses in twee rondes, met een tabel welke leverancier welke status heeft, plus `--echte-tokens`.

Gecontroleerd en in orde: alle npm-commando's in de documentatie bestaan, en er zijn geen dode verwijzingen tussen documenten.

## Getoetst

- **`npm run verify:volledig`: GROEN — de hele keten, van code tot browser**
- 392 e2e (was 391), 316 unittests, 54 browsertests (was 47)
- lint / format / typecheck schoon in beide repo's

> De doorloop meldt dat de productiedatabase achterloopt. Verwacht: 0017–0019 gaan pas mee bij uitrol.
