### PR TITLE
feat(auth): een uitgenodigde beheerder kan bij zijn eerste login inloggen

### DIFF
--- a/drizzle/0023_eerste_login_koppelen.sql
+++ b/drizzle/0023_eerste_login_koppelen.sql
@@ -1,0 +1,179 @@
+-- De eerste login van een uitgenodigde beheerder.
+--
+-- ── Het probleem ─────────────────────────────────────────────────────────────
+--
+-- Sinds de platformroute (0020) maakt een platformbeheerder een tenant aan met
+-- een eerste admin: naam en e-mailadres. Die gebruikersrij krijgt géén
+-- `external_subject`, want de `oid` uit Entra bestaat pas na een echte login.
+--
+-- Maar `clm.sessie_aanmaken()` zoekt juist op die kolom:
+--
+--     WHERE u.external_subject = p_external_subject
+--
+-- Een rij met NULL matcht nooit. De uitgenodigde admin kan dus niet inloggen,
+-- en de tenant blijft onbruikbaar. Vastgesteld op 2026-08-09 met de eerste
+-- echte tenant (AlingAdvies).
+--
+-- ── De oplossing, en waarom hij hier staat ───────────────────────────────────
+--
+-- Bij een login met een onbekende `oid` zoekt deze functie een wachtende rij op
+-- e-mailadres, en koppelt de `oid` daaraan — één keer, onomkeerbaar.
+--
+-- In de applicatielaag zou dat ook kunnen, maar dan is het één vergeten
+-- WHERE-clausule van een account-overname verwijderd. Hier is elke voorwaarde
+-- onderdeel van dezelfde query, en de functie is de enige weg naar binnen.
+--
+-- ── De voorwaarden, en wat elk ervan tegenhoudt ──────────────────────────────
+--
+--   1. precies één wachtende rij met dat e-mailadres
+--      → bij twee kandidaten weigeren in plaats van gokken
+--
+--   2. external_subject IS NULL
+--      → nooit een bestaande koppeling overschrijven; dat zou een
+--        account-overname zijn in plaats van een eerste login
+--
+--   3. koppelbaar_tot is niet verstreken
+--      → een uitnodiging die maanden blijft liggen sluit vanzelf. Zonder deze
+--        voorwaarde blijft elke ooit aangemaakte rij eeuwig koppelbaar.
+--
+--   4. het e-maildomein komt overeen
+--      → de aanroeper geeft het adres uit het ID-token door; de vergelijking
+--        gebeurt hier, hoofdletterongevoelig
+--
+--   5. de login kwam via een federatieve provider
+--      → de idp-claim moet aanwezig zijn. Bij Entra External ID betekent dat:
+--        de gebruiker is geauthenticeerd bij zijn eigen organisatie, met hun
+--        MFA-beleid. Een lokaal aangemaakt CIAM-account zonder federatie heeft
+--        die claim niet.
+--
+-- ── Wat dit NIET afdekt, en waarom dat aanvaard is ───────────────────────────
+--
+-- Entra levert geen `email_verified`-claim; dat is gemeten op 2026-08-08, niet
+-- aangenomen. Het restrisico is dat wie een uitgenodigd e-mailadres kent én bij
+-- dezelfde federatieve provider kan inloggen, de uitnodiging kan opeisen.
+--
+-- Op deze schaal — één platformbeheerder die zelf elke tenant aanmaakt, en een
+-- uitnodiging die na 90 dagen vervalt — is dat venster smal en het gevolg
+-- zichtbaar: de koppeling staat in de audit trail, en de echte admin merkt dat
+-- hij niet meer binnenkomt. Bij meer tenants hoort hier een uitnodigingstoken;
+-- zie docs/ontwerp/tenants-gebruikers-en-platformbeheer.md §5.2.
+
+-- ── 1. Hoe lang een uitnodiging geldig is ────────────────────────────────────
+--
+-- NULL betekent: geen uitnodiging, deze rij is niet koppelbaar. Dat is de
+-- veilige stand voor alle bestaande gebruikers — die hebben immers al een oid.
+
+ALTER TABLE clm."user"
+    ADD COLUMN koppelbaar_tot timestamptz;--> statement-breakpoint
+
+COMMENT ON COLUMN clm."user".koppelbaar_tot IS
+    'Tot wanneer een oid aan deze rij gekoppeld mag worden bij de eerste login. NULL is de veilige stand: niet koppelbaar. Wordt gezet door de platformroute bij het uitnodigen, standaard 90 dagen.';--> statement-breakpoint
+
+-- Bedient de lookup hieronder: welke wachtende rij hoort bij dit e-mailadres.
+-- Partieel, want alleen rijen zonder oid zijn ooit kandidaat.
+CREATE INDEX user_wachtend_op_koppeling_idx
+    ON clm."user" (lower(email))
+    WHERE external_subject IS NULL AND deleted_at IS NULL;--> statement-breakpoint
+
+-- ── 2. De koppelfunctie ──────────────────────────────────────────────────────
+
+CREATE OR REPLACE FUNCTION clm.koppel_eerste_login(
+    p_external_subject text,
+    p_email            text,
+    p_identity_provider text
+)
+RETURNS TABLE (user_id uuid, tenant_id uuid)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = clm, pg_temp
+AS $$
+DECLARE
+    v_user_id   uuid;
+    v_tenant_id uuid;
+    v_aantal    int;
+BEGIN
+    -- Voorwaarde 5: zonder federatie geen koppeling.
+    IF p_identity_provider IS NULL OR trim(p_identity_provider) = '' THEN
+        RETURN;
+    END IF;
+
+    IF p_email IS NULL OR trim(p_email) = '' THEN
+        RETURN;
+    END IF;
+
+    IF p_external_subject IS NULL OR trim(p_external_subject) = '' THEN
+        RETURN;
+    END IF;
+
+    -- Voorwaarde 2: nooit koppelen aan een oid die al bestaat. Zou die
+    -- controle ontbreken, dan kon een tweede login een bestaande gebruiker
+    -- overschrijven.
+    IF EXISTS (
+        SELECT 1 FROM clm."user"
+         WHERE external_subject = p_external_subject
+    ) THEN
+        RETURN;
+    END IF;
+
+    -- Voorwaarden 1, 3 en 4 in één query: tellen én ophalen.
+    SELECT count(*) INTO v_aantal
+      FROM clm."user" u
+     WHERE lower(u.email) = lower(p_email)
+       AND u.external_subject IS NULL
+       AND u.deleted_at IS NULL
+       AND u.koppelbaar_tot IS NOT NULL
+       AND u.koppelbaar_tot > now();
+
+    -- Voorwaarde 1: bij nul of meer dan één kandidaat weigeren. Gokken zou
+    -- betekenen dat de uitkomst van volgorde afhangt.
+    IF v_aantal <> 1 THEN
+        RETURN;
+    END IF;
+
+    SELECT u.user_id, u.tenant_id
+      INTO v_user_id, v_tenant_id
+      FROM clm."user" u
+     WHERE lower(u.email) = lower(p_email)
+       AND u.external_subject IS NULL
+       AND u.deleted_at IS NULL
+       AND u.koppelbaar_tot IS NOT NULL
+       AND u.koppelbaar_tot > now();
+
+    -- De tenantcontext moet gezet zijn vóór de UPDATE, en dat is het kip-ei
+    -- van deze hele functie: clm."user" heeft een policy op
+    -- clm.current_tenant_id(), maar bij een eerste login is die context er nog
+    -- niet — de tenant vólgt uit de rij die we net gevonden hebben.
+    --
+    -- De SELECT's hierboven konden nog zonder: die draaien als eigenaar op een
+    -- tabel zonder FORCE (migratie 0011). Schrijven kan dat niet.
+    --
+    -- `true` als derde argument: alleen binnen deze transactie, zodat de
+    -- aanroeper zijn eigen context niet kwijtraakt.
+    PERFORM set_config('app.current_tenant_id', v_tenant_id::text, true);
+
+    UPDATE clm."user"
+       SET external_subject = p_external_subject,
+           koppelbaar_tot   = NULL
+     WHERE clm."user".user_id = v_user_id;
+
+    -- De koppeling zelf is auditinformatie: hij bepaalt wie voortaan als deze
+    -- gebruiker binnenkomt. audit.audit_event heeft dezelfde policy, en de
+    -- context staat hierboven al goed.
+    INSERT INTO audit.audit_event
+        (tenant_id, action_type, entity_type, entity_id, new_values)
+    VALUES (
+        v_tenant_id, 'eerste_login_gekoppeld', 'user', v_user_id,
+        jsonb_build_object('identity_provider', p_identity_provider)
+    );
+
+    RETURN QUERY SELECT v_user_id, v_tenant_id;
+END;
+$$;--> statement-breakpoint
+
+COMMENT ON FUNCTION clm.koppel_eerste_login(text, text, text) IS
+    'Koppelt bij de eerste login een oid aan een uitgenodigde gebruikersrij. Vijf voorwaarden, alle vijf nodig: precies één kandidaat op e-mailadres, external_subject nog leeg, de oid nog nergens in gebruik, de uitnodiging niet verstreken, en een federatieve login. Geeft niets terug wanneer een voorwaarde niet gehaald wordt — nooit een exception met details, want die zou verklappen welk e-mailadres bestaat.';--> statement-breakpoint
+
+-- Zelfde rechten als de andere definer-functies (0009, 0010): PUBLIC eraf,
+-- expliciet aan de applicatierollen.
+REVOKE ALL ON FUNCTION clm.koppel_eerste_login(text, text, text) FROM PUBLIC;--> statement-breakpoint
+GRANT EXECUTE ON FUNCTION clm.koppel_eerste_login(text, text, text) TO clm_api, clm_admin;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -162,6 +162,13 @@
       "when": 1786723200000,
       "tag": "0022_rechten_expliciet",
       "breakpoints": true
+    },
+    {
+      "idx": 23,
+      "version": "7",
+      "when": 1786809600000,
+      "tag": "0023_eerste_login_koppelen",
+      "breakpoints": true
     }
   ]
 }

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -144,7 +144,14 @@ export class AuthService {
       throw err;
     }
 
-    return this.sessies.aanmaken(identiteit.externalSubject);
+    // E-mail en idp gaan alleen mee voor het geval dit een eerste login is van
+    // een uitgenodigde gebruiker. Voor iedereen die al een external_subject
+    // heeft, worden ze genegeerd — clm.sessie_aanmaken() slaagt dan meteen en
+    // de koppelfunctie wordt niet eens aangeroepen.
+    return this.sessies.aanmaken(identiteit.externalSubject, {
+      email: identiteit.email,
+      identityProvider: identiteit.identityProvider,
+    });
   }
 
   /** Beëindigt de sessie bij het ruwe token uit het cookie. */

--- a/src/auth/id-token-verificatie.ts
+++ b/src/auth/id-token-verificatie.ts
@@ -32,6 +32,14 @@ export interface GeverifieerdeIdentiteit {
   readonly naam?: string;
   /** De tenant-ID van de identity provider — niet die van MCM2. */
   readonly identityTenantId?: string;
+  /**
+   * De `idp`-claim: via welke provider deze login binnenkwam.
+   *
+   * Bij federatie wijst hij naar de eigen organisatie van de gebruiker. Alleen
+   * gebruikt bij de eerste login, als waarborg bij het koppelen van een oid aan
+   * een wachtende gebruikersrij.
+   */
+  readonly identityProvider?: string;
 }
 
 /** Wordt geworpen wanneer een token niet te vertrouwen is. */
@@ -123,6 +131,14 @@ export class IdTokenVerificateur {
       email: leesTekstClaim(payload, 'email'),
       naam: leesTekstClaim(payload, 'name'),
       identityTenantId: leesTekstClaim(payload, 'tid'),
+      // Bij federatie wijst deze claim naar de identity provider van de
+      // gebruiker zelf, niet naar onze CIAM-tenant — voor een AlingAdvies-
+      // account bijvoorbeeld naar login.microsoftonline.com/<hun tenant>.
+      //
+      // Alleen nodig bij de eerste login, waar een oid aan een wachtende
+      // gebruikersrij gekoppeld wordt: dan is "kwam deze login via een
+      // federatieve provider" een van de waarborgen. Zie koppelEersteLogin().
+      identityProvider: leesTekstClaim(payload, 'idp'),
     };
   }
 }

--- a/src/auth/sessie.service.ts
+++ b/src/auth/sessie.service.ts
@@ -30,6 +30,17 @@ export interface SessieContext {
   readonly role: string;
 }
 
+/**
+ * De claims die een eerste login mag gebruiken om zich te koppelen.
+ *
+ * Alleen bij de allereerste login van een uitgenodigde gebruiker; daarna doet
+ * `external_subject` het werk. Zie migratie 0023 voor de vijf voorwaarden.
+ */
+export interface EersteLoginGegevens {
+  readonly email?: string;
+  readonly identityProvider?: string;
+}
+
 /** Wat een geslaagde login oplevert: de context plus het ruwe token. */
 export interface NieuweSessie extends SessieContext {
   /**
@@ -65,13 +76,40 @@ export class SessieService {
    * Entra inloggen zonder in MCM2 bekend te zijn. Authenticatie is niet
    * hetzelfde als autorisatie.
    */
-  async aanmaken(externalSubject: string): Promise<NieuweSessie | null> {
+  async aanmaken(
+    externalSubject: string,
+    uitnodiging?: EersteLoginGegevens,
+  ): Promise<NieuweSessie | null> {
     const token = genereerSessieToken();
     const hash = hashSessieToken(token);
 
-    const resultaat = await this.db.db.execute<SessieRij>(
+    let resultaat = await this.db.db.execute<SessieRij>(
       sql`SELECT * FROM clm.sessie_aanmaken(${hash}, ${externalSubject}, ${GELDIGHEID_INTERVAL}::interval)`,
     );
+
+    // Geen sessie kan twee dingen betekenen: deze persoon hoort er niet bij, óf
+    // hij is uitgenodigd en logt voor het eerst in. Dat tweede geval krijgt één
+    // kans om zichzelf te koppelen; daarna verloopt het als een gewone login.
+    //
+    // De volgorde is opzet: eerst de gewone weg proberen. Een bestaande
+    // gebruiker raakt clm.koppel_eerste_login() daarmee nooit.
+    if (resultaat.rows.length === 0 && uitnodiging?.email) {
+      const gekoppeld = await this.db.db.execute<{ user_id: string }>(
+        sql`SELECT * FROM clm.koppel_eerste_login(
+              ${externalSubject}, ${uitnodiging.email},
+              ${uitnodiging.identityProvider ?? null})`,
+      );
+
+      if (gekoppeld.rows.length > 0) {
+        this.logger.log(
+          'Eerste login van een uitgenodigde gebruiker — identiteit gekoppeld.',
+        );
+
+        resultaat = await this.db.db.execute<SessieRij>(
+          sql`SELECT * FROM clm.sessie_aanmaken(${hash}, ${externalSubject}, ${GELDIGHEID_INTERVAL}::interval)`,
+        );
+      }
+    }
 
     const rij = resultaat.rows[0];
 

--- a/src/db/rechten-contract.ts
+++ b/src/db/rechten-contract.ts
@@ -189,4 +189,8 @@ export const DEFINER_FUNCTIES: Readonly<Record<string, FunctieContract>> = {
 
   // De leverancierstoken-lookup, spoor 2 (0003, herzien in 0006 en 0008).
   resolve_survey_token: DEFINER_STANDAARD,
+
+  // De eerste login van een uitgenodigde beheerder (0023). Koppelt een oid aan
+  // een wachtende gebruikersrij, onder vijf voorwaarden.
+  koppel_eerste_login: DEFINER_STANDAARD,
 };

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -73,6 +73,9 @@ export const user = clm.table(
     // Nooit het e-mailadres: dat verandert, een oid niet. NULL voor gebruikers
     // die niet inloggen — respondenten van interne beoordelingen bijvoorbeeld.
     externalSubject: text('external_subject'),
+    // Migratie 0023. Tot wanneer een oid aan deze rij gekoppeld mag worden bij
+    // de eerste login. NULL is de veilige stand: niet koppelbaar.
+    koppelbaarTot: timestamp('koppelbaar_tot', { withTimezone: true }),
     createdAt: timestamp('created_at', { withTimezone: true })
       .notNull()
       .defaultNow(),

--- a/src/platform/platform.service.ts
+++ b/src/platform/platform.service.ts
@@ -6,6 +6,16 @@ import { DatabaseService } from '../db/database.service';
 /** Hoe lang support-toegang standaard geldig is. */
 export const SUPPORT_TOEGANG_UREN = 8;
 
+/**
+ * Hoe lang een uitnodiging voor een eerste admin geldig blijft.
+ *
+ * Negentig dagen: ruim genoeg voor een klant die een paar weken nodig heeft om
+ * te beginnen, kort genoeg om niet jaren een koppelbare rij te laten staan.
+ * Verloopt hij, dan moet de platformbeheerder opnieuw uitnodigen — een
+ * zichtbare handeling in plaats van een deur die open blijft.
+ */
+export const UITNODIGING_GELDIG_DAGEN = 90;
+
 export interface NieuweTenant {
   readonly naam: string;
   /** Wordt de eerste admin. Zijn oid volgt bij de eerste login. */
@@ -110,9 +120,14 @@ export class PlatformService {
         throw fout;
       }
 
+      // koppelbaar_tot maakt dit een uitnodiging: bij zijn eerste Entra-login
+      // koppelt clm.koppel_eerste_login() de oid aan deze rij (migratie 0023).
+      // Zonder die datum is de rij niet koppelbaar en kan deze admin nooit
+      // inloggen — NULL is daar de veilige stand.
       const gebruiker = await tx.execute<{ user_id: string }>(
-        sql`INSERT INTO clm."user" (tenant_id, full_name, email)
-            VALUES (${tenantId}, ${invoer.adminNaam}, ${invoer.adminEmail})
+        sql`INSERT INTO clm."user" (tenant_id, full_name, email, koppelbaar_tot)
+            VALUES (${tenantId}, ${invoer.adminNaam}, ${invoer.adminEmail},
+                    now() + ${`${UITNODIGING_GELDIG_DAGEN} days`}::interval)
             RETURNING user_id`,
       );
 

--- a/test/eerste-login.e2e-spec.ts
+++ b/test/eerste-login.e2e-spec.ts
@@ -1,0 +1,308 @@
+import { Client } from 'pg';
+
+import { verwijderTestdata } from './opruimen';
+import { TEST_IDS } from './test-ids';
+
+/**
+ * De eerste login van een uitgenodigde beheerder (migratie 0023).
+ *
+ * ── Waarom deze suite zwaarder weegt dan hij lijkt ───────────────────────────
+ *
+ * `clm.koppel_eerste_login()` is de enige plek in het systeem waar een
+ * Entra-identiteit aan een bestaande gebruikersrij wordt gehecht. Gaat daar
+ * iets mis, dan is het gevolg niet "een test faalt" maar een account-overname:
+ * iemand anders komt binnen als de beheerder van een klant.
+ *
+ * De functie kent vijf voorwaarden. Deze suite lokt ze alle vijf uit — niet
+ * omdat de code er onbetrouwbaar uitziet, maar omdat een voorwaarde die niet
+ * getest is er net zo goed niet kan zijn (§15b).
+ *
+ * ── Wat er NIET getest wordt, en waarom ──────────────────────────────────────
+ *
+ * De echte Entra-flow. Die is op 2026-08-08 handmatig doorlopen en bewezen
+ * (claims-meten.js); hem hier nabootsen zou een mock testen in plaats van de
+ * database. Wat hier telt is wat de functie doet met de claims die binnenkomen.
+ */
+
+const {
+  tenant: TENANT,
+  tenantTweede: TENANT_TWEEDE,
+  uitgenodigd: USER_UITGENODIGD,
+  bestaand: USER_BESTAAND,
+} = TEST_IDS['eerste-login'];
+
+// Uniek per run: external_subject heeft een globale unieke index zonder
+// tenant_id erin. Zie het runbook, "Een nieuwe e2e-suite schrijven".
+const OID_NIEUW = `oid-eerste-login-${Date.now()}`;
+const OID_BESTAAND = `oid-bestaand-${Date.now()}`;
+const EMAIL_UITGENODIGD = `uitgenodigd-${Date.now()}@voorbeeld.nl`;
+const EMAIL_BESTAAND = `bestaand-${Date.now()}@voorbeeld.nl`;
+
+/** Een geloofwaardige idp-claim, zoals Entra hem bij federatie levert. */
+const IDP =
+  'https://login.microsoftonline.com/3ce5523c-cc8b-4422-a310-8bdfa3715168/v2.0';
+
+interface Koppeling {
+  user_id: string;
+  tenant_id: string;
+}
+
+describe('Eerste login koppelen (e2e, migratie 0023)', () => {
+  let client: Client;
+
+  /** Roept de functie aan zoals de applicatie dat doet. */
+  async function koppel(
+    oid: string,
+    email: string | null,
+    idp: string | null = IDP,
+  ): Promise<Koppeling[]> {
+    const { rows } = await client.query<Koppeling>(
+      'SELECT * FROM clm.koppel_eerste_login($1, $2, $3)',
+      [oid, email, idp],
+    );
+    return rows;
+  }
+
+  /** Zet de uitnodiging terug in de wachtende stand. */
+  async function herstelUitnodiging(dagen = 90): Promise<void> {
+    await client.query('BEGIN');
+    await client.query(`SET LOCAL app.current_tenant_id = '${TENANT}'`);
+    await client.query(
+      `UPDATE clm."user"
+          SET external_subject = NULL,
+              koppelbaar_tot = now() + ($1 || ' days')::interval
+        WHERE user_id = $2`,
+      [String(dagen), USER_UITGENODIGD],
+    );
+    await client.query('COMMIT');
+  }
+
+  beforeAll(async () => {
+    client = new Client({ connectionString: process.env.DATABASE_URL });
+    await client.connect();
+
+    await client.query('BEGIN');
+    await client.query(`SET LOCAL app.current_tenant_id = '${TENANT}'`);
+    await client.query(
+      'INSERT INTO clm.tenant (tenant_id, name) VALUES ($1, $2)',
+      [TENANT, `eerste-login-${Date.now()}`],
+    );
+
+    // De uitgenodigde: e-mailadres bekend, oid nog niet.
+    await client.query(
+      `INSERT INTO clm."user" (user_id, tenant_id, full_name, email, koppelbaar_tot)
+       VALUES ($1, $2, 'Uitgenodigde Admin', $3, now() + interval '90 days')`,
+      [USER_UITGENODIGD, TENANT, EMAIL_UITGENODIGD],
+    );
+    await client.query(
+      `INSERT INTO clm.tenant_membership (user_id, tenant_id, role)
+       VALUES ($1, $2, 'admin')`,
+      [USER_UITGENODIGD, TENANT],
+    );
+
+    // Iemand die al is ingelogd: heeft een oid, geen uitnodiging.
+    await client.query(
+      `INSERT INTO clm."user" (user_id, tenant_id, full_name, email, external_subject)
+       VALUES ($1, $2, 'Bestaande Gebruiker', $3, $4)`,
+      [USER_BESTAAND, TENANT, EMAIL_BESTAAND, OID_BESTAAND],
+    );
+    await client.query('COMMIT');
+  }, 30000);
+
+  afterAll(async () => {
+    await verwijderTestdata(TENANT, TENANT_TWEEDE);
+    await client.end();
+  }, 30000);
+
+  describe('de gelukkige weg', () => {
+    it('koppelt de oid aan de wachtende rij en geeft de tenant terug', async () => {
+      const rijen = await koppel(OID_NIEUW, EMAIL_UITGENODIGD);
+
+      expect(rijen).toHaveLength(1);
+      expect(rijen[0].user_id).toBe(USER_UITGENODIGD);
+      expect(rijen[0].tenant_id).toBe(TENANT);
+    });
+
+    it('sluit de uitnodiging na gebruik', async () => {
+      // koppelbaar_tot op NULL: de rij is niet nóg een keer koppelbaar. Zonder
+      // dit zou een tweede persoon met hetzelfde e-mailadres later alsnog
+      // kunnen proberen.
+      await client.query('BEGIN');
+      await client.query(`SET LOCAL app.current_tenant_id = '${TENANT}'`);
+      const { rows } = await client.query<{
+        external_subject: string;
+        koppelbaar_tot: Date | null;
+      }>(
+        'SELECT external_subject, koppelbaar_tot FROM clm."user" WHERE user_id = $1',
+        [USER_UITGENODIGD],
+      );
+      await client.query('COMMIT');
+
+      expect(rows[0].external_subject).toBe(OID_NIEUW);
+      expect(rows[0].koppelbaar_tot).toBeNull();
+    });
+
+    it('legt de koppeling vast in de audit trail', async () => {
+      // Op entity_id filteren en niet op tenant_id alleen: de suite koppelt in
+      // latere tests nog een paar keer, en de audit trail is append-only — die
+      // regels blijven dus staan. Precies wat een audit trail hoort te doen,
+      // maar het maakt "er is er één" een verkeerde verwachting.
+      await client.query('BEGIN');
+      await client.query(`SET LOCAL app.current_tenant_id = '${TENANT}'`);
+      const { rows } = await client.query<{
+        new_values: Record<string, unknown>;
+      }>(
+        `SELECT new_values FROM audit.audit_event
+          WHERE tenant_id = $1
+            AND action_type = 'eerste_login_gekoppeld'
+            AND entity_id = $2
+          ORDER BY created_at DESC
+          LIMIT 1`,
+        [TENANT, USER_UITGENODIGD],
+      );
+      await client.query('COMMIT');
+
+      expect(rows).toHaveLength(1);
+      expect(rows[0].new_values.identity_provider).toBe(IDP);
+    });
+
+    it('laat de gekoppelde gebruiker daarna gewoon inloggen', async () => {
+      // De hele reden dat deze functie bestaat: sessie_aanmaken() zoekt op
+      // external_subject, en die is nu gevuld.
+      const { rows } = await client.query<{ tenant_id: string; role: string }>(
+        `SELECT tenant_id, role
+           FROM clm.sessie_aanmaken($1, $2, '8 hours'::interval)`,
+        [`${'a'.repeat(48)}7e7e7e7e7e7e7e7e`, OID_NIEUW],
+      );
+
+      expect(rows).toHaveLength(1);
+      expect(rows[0].tenant_id).toBe(TENANT);
+      expect(rows[0].role).toBe('admin');
+    });
+  });
+
+  describe('de vijf voorwaarden', () => {
+    beforeEach(async () => {
+      await herstelUitnodiging();
+    });
+
+    it('weigert wanneer de oid al aan iemand anders hangt', async () => {
+      // Voorwaarde 2, en de gevaarlijkste van de vijf: dit zou een bestaande
+      // gebruiker overschrijven met de identiteit van een ander.
+      const rijen = await koppel(OID_BESTAAND, EMAIL_UITGENODIGD);
+
+      expect(rijen).toHaveLength(0);
+    });
+
+    it('weigert wanneer twee rijen hetzelfde e-mailadres hebben', async () => {
+      // Voorwaarde 1. Gokken zou betekenen dat de uitkomst van volgorde
+      // afhangt — en dan bepaalt toeval wie er binnenkomt.
+      await client.query('BEGIN');
+      await client.query(
+        `SET LOCAL app.current_tenant_id = '${TENANT_TWEEDE}'`,
+      );
+      await client.query(
+        'INSERT INTO clm.tenant (tenant_id, name) VALUES ($1, $2)',
+        [TENANT_TWEEDE, `eerste-login-tweede-${Date.now()}`],
+      );
+      await client.query(
+        `INSERT INTO clm."user" (tenant_id, full_name, email, koppelbaar_tot)
+         VALUES ($1, 'Dubbel Adres', $2, now() + interval '90 days')`,
+        [TENANT_TWEEDE, EMAIL_UITGENODIGD],
+      );
+      await client.query('COMMIT');
+
+      const rijen = await koppel(`${OID_NIEUW}-tweede`, EMAIL_UITGENODIGD);
+
+      expect(rijen).toHaveLength(0);
+
+      // Opruimen zodat de volgende test weer één kandidaat heeft.
+      await client.query('BEGIN');
+      await client.query(
+        `SET LOCAL app.current_tenant_id = '${TENANT_TWEEDE}'`,
+      );
+      await client.query('DELETE FROM clm."user" WHERE tenant_id = $1', [
+        TENANT_TWEEDE,
+      ]);
+      await client.query('DELETE FROM clm.tenant WHERE tenant_id = $1', [
+        TENANT_TWEEDE,
+      ]);
+      await client.query('COMMIT');
+    });
+
+    it('weigert een verlopen uitnodiging', async () => {
+      // Voorwaarde 3. Zonder deze grens blijft elke ooit aangemaakte rij
+      // eeuwig koppelbaar.
+      await herstelUitnodiging(-1);
+
+      const rijen = await koppel(`${OID_NIEUW}-verlopen`, EMAIL_UITGENODIGD);
+
+      expect(rijen).toHaveLength(0);
+    });
+
+    it('weigert een rij zonder uitnodiging', async () => {
+      // Voorwaarde 3, andere kant: koppelbaar_tot NULL is de veilige stand.
+      // Elke bestaande gebruiker in de database staat zo.
+      await client.query('BEGIN');
+      await client.query(`SET LOCAL app.current_tenant_id = '${TENANT}'`);
+      await client.query(
+        `UPDATE clm."user" SET external_subject = NULL, koppelbaar_tot = NULL
+          WHERE user_id = $1`,
+        [USER_UITGENODIGD],
+      );
+      await client.query('COMMIT');
+
+      const rijen = await koppel(`${OID_NIEUW}-zonder`, EMAIL_UITGENODIGD);
+
+      expect(rijen).toHaveLength(0);
+    });
+
+    it('weigert een onbekend e-mailadres', async () => {
+      // Voorwaarde 4.
+      const rijen = await koppel(
+        `${OID_NIEUW}-onbekend`,
+        `niemand-${Date.now()}@voorbeeld.nl`,
+      );
+
+      expect(rijen).toHaveLength(0);
+    });
+
+    it('weigert een login zonder federatieve provider', async () => {
+      // Voorwaarde 5. Entra levert geen email_verified; de idp-claim is wat er
+      // wél is, en die zegt dat de gebruiker bij zijn eigen organisatie is
+      // geauthenticeerd.
+      const rijen = await koppel(
+        `${OID_NIEUW}-geen-idp`,
+        EMAIL_UITGENODIGD,
+        null,
+      );
+
+      expect(rijen).toHaveLength(0);
+    });
+
+    it('weigert een leeg e-mailadres', async () => {
+      const rijen = await koppel(`${OID_NIEUW}-leeg`, null);
+
+      expect(rijen).toHaveLength(0);
+    });
+  });
+
+  describe('hoofdletters', () => {
+    beforeEach(async () => {
+      await herstelUitnodiging();
+    });
+
+    it('koppelt ongeacht de schrijfwijze van het e-mailadres', async () => {
+      // Een identity provider mag het adres anders teruggeven dan het is
+      // ingevoerd. Zou dat niet matchen, dan strandt een geldige uitnodiging op
+      // een hoofdletter — met een foutmelding die nergens naar wijst.
+      const rijen = await koppel(
+        `${OID_NIEUW}-hoofdletters`,
+        EMAIL_UITGENODIGD.toUpperCase(),
+      );
+
+      expect(rijen).toHaveLength(1);
+      expect(rijen[0].user_id).toBe(USER_UITGENODIGD);
+    });
+  });
+});

--- a/test/test-ids.ts
+++ b/test/test-ids.ts
@@ -317,6 +317,14 @@ export const TEST_IDS = {
     beheerder: id('76'),
     gewoneGebruiker: id('77'),
   },
+  'eerste-login': {
+    tenant: id('78'),
+    /** Tweede tenant, om een dubbel e-mailadres uit te lokken. */
+    tenantTweede: id('79'),
+    uitgenodigd: id('7e'),
+    /** Iemand die al een oid heeft — mag nooit overschreven worden. */
+    bestaand: id('7f'),
+  },
 } as const;
 
 /** Alle uitgedeelde id's, plat. Gebruikt door de bewakingstest. */


### PR DESCRIPTION
De laatste schakel: de tenant AlingAdvies staat sinds vandaag in productie, maar
Kees kan er niet in.

## Het gat

De platformroute maakt een gebruikersrij **zonder** `external_subject` — die
`oid` bestaat pas na een echte Entra-login. Maar `clm.sessie_aanmaken()` zoekt
juist daarop:

```sql
WHERE u.external_subject = p_external_subject
```

Een rij met `NULL` matcht nooit. De uitgenodigde admin komt er dus niet in, en
de tenant blijft onbruikbaar. Vastgesteld vandaag met de eerste echte tenant.

## De oplossing

`clm.koppel_eerste_login()` (migratie 0023): bij een login met een onbekende
`oid` wordt een wachtende rij op e-mailadres gezocht en de identiteit daaraan
gekoppeld — één keer, onomkeerbaar.

**Vijf voorwaarden, alle vijf in dezelfde query.** In de applicatielaag zou dit
één vergeten `WHERE`-clausule van een account-overname verwijderd zijn:

| | Voorwaarde | Wat het tegenhoudt |
|---|---|---|
| 1 | precies één kandidaat op e-mailadres | gokken bij twee rijen — dan bepaalt volgorde wie binnenkomt |
| 2 | de `oid` hangt nog nergens aan | een bestaande gebruiker overschrijven |
| 3 | de uitnodiging is niet verstreken | een rij die jaren koppelbaar blijft |
| 4 | het e-mailadres komt overeen | (hoofdletterongevoelig) |
| 5 | de login kwam via een federatieve provider | een lokaal CIAM-account zonder MFA van de eigen organisatie |

De functie geeft **niets** terug wanneer een voorwaarde niet gehaald wordt —
nooit een exception met details, want die zou verklappen welk e-mailadres
bestaat.

## Over voorwaarde 5

Het ontwerp (#109) eiste `email_verified`. **Entra levert die claim niet** —
gemeten op 2026-08-08 met `claims-meten.js`, niet aangenomen.

Besluit van de eigenaar: in plaats daarvan de `idp`-claim eisen. Die zegt dat de
gebruiker bij zijn eigen organisatie is geauthenticeerd, mét hun MFA-beleid.

Het restrisico staat expliciet in de migratie: wie een uitgenodigd adres kent
én bij dezelfde provider kan inloggen, kan de uitnodiging opeisen. Op deze
schaal — één platformbeheerder, uitnodigingen die na 90 dagen vervallen, de
koppeling in de audit trail — is dat venster smal en het gevolg zichtbaar. Bij
meer tenants hoort hier een uitnodigingstoken.

## Wat de tegenproef vond

Iets dat door lezen niet te zien was: **de `UPDATE` en de auditregel vallen
onder RLS**, en bij een eerste login is er nog geen tenantcontext — die vólgt
juist uit de rij die de functie net gevonden heeft. Vandaar `set_config` binnen
de transactie, vóór het schrijven.

Hetzelfde kip-ei-probleem waarvoor 0009 en 0010 al `SECURITY DEFINER` gebruiken.

## Bewezen

| | |
|---|---|
| Nieuwe suite | 12 tests, waarvan 7 tegenproeven |
| Volledige suite | **433 tests in 31 suites** |
| Herhaalbaarheid | 3 runs achtereen groen (2 vers, 1 herhaald) |
| `verify:volledig` | **GROEN, de hele keten** |

## Na het mergen — twee stappen, geen één

1. Migratie 0023 naar productie.
2. **De tenant AlingAdvies is aangemaakt vóór deze migratie** en heeft dus geen
   `koppelbaar_tot`. Die staat daarna op `NULL` — de veilige stand — en dan kan
   Kees nog steeds niet inloggen. Dat vraagt één `UPDATE` op productie, of de
   tenant opnieuw aanmaken via de route.

## Te controleren

- [ ] Is de `idp`-claim een aanvaardbare vervanging voor `email_verified`?
- [ ] Is 90 dagen de juiste geldigheid voor een uitnodiging?

🤖 Generated with [Claude Code](https://claude.com/claude-code)