### PR TITLE
feat(rechten): rechtencontract, poort over beide verbindingen, gedeelde opruiming

### DIFF
--- a/docs/testaanpak-en-architectuur.md
+++ b/docs/testaanpak-en-architectuur.md
@@ -8,6 +8,19 @@ samenhang met de architectuur — productiedatabase, backup, backend en frontend
 > datastructuur met alle cijfers, lagen en relaties. De rest van het document is
 > de onderbouwing. Voorgestelde visuele opbouw staat in §12.
 
+**Verhouding tot de runbooks.** Dit document beschrijft *waarom* er zo getest
+wordt. Het *hoe* staat in `docs/runbooks/`, en dat blijft daar leidend:
+
+| Runbook | Waarvoor |
+|---|---|
+| `commandos-en-omgeving.md` | welk commando bestaat, waar praat het naartoe, wat mag nooit |
+| `zelf-testen.md` | de demo-omgeving gebruiken |
+| `otap-doorloop.md` | de volledige doorloop naar productie-images |
+| `backupcontrole.md` | de dagelijkse dump nalopen |
+| `supabase-verificatie-en-restoretest.md` | herstel beproeven |
+
+Bij twijfel over een commando of doelwit: het runbook wint van dit document.
+
 ---
 
 ## 1. Het uitgangspunt
@@ -214,6 +227,45 @@ achterloopt zijn twee verschillende dingen.
 | `src/db/rechten-contract.ts` | legt vast wat de applicatierol mág |
 | `scripts/db-doelwit.js` | hostcontrole + `--extern`-bevestiging voor scripts |
 | `scripts/markeer-wegwerp.js` | de enige manier om een database als wegwerp te markeren |
+
+### Poorten — wie claimt wat
+
+| Poort | Wie | Wanneer |
+|---|---|---|
+| 55440 | handmatige wegwerpdatabase | als je hem zelf opzet |
+| 55441 | `verify:volledig` | tijdens stap 1 |
+| 55450 | `mcm2demo` | zolang de demo staat |
+| 5001 | API in de doorloopstack | `verify:volledig` en `npm run demo` |
+| 3000 | frontend | idem |
+
+`verify:volledig` faalt op een bezette 55441 met "geen testdatabase kunnen
+starten" — een melding die naar de verkeerde oorzaak wijst. Het script sluit
+bewust niets zelf af: een server op 3000 of 5001 kan van een ander project zijn.
+
+### De valkuil van gedeelde suites
+
+Alle e2e-suites delen één database. Een suite die los groen draait kan de
+volledige run alsnog rood maken, en welke suite dan omvalt hangt af van de
+volgorde — de vervelendste faalvorm die er is, want hij ziet eruit als toeval.
+
+**Vier unieke sleutels hebben géén `tenant_id` erin.** Je eigen tenant beschermt
+je dus niet:
+
+| Sleutel | Op | Oplossing |
+|---|---|---|
+| `survey_response_token_hash_key` | `survey_response.token_hash` | eigen herhaald teken per suite |
+| `tenant_name_key` | `tenant.name` | suitenaam in de tenantnaam |
+| `user_external_subject_key` | `user.external_subject` | suiteprefix **plus** `Date.now()` |
+| `survey_attachment_storage_key_key` | `survey_attachment.storage_key` | eigen prefix per suite |
+
+Daarom bestaat `test-ids.ts` als centraal register, met een bewakingstest die
+een botsing vangt en beide suites bij naam noemt. Die kost een seconde en heeft
+geen database nodig — draai hem vóór een volledige run.
+
+**De aanleiding:** op 2026-07-31 viel de suite onregelmatig om — één run 21
+falende tests, dan drie runs groen, dan weer 20. De foutmeldingen wezen naar
+`duplicate key` en een foreign key: allebei gevolgen, geen oorzaken. Drie suites
+deelden dezelfde UUID's.
 
 ### Twee registers, één principe
 
@@ -439,6 +491,28 @@ twee_registers:
     vraag: "Wat is toegestaan?"
     bron: "een expliciet besluit"
   samen: "een test leest de database terug en vergelijkt"
+
+gedeelde_database:              # waarom suites elkaar kunnen slopen
+  probleem: "alle e2e-suites delen één database"
+  kern: "vier unieke sleutels hebben géén tenant_id — je eigen tenant beschermt je niet"
+  sleutels:
+    - "survey_response.token_hash"
+    - "tenant.name"
+    - "user.external_subject"
+    - "survey_attachment.storage_key"
+  oplossing: "test-ids.ts — centraal register met bewakingstest"
+
+poorten:                        # eventueel als klein schema
+  - poort: 55440
+    wie: "handmatige wegwerpdatabase"
+  - poort: 55441
+    wie: "verify:volledig"
+  - poort: 55450
+    wie: "demo (beschermd)"
+  - poort: 5001
+    wie: "API"
+  - poort: 3000
+    wie: "frontend"
 
 backup:
   bron: "Supabase Free — geen providerbackup"

--- a/docs/testaanpak-en-architectuur.md
+++ b/docs/testaanpak-en-architectuur.md
@@ -1,0 +1,496 @@
+# Zo testen we MCM2 — principes, gereedschap en architectuur
+
+**Datum:** 2026-08-09
+**Doel van dit document:** de testaanpak van MCM2 volledig beschrijven, in
+samenhang met de architectuur — productiedatabase, backup, backend en frontend.
+
+> **Voor wie hier een infographic van maakt:** §11 bevat een compacte
+> datastructuur met alle cijfers, lagen en relaties. De rest van het document is
+> de onderbouwing. Voorgestelde visuele opbouw staat in §12.
+
+---
+
+## 1. Het uitgangspunt
+
+Dit project heeft één ontwerpprioriteit die boven de andere staat:
+
+> **Security en betrouwbare tenant-isolatie.**
+> Daarna: onderhoudbaarheid, functionele aansluiting, reproduceerbare uitrol,
+> en pas dan performance.
+
+De testaanpak is daar de directe afgeleide van. Niet "werkt de functie" is de
+kernvraag, maar **"kan tenant A ooit iets van tenant B zien"** — en die vraag
+laat zich niet met een unittest beantwoorden.
+
+Daaruit volgen vijf principes.
+
+---
+
+## 2. De vijf principes
+
+### P1 — Groen is alleen groen via één commando
+
+`npm run verify:volledig`. Losse commando's bewijzen niets.
+
+**Waarom deze regel bestaat:** op 2026-07-31 was CI rood terwijl lokaal alles
+groen leek — er was een stap overgeslagen die niemand miste. Een reeks losse
+groene commando's voelt als bewijs en is het niet.
+
+### P2 — Een groene test zonder tegenproef bewijst niets
+
+Bij elke bescherming hoort een test die hem probeert te omzeilen.
+
+**Voorbeeld dat dit rechtvaardigt:** de demo-seed had acht groene tests. Bij de
+tegenproef bleek dat de tokenhash vervangen kon worden door een omkeerbare
+hex-codering — alle acht bleven groen. De test keek naar de *vorm* van de hash,
+niet of het de hash ís. Een databasedump zou daarmee elke openstaande survey
+hebben geopend.
+
+### P3 — Lees het resultaat terug uit de database
+
+"Migraties voltooid" is geen bewijs.
+
+**Twee keer misgegaan:** één keer betekende die melding dat er niets was
+gebeurd (de migratie stond niet in het journal), één keer dat het op de
+verkeerde database was gebeurd.
+
+### P4 — Meet, reconstrueer niet
+
+Namen opzoeken vóór je ze typt. Bestaand gereedschap zoeken vóór je het
+naschrijft.
+
+**Op één dag drie keer fout gegaan:** een tabel heette `tenant_membership` en
+niet `membership`; er bestond al een `bootstrap-roles.sql`; en een tabeltelling
+gaf "tien migraties achter" waar het er vijf waren.
+
+### P5 — Elk recht en elke aanname is expliciet en getest
+
+Niets mag afhangen van een omgevingsinstelling die toevallig ergens greep.
+
+**De aanleiding:** `ALTER DEFAULT PRIVILEGES` gaf lokaal rechten die op
+productie ontbraken — en omgekeerd gaf het lokaal méér rechten dan productie
+had. Tests draaiden daardoor ruimer dan de werkelijkheid.
+
+---
+
+## 3. De vier testlagen
+
+```
+┌─ Laag 4 ── BROWSERTEST ────────────────────────────────────────┐
+│  Playwright tegen de productie-images                          │
+│  8 specs · bewijst: het scherm roept de juiste route aan       │
+├─ Laag 3 ── E2E / INTEGRATIE ───────────────────────────────────┤
+│  Jest + echte PostgreSQL 17 in Docker                          │
+│  30 suites · 421 tests · bewijst: RLS, guards, tenantgrens     │
+├─ Laag 2 ── UNITTESTS ──────────────────────────────────────────┤
+│  Jest, geen database                                           │
+│  14 bestanden · bewijst: losse logica, tokenvorm, validatie    │
+├─ Laag 1 ── STATISCH ───────────────────────────────────────────┤
+│  prettier · eslint · tsc --noEmit                              │
+│  bewijst: opmaak, stijl, types                                 │
+└────────────────────────────────────────────────────────────────┘
+```
+
+**Het zwaartepunt ligt bewust op laag 3.** In een systeem waar de tenantgrens in
+de *database* zit (row-level security), bewijst een unittest met een mock niets
+over de eigenschap die ertoe doet. Vandaar 421 e2e-tests tegen een echte
+PostgreSQL, en 14 unittestbestanden.
+
+---
+
+## 4. De architectuur waartegen getest wordt
+
+```
+        ┌──────────────────┐         ┌──────────────────┐
+        │   FRONTEND       │         │   Entra External │
+        │   Next.js 15     │◄───────►│   ID  (OIDC)     │
+        │   eigen repo     │  login  │   federatie+MFA  │
+        └────────┬─────────┘         └──────────────────┘
+                 │ HTTP + sessiecookie
+                 ▼
+        ┌──────────────────┐
+        │   BACKEND        │   NestJS / TypeScript / Node 22
+        │   7 controllers  │   guards: TenantContext → Rol → PlatformAdmin
+        └────────┬─────────┘
+                 │ rol: clm_api_runtime  (géén BYPASSRLS)
+                 ▼
+        ┌───────────────────────────────────────────────┐
+        │   POSTGRESQL 17                               │
+        │   ┌─────────────────────────────────────────┐ │
+        │   │  ROW-LEVEL SECURITY = de tenantgrens    │ │
+        │   │  SET LOCAL app.current_tenant_id        │ │
+        │   └─────────────────────────────────────────┘ │
+        │   clm 19 · ref 3 · audit 1  = 23 tabellen     │
+        │   5 SECURITY DEFINER-functies                 │
+        └───────────────────────────────────────────────┘
+```
+
+**Twee toegangssporen, allebei getest:**
+
+| | Spoor 1 — interne beheerder | Spoor 2 — externe leverancier |
+|---|---|---|
+| Identiteit | Entra External ID | **geen account** |
+| Toegang | sessiecookie na login | tijdgebonden token in een link |
+| Tenant uit | `tenant_membership` | het token zelf |
+
+---
+
+## 5. De vier omgevingen
+
+Dit is de kern van de aanpak: **elke omgeving heeft een eigen rol, en de
+database zegt zélf welke.**
+
+| Omgeving | Poort | Markering | Wie gebruikt hem | Mag weg? |
+|---|---|---|---|---|
+| **Wegwerp** | 55440 e.v. | `wegwerp` | e2e-tests | ja, altijd |
+| **Demo (lokaal)** | 55450 | `beschermd` | feature review, demo's geven | nee |
+| **CI** | in de runner | `wegwerp` | GitHub Actions | ja, per run |
+| **Productie** | Supabase | `beschermd` | de echte applicatie | **nooit** |
+
+### Hoe de bescherming werkt
+
+Sinds migratie 0019 staat in elke database een tabel `clm.omgeving` met één rij:
+`wegwerp` of `beschermd`. **Standaard is alles `beschermd`.** Een wegwerpdatabase
+moet zich expliciet aanmelden:
+
+```
+node scripts/markeer-wegwerp.js "waarvoor"
+```
+
+De e2e-suites weigeren te draaien tegen alles wat niet `wegwerp` is — voor
+**beide** databaseverbindingen (`DATABASE_URL` én `MIGRATION_DATABASE_URL`).
+
+**Waarom dit bestaat:** op 2026-08-07 wisten de e2e-tests de demo-database.
+`DATABASE_URL` wees naar poort 55450 in plaats van 55440. De demo-tenant
+verdween, 400 testleveranciers bleven achter, en er sloeg niets aan — de enige
+bescherming die er was kende één criterium: is de host lokaal? Binnen
+`localhost` was de demo niet van een wegwerpcontainer te onderscheiden.
+
+**Waarom beide verbindingen:** op 2026-08-08 praatte een e2e-suite via
+`MIGRATION_DATABASE_URL` tegen productie. Die variabele staat in `.env` en wijst
+naar Supabase; wordt hij niet meegegeven, dan vult dotenv hem aan. De eerste
+query faalde toevallig — anders had die test rijen in productie aangemaakt.
+
+---
+
+## 6. Het gereedschap
+
+### Verificatie
+
+| Commando | Wat het doet | Duur |
+|---|---|---|
+| `npm run verify:volledig` | **de norm** — zes stappen, code tot browser | ~3 min |
+| `npm run verify` | code, unittests, e2e | ~1 min |
+| `npm run verify:snel` | zonder e2e | ~30 s |
+| `npm run verify:schema` | schema, RLS en policies vs. de code | ~20 s |
+
+### De zes stappen van `verify:volledig`
+
+```
+1  Code, unittests en backend-e2e     format → lint → typecheck → unit → e2e
+2  Stack bouwen en starten            beide PRODUCTIE-images via docker compose
+3  Migraties, tenant en sessie        een échte sessie klaarzetten
+4  Browsertest                        Playwright tegen de draaiende stack
+5  Draaien de echte omgevingen mee?   read-only controle op productie
+6  Opruimen                           altijd, ook na een fout
+```
+
+**Stap 2 draait tegen productie-images, niet tegen een ontwikkelserver.** Dat
+verschil is de reden dat deze doorloop bestaat: een `next dev`-server had een
+EACCES-uploadfout in het productie-image nooit gevonden.
+
+**Stap 5 is read-only** en meldt wanneer productie achterloopt op het schema —
+zonder de doorloop rood te maken. De keten kloppen en een omgeving die
+achterloopt zijn twee verschillende dingen.
+
+### Specifiek gereedschap
+
+| Bestand | Rol |
+|---|---|
+| `test/jest-e2e.guard.ts` | **de poort** — weigert niet-wegwerpdatabases, beide verbindingen |
+| `test/opruimen.ts` | één gedeelde opruimhelper, alle tabellen in FK-volgorde |
+| `test/test-ids.ts` | UUID-register per suite — voorkomt botsingen |
+| `src/db/schema-inventory.ts` | leidt uit het Drizzle-schema af wat er hoort te bestaan |
+| `src/db/rechten-contract.ts` | legt vast wat de applicatierol mág |
+| `scripts/db-doelwit.js` | hostcontrole + `--extern`-bevestiging voor scripts |
+| `scripts/markeer-wegwerp.js` | de enige manier om een database als wegwerp te markeren |
+
+### Twee registers, één principe
+
+```
+   schema-inventory.ts          rechten-contract.ts
+   ────────────────────         ───────────────────
+   Wat hoort te BESTAAN?        Wat is TOEGESTAAN?
+   afgeleid uit de code         een expliciet besluit
+   tabellen, kolommen, RLS      GRANT, search_path, EXECUTE
+                    │                    │
+                    └────────┬───────────┘
+                             ▼
+              een test leest de database terug
+              en vergelijkt met het register
+```
+
+Een nieuwe tabel of functie zonder regel in het register maakt de test rood.
+Dat dwingt een besluit af op het moment dat het object ontstaat — niet bij de
+eerste route die erover struikelt.
+
+---
+
+## 7. Wat de e2e-tests werkelijk bewijzen
+
+Niet "de functie werkt", maar dat de beschermingen niet te omzeilen zijn. De
+grootste suites, naar aantal tests:
+
+| Suite | Wat het bewaakt |
+|---|---|
+| `bijlage-upload` (18) | inhoud bepaalt het bestandstype, niet de naam |
+| `schema-conformiteit` (17) | policies, FORCE RLS, tabeleigenaarschap, `search_path` |
+| `vragenlijst-seed` (15) | inlezen van de vragenlijst |
+| `sessie` (14) | aanmaken, verlopen, intrekken; de tabel is afgesloten |
+| `membership-isolatie` (13) | lidmaatschap bepaalt de tenant, niet de invoer |
+| `rechten-contract` (8) | tabelrechten, `search_path`, `EXECUTE` |
+| `tenant-rls-isolation` (5) | lezen én schrijven over de tenantgrens heen |
+| `actor-context` (5) | **de actorgrens: medewerker, leverancier, onbekend** |
+
+### Drie tegenproeven die er echt toe doen
+
+1. **Een tenant uit de invoer wordt genegeerd.** Drie tests sturen een tenant
+   mee via een header, een query-parameter, en een ongeldig cookie náást een
+   header. Alle drie horen 401 te geven. Geschreven ná een tegenproef waarin de
+   guard wél op de header terugviel.
+2. **De sessietabel is dicht.** Een directe `SELECT` en `INSERT` als
+   applicatierol geven beide "permission denied".
+3. **De applicatie kan de audit trail niet wijzigen.** Append-only, afgedwongen
+   in de rechten en getest.
+
+---
+
+## 8. Data en herstel
+
+```
+  PRODUCTIE (Supabase Free)          geen providerbackup — Issue #30
+        │
+        │  npm run backup:dump   ─── dagelijks 07:00, automatisch
+        ▼
+  LOKALE DUMP  ──►  OneDrive        het enige vangnet (ADR-011)
+        │
+        │  npm run backup:controle
+        ▼
+  CONTROLE op de laatste dump       meldt stilstand
+```
+
+**De backup is niet "extra zekerheid" maar het enige vangnet.** Supabase Free
+levert geen providerbackups. De dagelijkse dump houdt bovendien het project
+actief, wat pauzeren na ~7 dagen inactiviteit voorkomt.
+
+**Waarom dit bij de testaanpak hoort:** stap 5 van `verify:volledig` meldt
+wanneer productie achterloopt op het schema — en dus ook dat de backup mist wat
+er niet in staat. Een backup van een verouderd schema herstelt een verouderde
+werkelijkheid.
+
+---
+
+## 9. CI: wat er bij elke push draait
+
+| Job | Wat |
+|---|---|
+| **Format, lint en typecheck** | prettier `--check`, eslint `--max-warnings=0`, `tsc --noEmit`, unittests |
+| **Docker productiebuild** | image bouwt, start, draait als non-root, serveert een pagina |
+| **RLS tenant-isolatietest** | de tenantgrens tegen een echte PostgreSQL |
+
+CI draait `lint:check` en `format:check` — de **controlerende** varianten.
+`npm run lint` en `npm run format` wijzigen bestanden en horen daarom niet in CI.
+
+---
+
+## 10. De incidenten die deze aanpak vormden
+
+Elke regel hierboven is er omdat er iets misging. Dat is geen zwakte van het
+document maar de reden dat het te vertrouwen is.
+
+| Datum | Wat er gebeurde | Wat eruit volgde |
+|---|---|---|
+| 2026-07-31 | CI rood, lokaal groen — een stap overgeslagen | P1: één commando |
+| 2026-07-31 | Drie suites deelden UUID's; onregelmatig falen | `test-ids.ts` |
+| 2026-08-06 | `migrate:deploy` draaide tegen productie (Issue #86) | doelwitmelding vóór verbinden |
+| 2026-08-07 | E2e-tests wisten de demo-database | migratie 0019: `clm.omgeving` |
+| 2026-08-07 | "Migraties voltooid" terwijl er niets gebeurde | P3: teruglezen |
+| 2026-08-08 | Suite praatte via de migratie-URL tegen productie | poort over **beide** verbindingen |
+| 2026-08-08 | Rechten lokaal ruimer dan productie | `rechten-contract.ts` |
+
+---
+
+## 11. Datastructuur voor de infographic
+
+```yaml
+titel: "Zo testen we MCM2"
+ondertitel: "Security-first testaanpak voor een multi-tenant SaaS-platform"
+
+kernboodschap: >
+  De tenantgrens zit in de database, niet in de code.
+  Daarom testen we tegen een echte database, en bewijst
+  elke bescherming zichzelf met een tegenproef.
+
+kerncijfers:
+  - waarde: "421"
+    label: "e2e-tests"
+  - waarde: "30"
+    label: "testsuites"
+  - waarde: "8"
+    label: "browsertests"
+  - waarde: "1"
+    label: "commando voor 'groen'"
+  - waarde: "6"
+    label: "stappen van code tot browser"
+
+testlagen:                      # piramide, breedste onderaan
+  - laag: 4
+    naam: "Browsertest"
+    gereedschap: "Playwright tegen productie-images"
+    omvang: "8 specs"
+    bewijst: "het scherm roept de juiste route aan"
+  - laag: 3
+    naam: "E2E / integratie"
+    gereedschap: "Jest + echte PostgreSQL 17"
+    omvang: "30 suites, 421 tests"
+    bewijst: "RLS, guards, tenantgrens"
+    accent: true                # zwaartepunt
+  - laag: 2
+    naam: "Unittests"
+    gereedschap: "Jest, geen database"
+    omvang: "14 bestanden"
+    bewijst: "losse logica"
+  - laag: 1
+    naam: "Statisch"
+    gereedschap: "prettier, eslint, tsc"
+    bewijst: "opmaak, stijl, types"
+
+principes:
+  - code: "P1"
+    naam: "Eén commando"
+    kort: "verify:volledig of niets"
+  - code: "P2"
+    naam: "Tegenproef verplicht"
+    kort: "groen zonder tegenproef bewijst niets"
+  - code: "P3"
+    naam: "Teruglezen"
+    kort: "een melding is geen bewijs"
+  - code: "P4"
+    naam: "Meten, niet reconstrueren"
+    kort: "opzoeken vóór je typt"
+  - code: "P5"
+    naam: "Expliciet en getest"
+    kort: "geen impliciete aannames"
+
+architectuur:
+  lagen:
+    - naam: "Frontend"
+      tech: "Next.js 15, eigen repo"
+    - naam: "Identity"
+      tech: "Entra External ID, OIDC + MFA"
+    - naam: "Backend"
+      tech: "NestJS, Node 22 — 7 controllers"
+      detail: "3 guards: TenantContext → Rol → PlatformAdmin"
+    - naam: "Database"
+      tech: "PostgreSQL 17 (Supabase)"
+      detail: "RLS = de tenantgrens · 23 tabellen · 5 definer-functies"
+      accent: true
+  verbinding_backend_db: "rol clm_api_runtime, géén BYPASSRLS"
+
+omgevingen:                     # vier kolommen, kleur op 'markering'
+  - naam: "Wegwerp"
+    poort: "55440+"
+    markering: "wegwerp"
+    kleur: "groen"
+    mag_weg: true
+    gebruik: "e2e-tests"
+  - naam: "Demo lokaal"
+    poort: "55450"
+    markering: "beschermd"
+    kleur: "oranje"
+    mag_weg: false
+    gebruik: "feature review, demo's"
+  - naam: "CI"
+    poort: "in de runner"
+    markering: "wegwerp"
+    kleur: "groen"
+    mag_weg: true
+    gebruik: "GitHub Actions"
+  - naam: "Productie"
+    poort: "Supabase"
+    markering: "beschermd"
+    kleur: "rood"
+    mag_weg: false
+    gebruik: "de echte applicatie"
+
+de_poort:                       # centraal visueel element
+  naam: "De wegwerppoort"
+  regel: "elke database is 'beschermd' tot hij zich als wegwerp meldt"
+  bewaakt:
+    - "DATABASE_URL"
+    - "MIGRATION_DATABASE_URL"
+  gevolg: "e2e-tests kunnen productie en demo per constructie niet raken"
+
+twee_registers:
+  - naam: "schema-inventory.ts"
+    vraag: "Wat hoort te bestaan?"
+    bron: "afgeleid uit de code"
+  - naam: "rechten-contract.ts"
+    vraag: "Wat is toegestaan?"
+    bron: "een expliciet besluit"
+  samen: "een test leest de database terug en vergelijkt"
+
+backup:
+  bron: "Supabase Free — geen providerbackup"
+  stroom: ["productie", "dagelijkse dump 07:00", "OneDrive", "controle"]
+  status: "het enige vangnet"
+
+tijdlijn_incidenten:            # elk incident → een maatregel
+  - datum: "2026-07-31"
+    incident: "CI rood, lokaal groen"
+    maatregel: "één commando"
+  - datum: "2026-08-06"
+    incident: "migratie tegen productie"
+    maatregel: "doelwit melden vóór verbinden"
+  - datum: "2026-08-07"
+    incident: "tests wisten de demo-database"
+    maatregel: "clm.omgeving: wegwerp of beschermd"
+  - datum: "2026-08-08"
+    incident: "suite praatte tegen productie"
+    maatregel: "poort over beide verbindingen"
+  - datum: "2026-08-08"
+    incident: "rechten lokaal ruimer dan productie"
+    maatregel: "rechtencontract met terugleestest"
+```
+
+---
+
+## 12. Aanwijzingen voor de infographic
+
+**Voorgestelde opbouw, van boven naar beneden:**
+
+1. **Kop** — titel, ondertitel, de vijf kerncijfers als tegels
+2. **De kernboodschap** in één kader: *de tenantgrens zit in de database*
+3. **De testpiramide** (§11 `testlagen`) — laag 3 visueel het zwaarst, want
+   daar ligt het zwaartepunt. Dat is het tegenovergestelde van de klassieke
+   piramide, en dat is opzet.
+4. **De architectuurkolom** ernaast, met de pijl backend → database gelabeld
+   *"géén BYPASSRLS"*
+5. **De vier omgevingen** als kaarten, kleur op markering (groen = wegwerp,
+   oranje = demo, rood = productie)
+6. **De poort** als centraal element tussen de tests en de omgevingen — een
+   slot met twee sleutelgaten (`DATABASE_URL` en `MIGRATION_DATABASE_URL`)
+7. **De twee registers** als tweeluik dat samenkomt in één test
+8. **De backupstroom** als horizontale pijlketen
+9. **De tijdlijn** onderaan: incident → maatregel, als bewijs dat de aanpak
+   uit ervaring komt en niet uit een boek
+
+**Toon:** feitelijk en rustig. Dit is een compliance-product; de infographic
+mag technisch zijn.
+
+**Wat je vooral moet overbrengen:** dat elke regel uit een incident komt. De
+tijdlijn is daarom geen bijzaak maar de onderbouwing van het geheel.
+
+**Wat je niet moet doen:** de klassieke testpiramide tekenen met unittests als
+brede basis. Hier is dat feitelijk onjuist — het zwaartepunt ligt op laag 3, en
+dat is een bewuste keuze die volgt uit waar de tenantgrens zit.

--- a/drizzle/0022_rechten_expliciet.sql
+++ b/drizzle/0022_rechten_expliciet.sql
@@ -1,0 +1,109 @@
+-- Elk recht expliciet, ongeacht wat ALTER DEFAULT PRIVILEGES doet.
+--
+-- ── Waarom deze migratie bestaat ─────────────────────────────────────────────
+--
+-- Migratie 0001 zet `ALTER DEFAULT PRIVILEGES IN SCHEMA clm GRANT SELECT,
+-- INSERT, UPDATE, DELETE ON TABLES TO clm_api, clm_admin`. Dat leek destijds
+-- gemak; het bleek een lek dat twee kanten op werkt, en op 2026-08-08 kostte
+-- het de eerste echte tenant een 500.
+--
+-- Een DEFAULT PRIVILEGE geldt alleen voor tabellen die daarná worden aangemaakt
+-- door de rol die de instelling zette. Wordt de database elders opgebouwd — een
+-- restore, een andere provider, een migratie die als een andere rol draait —
+-- dan geldt hij niet. Op Supabase staat hij niet geregistreerd.
+--
+-- Gevolg, gemeten op 2026-08-08:
+--
+--   clm.tenant_membership   migratie 0009 geeft geen GRANT
+--                           productie: GEEN rechten  → de 500
+--                           lokaal:    alles         → tests groen
+--
+--   clm.omgeving            migratie 0019 geeft GRANT SELECT
+--   clm.survey_review       productie: alleen wat de migratie zegt
+--   clm.response_note       lokaal:    álles, want een GRANT beperkt niet —
+--   clm.template_reviewer              hij vult aan wat de default al gaf
+--
+-- De tweede is de gevaarlijkste: lokaal en in CI draaide alles met ruimere
+-- rechten dan productie. Een route die `DELETE FROM clm.omgeving` doet, faalt
+-- in productie en slaagt in de tests.
+--
+-- ── Wat deze migratie doet ───────────────────────────────────────────────────
+--
+-- Per tabel: eerst alles intrekken, dan geven wat het contract voorschrijft
+-- (src/db/rechten-contract.ts). REVOKE vóór GRANT, want alleen zo maakt het
+-- niet meer uit wat er stond.
+--
+-- De default zelf blijft staan. Hem weghalen zou nieuwe tabellen zonder enig
+-- recht laten ontstaan, en dat faalt dan pas bij de eerste query. Met deze
+-- migratie én de bijbehorende test is dat niet langer nodig: een nieuwe tabel
+-- zonder regel in het contract maakt de test rood, en dat is een betere plek om
+-- het te merken.
+
+-- ── 1. Het gat: tenant_membership ────────────────────────────────────────────
+--
+-- De tabel waar de platformroute op strandde. Gewone tenantdata: de applicatie
+-- maakt hier memberships aan en kent support-toegang toe.
+
+REVOKE ALL ON clm.tenant_membership FROM clm_api, clm_admin, clm_readonly;--> statement-breakpoint
+GRANT SELECT, INSERT, UPDATE, DELETE ON clm.tenant_membership TO clm_api, clm_admin;--> statement-breakpoint
+GRANT SELECT ON clm.tenant_membership TO clm_readonly;--> statement-breakpoint
+
+-- ── 2. Te ruim op een verse database ─────────────────────────────────────────
+--
+-- Deze vier hebben op productie de juiste, beperkte rechten en lokaal alles.
+-- De REVOKE hieronder maakt beide gelijk.
+--
+-- omgeving (0019): de applicatie moet weten of dit een wegwerpdatabase is,
+-- niet kunnen veranderen wat het antwoord is.
+
+REVOKE ALL ON clm.omgeving FROM clm_api, clm_admin, clm_readonly;--> statement-breakpoint
+GRANT SELECT ON clm.omgeving TO clm_api, clm_admin;--> statement-breakpoint
+
+-- survey_review en response_note: een oordeel of een notitie verdwijnt niet,
+-- die wordt zacht verwijderd. Geen DELETE.
+
+REVOKE ALL ON clm.survey_review FROM clm_api, clm_admin, clm_readonly;--> statement-breakpoint
+GRANT SELECT, INSERT, UPDATE ON clm.survey_review TO clm_api, clm_admin;--> statement-breakpoint
+
+REVOKE ALL ON clm.response_note FROM clm_api, clm_admin, clm_readonly;--> statement-breakpoint
+GRANT SELECT, INSERT, UPDATE ON clm.response_note TO clm_api, clm_admin;--> statement-breakpoint
+
+-- template_reviewer: een koppeling bestaat of niet. Wijzigen heeft geen
+-- betekenis — ontkoppelen en opnieuw koppelen wel.
+
+REVOKE ALL ON clm.template_reviewer FROM clm_api, clm_admin, clm_readonly;--> statement-breakpoint
+GRANT SELECT, INSERT, DELETE ON clm.template_reviewer TO clm_api, clm_admin;--> statement-breakpoint
+
+-- ── 3. platform_admin: bevestigen wat 0020 al deed ───────────────────────────
+--
+-- Hier stond de REVOKE al goed (0020). Herhaald zodat deze migratie de
+-- volledige stand zet en niet half — wie hem leest, ziet alles.
+
+REVOKE ALL ON clm.platform_admin FROM clm_api, clm_admin, clm_readonly;--> statement-breakpoint
+GRANT SELECT ON clm.platform_admin TO clm_api, clm_admin;--> statement-breakpoint
+
+-- ── 4. De audit trail blijft append-only ─────────────────────────────────────
+--
+-- §7.7: schrijven mag, wijzigen en verwijderen nooit. Expliciet zetten in
+-- plaats van vertrouwen op de default in 0001, om dezelfde reden als hierboven.
+
+REVOKE ALL ON audit.audit_event FROM clm_api, clm_admin;--> statement-breakpoint
+GRANT SELECT, INSERT ON audit.audit_event TO clm_api, clm_admin;--> statement-breakpoint
+GRANT SELECT ON audit.audit_event TO clm_readonly, clm_audit_reader;--> statement-breakpoint
+
+-- ── Wat deze migratie NIET aanraakt ──────────────────────────────────────────
+--
+-- clm.sessie: die is in 0010 bewust volledig dichtgezet (REVOKE ALL), omdat de
+-- sessie wordt opgezocht vóórdat de tenantcontext bestaat. Toegang loopt via
+-- SECURITY DEFINER-functies. Ongemoeid laten.
+--
+-- De ref-tabellen: die hebben nu volledige schrijfrechten, wat ruimer is dan
+-- nodig — de applicatie heeft geen route die ze wijzigt. Aanscherpen hoort bij
+-- een eigen afweging en niet bij het dichten van dit gat; het contract legt de
+-- huidige stand vast zodat de wijziging zichtbaar wordt wanneer hij komt.
+--
+-- FORCE ROW LEVEL SECURITY: de vijf tabellen zonder FORCE zijn geen
+-- scheefgroei maar een gemeten besluit uit 0011 — met FORCE vallen de
+-- SECURITY DEFINER-functies zelf onder RLS, en die draaien juist vóórdat er
+-- tenantcontext is. Gevolg destijds: 77 falende tests, en in productie geen
+-- login. Zie FORCE_RLS_UITZONDERINGEN in src/db/schema-inventory.ts.

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -155,6 +155,13 @@
       "when": 1786636800000,
       "tag": "0021_tenantnaam_hoofdletterongevoelig",
       "breakpoints": true
+    },
+    {
+      "idx": 22,
+      "version": "7",
+      "when": 1786723200000,
+      "tag": "0022_rechten_expliciet",
+      "breakpoints": true
     }
   ]
 }

--- a/scripts/seed-demo-tenant.js
+++ b/scripts/seed-demo-tenant.js
@@ -170,6 +170,33 @@ function hashToken(token) {
  * typefout op. sql.param() houdt de array bij elkaar, en de pg-driver zet hem
  * om naar het array-formaat dat Postgres verwacht.
  */
+/**
+ * De verbinding voor `--verwijder`: dezelfde database, maar als migratierol.
+ *
+ * Waarom niet gewoon MIGRATION_DATABASE_URL lezen: die staat in `.env` en wijst
+ * naar productie. Wordt hij niet expliciet meegegeven, dan vult dotenv hem aan
+ * — en dan wist dit script in de verkeerde database. Dat patroon kostte op
+ * 2026-08-08 bijna een ongeluk in een e2e-suite.
+ *
+ * Vandaar: alleen gebruiken als hij op dezelfde database uitkomt als de
+ * opgegeven URL. Anders de rol vervangen en verder alles laten staan.
+ */
+function opruimUrl(runtimeUrl) {
+  const doel = new URL(runtimeUrl);
+  const expliciet = process.env.MIGRATION_DATABASE_URL;
+
+  if (expliciet) {
+    const gegeven = new URL(expliciet);
+
+    if (gegeven.host === doel.host && gegeven.pathname === doel.pathname) {
+      return expliciet;
+    }
+  }
+
+  doel.username = 'clm_migrator';
+  return doel.toString();
+}
+
 function arrayOfNull(waarde) {
   return Array.isArray(waarde) && waarde.length > 0
     ? sql.param(waarde)
@@ -914,7 +941,23 @@ async function main() {
   ) {
     process.exit(1);
   }
-  const pool = new Pool({ connectionString: url });
+
+  // ── Opruimen gaat via de migratierol, seeden via de runtime-rol ────────────
+  //
+  // Sinds migratie 0022 heeft de applicatierol geen DELETE op clm.survey_review
+  // en clm.response_note: een oordeel of notitie wordt zacht verwijderd. Dat is
+  // de stand op productie, en dit script hoort die te delen.
+  //
+  // Opruimen is daarmee geen applicatiehandeling meer maar een beheerhandeling.
+  // Dat is geen omweg om de beperking heen — de applicatie kán het niet, en dat
+  // is het punt. De wegwerpeis hierboven staat er nog steeds vóór.
+  //
+  // Seeden blijft bewust op de runtime-rol: dat moet werken met exact de rechten
+  // die de applicatie heeft, anders bewijst een geslaagde seed niets over of de
+  // data langs de normale weg bereikbaar is.
+  const verbinding = moetVerwijderen ? opruimUrl(url) : url;
+
+  const pool = new Pool({ connectionString: verbinding });
   const db = drizzle(pool);
 
   try {

--- a/src/db/rechten-contract.ts
+++ b/src/db/rechten-contract.ts
@@ -1,0 +1,190 @@
+/**
+ * Wat de applicatierol op elk databaseobject mag — expliciet vastgelegd.
+ *
+ * ── Waarom dit bestand bestaat ───────────────────────────────────────────────
+ *
+ * Op 2026-08-08 strandde de eerste echte tenant op een 500: `clm_api_runtime`
+ * bleek geen enkel recht te hebben op `clm.tenant_membership`. Migratie 0009
+ * geeft die tabel geen `GRANT`; lokaal werkte het toch, omdat
+ * `ALTER DEFAULT PRIVILEGES` uit 0001 elke nieuwe tabel van rechten voorziet.
+ * Op Supabase is die default niet geregistreerd, dus daar viel de tabel buiten
+ * de boot — en dat viel pas op toen de eerste route hem raakte.
+ *
+ * De les is niet "vergeten GRANT" maar dieper: de rechtenstand was een optelsom
+ * van een omgevingsafhankelijke default en losse GRANT's in migraties. Niet te
+ * overzien, en dus niet te verifiëren.
+ *
+ * Dit bestand is de andere helft van `schema-inventory.ts`. Dat leidt af wat er
+ * hoort te bestaan; dit legt vast wat er mag. Het verschil is opzet: tabellen
+ * volgen uit de code, rechten zijn een besluit — en een besluit hoort
+ * opgeschreven te staan, niet afgeleid.
+ *
+ * ── Wat de eerste run van de bijbehorende test aantoonde ─────────────────────
+ *
+ * Het gat in `tenant_membership` was niet het enige gevolg van die default. Hij
+ * werkt namelijk twee kanten op, en de tweede is de gevaarlijkste:
+ *
+ *   tenant_membership   migratie zonder GRANT
+ *                       → productie: geen rechten (de 500 van 2026-08-08)
+ *                       → lokaal:    alles, want de default vult aan
+ *
+ *   omgeving,           migratie mét een beperkende GRANT
+ *   survey_review,      → productie: precies wat de migratie zegt
+ *   response_note,      → lokaal:    álles, want een GRANT beperkt niets —
+ *   template_reviewer               hij voegt alleen toe aan wat de default
+ *                                   al gaf
+ *
+ * Gevolg: elke lokale testrun en elke CI-run draait met **ruimere** rechten dan
+ * productie. Een route die per ongeluk `DELETE FROM clm.omgeving` doet, faalt
+ * in productie en slaagt in de tests. Dat is precies de verkeerde kant op: de
+ * tests keuren goed wat productie weigert.
+ *
+ * Dit contract legt vast wat het *hoort* te zijn — de striktste van de twee
+ * standen — en de migratie die erbij hoort trekt beide omgevingen daarheen.
+ *
+ * ── Hoe je dit onderhoudt ────────────────────────────────────────────────────
+ *
+ * Een nieuwe tabel of functie zonder regel hier maakt `rechten-contract.e2e`
+ * rood. Dat is de bedoeling: het dwingt een besluit af op het moment dat de
+ * tabel ontstaat, in plaats van bij de eerste route die erover struikelt.
+ *
+ * Wijzig je een regel hier, dan hoort daar een migratie bij die de database
+ * meeneemt. Dit bestand beschrijft, het verandert niets.
+ */
+
+/** De rechten die één rol op één tabel heeft. `[]` betekent: geen enkel recht. */
+export type Tabelrechten = readonly (
+  | 'SELECT'
+  | 'INSERT'
+  | 'UPDATE'
+  | 'DELETE'
+)[];
+
+const LEZEN_EN_SCHRIJVEN: Tabelrechten = ['SELECT', 'INSERT', 'UPDATE', 'DELETE'];
+
+/** Toevoegen en bijwerken mag, verwijderen niet. */
+const NIET_VERWIJDEREN: Tabelrechten = ['SELECT', 'INSERT', 'UPDATE'];
+
+const ALLEEN_LEZEN: Tabelrechten = ['SELECT'];
+
+const GEEN: Tabelrechten = [];
+
+/**
+ * Wat `clm_api_runtime` (via `clm_api`) op elke tabel mag.
+ *
+ * De sleutel is de volledige naam zoals `schema-inventory.ts` die opbouwt.
+ */
+export const TABELRECHTEN: Readonly<Record<string, Tabelrechten>> = {
+  // ── Gewone tenantdata ──────────────────────────────────────────────────────
+  'clm.tenant': LEZEN_EN_SCHRIJVEN,
+  'clm.user': LEZEN_EN_SCHRIJVEN,
+  'clm.vendor': LEZEN_EN_SCHRIJVEN,
+  'clm.vendor_contact': LEZEN_EN_SCHRIJVEN,
+  'clm.vendor_tag': LEZEN_EN_SCHRIJVEN,
+  'clm.survey_template': LEZEN_EN_SCHRIJVEN,
+  'clm.survey_question': LEZEN_EN_SCHRIJVEN,
+  'clm.survey_category': LEZEN_EN_SCHRIJVEN,
+  'clm.survey_run': LEZEN_EN_SCHRIJVEN,
+  'clm.survey_response': LEZEN_EN_SCHRIJVEN,
+  'clm.survey_answer': LEZEN_EN_SCHRIJVEN,
+  'clm.survey_attachment': LEZEN_EN_SCHRIJVEN,
+
+  // Wie waar mag werken. Hoort bij de gewone tenantdata: de platformroute
+  // maakt hier rijen aan, en support-toegang wordt hier toegekend.
+  'clm.tenant_membership': LEZEN_EN_SCHRIJVEN,
+
+  // ── Van nature append-only ─────────────────────────────────────────────────
+  //
+  // Een oordeel, een notitie of een koppeling verdwijnt niet: hij wordt zacht
+  // verwijderd. Geen DELETE dus — niet omdat het gevaarlijk is, maar omdat een
+  // route die het nodig heeft een ontwerpfout zou zijn.
+  'clm.survey_review': NIET_VERWIJDEREN,
+  'clm.response_note': NIET_VERWIJDEREN,
+  'clm.template_reviewer': ['SELECT', 'INSERT', 'DELETE'],
+
+  // ── Alleen lezen ───────────────────────────────────────────────────────────
+  //
+  // clm.omgeving (0019): zegt of dit een wegwerpdatabase is. De applicatie
+  // hoeft dat te weten, niet te veranderen — anders is de bescherming die
+  // hierop rust zelf te omzeilen.
+  'clm.omgeving': ALLEEN_LEZEN,
+
+  // clm.platform_admin (0020): wie het platform beheert. De guard leest dit per
+  // verzoek. Schrijven gaat bewust buiten de applicatie om, via de migratierol
+  // (scripts/platformbeheerder-inrichten.js) — zolang er geen scherm voor is,
+  // is dat de veiligste stand.
+  'clm.platform_admin': ALLEEN_LEZEN,
+
+  // ── Volledig gesloten ──────────────────────────────────────────────────────
+  //
+  // clm.sessie (0010): expliciete REVOKE ALL. De sessie wordt opgezocht vóórdat
+  // de tenantcontext bestaat, dus RLS kan hem niet beschermen. Alle toegang
+  // loopt via SECURITY DEFINER-functies met een scherp begrensde opdracht.
+  // Bewezen in test/sessie.e2e-spec.ts: een directe SELECT en INSERT geven
+  // beide "permission denied".
+  'clm.sessie': GEEN,
+
+  // ── Audit ──────────────────────────────────────────────────────────────────
+  //
+  // Append-only in de striktste zin (§7.7): schrijven mag, wijzigen en
+  // verwijderen nooit. Een audit trail die de applicatie kan aanpassen is geen
+  // audit trail.
+  'audit.audit_event': ['SELECT', 'INSERT'],
+
+  // ── Referentiedata ─────────────────────────────────────────────────────────
+  //
+  // Lookup-tabellen zonder tenant_id: categorieën, statussen, criticality.
+  // Gevuld door migraties (0012 breidde ze uit), niet door de applicatie.
+  //
+  // Hier staat volledige schrijftoegang, en dat is de stand die er is — niet de
+  // stand die je zou kiezen. De applicatie heeft geen route die deze tabellen
+  // wijzigt; ALLEEN_LEZEN zou hier verdedigbaar zijn.
+  //
+  // Bewust niet in deze wijziging aangescherpt: dit contract legt eerst vast
+  // wat er is, zodat het gat in tenant_membership zichtbaar wordt. Aanscherpen
+  // is een eigen migratie met een eigen afweging — zie het openstaande punt in
+  // docs/ontwerp/tenants-gebruikers-en-platformbeheer.md §6.
+  'ref.business_criticality': LEZEN_EN_SCHRIJVEN,
+  'ref.compliance_status': LEZEN_EN_SCHRIJVEN,
+  'ref.vendor_category': LEZEN_EN_SCHRIJVEN,
+};
+
+/**
+ * De SECURITY DEFINER-functies, en wat er over hun beveiliging vastligt.
+ *
+ * ── Waarom search_path hier staat ────────────────────────────────────────────
+ *
+ * Een SECURITY DEFINER-functie zonder vaste `search_path` is een bekend
+ * escalatiepad: wie CREATE-recht heeft op een doorzocht schema kan een object
+ * schaduwen en zo code laten draaien met de rechten van de functie-eigenaar —
+ * dwars door RLS heen.
+ *
+ * Alle vijf functies hebben dat vandaag goed. Maar dat is een eigenschap van
+ * vijf migraties die iemand bij een zesde kan vergeten, en een reviewer merkte
+ * het op 2026-08-08 terecht aan als onbewaakt. Vandaar deze lijst: de zesde
+ * functie zonder regel hier maakt de test rood.
+ */
+export interface FunctieContract {
+  /** Verwachte waarde van `proconfig`, exact zoals PostgreSQL hem teruggeeft. */
+  readonly searchPath: string;
+  /** Rollen die EXECUTE horen te hebben. PUBLIC hoort er nooit bij. */
+  readonly execute: readonly string[];
+}
+
+const DEFINER_STANDAARD: FunctieContract = {
+  searchPath: 'search_path=clm, pg_temp',
+  execute: ['clm_migrator', 'clm_api', 'clm_admin'],
+};
+
+export const DEFINER_FUNCTIES: Readonly<Record<string, FunctieContract>> = {
+  // Identiteit vóór tenantcontext (0009).
+  gebruiker_bij_subject: DEFINER_STANDAARD,
+
+  // Sessies (0010). De tabel is dicht; deze drie zijn de enige weg naar binnen.
+  sessie_aanmaken: DEFINER_STANDAARD,
+  sessie_oplossen: DEFINER_STANDAARD,
+  sessie_beeindigen: DEFINER_STANDAARD,
+
+  // De leverancierstoken-lookup, spoor 2 (0003, herzien in 0006 en 0008).
+  resolve_survey_token: DEFINER_STANDAARD,
+};

--- a/src/db/rechten-contract.ts
+++ b/src/db/rechten-contract.ts
@@ -54,13 +54,15 @@
 
 /** De rechten die één rol op één tabel heeft. `[]` betekent: geen enkel recht. */
 export type Tabelrechten = readonly (
-  | 'SELECT'
-  | 'INSERT'
-  | 'UPDATE'
-  | 'DELETE'
+  'SELECT' | 'INSERT' | 'UPDATE' | 'DELETE'
 )[];
 
-const LEZEN_EN_SCHRIJVEN: Tabelrechten = ['SELECT', 'INSERT', 'UPDATE', 'DELETE'];
+const LEZEN_EN_SCHRIJVEN: Tabelrechten = [
+  'SELECT',
+  'INSERT',
+  'UPDATE',
+  'DELETE',
+];
 
 /** Toevoegen en bijwerken mag, verwijderen niet. */
 const NIET_VERWIJDEREN: Tabelrechten = ['SELECT', 'INSERT', 'UPDATE'];

--- a/test/beoordelaar-koppelen.e2e-spec.ts
+++ b/test/beoordelaar-koppelen.e2e-spec.ts
@@ -9,6 +9,7 @@ import { AppModule } from '../src/app.module';
 import { cookieInstellingen } from '../src/auth/sessie';
 import { SessieService } from '../src/auth/sessie.service';
 import { TEST_IDS } from './test-ids';
+import { verwijderTestdata } from './opruimen';
 
 /**
  * Beoordelaars koppelen aan een vragenlijst (fase C3, ADR-013).
@@ -64,30 +65,6 @@ interface WerkvoorraadBody {
   }>;
 }
 
-async function verwijderTestdata(client: Client) {
-  for (const tenant of [tenantA, tenantB]) {
-    await client.query('BEGIN');
-    await client.query(`SET LOCAL app.current_tenant_id = '${tenant}'`);
-    await client.query(`SET LOCAL app.current_actor = 'medewerker'`);
-    for (const tabel of [
-      'clm.template_reviewer',
-      'clm.survey_review',
-      'clm.survey_answer',
-      'clm.survey_response',
-      'clm.survey_run',
-      'clm.survey_question',
-      'clm.survey_template',
-      'clm.vendor',
-      'clm.tenant_membership',
-      'clm."user"',
-      'clm.tenant',
-    ]) {
-      await client.query(`DELETE FROM ${tabel} WHERE tenant_id = $1`, [tenant]);
-    }
-    await client.query('COMMIT');
-  }
-}
-
 describe('Beoordelaar koppelen aan een vragenlijst (e2e)', () => {
   let app: INestApplication<App>;
   let server: App;
@@ -100,7 +77,7 @@ describe('Beoordelaar koppelen aan een vragenlijst (e2e)', () => {
   beforeAll(async () => {
     client = new Client({ connectionString: process.env.DATABASE_URL });
     await client.connect();
-    await verwijderTestdata(client);
+    await verwijderTestdata(tenantA, tenantB);
 
     await client.query('BEGIN');
     await client.query(`SET LOCAL app.current_tenant_id = '${tenantA}'`);
@@ -215,7 +192,7 @@ describe('Beoordelaar koppelen aan een vragenlijst (e2e)', () => {
 
   afterAll(async () => {
     await app.close();
-    await verwijderTestdata(client);
+    await verwijderTestdata(tenantA, tenantB);
     await client.end();
   }, 30000);
 

--- a/test/beoordeling.e2e-spec.ts
+++ b/test/beoordeling.e2e-spec.ts
@@ -9,6 +9,7 @@ import { AppModule } from '../src/app.module';
 import { cookieInstellingen } from '../src/auth/sessie';
 import { SessieService } from '../src/auth/sessie.service';
 import { TEST_IDS } from './test-ids';
+import { verwijderTestdata } from './opruimen';
 
 /**
  * Beoordelen van een ingediende respons (fase C2 van het surveybeheerplan).
@@ -69,32 +70,6 @@ interface LijstBody {
   }>;
 }
 
-async function verwijderTestdata(client: Client) {
-  for (const tenant of [tenantA, tenantB]) {
-    await client.query('BEGIN');
-    await client.query(`SET LOCAL app.current_tenant_id = '${tenant}'`);
-    // De actor moet 'medewerker' zijn: zonder dat weigert de policy op
-    // survey_review élke rij, ook bij het opruimen. Dat is precies wat de
-    // policy hoort te doen.
-    await client.query(`SET LOCAL app.current_actor = 'medewerker'`);
-    for (const tabel of [
-      'clm.survey_review',
-      'clm.survey_answer',
-      'clm.survey_response',
-      'clm.survey_run',
-      'clm.survey_question',
-      'clm.survey_template',
-      'clm.vendor',
-      'clm.tenant_membership',
-      'clm."user"',
-      'clm.tenant',
-    ]) {
-      await client.query(`DELETE FROM ${tabel} WHERE tenant_id = $1`, [tenant]);
-    }
-    await client.query('COMMIT');
-  }
-}
-
 describe('Beoordelen van een respons (e2e)', () => {
   // Met de generic erbij: zonder <App> geeft getHttpServer() `any` terug en
   // slaat no-unsafe-assignment aan.
@@ -108,7 +83,7 @@ describe('Beoordelen van een respons (e2e)', () => {
   beforeAll(async () => {
     client = new Client({ connectionString: process.env.DATABASE_URL });
     await client.connect();
-    await verwijderTestdata(client);
+    await verwijderTestdata(tenantA, tenantB);
 
     await client.query('BEGIN');
     await client.query(`SET LOCAL app.current_tenant_id = '${tenantA}'`);
@@ -229,7 +204,7 @@ describe('Beoordelen van een respons (e2e)', () => {
 
   afterAll(async () => {
     await app.close();
-    await verwijderTestdata(client);
+    await verwijderTestdata(tenantA, tenantB);
     await client.end();
   }, 30000);
 

--- a/test/goedkeuren.e2e-spec.ts
+++ b/test/goedkeuren.e2e-spec.ts
@@ -9,6 +9,7 @@ import { AppModule } from '../src/app.module';
 import { cookieInstellingen } from '../src/auth/sessie';
 import { SessieService } from '../src/auth/sessie.service';
 import { TEST_IDS } from './test-ids';
+import { verwijderTestdata } from './opruimen';
 
 /**
  * Goedkeuren als vierde oordeel (migratie 0017).
@@ -79,31 +80,6 @@ interface LijstBody {
   }>;
 }
 
-async function verwijderTestdata(client: Client) {
-  for (const tenant of [tenantA, tenantB]) {
-    await client.query('BEGIN');
-    await client.query(`SET LOCAL app.current_tenant_id = '${tenant}'`);
-    // Actor 'medewerker' is nodig: zonder dat weigert de policy op
-    // survey_review élke rij, ook bij het opruimen.
-    await client.query(`SET LOCAL app.current_actor = 'medewerker'`);
-    for (const tabel of [
-      'clm.survey_review',
-      'clm.survey_answer',
-      'clm.survey_response',
-      'clm.survey_run',
-      'clm.survey_question',
-      'clm.survey_template',
-      'clm.vendor',
-      'clm.tenant_membership',
-      'clm."user"',
-      'clm.tenant',
-    ]) {
-      await client.query(`DELETE FROM ${tabel} WHERE tenant_id = $1`, [tenant]);
-    }
-    await client.query('COMMIT');
-  }
-}
-
 describe('Goedkeuren van een respons (e2e)', () => {
   let app: INestApplication<App>;
   let server: App;
@@ -114,7 +90,7 @@ describe('Goedkeuren van een respons (e2e)', () => {
   beforeAll(async () => {
     client = new Client({ connectionString: process.env.DATABASE_URL });
     await client.connect();
-    await verwijderTestdata(client);
+    await verwijderTestdata(tenantA, tenantB);
 
     await client.query('BEGIN');
     await client.query(`SET LOCAL app.current_tenant_id = '${tenantA}'`);
@@ -212,7 +188,7 @@ describe('Goedkeuren van een respons (e2e)', () => {
 
   afterAll(async () => {
     await app.close();
-    await verwijderTestdata(client);
+    await verwijderTestdata(tenantA, tenantB);
     await client.end();
   }, 30000);
 

--- a/test/jest-e2e.guard.ts
+++ b/test/jest-e2e.guard.ts
@@ -33,6 +33,21 @@ import { Client } from 'pg';
  * een oude wegwerpcontainer zijn — maar net zo goed een kopie van productie van
  * vóór die migratie. Doorgaan zou betekenen dat de bescherming zwijgt op
  * precies het moment dat je hem nodig hebt.
+ *
+ * ── Waarom BEIDE verbindingen worden gecontroleerd ──────────────────────────
+ *
+ * Toegevoegd op 2026-08-09. Tot dan keek deze poort alleen naar DATABASE_URL,
+ * en dat was een gat zo groot als het probleem dat hij moest oplossen:
+ * MIGRATION_DATABASE_URL staat in `.env` en wijst naar Supabase.
+ *
+ * Op 2026-08-08 liep een e2e-suite daar doorheen. `platformbeheer.e2e-spec.ts`
+ * had de migratierol nodig om clm.platform_admin te vullen, las
+ * MIGRATION_DATABASE_URL, en dotenv vulde die aan met de productie-URL. De
+ * eerste query faalde toevallig op een ontbrekende tabel; anders had die test
+ * rijen in de productiedatabase aangemaakt.
+ *
+ * Elke verbinding die een suite opent hoort door dezelfde poort. Wordt er ooit
+ * een derde toegevoegd, dan hoort die hier in deze lijst — niet ernaast.
  */
 
 const UITWEG = 'MCM2_E2E_ONBESCHERMD';
@@ -86,43 +101,66 @@ function zonderWachtwoord(url: string): string {
   }
 }
 
-beforeAll(async () => {
-  const url = process.env.DATABASE_URL;
+/**
+ * Elke verbinding die een e2e-suite mag openen.
+ *
+ * Beide moeten door de poort. MIGRATION_DATABASE_URL staat in `.env` en wijst
+ * naar Supabase; een suite die hem leest zonder dat hij is overschreven, praat
+ * tegen productie. Zie de toelichting bovenaan.
+ */
+const TE_CONTROLEREN = ['DATABASE_URL', 'MIGRATION_DATABASE_URL'] as const;
 
-  if (!url) {
-    // Geen database: de suites die er een nodig hebben falen vanzelf met een
-    // duidelijke fout. Hier stoppen zou de read-only controles onterecht
-    // blokkeren.
-    return;
-  }
-
-  if (process.env[UITWEG] === 'ja') {
-    console.warn(
-      `\n${UITWEG}=ja — de omgevingscontrole is overgeslagen.\n` +
-        `Doelwit: ${zonderWachtwoord(url)}\n`,
-    );
-    return;
-  }
-
-  const { soort, reden } = await leesOmgevingssoort(url);
-
-  if (soort === 'wegwerp') return;
-
-  const wat = soort ? `gemarkeerd als '${soort}'` : (reden ?? 'onbekend');
-
-  throw new Error(
+function foutmelding(
+  variabele: string,
+  url: string,
+  wat: string,
+): string {
+  return (
     '\n\n' +
-      '  E2E GESTOPT — deze database is geen wegwerpdatabase.\n\n' +
-      `  Doelwit: ${zonderWachtwoord(url)}\n` +
-      `  Status:  ${wat}\n\n` +
-      '  Deze suites maken tenants aan en voeren DELETE uit. Op een database\n' +
-      '  die niet als wegwerp is gemarkeerd, is dat gegevensverlies.\n\n' +
-      '  Dit gebeurde op 2026-08-07 met de demo-database: de demo-tenant\n' +
-      '  verdween en er bleven 400 testleveranciers achter.\n\n' +
-      '  Een verse wegwerpdatabase opzetten:\n' +
-      '    zie docs/runbooks/commandos-en-omgeving.md\n\n' +
-      '  Is dit wel een wegwerpdatabase, markeer hem dan:\n' +
-      '    node scripts/markeer-wegwerp.js\n\n' +
-      `  Alleen als je zeker weet wat je doet: ${UITWEG}=ja\n`,
+    '  E2E GESTOPT — deze database is geen wegwerpdatabase.\n\n' +
+    `  Variabele: ${variabele}\n` +
+    `  Doelwit:   ${zonderWachtwoord(url)}\n` +
+    `  Status:    ${wat}\n\n` +
+    '  Deze suites maken tenants aan en voeren DELETE uit. Op een database\n' +
+    '  die niet als wegwerp is gemarkeerd, is dat gegevensverlies.\n\n' +
+    '  Dit gebeurde op 2026-08-07 met de demo-database: de demo-tenant\n' +
+    '  verdween en er bleven 400 testleveranciers achter. En op 2026-08-08\n' +
+    '  praatte een suite via MIGRATION_DATABASE_URL tegen productie — dotenv\n' +
+    '  vult die aan wanneer je hem niet zelf meegeeft.\n\n' +
+    '  Een verse wegwerpdatabase opzetten:\n' +
+    '    zie docs/runbooks/commandos-en-omgeving.md\n\n' +
+    '  Is dit wel een wegwerpdatabase, markeer hem dan:\n' +
+    '    node scripts/markeer-wegwerp.js\n\n' +
+    `  Alleen als je zeker weet wat je doet: ${UITWEG}=ja\n`
   );
+}
+
+beforeAll(async () => {
+  if (process.env[UITWEG] === 'ja') {
+    console.warn(`\n${UITWEG}=ja — de omgevingscontrole is overgeslagen.\n`);
+    return;
+  }
+
+  for (const variabele of TE_CONTROLEREN) {
+    const url = process.env[variabele];
+
+    if (!url) {
+      // Niet gezet: de suites die deze verbinding nodig hebben falen vanzelf
+      // met een duidelijke fout. Hier stoppen zou de read-only controles
+      // onterecht blokkeren.
+      continue;
+    }
+
+    const { soort, reden } = await leesOmgevingssoort(url);
+
+    if (soort === 'wegwerp') continue;
+
+    throw new Error(
+      foutmelding(
+        variabele,
+        url,
+        soort ? `gemarkeerd als '${soort}'` : (reden ?? 'onbekend'),
+      ),
+    );
+  }
 }, 30000);

--- a/test/jest-e2e.guard.ts
+++ b/test/jest-e2e.guard.ts
@@ -110,11 +110,7 @@ function zonderWachtwoord(url: string): string {
  */
 const TE_CONTROLEREN = ['DATABASE_URL', 'MIGRATION_DATABASE_URL'] as const;
 
-function foutmelding(
-  variabele: string,
-  url: string,
-  wat: string,
-): string {
+function foutmelding(variabele: string, url: string, wat: string): string {
   return (
     '\n\n' +
     '  E2E GESTOPT — deze database is geen wegwerpdatabase.\n\n' +

--- a/test/notities.e2e-spec.ts
+++ b/test/notities.e2e-spec.ts
@@ -9,6 +9,7 @@ import { AppModule } from '../src/app.module';
 import { cookieInstellingen } from '../src/auth/sessie';
 import { SessieService } from '../src/auth/sessie.service';
 import { TEST_IDS } from './test-ids';
+import { verwijderTestdata } from './opruimen';
 
 /**
  * Notities bij een inzending (migratie 0018).
@@ -64,30 +65,6 @@ interface LijstBody {
   }>;
 }
 
-async function verwijderTestdata(client: Client) {
-  for (const tenant of [tenantA, tenantB]) {
-    await client.query('BEGIN');
-    await client.query(`SET LOCAL app.current_tenant_id = '${tenant}'`);
-    await client.query(`SET LOCAL app.current_actor = 'medewerker'`);
-    for (const tabel of [
-      'clm.response_note',
-      'clm.survey_review',
-      'clm.survey_answer',
-      'clm.survey_response',
-      'clm.survey_run',
-      'clm.survey_question',
-      'clm.survey_template',
-      'clm.vendor',
-      'clm.tenant_membership',
-      'clm."user"',
-      'clm.tenant',
-    ]) {
-      await client.query(`DELETE FROM ${tabel} WHERE tenant_id = $1`, [tenant]);
-    }
-    await client.query('COMMIT');
-  }
-}
-
 describe('Notities bij een inzending (e2e)', () => {
   let app: INestApplication<App>;
   let server: App;
@@ -98,7 +75,7 @@ describe('Notities bij een inzending (e2e)', () => {
   beforeAll(async () => {
     client = new Client({ connectionString: process.env.DATABASE_URL });
     await client.connect();
-    await verwijderTestdata(client);
+    await verwijderTestdata(tenantA, tenantB);
 
     await client.query('BEGIN');
     await client.query(`SET LOCAL app.current_tenant_id = '${tenantA}'`);
@@ -200,7 +177,7 @@ describe('Notities bij een inzending (e2e)', () => {
 
   afterAll(async () => {
     await app.close();
-    await verwijderTestdata(client);
+    await verwijderTestdata(tenantA, tenantB);
     await client.end();
   }, 30000);
 

--- a/test/opruimen.ts
+++ b/test/opruimen.ts
@@ -1,0 +1,154 @@
+import { Client } from 'pg';
+
+/**
+ * Testdata opruimen — één plek, voor alle suites.
+ *
+ * ── Waarom dit bestaat ───────────────────────────────────────────────────────
+ *
+ * Vijf suites hadden elk een eigen `verwijderTestdata`, vrijwel identiek maar
+ * net niet. Twee ervan ruimden `clm.response_note` niet op, en dat is precies
+ * hoe een berg testdata ontstaat: niet met een grote fout, maar met vijf kopieën
+ * die uit elkaar groeien.
+ *
+ * ── Waarom via de migratierol ────────────────────────────────────────────────
+ *
+ * Sinds migratie 0022 heeft de applicatierol geen `DELETE` op `survey_review`
+ * en `response_note`: een oordeel of notitie wordt zacht verwijderd. Dat is de
+ * stand op productie, en de tests horen die te delen — anders bewijzen ze niet
+ * wat ze lijken te bewijzen.
+ *
+ * Opruimen is dan ook geen applicatiehandeling meer maar een beheerhandeling,
+ * en die hoort bij de migratierol. Dat is geen omweg om de beperking heen: de
+ * applicatie kán het niet, en dat is het punt.
+ *
+ * ── Waarom dat veilig is ─────────────────────────────────────────────────────
+ *
+ * Sinds 2026-08-09 controleert `jest-e2e.guard.ts` **beide** verbindingen op de
+ * wegwerpmarkering. Een suite die deze helper gebruikt kan dus per constructie
+ * niet tegen productie of tegen de demo-database draaien — ongeacht wat er in
+ * `.env` staat. Zonder die poort zou deze helper een achterdeur zijn.
+ */
+
+/**
+ * De volgorde waarin tabellen leeg moeten, en waarom die vastligt.
+ *
+ * Van blad naar wortel: elke tabel verwijst naar iets dat verderop in deze
+ * lijst staat. `clm.tenant` moet als laatste, want `clm."user"` heeft er een
+ * `ON DELETE RESTRICT` naartoe — omgekeerd stuit het opruimen op een
+ * foreign-keyfout die naar de verkeerde oorzaak wijst.
+ *
+ * Alle tenantgebonden tabellen staan hier, ook als een suite ze niet gebruikt.
+ * Een `DELETE` op een lege tabel kost niets; een vergeten tabel kost een
+ * volgende testrun.
+ */
+const TABELLEN_IN_VOLGORDE = [
+  'clm.response_note',
+  'clm.survey_review',
+  'clm.template_reviewer',
+  'clm.survey_answer',
+  'clm.survey_attachment',
+  'clm.survey_response',
+  'clm.survey_run',
+  'clm.survey_question',
+  'clm.survey_category',
+  'clm.survey_template',
+  'clm.vendor_tag',
+  'clm.vendor_contact',
+  'clm.vendor',
+  'clm.tenant_membership',
+  'clm."user"',
+  'clm.tenant',
+] as const;
+
+const UUID_REGEX =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/**
+ * De verbinding als migratierol, altijd naar dezelfde database als de tests.
+ *
+ * Leest MIGRATION_DATABASE_URL alleen als die op dezelfde database uitkomt als
+ * DATABASE_URL. Wijst hij ergens anders heen, dan is dat vrijwel zeker de
+ * productie-URL uit `.env` die dotenv heeft aangevuld — en dan negeren we hem
+ * en leiden we de verbinding af.
+ *
+ * Dat is een tweede slot naast de wegwerppoort. Die zou hier al ingrijpen; deze
+ * controle zorgt dat het niet eens zover komt.
+ */
+function migratieUrl(): string {
+  const runtime = process.env.DATABASE_URL;
+
+  if (!runtime) {
+    throw new Error('DATABASE_URL ontbreekt — opruimen kan niet.');
+  }
+
+  const doel = new URL(runtime);
+  const expliciet = process.env.MIGRATION_DATABASE_URL;
+
+  if (expliciet) {
+    const gegeven = new URL(expliciet);
+
+    if (gegeven.host === doel.host && gegeven.pathname === doel.pathname) {
+      return expliciet;
+    }
+  }
+
+  doel.username = 'clm_migrator';
+  return doel.toString();
+}
+
+/**
+ * Verwijdert alle data van de opgegeven tenants.
+ *
+ * Opent een eigen verbinding als migratierol en sluit die weer. Dat is bewust:
+ * een suite die deze helper aanroept hoeft niets te weten over rollen, en er
+ * blijft geen verbinding open na afloop.
+ *
+ * @param tenantIds De tenants die opgeruimd moeten worden.
+ */
+export async function verwijderTestdata(
+  ...tenantIds: readonly string[]
+): Promise<void> {
+  for (const id of tenantIds) {
+    if (!UUID_REGEX.test(id)) {
+      throw new Error(`Ongeldige tenant-id bij opruimen: '${id}'`);
+    }
+  }
+
+  const client = new Client({ connectionString: migratieUrl() });
+  await client.connect();
+
+  try {
+    for (const tenantId of tenantIds) {
+      await client.query('BEGIN');
+
+      // SET LOCAL accepteert geen parameters — vandaar de UUID-controle
+      // hierboven, vóór de verbinding.
+      await client.query(`SET LOCAL app.current_tenant_id = '${tenantId}'`);
+
+      // Zonder 'medewerker' weigert de policy op survey_review élke rij, ook
+      // bij het opruimen. Dat is precies wat die policy hoort te doen.
+      await client.query(`SET LOCAL app.current_actor = 'medewerker'`);
+
+      for (const tabel of TABELLEN_IN_VOLGORDE) {
+        await client.query(`DELETE FROM ${tabel} WHERE tenant_id = $1`, [
+          tenantId,
+        ]);
+      }
+
+      await client.query('COMMIT');
+    }
+
+    // De audit trail staat buiten de lus: audit.audit_event heeft geen policy
+    // die tenantcontext nodig heeft, en de runtime-rol mag er sowieso niet uit
+    // verwijderen (§7.7 — append-only).
+    for (const tenantId of tenantIds) {
+      await client.query('DELETE FROM audit.audit_event WHERE tenant_id = $1', [
+        tenantId,
+      ]);
+    }
+  } finally {
+    await client.end().catch(() => {
+      // Sluiten mag mislukken; het opruimen is dan al gebeurd.
+    });
+  }
+}

--- a/test/rechten-contract.e2e-spec.ts
+++ b/test/rechten-contract.e2e-spec.ts
@@ -1,0 +1,250 @@
+import { Client } from 'pg';
+
+import {
+  DEFINER_FUNCTIES,
+  TABELRECHTEN,
+  type Tabelrechten,
+} from '../src/db/rechten-contract';
+import { inventariseerSchema } from '../src/db/schema-inventory';
+
+/**
+ * Houdt het rechtencontract tegen de werkelijkheid.
+ *
+ * ── Waarom deze suite bestaat ────────────────────────────────────────────────
+ *
+ * Op 2026-08-08 strandde de eerste echte tenant op een 500: de applicatierol
+ * had geen enkel recht op `clm.tenant_membership`. Migratie 0009 geeft die
+ * tabel geen GRANT; lokaal werkte het toch, omdat `ALTER DEFAULT PRIVILEGES`
+ * uit 0001 elke nieuwe tabel van rechten voorziet. Op Supabase is die default
+ * niet geregistreerd.
+ *
+ * Dat verschil is precies wat `verify:volledig` níét kan zien: die bouwt een
+ * verse database uit de migratieketen en meet de keten, niet de rechtenstand
+ * van een bestaande omgeving.
+ *
+ * Deze suite dekt drie dingen af, en dat is geen willekeurige drieslag — het
+ * zijn de drie plekken waar een impliciete aanname zich kan verstoppen:
+ *
+ *   1. tabelrechten        het gat van 2026-08-08
+ *   2. search_path         goed geregeld, maar door niets bewaakt
+ *   3. EXECUTE-rechten     stond alleen in tekst
+ *
+ * ── Wat deze suite bewust NIET doet ──────────────────────────────────────────
+ *
+ * Hij vergelijkt niet met "wat er toevallig staat" maar met wat het contract
+ * voorschrijft. Een test die de database als waarheid neemt, keurt elke fout
+ * goed die er al in zit — en dat is precies hoe dit gat maanden onopgemerkt
+ * bleef.
+ */
+
+/** Rollen waarlangs de applicatie rechten krijgt: clm_api_runtime erft van clm_api. */
+const APP_ROLLEN = ['clm_api', 'clm_api_runtime'];
+
+function sorteer(rechten: readonly string[]): string[] {
+  return [...rechten].sort();
+}
+
+describe('Rechtencontract (e2e)', () => {
+  let client: Client;
+
+  beforeAll(async () => {
+    client = new Client({ connectionString: process.env.DATABASE_URL });
+    await client.connect();
+  });
+
+  afterAll(async () => {
+    await client.end();
+  });
+
+  describe('het contract zelf is compleet', () => {
+    it('kent elke tabel uit het schema', () => {
+      // Zonder deze test groeit het contract niet mee: een nieuwe tabel zou
+      // stilzwijgend buiten de controle vallen, en dat is exact het gat dat
+      // deze suite moet dichten.
+      const ontbreekt = inventariseerSchema()
+        .map((t) => t.volledigeNaam)
+        .filter((naam) => !(naam in TABELRECHTEN));
+
+      expect(ontbreekt).toEqual([]);
+    });
+
+    it('noemt geen tabellen die niet bestaan', () => {
+      const bestaand = new Set(
+        inventariseerSchema().map((t) => t.volledigeNaam),
+      );
+
+      const overbodig = Object.keys(TABELRECHTEN).filter(
+        (naam) => !bestaand.has(naam),
+      );
+
+      expect(overbodig).toEqual([]);
+    });
+  });
+
+  describe('tabelrechten', () => {
+    it('geeft de applicatierol precies wat het contract voorschrijft', async () => {
+      // string_agg en niet array_agg: de pg-driver levert een array uit een
+      // subquery als tekst aan, en dan telt JavaScript de losse letters. Een
+      // door komma's gescheiden string is hier ondubbelzinnig.
+      const { rows } = await client.query<{
+        volledige_naam: string;
+        rechten: string | null;
+      }>(
+        `SELECT t.schemaname || '.' || t.tablename AS volledige_naam,
+                string_agg(DISTINCT g.privilege_type, ',')
+                  FILTER (WHERE g.grantee = ANY($1)) AS rechten
+           FROM pg_tables t
+           LEFT JOIN information_schema.role_table_grants g
+             ON g.table_schema = t.schemaname AND g.table_name = t.tablename
+          WHERE t.schemaname IN ('clm', 'audit', 'ref')
+          GROUP BY 1`,
+        [APP_ROLLEN],
+      );
+
+      const werkelijk = new Map(
+        rows.map((r) => [
+          r.volledige_naam,
+          sorteer(r.rechten ? r.rechten.split(',') : []),
+        ]),
+      );
+
+      const afwijkingen: string[] = [];
+
+      for (const [naam, verwacht] of Object.entries(TABELRECHTEN)) {
+        const gevonden = werkelijk.get(naam);
+
+        if (gevonden === undefined) {
+          afwijkingen.push(`${naam}: tabel niet gevonden in de database`);
+          continue;
+        }
+
+        const verwachtGesorteerd = sorteer(verwacht as Tabelrechten);
+
+        if (gevonden.join(',') !== verwachtGesorteerd.join(',')) {
+          afwijkingen.push(
+            `${naam}: verwacht [${verwachtGesorteerd.join(', ') || 'geen'}], ` +
+              `gevonden [${gevonden.join(', ') || 'geen'}]`,
+          );
+        }
+      }
+
+      expect(afwijkingen).toEqual([]);
+    });
+
+    it('houdt de audit trail append-only', async () => {
+      // Apart van de tabel hierboven, omdat dit een harde regel is (§7.7) en
+      // geen contractkeuze: een audit trail die de applicatie kan wijzigen of
+      // wissen bewijst niets meer.
+      const { rows } = await client.query<{ privilege_type: string }>(
+        `SELECT DISTINCT privilege_type
+           FROM information_schema.role_table_grants
+          WHERE table_schema = 'audit' AND grantee = ANY($1)`,
+        [APP_ROLLEN],
+      );
+
+      const rechten = sorteer(rows.map((r) => r.privilege_type));
+
+      expect(rechten).not.toContain('UPDATE');
+      expect(rechten).not.toContain('DELETE');
+      expect(rechten).not.toContain('TRUNCATE');
+    });
+  });
+
+  describe('SECURITY DEFINER-functies', () => {
+    it('heeft precies de functies die het contract kent', async () => {
+      const { rows } = await client.query<{ proname: string }>(
+        `SELECT proname FROM pg_proc
+          WHERE pronamespace = 'clm'::regnamespace AND prosecdef
+          ORDER BY proname`,
+      );
+
+      const gevonden = rows.map((r) => r.proname).sort();
+      const verwacht = Object.keys(DEFINER_FUNCTIES).sort();
+
+      // Een nieuwe definer-functie zonder regel in het contract hoort hier op
+      // te vallen. Dat is het hele punt: search_path vergeten is stil, deze
+      // test is dat niet.
+      expect(gevonden).toEqual(verwacht);
+    });
+
+    it('pint search_path op elke definer-functie', async () => {
+      const { rows } = await client.query<{
+        proname: string;
+        config: string | null;
+      }>(
+        `SELECT proname, array_to_string(proconfig, ', ') AS config
+           FROM pg_proc
+          WHERE pronamespace = 'clm'::regnamespace AND prosecdef`,
+      );
+
+      const afwijkingen = rows
+        .filter((r) => {
+          const contract = DEFINER_FUNCTIES[r.proname];
+          return !contract || r.config !== contract.searchPath;
+        })
+        .map((r) => `${r.proname}: '${r.config ?? 'GEEN search_path'}'`);
+
+      expect(afwijkingen).toEqual([]);
+    });
+
+    it('geeft PUBLIC nooit EXECUTE op een definer-functie', async () => {
+      // De gevaarlijkste van de drie. Een definer-functie die iedereen mag
+      // aanroepen draait met de rechten van de eigenaar — en die is eigenaar
+      // van alle tabellen.
+      const { rows } = await client.query<{
+        proname: string;
+        rechten: string | null;
+      }>(
+        `SELECT proname, array_to_string(proacl, ' ') AS rechten
+           FROM pg_proc
+          WHERE pronamespace = 'clm'::regnamespace AND prosecdef`,
+      );
+
+      const publiek = rows
+        // proacl NULL betekent: de standaardrechten gelden, en die geven
+        // PUBLIC uitvoerrecht. Een lege ACL is dus géén veilige stand.
+        .filter((r) => r.rechten === null || /(^|\s)=X/.test(r.rechten))
+        .map((r) => r.proname);
+
+      expect(publiek).toEqual([]);
+    });
+
+    it('geeft EXECUTE aan precies de rollen uit het contract', async () => {
+      // Uit proacl en niet uit information_schema.role_routine_grants: die view
+      // matcht op routinenaam, en bij overloads (resolve_survey_token is drie
+      // keer herzien) levert dat de rechten van meerdere signaturen door elkaar.
+      // proacl hoort bij precies één functie.
+      const { rows } = await client.query<{
+        proname: string;
+        rollen: string | null;
+      }>(
+        `SELECT p.proname,
+                (SELECT string_agg(DISTINCT split_part(acl, '=', 1), ',')
+                   FROM unnest(p.proacl::text[]) AS acl
+                  WHERE split_part(acl, '=', 1) LIKE 'clm%') AS rollen
+           FROM pg_proc p
+          WHERE p.pronamespace = 'clm'::regnamespace AND p.prosecdef`,
+      );
+
+      const afwijkingen: string[] = [];
+
+      for (const rij of rows) {
+        const contract = DEFINER_FUNCTIES[rij.proname];
+        if (!contract) continue; // gedekt door de test hierboven
+
+        const gevonden = sorteer(
+          rij.rollen ? rij.rollen.split(',') : [],
+        ).join(', ');
+        const verwacht = sorteer(contract.execute).join(', ');
+
+        if (gevonden !== verwacht) {
+          afwijkingen.push(
+            `${rij.proname}: verwacht [${verwacht}], gevonden [${gevonden}]`,
+          );
+        }
+      }
+
+      expect(afwijkingen).toEqual([]);
+    });
+  });
+});

--- a/test/rechten-contract.e2e-spec.ts
+++ b/test/rechten-contract.e2e-spec.ts
@@ -1,10 +1,6 @@
 import { Client } from 'pg';
 
-import {
-  DEFINER_FUNCTIES,
-  TABELRECHTEN,
-  type Tabelrechten,
-} from '../src/db/rechten-contract';
+import { DEFINER_FUNCTIES, TABELRECHTEN } from '../src/db/rechten-contract';
 import { inventariseerSchema } from '../src/db/schema-inventory';
 
 /**
@@ -118,7 +114,7 @@ describe('Rechtencontract (e2e)', () => {
           continue;
         }
 
-        const verwachtGesorteerd = sorteer(verwacht as Tabelrechten);
+        const verwachtGesorteerd = sorteer(verwacht);
 
         if (gevonden.join(',') !== verwachtGesorteerd.join(',')) {
           afwijkingen.push(
@@ -232,9 +228,9 @@ describe('Rechtencontract (e2e)', () => {
         const contract = DEFINER_FUNCTIES[rij.proname];
         if (!contract) continue; // gedekt door de test hierboven
 
-        const gevonden = sorteer(
-          rij.rollen ? rij.rollen.split(',') : [],
-        ).join(', ');
+        const gevonden = sorteer(rij.rollen ? rij.rollen.split(',') : []).join(
+          ', ',
+        );
         const verwacht = sorteer(contract.execute).join(', ');
 
         if (gevonden !== verwacht) {

--- a/test/werkvoorraad-contractmanager.e2e-spec.ts
+++ b/test/werkvoorraad-contractmanager.e2e-spec.ts
@@ -9,6 +9,7 @@ import { AppModule } from '../src/app.module';
 import { cookieInstellingen } from '../src/auth/sessie';
 import { SessieService } from '../src/auth/sessie.service';
 import { TEST_IDS } from './test-ids';
+import { verwijderTestdata } from './opruimen';
 
 /**
  * De werkvoorraad van de contractmanager (plan 2026-08-07, §4.1 B4).
@@ -72,30 +73,6 @@ interface WerkvoorraadBody {
   }>;
 }
 
-async function verwijderTestdata(client: Client) {
-  for (const tenant of [tenantA, tenantB]) {
-    await client.query('BEGIN');
-    await client.query(`SET LOCAL app.current_tenant_id = '${tenant}'`);
-    await client.query(`SET LOCAL app.current_actor = 'medewerker'`);
-    for (const tabel of [
-      'clm.response_note',
-      'clm.survey_review',
-      'clm.survey_answer',
-      'clm.survey_response',
-      'clm.survey_run',
-      'clm.survey_question',
-      'clm.survey_template',
-      'clm.vendor',
-      'clm.tenant_membership',
-      'clm."user"',
-      'clm.tenant',
-    ]) {
-      await client.query(`DELETE FROM ${tabel} WHERE tenant_id = $1`, [tenant]);
-    }
-    await client.query('COMMIT');
-  }
-}
-
 describe('Werkvoorraad contractmanager (e2e)', () => {
   let app: INestApplication<App>;
   let server: App;
@@ -106,7 +83,7 @@ describe('Werkvoorraad contractmanager (e2e)', () => {
   beforeAll(async () => {
     client = new Client({ connectionString: process.env.DATABASE_URL });
     await client.connect();
-    await verwijderTestdata(client);
+    await verwijderTestdata(tenantA, tenantB);
 
     await client.query('BEGIN');
     await client.query(`SET LOCAL app.current_tenant_id = '${tenantA}'`);
@@ -230,7 +207,7 @@ describe('Werkvoorraad contractmanager (e2e)', () => {
 
   afterAll(async () => {
     await app.close();
-    await verwijderTestdata(client);
+    await verwijderTestdata(tenantA, tenantB);
     await client.end();
   }, 30000);
 


### PR DESCRIPTION
Stap 2 uit het ontwerp (#109): de klasse fouten die de eerste tenant deed
stranden, wordt nu bij commit gevonden in plaats van in productie.

## Wat het contract vond

`src/db/rechten-contract.ts` legt per tabel vast wat de applicatierol mág; de
bijbehorende e2e-suite leest terug wat er werkelijk staat. Dat is de tegenhanger
van `schema-inventory.ts` — dat leidt af wat er hoort te bestaan, dit legt vast
wat er mag. Rechten zijn een besluit, geen afleiding.

De eerste run vond meteen iets groters dan het gat van gisteren.
**`ALTER DEFAULT PRIVILEGES` uit 0001 werkt twee kanten op:**

| Tabel | Migratie | Productie | Lokaal |
|---|---|---|---|
| `tenant_membership` | geen `GRANT` | **niets** → de 500 | alles |
| `omgeving`, `survey_review`, `response_note`, `template_reviewer` | beperkende `GRANT` | correct beperkt | **alles** |

De tweede regel is de vervelendste: **lokaal en in CI draaide alles met ruimere
rechten dan productie.** Een route die `DELETE FROM clm.omgeving` doet, faalt in
productie en slaagt in de tests. Productie was hier dus correct en de
wegwerpdatabase te ruim — andersom dan verwacht.

Migratie 0022 zet per tabel eerst `REVOKE` en dan `GRANT`, zodat het niet meer
uitmaakt wat er stond.

## De poort geldt nu voor beide verbindingen

Hij keek alleen naar `DATABASE_URL`. Dat was een gat zo groot als het probleem
dat hij moest oplossen: `MIGRATION_DATABASE_URL` staat in `.env` en wijst naar
Supabase.

Gisteren liep er een suite doorheen — `platformbeheer.e2e-spec.ts` had de
migratierol nodig, las die variabele, en dotenv vulde hem aan met de
productie-URL. De eerste query faalde toevallig; anders had die test rijen in
productie aangemaakt.

Getoetst door de situatie na te bootsen: `DATABASE_URL` naar wegwerp,
`MIGRATION_DATABASE_URL` naar productie → de run stopt en noemt de variabele bij
naam.

## Opruimen via de migratierol, uit één helper

Besluit van de eigenaar: de applicatierol houdt geen `DELETE` op `survey_review`
en `response_note` (zachte verwijdering, zoals productie al is). Opruimen wordt
daarmee een beheerhandeling.

Vijf suites hadden elk een eigen `verwijderTestdata`, vrijwel identiek maar net
niet: **twee ervan ruimden `clm.response_note` niet op.** Zo ontstaat een berg
testdata — niet met een grote fout, maar met vijf kopieën die uit elkaar
groeien. Nu één helper met alle tabellen in FK-volgorde.

Netto 81 regels minder code.

## Ook in deze PR

`docs/testaanpak-en-architectuur.md` — de testaanpak in samenhang met de
architectuur, opgezet als input voor een infographic (§11 datastructuur, §12
visuele aanwijzingen). Aangevuld uit de runbooks nadat bleek dat ik de
poorttabel en de valkuil van de gedeelde database gemist had.

## Bewezen

`verify:volledig`: **GROEN, de hele keten.** 421 e2e-tests in 30 suites.

## Nog niet gedaan

Migratie 0022 staat nog niet op productie — bewust, na het mergen.

## Te controleren

- [ ] Is `NIET_VERWIJDEREN` (geen `DELETE`) de juiste keuze voor `survey_review` en `response_note`?
- [ ] De `ref`-tabellen houden volledige schrijfrechten; het contract legt de huidige stand vast. Aanscherpen in een volgende ronde?

🤖 Generated with [Claude Code](https://claude.com/claude-code)