### PR TITLE
feat(platformbeheer): tenant aanmaken via de app, met tijdelijke support-toegang

### DIFF
--- a/drizzle/0021_tenantnaam_hoofdletterongevoelig.sql
+++ b/drizzle/0021_tenantnaam_hoofdletterongevoelig.sql
@@ -1,0 +1,30 @@
+-- Tenantnamen botsen ook als alleen de hoofdletters verschillen.
+--
+-- ── Wat er misging ───────────────────────────────────────────────────────────
+--
+-- `tenant_name_key` (baseline 0000) is hoofdlettergevoelig. Daarmee kunnen
+-- 'AlingAdvies' en 'alingadvies' naast elkaar bestaan als twee verschillende
+-- klanten. Voor een tenantnaam — die in schermen, mails en de audit trail
+-- verschijnt — is dat vrijwel altijd een vergissing en nooit een bedoeling.
+--
+-- Gevonden op 2026-08-08 door de e2e-suite van de platformroutes: het
+-- aanmaken van 'alingadvies' náást 'AlingAdvies' hoorde 409 te geven en gaf
+-- 201. In de applicatielaag was dat niet op te lossen: die draait in de
+-- tenantcontext van de nieuwe tenant, en RLS verbergt daar elke bestaande
+-- tenant. Een SELECT vindt dus nooit iets, hoeveel gelijknamige tenants er ook
+-- zijn.
+--
+-- Een constraint kent geen RLS. Daarom hoort deze regel hier en niet in de code.
+--
+-- ── Waarom de oude index blijft ──────────────────────────────────────────────
+--
+-- Hij is strenger noch zwakker maar iets anders: hij bewaakt de exacte naam.
+-- Beide houden is geen dubbelop — de nieuwe vangt wat de oude doorlaat. Hem
+-- weghalen zou bovendien een tweede migratie in dezelfde stap zijn, zonder dat
+-- iets erom vraagt.
+
+CREATE UNIQUE INDEX tenant_name_ongeacht_hoofdletters
+    ON clm.tenant (lower(name));--> statement-breakpoint
+
+COMMENT ON INDEX clm.tenant_name_ongeacht_hoofdletters IS
+    'Tenantnamen zijn uniek ongeacht hoofdletters. tenant_name_key bewaakt de exacte schrijfwijze; deze index vangt wat die doorlaat — twee klanten die alleen in hoofdletters verschillen zijn een vergissing, geen bedoeling.';

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -148,6 +148,13 @@
       "when": 1786550400000,
       "tag": "0020_platformbeheer",
       "breakpoints": true
+    },
+    {
+      "idx": 21,
+      "version": "7",
+      "when": 1786636800000,
+      "tag": "0021_tenantnaam_hoofdletterongevoelig",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -5,6 +5,7 @@ import { AuthModule } from './auth/auth.module';
 import { DatabaseModule } from './db/database.module';
 import { HealthModule } from './health/health.module';
 import { MailModule } from './mail/mail.module';
+import { PlatformModule } from './platform/platform.module';
 import { SurveyModule } from './survey/survey.module';
 import { VendorModule } from './vendor/vendor.module';
 
@@ -16,6 +17,7 @@ import { VendorModule } from './vendor/vendor.module';
     AuthModule,
     VendorModule,
     MailModule,
+    PlatformModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -49,7 +49,15 @@ export const tenant = clm.table(
       .notNull()
       .defaultNow(),
   },
-  (t) => [uniqueIndex('tenant_name_key').on(t.name)],
+  (t) => [
+    uniqueIndex('tenant_name_key').on(t.name),
+    // Migratie 0021. tenant_name_key bewaakt de exacte schrijfwijze; deze
+    // vangt wat die doorlaat — 'AlingAdvies' naast 'alingadvies' is een
+    // vergissing, geen tweede klant. Hoort in de database en niet in de code,
+    // want de aanmaakroute draait in de context van de nieuwe tenant en RLS
+    // verbergt daar elke bestaande tenant.
+    uniqueIndex('tenant_name_ongeacht_hoofdletters').on(sql`lower(${t.name})`),
+  ],
 );
 
 export const user = clm.table(

--- a/src/platform/platform-admin.guard.ts
+++ b/src/platform/platform-admin.guard.ts
@@ -1,0 +1,82 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  ForbiddenException,
+  Injectable,
+} from '@nestjs/common';
+import { sql } from 'drizzle-orm';
+
+import type { RequestMetSessie } from '../auth/tenant-context.guard';
+import { DatabaseService } from '../db/database.service';
+
+/**
+ * Bewaakt de platformroutes: alleen wie in `clm.platform_admin` staat mag hier
+ * langs (migratie 0020, ADR-015).
+ *
+ * ── Waarom náást TenantContextGuard en niet erin ─────────────────────────────
+ *
+ * Dezelfde reden als bij RolGuard: die guard stelt vast wíé er is en bij welke
+ * tenant. Wat iemand mag is een aparte vraag. Hier komt er een derde bij —
+ * mag deze persoon iets doen dat *buiten* elke tenant staat — en dat hoort al
+ * helemaal niet vermengd te raken met het vaststellen van de tenantcontext.
+ *
+ * De volgorde is dus: TenantContextGuard stelt de sessie vast, deze guard
+ * kijkt of die gebruiker platformbeheerder is.
+ *
+ * ── Waarom de vraag naar de database gaat en niet naar de sessie ─────────────
+ *
+ * Platformbeheerder-zijn staat niet in het sessiecookie en hoort daar ook niet.
+ * Een sessie leeft acht uur; het intrekken van platformbeheer moet direct
+ * werken, niet pas bij de volgende login. Eén indexlookup op de primaire
+ * sleutel per platformverzoek is die zekerheid ruimschoots waard — en het gaat
+ * om een handvol routes, niet om de hele applicatie.
+ *
+ * ── Waarom withTenant() ondanks dat de tabel buiten RLS staat ────────────────
+ *
+ * `clm.platform_admin` heeft geen tenant_id en dus geen RLS-policy. De query
+ * zou zonder tenantcontext werken. Toch loopt hij via withTenant(), omdat
+ * DatabaseService de enige weg naar de database is (ADR-008): een tweede,
+ * contextloze weg openen zou precies de uitzondering zijn waarvan dit ontwerp
+ * juist wilde afzien. De tenant van de sessie is hier verder betekenisloos.
+ */
+@Injectable()
+export class PlatformAdminGuard implements CanActivate {
+  constructor(private readonly db: DatabaseService) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const request = context.switchToHttp().getRequest<RequestMetSessie>();
+    const sessie = request.sessie;
+
+    // Geen sessie betekent dat TenantContextGuard niet gedraaid heeft — een
+    // programmeerfout. Weigeren, niet doorlaten: een guard die bij twijfel
+    // toestaat is geen guard.
+    if (!sessie) {
+      throw new ForbiddenException('Geen sessie.');
+    }
+
+    const isBeheerder = await this.db.withTenant(
+      sessie.tenantId,
+      async (tx) => {
+        const { rows } = await tx.execute<{ bestaat: boolean }>(
+          sql`SELECT true AS bestaat
+                FROM clm.platform_admin
+               WHERE user_id = ${sessie.userId}
+                 AND deleted_at IS NULL`,
+        );
+
+        return rows.length > 0;
+      },
+    );
+
+    if (!isBeheerder) {
+      // 403 en niet 404: de gebruiker is geverifieerd en weet dat deze route
+      // bestaat. Verbergen zou hem laten zoeken naar een probleem dat er niet
+      // is. Zelfde afweging als in RolGuard.
+      throw new ForbiddenException(
+        'Deze handeling is voorbehouden aan het platformbeheer.',
+      );
+    }
+
+    return true;
+  }
+}

--- a/src/platform/platform-invoer.ts
+++ b/src/platform/platform-invoer.ts
@@ -1,0 +1,95 @@
+import { InvoerFout } from '../vendor/vendor-invoer';
+
+import type { NieuweTenant } from './platform.service';
+
+/**
+ * Validatie van wat het beheerscherm opstuurt bij het aanmaken van een tenant.
+ *
+ * Zelfde stijl en dezelfde `InvoerFout` als `vendor-invoer.ts`: handmatig, met
+ * `unknown` als invoer. Een tweede validatiestijl ernaast zou het geheel
+ * ongelijkmatig maken zonder iets op te lossen.
+ */
+
+const MAX_NAAM = 200;
+const MAX_EMAIL = 320; // RFC 5321: 64 lokaal + @ + 255 domein.
+
+function verplichteTekst(
+  waarde: unknown,
+  veld: string,
+  maxLengte: number,
+): string {
+  if (typeof waarde !== 'string' || waarde.trim() === '') {
+    throw new InvoerFout(veld, `${veld} is verplicht.`);
+  }
+
+  const schoon = waarde.trim();
+
+  if (schoon.length > maxLengte) {
+    throw new InvoerFout(
+      veld,
+      `${veld} mag hoogstens ${maxLengte} tekens zijn.`,
+    );
+  }
+
+  return schoon;
+}
+
+/**
+ * Bewust ruim: één @, iets ervoor, en een punt erachter.
+ *
+ * Strenger valideren op e-mail levert vooral valse afwijzingen op — de
+ * werkelijke syntaxis van RFC 5322 laat meer toe dan welke reguliere expressie
+ * dan ook fatsoenlijk vangt. Of het adres bestaat blijkt toch pas als er post
+ * naartoe gaat.
+ */
+function email(waarde: unknown, veld: string): string {
+  const tekst = verplichteTekst(waarde, veld, MAX_EMAIL);
+
+  if (!/^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(tekst)) {
+    throw new InvoerFout(veld, `${veld} is geen geldig e-mailadres.`);
+  }
+
+  return tekst;
+}
+
+export function leesNieuweTenant(body: unknown): NieuweTenant {
+  if (typeof body !== 'object' || body === null) {
+    throw new InvoerFout('body', 'Verwacht een JSON-object.');
+  }
+
+  const invoer = body as Record<string, unknown>;
+
+  return {
+    naam: verplichteTekst(invoer.naam, 'naam', MAX_NAAM),
+    adminNaam: verplichteTekst(invoer.adminNaam, 'adminNaam', MAX_NAAM),
+    adminEmail: email(invoer.adminEmail, 'adminEmail'),
+  };
+}
+
+/**
+ * De reden bij support-toegang.
+ *
+ * Verplicht, en dat is geen formaliteit: SOC 2 CC6.3 vraagt een justification
+ * bij elke elevation, en een reden die achteraf niets zegt maakt de audit trail
+ * waardeloos. Vandaar ook een ondergrens — "test" of "x" is geen reden.
+ */
+export function leesSupportReden(body: unknown): string {
+  if (typeof body !== 'object' || body === null) {
+    throw new InvoerFout('body', 'Verwacht een JSON-object.');
+  }
+
+  const reden = verplichteTekst(
+    (body as Record<string, unknown>).reden,
+    'reden',
+    500,
+  );
+
+  if (reden.length < 10) {
+    throw new InvoerFout(
+      'reden',
+      'Geef een reden van minstens tien tekens. Deze komt in de audit trail en moet later nog te begrijpen zijn.',
+    );
+  }
+
+  return reden;
+}

--- a/src/platform/platform.controller.ts
+++ b/src/platform/platform.controller.ts
@@ -1,0 +1,118 @@
+import {
+  BadRequestException,
+  Body,
+  Controller,
+  Get,
+  NotFoundException,
+  Param,
+  Post,
+  Req,
+  UseGuards,
+} from '@nestjs/common';
+
+import {
+  TenantContextGuard,
+  type RequestMetSessie,
+} from '../auth/tenant-context.guard';
+import { InvoerFout } from '../vendor/vendor-invoer';
+import { PlatformAdminGuard } from './platform-admin.guard';
+import { leesNieuweTenant, leesSupportReden } from './platform-invoer';
+import { PlatformService } from './platform.service';
+
+/**
+ * Platformbeheer: een tenant aanmaken, en tijdelijk meekijken (ADR-015).
+ *
+ * Twee guards op klasseniveau, in deze volgorde: TenantContextGuard stelt de
+ * sessie vast, PlatformAdminGuard kijkt of die persoon platformbeheerder is.
+ * Op klasseniveau en niet per methode — een nieuwe route hier zou de guard
+ * anders kunnen missen, en dan staat platformbeheer open zonder dat iets rood
+ * wordt. Zelfde afweging als in VendorController.
+ *
+ * ── De enige plek waar een tenant uit de invoer komt ─────────────────────────
+ *
+ * MCM2-CLAUDE.md §6 verbiedt een tenant in een header of URL, en
+ * TenantContextGuard dwingt dat af voor de hele applicatie. Deze controller is
+ * de uitzondering, en dat kan alleen omdat PlatformAdminGuard ervoor staat:
+ * de tenant in het pad is niet wíé je bent, maar wáár je iets aan doet.
+ *
+ * Dat verschil is precies waarom platformbeheer een aparte tabel heeft en geen
+ * rol binnen een tenant.
+ */
+@Controller('platform')
+@UseGuards(TenantContextGuard, PlatformAdminGuard)
+export class PlatformController {
+  constructor(private readonly platform: PlatformService) {}
+
+  @Post('tenants')
+  async tenantAanmaken(@Body() body: unknown) {
+    try {
+      const invoer = leesNieuweTenant(body);
+      const tenant = await this.platform.tenantAanmaken(invoer);
+
+      return {
+        ...tenant,
+        // De eerste admin kan pas inloggen nadat hij zich bij Entra heeft
+        // gemeld; zijn oid koppelt dan aan deze rij. Het scherm hoort dat te
+        // vertellen, anders lijkt een aangemaakte tenant onbruikbaar.
+        melding:
+          `Tenant aangemaakt. ${invoer.adminNaam} kan inloggen zodra hij zich ` +
+          'met dit e-mailadres bij de identity provider aanmeldt.',
+      };
+    } catch (fout) {
+      if (fout instanceof InvoerFout) {
+        throw new BadRequestException({
+          veld: fout.veld,
+          melding: fout.message,
+        });
+      }
+      throw fout;
+    }
+  }
+
+  @Get('tenants/:id')
+  async tenantLezen(@Param('id') id: string) {
+    const tenant = await this.platform.tenantLezen(id);
+
+    if (!tenant) {
+      throw new NotFoundException('Onbekende tenant.');
+    }
+
+    return tenant;
+  }
+
+  /**
+   * Tijdelijke support-toegang tot één tenant.
+   *
+   * Geen impersonatie: de beheerder komt binnen als zichzelf, in de rol
+   * `support`, en blijft daarmee te onderscheiden van een medewerker van de
+   * klant (Issue #57).
+   */
+  @Post('tenants/:id/toegang')
+  async supportToegang(
+    @Param('id') id: string,
+    @Body() body: unknown,
+    @Req() request: RequestMetSessie,
+  ) {
+    try {
+      const reden = leesSupportReden(body);
+      const bestaat = await this.platform.tenantLezen(id);
+
+      if (!bestaat) {
+        throw new NotFoundException('Onbekende tenant.');
+      }
+
+      // De sessie is gegarandeerd aanwezig: beide guards hebben gedraaid.
+      const sessie = request.sessie!;
+
+      return await this.platform.supportToegangGeven(id, sessie.userId, reden);
+    } catch (fout) {
+      if (fout instanceof InvoerFout) {
+        throw new BadRequestException({
+          veld: fout.veld,
+          melding: fout.message,
+        });
+      }
+      throw fout;
+    }
+  }
+}

--- a/src/platform/platform.module.ts
+++ b/src/platform/platform.module.ts
@@ -1,0 +1,22 @@
+import { Module } from '@nestjs/common';
+
+import { AuthModule } from '../auth/auth.module';
+import { PlatformAdminGuard } from './platform-admin.guard';
+import { PlatformController } from './platform.controller';
+import { PlatformService } from './platform.service';
+
+/**
+ * Platformbeheer (ADR-015, migratie 0020).
+ *
+ * `AuthModule` levert TenantContextGuard; PlatformAdminGuard staat hier omdat
+ * hij alleen door deze module gebruikt wordt. Een guard is een gewone
+ * provider: zonder registratie kent NestJS hem niet en faalt het opstarten —
+ * zichtbaar, niet stil.
+ */
+@Module({
+  imports: [AuthModule],
+  controllers: [PlatformController],
+  providers: [PlatformService, PlatformAdminGuard],
+  exports: [PlatformService],
+})
+export class PlatformModule {}

--- a/src/platform/platform.service.ts
+++ b/src/platform/platform.service.ts
@@ -1,0 +1,234 @@
+import { ConflictException, Injectable } from '@nestjs/common';
+import { sql } from 'drizzle-orm';
+
+import { DatabaseService } from '../db/database.service';
+
+/** Hoe lang support-toegang standaard geldig is. */
+export const SUPPORT_TOEGANG_UREN = 8;
+
+export interface NieuweTenant {
+  readonly naam: string;
+  /** Wordt de eerste admin. Zijn oid volgt bij de eerste login. */
+  readonly adminEmail: string;
+  readonly adminNaam: string;
+}
+
+export interface TenantOverzicht {
+  readonly tenantId: string;
+  readonly naam: string;
+  readonly aangemaaktOp: Date;
+  readonly aantalLeden: number;
+}
+
+export interface SupportToegang {
+  readonly tenantId: string;
+  readonly verlooptOp: Date;
+  readonly reden: string;
+}
+
+/**
+ * Platformbeheer: tenants aanmaken en tijdelijke support-toegang toekennen
+ * (ADR-015, migratie 0020).
+ *
+ * ── Waarom hier withTenant() met de dóél-tenant staat ────────────────────────
+ *
+ * Elke schrijfactie loopt via de tenantcontext van de tenant waar hij landt,
+ * niet die van de aanroeper. Dat is geen omweg maar de kern: ook een
+ * platformbeheerder schrijft binnen RLS, en een fout in deze service kan
+ * daardoor geen rijen in een andere tenant raken.
+ *
+ * De tenant komt hier wél uit de invoer, en dat is de enige plek in de
+ * applicatie waar dat mag — bewaakt door PlatformAdminGuard. Voor alle andere
+ * routes geldt onverkort dat de tenant uit de sessie komt (§6).
+ */
+/**
+ * De twee indexen die een dubbele tenantnaam tegenhouden.
+ *
+ * `tenant_name_key` (baseline) bewaakt de exacte schrijfwijze,
+ * `tenant_name_ongeacht_hoofdletters` (0021) vangt wat die doorlaat.
+ */
+const NAAM_CONSTRAINTS = new Set([
+  'tenant_name_key',
+  'tenant_name_ongeacht_hoofdletters',
+]);
+
+/**
+ * Herkent een dubbele tenantnaam.
+ *
+ * Drizzle verpakt de pg-fout in een DrizzleQueryError; de PostgreSQL-code
+ * (23505) en de constraintnaam staan in `cause`. Op de constraintnaam toetsen
+ * en niet alleen op 23505: een andere unieke index zou anders óók als
+ * "naam bestaat al" naar buiten komen, en dat is een misleidende melding.
+ */
+function isUniekeNaamFout(fout: unknown): boolean {
+  const oorzaak = (fout as { cause?: unknown })?.cause ?? fout;
+  const details = oorzaak as { code?: string; constraint?: string };
+
+  return (
+    details?.code === '23505' &&
+    typeof details?.constraint === 'string' &&
+    NAAM_CONSTRAINTS.has(details.constraint)
+  );
+}
+
+@Injectable()
+export class PlatformService {
+  constructor(private readonly db: DatabaseService) {}
+
+  /**
+   * Maakt een tenant met zijn eerste beheerder.
+   *
+   * De gebruikersrij krijgt géén `external_subject`: die is pas bekend als de
+   * persoon voor het eerst inlogt bij Entra. De partiële unieke index op die
+   * kolom (migratie 0009, `WHERE external_subject IS NOT NULL`) staat dat
+   * uitdrukkelijk toe — precies met deze situatie in gedachten.
+   */
+  async tenantAanmaken(invoer: NieuweTenant): Promise<TenantOverzicht> {
+    const tenantId = crypto.randomUUID();
+
+    return this.db.withTenant(tenantId, async (tx) => {
+      // ── Waarom hier geen "bestaat de naam al?"-query staat ─────────────────
+      //
+      // Die zou niets vinden. We draaien in de tenantcontext van de nieuwe,
+      // nog niet bestaande tenant, en RLS verbergt elke andere tenant — een
+      // SELECT levert dus altijd nul rijen op, hoeveel gelijknamige tenants er
+      // ook zijn.
+      //
+      // De unieke index `tenant_name_key` (baseline 0000) doet het werk wel,
+      // want een constraint kent geen RLS. Vandaar: proberen, en de fout
+      // vertalen naar iets wat het scherm kan tonen.
+      try {
+        await tx.execute(
+          sql`INSERT INTO clm.tenant (tenant_id, name) VALUES (${tenantId}, ${invoer.naam})`,
+        );
+      } catch (fout) {
+        if (isUniekeNaamFout(fout)) {
+          throw new ConflictException(
+            `Er bestaat al een tenant met de naam '${invoer.naam}'.`,
+          );
+        }
+        throw fout;
+      }
+
+      const gebruiker = await tx.execute<{ user_id: string }>(
+        sql`INSERT INTO clm."user" (tenant_id, full_name, email)
+            VALUES (${tenantId}, ${invoer.adminNaam}, ${invoer.adminEmail})
+            RETURNING user_id`,
+      );
+
+      const userId = gebruiker.rows[0].user_id;
+
+      await tx.execute(
+        sql`INSERT INTO clm.tenant_membership (user_id, tenant_id, role)
+            VALUES (${userId}, ${tenantId}, 'admin')`,
+      );
+
+      await tx.execute(
+        sql`INSERT INTO audit.audit_event
+              (tenant_id, action_type, entity_type, entity_id, new_values)
+            VALUES (${tenantId}, 'tenant_aangemaakt', 'tenant', ${tenantId},
+                    ${JSON.stringify({
+                      naam: invoer.naam,
+                      eersteAdmin: invoer.adminEmail,
+                    })}::jsonb)`,
+      );
+
+      const rij = await tx.execute<{ created_at: Date }>(
+        sql`SELECT created_at FROM clm.tenant WHERE tenant_id = ${tenantId}`,
+      );
+
+      return {
+        tenantId,
+        naam: invoer.naam,
+        aangemaaktOp: rij.rows[0].created_at,
+        aantalLeden: 1,
+      };
+    });
+  }
+
+  /**
+   * Kent de platformbeheerder tijdelijke support-toegang toe tot één tenant.
+   *
+   * Geen impersonatie: hij komt binnen als zichzelf, in de rol `support`, en
+   * blijft daarmee in elk spoor te onderscheiden van een medewerker van de
+   * klant. Dat is de eis uit Issue #57 en de reden dat 'support' bestaat.
+   */
+  async supportToegangGeven(
+    tenantId: string,
+    beheerderUserId: string,
+    reden: string,
+  ): Promise<SupportToegang> {
+    return this.db.withTenant(tenantId, async (tx) => {
+      // Een bestaande support-rij wordt vervangen, niet gedupliceerd: de
+      // primaire sleutel is (user_id, tenant_id). Verlengen is hetzelfde als
+      // opnieuw toekennen, met een nieuwe reden en een nieuwe einddatum.
+      const rij = await tx.execute<{ verloopt_op: Date }>(
+        sql`INSERT INTO clm.tenant_membership
+              (user_id, tenant_id, role, verloopt_op, reden, toegekend_door)
+            VALUES (${beheerderUserId}, ${tenantId}, 'support',
+                    now() + ${`${SUPPORT_TOEGANG_UREN} hours`}::interval,
+                    ${reden}, ${beheerderUserId})
+            ON CONFLICT (user_id, tenant_id) DO UPDATE
+              SET role = 'support',
+                  verloopt_op = now() + ${`${SUPPORT_TOEGANG_UREN} hours`}::interval,
+                  reden = ${reden},
+                  deleted_at = NULL
+            RETURNING verloopt_op`,
+      );
+
+      await tx.execute(
+        sql`INSERT INTO audit.audit_event
+              (tenant_id, action_type, entity_type, entity_id, new_values)
+            VALUES (${tenantId}, 'support_toegang_toegekend', 'tenant_membership',
+                    ${tenantId},
+                    ${JSON.stringify({
+                      beheerder: beheerderUserId,
+                      reden,
+                      urenGeldig: SUPPORT_TOEGANG_UREN,
+                    })}::jsonb)`,
+      );
+
+      return { tenantId, verlooptOp: rij.rows[0].verloopt_op, reden };
+    });
+  }
+
+  /**
+   * Alle tenants, voor het beheerscherm.
+   *
+   * Deze query moet langs RLS heen kijken — een lijst van álle tenants is per
+   * definitie tenant-overstijgend. Dat kan alleen omdat clm.tenant een
+   * policy heeft op current_tenant_id(): zonder context levert hij niets op.
+   * Vandaar de lus over de tenants die de beheerder mag zien, niet één query.
+   *
+   * Voor nu is dat één tenant per aanroep en dus onbruikbaar als overzicht.
+   * De lijst komt in fase 3, samen met het scherm; hier staat alleen wat de
+   * route vandaag nodig heeft.
+   */
+  async tenantLezen(tenantId: string): Promise<TenantOverzicht | null> {
+    return this.db.withTenant(tenantId, async (tx) => {
+      const { rows } = await tx.execute<{
+        tenant_id: string;
+        name: string;
+        created_at: Date;
+        leden: string;
+      }>(
+        sql`SELECT t.tenant_id, t.name, t.created_at,
+                   (SELECT count(*) FROM clm.tenant_membership m
+                     WHERE m.tenant_id = t.tenant_id AND m.deleted_at IS NULL) AS leden
+              FROM clm.tenant t
+             WHERE t.tenant_id = ${tenantId}`,
+      );
+
+      if (rows.length === 0) {
+        return null;
+      }
+
+      return {
+        tenantId: rows[0].tenant_id,
+        naam: rows[0].name,
+        aangemaaktOp: rows[0].created_at,
+        aantalLeden: Number(rows[0].leden),
+      };
+    });
+  }
+}

--- a/test/platform-routes.e2e-spec.ts
+++ b/test/platform-routes.e2e-spec.ts
@@ -1,0 +1,398 @@
+import { INestApplication } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import cookieParser from 'cookie-parser';
+import { Client } from 'pg';
+import request from 'supertest';
+import type { App } from 'supertest/types';
+
+import { AppModule } from '../src/app.module';
+import { cookieInstellingen } from '../src/auth/sessie';
+import { SessieService } from '../src/auth/sessie.service';
+import { TEST_IDS } from './test-ids';
+
+/**
+ * De platformroutes van buitenaf (ADR-015, migratie 0020).
+ *
+ * Wat hier bewezen moet worden is niet dat een tenant aangemaakt kan worden —
+ * dat is het makkelijke deel — maar dat de route dicht zit voor iedereen die
+ * geen platformbeheerder is. Een beheerscherm waarvan de route openstaat is
+ * gevaarlijker dan geen scherm: het wekt de indruk dat er iets geregeld is.
+ *
+ * De tweede kern: deze controller is de enige plek in de applicatie waar een
+ * tenant uit de invoer komt (§6). Dat mag alleen omdat PlatformAdminGuard
+ * ervoor staat, en die uitzondering hoort dus zwaarder bewaakt dan de regel.
+ */
+
+const {
+  tenantThuis: TENANT_THUIS,
+  tenantVreemd: TENANT_VREEMD,
+  beheerder: USER_BEHEERDER,
+  gewoneGebruiker: USER_GEWOON,
+} = TEST_IDS['platform-routes'];
+
+const SUBJECT_BEHEERDER = `oid-platroute-beheer-${Date.now()}`;
+const SUBJECT_GEWOON = `oid-platroute-gewoon-${Date.now()}`;
+
+interface TenantAntwoord {
+  tenantId?: string;
+  naam?: string;
+  aantalLeden?: number;
+  melding?: string;
+  verlooptOp?: string;
+  reden?: string;
+  veld?: string;
+}
+
+const body = (res: { body: unknown }) => res.body as TenantAntwoord;
+
+/** Migratierol, altijd naar dezelfde database als DATABASE_URL — zie 0020. */
+function migratieUrl(): string {
+  const runtime = process.env.DATABASE_URL;
+  if (!runtime) throw new Error('DATABASE_URL ontbreekt.');
+
+  const doel = new URL(runtime);
+  const expliciet = process.env.MIGRATION_DATABASE_URL;
+
+  if (expliciet) {
+    const gegeven = new URL(expliciet);
+    if (gegeven.host === doel.host && gegeven.pathname === doel.pathname) {
+      return expliciet;
+    }
+  }
+
+  doel.username = 'clm_migrator';
+  return doel.toString();
+}
+
+describe('Platformroutes (e2e, ADR-015)', () => {
+  let app: INestApplication<App>;
+  let server: App;
+  let client: Client;
+  let migratieClient: Client;
+  let cookieBeheerder: string;
+  let cookieGewoon: string;
+  /** Tenants die de tests aanmaken; in afterAll op te ruimen. */
+  const aangemaakt: string[] = [];
+
+  beforeAll(async () => {
+    client = new Client({ connectionString: process.env.DATABASE_URL });
+    await client.connect();
+
+    for (const [tenant, user, subject, naam] of [
+      [TENANT_THUIS, USER_BEHEERDER, SUBJECT_BEHEERDER, 'Platformbeheerder'],
+      [TENANT_VREEMD, USER_GEWOON, SUBJECT_GEWOON, 'Gewone gebruiker'],
+    ] as const) {
+      await client.query('BEGIN');
+      await client.query(`SET LOCAL app.current_tenant_id = '${tenant}'`);
+      await client.query(
+        'INSERT INTO clm.tenant (tenant_id, name) VALUES ($1, $2)',
+        [tenant, `platroute-${naam}`],
+      );
+      await client.query(
+        `INSERT INTO clm."user" (user_id, tenant_id, full_name, email, external_subject)
+         VALUES ($1, $2, $3, $4, $5)`,
+        [user, tenant, naam, `${subject}@voorbeeld.nl`, subject],
+      );
+      await client.query(
+        `INSERT INTO clm.tenant_membership (user_id, tenant_id, role)
+         VALUES ($1, $2, 'admin')`,
+        [user, tenant],
+      );
+      await client.query('COMMIT');
+    }
+
+    // Alleen de eerste is platformbeheerder. Via de migratierol, want de
+    // runtime-rol mag deze tabel niet schrijven — dat is het punt van 0020.
+    migratieClient = new Client({ connectionString: migratieUrl() });
+    await migratieClient.connect();
+    await migratieClient.query(
+      `INSERT INTO clm.platform_admin (user_id, toelichting)
+       VALUES ($1, 'e2e platformroutes') ON CONFLICT DO NOTHING`,
+      [USER_BEHEERDER],
+    );
+
+    const moduleRef = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleRef.createNestApplication();
+    app.use(cookieParser());
+    await app.init();
+    server = app.getHttpServer();
+
+    const sessies = app.get(SessieService);
+    const cookieNaam = cookieInstellingen().naam;
+
+    const sessieBeheerder = await sessies.aanmaken(SUBJECT_BEHEERDER);
+    const sessieGewoon = await sessies.aanmaken(SUBJECT_GEWOON);
+    expect(sessieBeheerder).not.toBeNull();
+    expect(sessieGewoon).not.toBeNull();
+
+    cookieBeheerder = `${cookieNaam}=${sessieBeheerder!.token}`;
+    cookieGewoon = `${cookieNaam}=${sessieGewoon!.token}`;
+  }, 30000);
+
+  afterAll(async () => {
+    await app.close();
+
+    for (const tenant of [...aangemaakt, TENANT_VREEMD, TENANT_THUIS]) {
+      // De audit trail is append-only: de runtime-rol heeft alleen INSERT en
+      // SELECT (migratie 0001, §7.7). Opruimen kan daarom alleen via de
+      // migratierol — en dat is precies zoals het hoort.
+      await migratieClient.query(
+        'DELETE FROM audit.audit_event WHERE tenant_id = $1',
+        [tenant],
+      );
+
+      await client.query('BEGIN');
+      await client.query(`SET LOCAL app.current_tenant_id = '${tenant}'`);
+      await client.query(
+        'DELETE FROM clm.tenant_membership WHERE tenant_id = $1',
+        [tenant],
+      );
+      await client.query('DELETE FROM clm."user" WHERE tenant_id = $1', [
+        tenant,
+      ]);
+      await client.query('DELETE FROM clm.tenant WHERE tenant_id = $1', [
+        tenant,
+      ]);
+      await client.query('COMMIT');
+    }
+
+    await migratieClient.query(
+      'DELETE FROM clm.platform_admin WHERE user_id = $1',
+      [USER_BEHEERDER],
+    );
+    await migratieClient.end();
+    await client.end();
+  }, 30000);
+
+  describe('de deur', () => {
+    it('weigert een verzoek zonder sessie met 401', async () => {
+      await request(server)
+        .post('/platform/tenants')
+        .send({ naam: 'Zomaar', adminNaam: 'X', adminEmail: 'x@y.nl' })
+        .expect(401);
+    });
+
+    it('weigert een gewone tenant-admin met 403', async () => {
+      // Dit is de belangrijkste test van deze suite. Een geldige sessie, een
+      // echte admin — maar geen platformbeheerder. Zonder deze grens zou elke
+      // klantbeheerder tenants kunnen aanmaken.
+      const antwoord = await request(server)
+        .post('/platform/tenants')
+        .set('Cookie', cookieGewoon)
+        .send({
+          naam: 'Stiekem BV',
+          adminNaam: 'Indringer',
+          adminEmail: 'indringer@voorbeeld.nl',
+        })
+        .expect(403);
+
+      expect(JSON.stringify(antwoord.body)).toContain('platformbeheer');
+    });
+
+    it('weigert ook lezen voor een gewone tenant-admin', async () => {
+      await request(server)
+        .get(`/platform/tenants/${TENANT_THUIS}`)
+        .set('Cookie', cookieGewoon)
+        .expect(403);
+    });
+  });
+
+  describe('een tenant aanmaken', () => {
+    it('maakt tenant, eerste admin en membership in één handeling', async () => {
+      const antwoord = await request(server)
+        .post('/platform/tenants')
+        .set('Cookie', cookieBeheerder)
+        .send({
+          naam: 'AlingAdvies',
+          adminNaam: 'Kees',
+          adminEmail: 'kees@alingadvies.nl',
+        })
+        .expect(201);
+
+      const uit = body(antwoord);
+      expect(uit.tenantId).toBeDefined();
+      expect(uit.naam).toBe('AlingAdvies');
+      expect(uit.aantalLeden).toBe(1);
+      expect(uit.melding).toContain('inloggen');
+
+      aangemaakt.push(uit.tenantId!);
+
+      // De admin bestaat, nog zonder external_subject: die komt bij zijn
+      // eerste login. De partiële unieke index staat dat toe (migratie 0009).
+      await client.query('BEGIN');
+      await client.query(
+        `SET LOCAL app.current_tenant_id = '${uit.tenantId!}'`,
+      );
+      const { rows } = await client.query<{
+        email: string;
+        external_subject: string | null;
+        role: string;
+      }>(
+        `SELECT u.email, u.external_subject, m.role
+           FROM clm."user" u
+           JOIN clm.tenant_membership m ON m.user_id = u.user_id
+          WHERE u.tenant_id = $1`,
+        [uit.tenantId],
+      );
+      await client.query('COMMIT');
+
+      expect(rows).toHaveLength(1);
+      expect(rows[0].email).toBe('kees@alingadvies.nl');
+      expect(rows[0].external_subject).toBeNull();
+      expect(rows[0].role).toBe('admin');
+    });
+
+    it('legt het aanmaken vast in de audit trail', async () => {
+      const tenantId = aangemaakt[0];
+
+      await client.query('BEGIN');
+      await client.query(`SET LOCAL app.current_tenant_id = '${tenantId}'`);
+      const { rows } = await client.query<{
+        action_type: string;
+        new_values: Record<string, unknown>;
+      }>(
+        `SELECT action_type, new_values FROM audit.audit_event
+          WHERE tenant_id = $1 AND action_type = 'tenant_aangemaakt'`,
+        [tenantId],
+      );
+      await client.query('COMMIT');
+
+      expect(rows).toHaveLength(1);
+      expect(rows[0].new_values.naam).toBe('AlingAdvies');
+      expect(rows[0].new_values.eersteAdmin).toBe('kees@alingadvies.nl');
+    });
+
+    it('weigert dezelfde naam met 409', async () => {
+      await request(server)
+        .post('/platform/tenants')
+        .set('Cookie', cookieBeheerder)
+        .send({
+          naam: 'AlingAdvies',
+          adminNaam: 'Iemand',
+          adminEmail: 'iemand@voorbeeld.nl',
+        })
+        .expect(409);
+    });
+
+    it('weigert een naam die alleen in hoofdletters verschilt', async () => {
+      // Migratie 0021. Deze test gaf 201 vóórdat die index bestond: de
+      // baseline-index is hoofdlettergevoelig, en in de applicatielaag was het
+      // niet te vangen — de route draait in de context van de níéuwe tenant en
+      // RLS verbergt daar elke bestaande tenant.
+      await request(server)
+        .post('/platform/tenants')
+        .set('Cookie', cookieBeheerder)
+        .send({
+          naam: 'alingadvies',
+          adminNaam: 'Iemand',
+          adminEmail: 'iemand@voorbeeld.nl',
+        })
+        .expect(409);
+    });
+
+    it('weigert een onvolledig verzoek met 400', async () => {
+      const antwoord = await request(server)
+        .post('/platform/tenants')
+        .set('Cookie', cookieBeheerder)
+        .send({ naam: 'Zonder admin' })
+        .expect(400);
+
+      expect(JSON.stringify(antwoord.body)).toContain('adminNaam');
+    });
+
+    it('weigert een onzinnig e-mailadres met 400', async () => {
+      await request(server)
+        .post('/platform/tenants')
+        .set('Cookie', cookieBeheerder)
+        .send({
+          naam: 'Kapot Adres BV',
+          adminNaam: 'Iemand',
+          adminEmail: 'geen-apenstaartje',
+        })
+        .expect(400);
+    });
+  });
+
+  describe('support-toegang', () => {
+    it('kent tijdelijke toegang toe, met reden en einddatum', async () => {
+      const tenantId = aangemaakt[0];
+
+      const antwoord = await request(server)
+        .post(`/platform/tenants/${tenantId}/toegang`)
+        .set('Cookie', cookieBeheerder)
+        .send({ reden: 'Klant meldt dat ronde 3 niet opent' })
+        .expect(201);
+
+      const uit = body(antwoord);
+      expect(uit.reden).toBe('Klant meldt dat ronde 3 niet opent');
+      expect(new Date(uit.verlooptOp!).getTime()).toBeGreaterThan(Date.now());
+
+      await client.query('BEGIN');
+      await client.query(`SET LOCAL app.current_tenant_id = '${tenantId}'`);
+      const { rows } = await client.query<{ role: string; reden: string }>(
+        `SELECT role, reden FROM clm.tenant_membership
+          WHERE tenant_id = $1 AND user_id = $2`,
+        [tenantId, USER_BEHEERDER],
+      );
+      await client.query('COMMIT');
+
+      // Rol 'support', niet 'admin': de beheerder is herkenbaar als platform,
+      // niet als medewerker van de klant (Issue #57).
+      expect(rows).toHaveLength(1);
+      expect(rows[0].role).toBe('support');
+    });
+
+    it('legt de toekenning vast in de audit trail', async () => {
+      const tenantId = aangemaakt[0];
+
+      await client.query('BEGIN');
+      await client.query(`SET LOCAL app.current_tenant_id = '${tenantId}'`);
+      const { rows } = await client.query<{
+        new_values: Record<string, unknown>;
+      }>(
+        `SELECT new_values FROM audit.audit_event
+          WHERE tenant_id = $1 AND action_type = 'support_toegang_toegekend'`,
+        [tenantId],
+      );
+      await client.query('COMMIT');
+
+      expect(rows).toHaveLength(1);
+      expect(rows[0].new_values.reden).toBe(
+        'Klant meldt dat ronde 3 niet opent',
+      );
+      expect(rows[0].new_values.beheerder).toBe(USER_BEHEERDER);
+    });
+
+    it('eist een reden van betekenis', async () => {
+      const tenantId = aangemaakt[0];
+
+      // 'test' is geen reden. Wat hier wordt tegengehouden is de gewoonte om
+      // het veld met een teken te vullen — dan staat er straks een audit trail
+      // vol regels die niets verklaren.
+      await request(server)
+        .post(`/platform/tenants/${tenantId}/toegang`)
+        .set('Cookie', cookieBeheerder)
+        .send({ reden: 'test' })
+        .expect(400);
+    });
+
+    it('weigert support-toegang voor een gewone tenant-admin', async () => {
+      await request(server)
+        .post(`/platform/tenants/${TENANT_THUIS}/toegang`)
+        .set('Cookie', cookieGewoon)
+        .send({ reden: 'Ik wil ook wel eens meekijken' })
+        .expect(403);
+    });
+
+    it('geeft 404 op een onbekende tenant', async () => {
+      await request(server)
+        .post('/platform/tenants/00000000-0000-0000-0000-0000000000ff/toegang')
+        .set('Cookie', cookieBeheerder)
+        .send({ reden: 'Bestaat helemaal niet, deze tenant' })
+        .expect(404);
+    });
+  });
+});

--- a/test/test-ids.ts
+++ b/test/test-ids.ts
@@ -309,6 +309,14 @@ export const TEST_IDS = {
     beheerder: id('72'),
     klantmedewerker: id('73'),
   },
+  'platform-routes': {
+    /** De tenant waar de platformbeheerder zelf in zit. */
+    tenantThuis: id('74'),
+    /** De tenant van een gewone gebruiker, zonder platformrechten. */
+    tenantVreemd: id('75'),
+    beheerder: id('76'),
+    gewoneGebruiker: id('77'),
+  },
 } as const;
 
 /** Alle uitgedeelde id's, plat. Gebruikt door de bewakingstest. */


### PR DESCRIPTION
Fase 2 van het plan: de routes achter migratie 0020. De eigenaar kan nu een
tenant aanmaken zonder handmatig in de database te schrijven.

## De routes

| Route | Wat |
|---|---|
| `POST /platform/tenants` | Tenant + eerste admin + membership, in één transactie |
| `GET /platform/tenants/:id` | Lezen |
| `POST /platform/tenants/:id/toegang` | Support-toegang, 8 uur, verplichte reden |

`PlatformAdminGuard` staat **náást** `TenantContextGuard`, niet erin. Die stelt
vast wie er is en bij welke tenant; deze of die persoon iets mag dat buiten elke
tenant staat. De vraag gaat naar de database en niet naar de sessie: het
intrekken van platformbeheer moet direct werken, niet pas na acht uur.

De eerste admin krijgt géén `external_subject` — die komt bij zijn eerste
Entra-login. De partiële unieke index uit 0009 (`WHERE external_subject IS NOT
NULL`) staat dat toe, precies met deze situatie in gedachten.

De reden bij support-toegang is verplicht en minstens tien tekens. Geen
vormvereiste: SOC 2 CC6.3 vraagt een justification bij elke elevation, en een
audit trail vol regels met "test" verklaart later niets.

## De uitzondering, zwaarder bewaakt dan de regel

Deze controller is de **enige plek in de applicatie waar een tenant uit de
invoer komt** (§6). Dat kan alleen omdat de guard ervoor staat. Drie van de
veertien tests gaan daarom alleen over de deur: geen sessie → 401, gewone
tenant-admin → 403, ook voor lezen → 403.

## Migratie 0021 — een bug die de tests vonden

`tenant_name_key` uit de baseline is hoofdlettergevoelig. `alingadvies` naast
`AlingAdvies` gaf daardoor **201 in plaats van 409**: twee "klanten" die alleen
in hoofdletters verschillen.

Het interessante is waarom dat niet in de applicatielaag te repareren was. De
aanmaakroute draait in de tenantcontext van de **nieuwe** tenant, en RLS
verbergt daar elke bestaande tenant — een `SELECT ... WHERE lower(name) = ...`
vindt dus nooit iets, hoeveel gelijknamige tenants er ook zijn. Een constraint
kent geen RLS, dus hoort de regel daar.

**Deze bug verstopte zich.** Hij was groen bij een tweede run op dezelfde
database (restdata met exact dezelfde naam) en rood op een verse — het
onregelmatige patroon waar het runbook voor waarschuwt. Vier runs achtereen
bevestigen nu 14/14: drie keer vers, één keer herhaald.

## Bewezen, niet aangenomen

```
GROEN — de hele keten, van code tot browser.
```

`verify:volledig` tegen een wegwerpdatabase, alle zes stappen. **413 e2e-tests
in 29 suites**, waarvan 14 nieuw, plus de test-id-bewaking.

De veertien nieuwe tests dekken: de deur (3), aanmaken inclusief audit trail en
invoervalidatie (6), en support-toegang inclusief audit trail en de rol
`support` in plaats van `admin` (5).

## Te controleren

- [ ] Is acht uur de juiste standaardduur voor support-toegang?
- [ ] Is een reden van tien tekens streng genoeg, of te streng?

## Na het mergen

Migratie 0021 moet nog op productie — bewust niet vooraf gedraaid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)