### PR TITLE
feat(auth): een uitnodigingstoken in plaats van een claim over de inlogmethode

### DIFF
--- a/drizzle/0024_uitnodigingstoken.sql
+++ b/drizzle/0024_uitnodigingstoken.sql
@@ -1,0 +1,202 @@
+-- Een uitgenodigde beheerder koppelt zich met een token, niet met een claim.
+--
+-- ── Wat er mis was aan voorwaarde 5 ──────────────────────────────────────────
+--
+-- Migratie 0023 eist bij de eerste login dat er een `idp`-claim aanwezig is:
+-- de login moet via een federatieve provider zijn binnengekomen. Dat leek een
+-- waarborg, maar hij toetst de *vorm* van de login en niet de identiteit van
+-- de aanvrager. Welke provider het is, wordt niet gecontroleerd — wie zich bij
+-- een willekeurige federatieve provider aanmeldt én het uitgenodigde
+-- e-mailadres kent, komt binnen.
+--
+-- Daarmee was de koppeling in de praktijk beveiligd door één ding: het kennen
+-- van een e-mailadres. Dat stond in 0023 ook eerlijk opgeschreven, als aanvaard
+-- restrisico (regels 49-59), met de aantekening dat hier een uitnodigingstoken
+-- hoort zodra er meer tenants zijn.
+--
+-- Dat moment is nu, en om twee redenen tegelijk:
+--
+--   1. De eis kost méér dan hij oplevert. Ze sluit elke inlogmethode uit die
+--      geen federatie is — e-mail met eenmalige code bijvoorbeeld — terwijl ze
+--      de aanval waar het om gaat niet tegenhoudt.
+--
+--   2. Wat een zakelijke klant werkelijk vraagt is niet "kwam deze login via
+--      een federatie", maar "is deze toegang aantoonbaar toegekend". Een token
+--      dat de platformbeheerder uitgeeft beantwoordt die vraag; een claim over
+--      de inlogmethode niet.
+--
+-- ── Wat er voor in de plaats komt ────────────────────────────────────────────
+--
+-- Bij het aanmaken geeft de platformroute een token uit, precies zoals bij de
+-- leverancierstokens (0003): 32 bytes willekeur, base64url in de link, SHA-256
+-- in de database. Het ruwe token verlaat de applicatie één keer en is daarna
+-- nergens meer op te vragen.
+--
+-- De winst zit in de unieke index. In 0023 was "precies één kandidaat" een
+-- telling in de functie — code die kon meetellen wat niet meegeteld had moeten
+-- worden. Nu is het een eigenschap van de database: twee rijen met dezelfde
+-- hash kúnnen niet bestaan. De voorwaarde is daarmee niet zozeer strenger als
+-- wel onmogelijk om per ongeluk te overtreden.
+--
+-- Het e-mailadres blijft als tweede controle staan. Token én adres moeten
+-- kloppen; dat kost niets en maakt een link die bij de verkeerde persoon
+-- belandt waardeloos.
+--
+-- ── Federatie afdwingen: bewust niet hier ────────────────────────────────────
+--
+-- Een tenant die eist dat alleen zijn eigen AD toegang geeft, hoort dat per
+-- tenant en bij *elke* login afgedwongen te krijgen — niet globaal en alleen
+-- bij de eerste. Dat is een kolom op clm.tenant en een controle in
+-- clm.sessie_aanmaken(), en dat bouwen we bij de eerste klant die het vraagt,
+-- omdat pas dan bekend is wat hij precies eist.
+--
+-- Voorwaarde 5 laten staan zou dat gat níét vullen: hij bewaakt alleen de
+-- allereerste login en laat elke volgende ongemoeid.
+
+-- ── 1. De kolom ──────────────────────────────────────────────────────────────
+
+ALTER TABLE clm."user"
+    ADD COLUMN uitnodiging_hash text;--> statement-breakpoint
+
+COMMENT ON COLUMN clm."user".uitnodiging_hash IS
+    'SHA-256 van het uitnodigingstoken, hex. NULL betekent: geen openstaande uitnodiging. Wordt gewist zodra de koppeling gelukt is — een token werkt precies één keer.';--> statement-breakpoint
+
+-- Dezelfde controle als op survey_response.token_hash (0003): een afwijkende
+-- lengte betekent dat er iets anders is opgeslagen dan een hash, en het meest
+-- waarschijnlijke "iets anders" is het ruwe token.
+ALTER TABLE clm."user"
+    ADD CONSTRAINT user_uitnodiging_hash_format_check
+    CHECK (uitnodiging_hash IS NULL OR uitnodiging_hash ~ '^[0-9a-f]{64}$');--> statement-breakpoint
+
+-- Hier zit de kern van deze migratie. Partieel, want alleen openstaande
+-- uitnodigingen doen mee; uniek, want twee rijen met dezelfde hash zouden
+-- betekenen dat één token naar twee gebruikers leidt.
+CREATE UNIQUE INDEX user_uitnodiging_hash_key
+    ON clm."user" (uitnodiging_hash)
+    WHERE uitnodiging_hash IS NOT NULL;--> statement-breakpoint
+
+-- ── 2. De koppelfunctie ──────────────────────────────────────────────────────
+--
+-- DROP en opnieuw aanmaken, niet CREATE OR REPLACE: de parameterlijst
+-- verandert (p_identity_provider eruit, p_uitnodiging_hash erin) en dat is een
+-- andere functiehandtekening. Zonder DROP zouden er twee versies naast elkaar
+-- staan en bepaalt PostgreSQL op grond van de argumenttypen welke hij pakt —
+-- allebei text, dus dat zou een gok worden.
+
+DROP FUNCTION IF EXISTS clm.koppel_eerste_login(text, text, text);--> statement-breakpoint
+
+CREATE FUNCTION clm.koppel_eerste_login(
+    p_external_subject  text,
+    p_email             text,
+    p_uitnodiging_hash  text
+)
+RETURNS TABLE (user_id uuid, tenant_id uuid)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = clm, pg_temp
+AS $$
+DECLARE
+    v_user_id   uuid;
+    v_tenant_id uuid;
+BEGIN
+    IF p_uitnodiging_hash IS NULL OR trim(p_uitnodiging_hash) = '' THEN
+        RETURN;
+    END IF;
+
+    IF p_email IS NULL OR trim(p_email) = '' THEN
+        RETURN;
+    END IF;
+
+    IF p_external_subject IS NULL OR trim(p_external_subject) = '' THEN
+        RETURN;
+    END IF;
+
+    -- Nooit koppelen aan een oid die al bestaat. Zonder deze controle kon een
+    -- tweede login een bestaande gebruiker overschrijven — een account-overname
+    -- in plaats van een eerste login.
+    IF EXISTS (
+        SELECT 1 FROM clm."user"
+         WHERE external_subject = p_external_subject
+    ) THEN
+        RETURN;
+    END IF;
+
+    -- Alle voorwaarden in één query. Geen aparte telling meer zoals in 0023:
+    -- de unieke index garandeert dat dit er hoogstens één is.
+    --
+    -- Het e-mailadres staat er als tweede controle bij, hoofdletterongevoelig.
+    -- Een token dat bij de verkeerde persoon belandt werkt daardoor niet, ook
+    -- niet als die persoon hem in handen krijgt vóór de geadresseerde.
+    SELECT u.user_id, u.tenant_id
+      INTO v_user_id, v_tenant_id
+      FROM clm."user" u
+     WHERE u.uitnodiging_hash = p_uitnodiging_hash
+       AND lower(u.email)     = lower(p_email)
+       AND u.external_subject IS NULL
+       AND u.deleted_at       IS NULL
+       AND u.koppelbaar_tot   IS NOT NULL
+       AND u.koppelbaar_tot   > now();
+
+    IF v_user_id IS NULL THEN
+        RETURN;
+    END IF;
+
+    -- De tenantcontext moet gezet zijn vóór de UPDATE, en dat is het kip-ei van
+    -- deze hele functie: clm."user" heeft een policy op clm.current_tenant_id(),
+    -- maar bij een eerste login is die context er nog niet — de tenant vólgt uit
+    -- de rij die we net gevonden hebben.
+    --
+    -- De SELECT hierboven kon nog zonder: die draait als eigenaar op een tabel
+    -- zonder FORCE (migratie 0011). Schrijven kan dat niet.
+    --
+    -- `true` als derde argument: alleen binnen deze transactie, zodat de
+    -- aanroeper zijn eigen context niet kwijtraakt.
+    PERFORM set_config('app.current_tenant_id', v_tenant_id::text, true);
+
+    -- Alle drie tegelijk: de oid erin, en beide sporen van de uitnodiging eruit.
+    -- Daarmee werkt het token precies één keer, ook wanneer twee aanvragen
+    -- elkaar overlappen — de tweede vindt niets meer.
+    UPDATE clm."user"
+       SET external_subject  = p_external_subject,
+           uitnodiging_hash  = NULL,
+           koppelbaar_tot    = NULL
+     WHERE clm."user".user_id = v_user_id;
+
+    -- De koppeling bepaalt wie voortaan als deze gebruiker binnenkomt, en is
+    -- daarmee auditinformatie. Het token staat er niet in, ook niet gehasht:
+    -- de audit trail is voor de tenant leesbaar en hoeft geen sleutelmateriaal
+    -- te bevatten.
+    INSERT INTO audit.audit_event
+        (tenant_id, action_type, entity_type, entity_id, new_values)
+    VALUES (
+        v_tenant_id, 'eerste_login_gekoppeld', 'user', v_user_id,
+        jsonb_build_object('via', 'uitnodigingstoken')
+    );
+
+    RETURN QUERY SELECT v_user_id, v_tenant_id;
+END;
+$$;--> statement-breakpoint
+
+COMMENT ON FUNCTION clm.koppel_eerste_login(text, text, text) IS
+    'Koppelt bij de eerste login een oid aan een uitgenodigde gebruikersrij, op vertoon van het uitnodigingstoken. Voorwaarden: de hash hoort bij precies een openstaande uitnodiging (afgedwongen door een unieke index), het e-mailadres komt overeen, external_subject is nog leeg, de oid is nog nergens in gebruik, en de uitnodiging is niet verstreken. Geeft niets terug wanneer een voorwaarde niet gehaald wordt — nooit een exception met details, want die zou verklappen welke uitnodiging bestaat.';--> statement-breakpoint
+
+-- Zelfde rechten als de andere definer-functies (0009, 0010, 0023): PUBLIC
+-- eraf, expliciet aan de applicatierollen. Na een DROP zijn de oude rechten
+-- weg, dus dit is geen herhaling maar noodzaak.
+REVOKE ALL ON FUNCTION clm.koppel_eerste_login(text, text, text) FROM PUBLIC;--> statement-breakpoint
+GRANT EXECUTE ON FUNCTION clm.koppel_eerste_login(text, text, text) TO clm_api, clm_admin;--> statement-breakpoint
+
+-- ── 3. Bestaande uitnodigingen ───────────────────────────────────────────────
+--
+-- Een rij die nog wacht op zijn eerste login heeft geen uitnodiging_hash en is
+-- daarmee niet meer koppelbaar. Dat is opzet: hij is uitgegeven onder de oude
+-- voorwaarden, en die zijn zwakker dan de nieuwe.
+--
+-- koppelbaar_tot wordt hier op NULL gezet zodat de stand ook zichtbaar klopt:
+-- een openstaande uitnodiging zonder token is geen openstaande uitnodiging.
+-- Opnieuw uitnodigen levert een rij op die wél deugt.
+
+UPDATE clm."user"
+   SET koppelbaar_tot = NULL
+ WHERE external_subject IS NULL
+   AND koppelbaar_tot IS NOT NULL;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -169,6 +169,13 @@
       "when": 1786809600000,
       "tag": "0023_eerste_login_koppelen",
       "breakpoints": true
+    },
+    {
+      "idx": 24,
+      "version": "7",
+      "when": 1786896000000,
+      "tag": "0024_uitnodigingstoken",
+      "breakpoints": true
     }
   ]
 }

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -20,6 +20,7 @@ import {
   stateKlopt,
 } from './inlogpoging';
 import { cookieInstellingen } from './sessie';
+import { heeftGeldigeVorm as heeftGeldigeUitnodigingsVorm } from './uitnodigingstoken';
 import {
   TenantContextGuard,
   leesCookies,
@@ -51,8 +52,26 @@ export class AuthController {
    * cookie, en stuur de browser naar de provider.
    */
   @Get('login')
-  login(@Res() response: Response): void {
-    const { url, poging } = this.auth.beginInlog();
+  login(
+    @Res() response: Response,
+    @Query('uitnodiging') uitnodiging?: string,
+  ): void {
+    // De vorm wordt hier gecontroleerd en niet pas bij de koppeling: onzin in
+    // de query hoort niet in een cookie te belanden dat vijftien minuten
+    // meereist. Een ongeldige waarde wordt genegeerd, niet geweigerd — de
+    // login zelf mag er niet op stuklopen, die verloopt dan gewoon als een
+    // gewone login zonder uitnodiging.
+    const token = heeftGeldigeUitnodigingsVorm(uitnodiging)
+      ? uitnodiging
+      : undefined;
+
+    if (uitnodiging && !token) {
+      this.logger.warn(
+        'Inlogpoging met een uitnodigingsparameter van de verkeerde vorm — genegeerd.',
+      );
+    }
+
+    const { url, poging } = this.auth.beginInlog(token);
 
     const sessieCookie = cookieInstellingen();
     const naam = sessieCookie.secure
@@ -126,6 +145,7 @@ export class AuthController {
     const sessie = await this.auth.voltooiInlog(
       code ?? '',
       poging.codeVerifier,
+      poging.uitnodigingstoken,
     );
 
     if (!sessie) {

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -84,8 +84,11 @@ export class AuthService {
    * configuratie. Zo hoeft er geen zesde variabele bij die altijd samen met de
    * andere verandert.
    */
-  beginInlog(): { url: string; poging: Inlogpoging } {
-    const poging = nieuweInlogpoging();
+  beginInlog(uitnodigingstoken?: string): {
+    url: string;
+    poging: Inlogpoging;
+  } {
+    const poging = nieuweInlogpoging(uitnodigingstoken);
 
     const parameters = new URLSearchParams({
       client_id: this.config.clientId,
@@ -118,6 +121,7 @@ export class AuthService {
   async voltooiInlog(
     code: string,
     codeVerifier: string,
+    uitnodigingstoken?: string,
   ): Promise<NieuweSessie | null> {
     let idToken: string;
 
@@ -144,13 +148,17 @@ export class AuthService {
       throw err;
     }
 
-    // E-mail en idp gaan alleen mee voor het geval dit een eerste login is van
-    // een uitgenodigde gebruiker. Voor iedereen die al een external_subject
+    // E-mail en token gaan alleen mee voor het geval dit een eerste login is
+    // van een uitgenodigde gebruiker. Voor iedereen die al een external_subject
     // heeft, worden ze genegeerd — clm.sessie_aanmaken() slaagt dan meteen en
     // de koppelfunctie wordt niet eens aangeroepen.
+    //
+    // Het e-mailadres komt uit het geverifieerde ID-token, het token uit het
+    // pogingcookie. Die twee moeten allebei kloppen (migratie 0024), en dat is
+    // opzet: ze komen langs verschillende wegen binnen.
     return this.sessies.aanmaken(identiteit.externalSubject, {
       email: identiteit.email,
-      identityProvider: identiteit.identityProvider,
+      uitnodigingstoken,
     });
   }
 

--- a/src/auth/inlogpoging.spec.ts
+++ b/src/auth/inlogpoging.spec.ts
@@ -7,6 +7,7 @@ import {
   serialiseer,
   stateKlopt,
 } from './inlogpoging';
+import { genereerUitnodigingstoken } from './uitnodigingstoken';
 
 describe('inlogpoging', () => {
   describe('nieuweInlogpoging', () => {
@@ -107,10 +108,44 @@ describe('inlogpoging', () => {
       ['zonder scheidingsteken', 'alleenstate'],
       ['met een leeg eerste deel', '.verifier'],
       ['met een leeg tweede deel', 'state.'],
-      ['met te veel delen', 'a.b.c'],
+      ['met een leeg derde deel', 'state.verifier.'],
+      ['met te veel delen', 'a.b.c.d'],
       ['een getal', 42],
     ])('geeft null bij een cookie dat %s is', (_omschrijving, waarde) => {
       expect(deserialiseer(waarde)).toBeNull();
+    });
+  });
+
+  describe('het uitnodigingstoken over de omweg langs de provider', () => {
+    it('reist mee en komt er ongeschonden uit', () => {
+      const poging = nieuweInlogpoging('token-uit-de-link');
+
+      expect(deserialiseer(serialiseer(poging))?.uitnodigingstoken).toBe(
+        'token-uit-de-link',
+      );
+    });
+
+    it('ontbreekt bij een gewone login, en dat mag', () => {
+      // De belangrijkste van deze twee: elke bestaande login gaat langs dit
+      // pad, en die heeft geen token. Zou het veld verplicht zijn, dan zou
+      // niemand meer kunnen inloggen.
+      const poging = nieuweInlogpoging();
+
+      expect(serialiseer(poging).split('.')).toHaveLength(2);
+      expect(deserialiseer(serialiseer(poging))?.uitnodigingstoken).toBe(
+        undefined,
+      );
+    });
+
+    it('overleeft een echt token, dat base64url is', () => {
+      // Het scheidingsteken is een punt, en base64url bevat er geen. Deze test
+      // legt vast waaróm dat formaat werkt: met een alfabet dat wél punten kent
+      // zou een token het cookie van binnenuit kunnen breken.
+      const token = genereerUitnodigingstoken();
+      const poging = nieuweInlogpoging(token);
+
+      expect(token).not.toContain('.');
+      expect(deserialiseer(serialiseer(poging))?.uitnodigingstoken).toBe(token);
     });
   });
 });

--- a/src/auth/inlogpoging.ts
+++ b/src/auth/inlogpoging.ts
@@ -29,13 +29,27 @@ export const INLOGPOGING_COOKIE_ONVEILIG = 'mcm2_inlog';
 export interface Inlogpoging {
   readonly state: string;
   readonly codeVerifier: string;
+  /**
+   * Het uitnodigingstoken, alleen aanwezig wanneer de gebruiker via een
+   * uitnodigingslink binnenkwam.
+   *
+   * Reist mee om precies dezelfde reden als de twee velden hierboven: tussen de
+   * klik op de link en de terugkeer van de provider zit een omweg, en het token
+   * moet die overleven. Een aparte opslag zou een tweede mechanisme zijn voor
+   * hetzelfde probleem.
+   *
+   * Optioneel, en dat is wezenlijk: een gewone login heeft geen token en mag er
+   * niet op stuklopen.
+   */
+  readonly uitnodigingstoken?: string;
 }
 
 /** Genereert een verse inlogpoging. */
-export function nieuweInlogpoging(): Inlogpoging {
+export function nieuweInlogpoging(uitnodigingstoken?: string): Inlogpoging {
   return {
     state: randomBytes(BYTES).toString('base64url'),
     codeVerifier: randomBytes(BYTES).toString('base64url'),
+    uitnodigingstoken,
   };
 }
 
@@ -67,12 +81,28 @@ export function stateKlopt(uitCookie: string, uitCallback: unknown): boolean {
   return timingSafeEqual(a, b);
 }
 
-/** Serialiseert de poging voor in het cookie. */
+/**
+ * Serialiseert de poging voor in het cookie.
+ *
+ * De punt kan als scheidingsteken omdat base64url hem niet bevat: het alfabet
+ * is `A-Za-z0-9_-`. Een waarde kan het formaat dus niet van binnenuit breken.
+ */
 export function serialiseer(poging: Inlogpoging): string {
-  return `${poging.state}.${poging.codeVerifier}`;
+  const basis = `${poging.state}.${poging.codeVerifier}`;
+
+  return poging.uitnodigingstoken
+    ? `${basis}.${poging.uitnodigingstoken}`
+    : basis;
 }
 
-/** Leest de poging terug. Geeft `null` bij alles wat niet de juiste vorm heeft. */
+/**
+ * Leest de poging terug. Geeft `null` bij alles wat niet de juiste vorm heeft.
+ *
+ * Twee delen is een gewone login, drie een login via een uitnodigingslink.
+ * Beide worden aanvaard; alles daarbuiten niet. Dat het derde deel mag
+ * ontbreken is geen soepelheid maar noodzaak — anders zou deze wijziging elke
+ * bestaande login breken.
+ */
 export function deserialiseer(waarde: unknown): Inlogpoging | null {
   if (typeof waarde !== 'string') {
     return null;
@@ -80,9 +110,19 @@ export function deserialiseer(waarde: unknown): Inlogpoging | null {
 
   const delen = waarde.split('.');
 
-  if (delen.length !== 2 || !delen[0] || !delen[1]) {
+  if (delen.length < 2 || delen.length > 3 || !delen[0] || !delen[1]) {
     return null;
   }
 
-  return { state: delen[0], codeVerifier: delen[1] };
+  // Een aanwezig maar leeg derde deel is een kapot cookie, geen login zonder
+  // token: `a.b.` hoort niet stilzwijgend als gewone login door te gaan.
+  if (delen.length === 3 && !delen[2]) {
+    return null;
+  }
+
+  return {
+    state: delen[0],
+    codeVerifier: delen[1],
+    uitnodigingstoken: delen[2],
+  };
 }

--- a/src/auth/sessie.service.ts
+++ b/src/auth/sessie.service.ts
@@ -8,6 +8,10 @@ import {
   hashSessieToken,
   heeftGeldigeSessieVorm,
 } from './sessie';
+import {
+  hashUitnodigingstoken,
+  heeftGeldigeVorm as heeftGeldigeUitnodigingsVorm,
+} from './uitnodigingstoken';
 
 /**
  * De sessielaag: de enige route naar clm.sessie (Issue #7, spoor 1).
@@ -31,14 +35,18 @@ export interface SessieContext {
 }
 
 /**
- * De claims die een eerste login mag gebruiken om zich te koppelen.
+ * Wat een eerste login mag gebruiken om zich te koppelen.
  *
  * Alleen bij de allereerste login van een uitgenodigde gebruiker; daarna doet
- * `external_subject` het werk. Zie migratie 0023 voor de vijf voorwaarden.
+ * `external_subject` het werk. Zie migratie 0024 voor de voorwaarden.
+ *
+ * Twee gegevens langs twee wegen: het e-mailadres uit het geverifieerde
+ * ID-token, het token uit de uitnodigingslink. Beide moeten kloppen.
  */
 export interface EersteLoginGegevens {
   readonly email?: string;
-  readonly identityProvider?: string;
+  /** Het ruwe token uit de link; de hash gaat naar de database. */
+  readonly uitnodigingstoken?: string;
 }
 
 /** Wat een geslaagde login oplevert: de context plus het ruwe token. */
@@ -93,11 +101,19 @@ export class SessieService {
     //
     // De volgorde is opzet: eerst de gewone weg proberen. Een bestaande
     // gebruiker raakt clm.koppel_eerste_login() daarmee nooit.
-    if (resultaat.rows.length === 0 && uitnodiging?.email) {
+    //
+    // De vormcontrole staat er vóór de query: een token uit een cookie dat door
+    // iets anders gevuld is hoort af te ketsen op zijn vorm, niet op een
+    // databaseaanroep.
+    if (
+      resultaat.rows.length === 0 &&
+      uitnodiging?.email &&
+      heeftGeldigeUitnodigingsVorm(uitnodiging.uitnodigingstoken)
+    ) {
       const gekoppeld = await this.db.db.execute<{ user_id: string }>(
         sql`SELECT * FROM clm.koppel_eerste_login(
               ${externalSubject}, ${uitnodiging.email},
-              ${uitnodiging.identityProvider ?? null})`,
+              ${hashUitnodigingstoken(uitnodiging.uitnodigingstoken)})`,
       );
 
       if (gekoppeld.rows.length > 0) {

--- a/src/auth/uitnodigingstoken.spec.ts
+++ b/src/auth/uitnodigingstoken.spec.ts
@@ -1,0 +1,99 @@
+import {
+  UITNODIGINGSTOKEN_LENGTE,
+  genereerUitnodigingstoken,
+  hashUitnodigingstoken,
+  heeftGeldigeVorm,
+} from './uitnodigingstoken';
+
+describe('uitnodigingstoken', () => {
+  describe('genereren', () => {
+    it('levert 43 tekens base64url — 256 bits entropie', () => {
+      const token = genereerUitnodigingstoken();
+
+      expect(token).toHaveLength(UITNODIGINGSTOKEN_LENGTE);
+      expect(token).toMatch(/^[A-Za-z0-9_-]+$/);
+    });
+
+    it('levert bij elke aanroep iets anders', () => {
+      const tokens = new Set(
+        Array.from({ length: 100 }, () => genereerUitnodigingstoken()),
+      );
+
+      expect(tokens.size).toBe(100);
+    });
+
+    it('bevat geen punt, want die scheidt de velden in het pogingcookie', () => {
+      // Zie inlogpoging.ts: het token reist mee in een cookie waarin de punt
+      // het scheidingsteken is. Een token met een punt zou dat formaat van
+      // binnenuit breken.
+      const tokens = Array.from({ length: 100 }, () =>
+        genereerUitnodigingstoken(),
+      );
+
+      expect(tokens.every((t) => !t.includes('.'))).toBe(true);
+    });
+  });
+
+  describe('hashen', () => {
+    it('levert SHA-256 in hex — 64 tekens, zoals de CHECK-constraint eist', () => {
+      expect(hashUitnodigingstoken(genereerUitnodigingstoken())).toMatch(
+        /^[0-9a-f]{64}$/,
+      );
+    });
+
+    it('geeft voor hetzelfde token altijd dezelfde hash', () => {
+      const token = genereerUitnodigingstoken();
+
+      expect(hashUitnodigingstoken(token)).toBe(hashUitnodigingstoken(token));
+    });
+
+    it('geeft voor een ander token een andere hash', () => {
+      expect(hashUitnodigingstoken(genereerUitnodigingstoken())).not.toBe(
+        hashUitnodigingstoken(genereerUitnodigingstoken()),
+      );
+    });
+
+    it('is niet terug te rekenen naar het token', () => {
+      // Geen bewijs van onomkeerbaarheid — dat is een eigenschap van SHA-256 —
+      // maar wel de eis die ertoe doet: wie de database leest, heeft niet het
+      // token. Dat is de scheiding tussen databasetoegang en uitnodiging.
+      const token = genereerUitnodigingstoken();
+
+      expect(hashUitnodigingstoken(token)).not.toContain(token);
+    });
+  });
+
+  describe('vormcontrole', () => {
+    it('aanvaardt een echt token', () => {
+      expect(heeftGeldigeVorm(genereerUitnodigingstoken())).toBe(true);
+    });
+
+    it.each([
+      ['undefined', undefined],
+      ['null', null],
+      ['leeg', ''],
+      ['een getal', 42],
+      ['een object', {}],
+      ['te kort', 'abc'],
+      ['een hash in plaats van een token', 'a'.repeat(64)],
+    ])('weigert %s zonder te werpen', (_omschrijving, waarde) => {
+      // Dit komt uit een query-parameter of een cookie: alles kan er staan.
+      expect(heeftGeldigeVorm(waarde)).toBe(false);
+    });
+
+    it('weigert tekens die buiten base64url vallen', () => {
+      const token = genereerUitnodigingstoken();
+
+      expect(heeftGeldigeVorm(`${token.slice(0, -1)}.`)).toBe(false);
+      expect(heeftGeldigeVorm(`${token.slice(0, -1)}+`)).toBe(false);
+      expect(heeftGeldigeVorm(`${token.slice(0, -1)}/`)).toBe(false);
+    });
+
+    it('weigert een token dat één teken te lang of te kort is', () => {
+      const token = genereerUitnodigingstoken();
+
+      expect(heeftGeldigeVorm(token.slice(0, -1))).toBe(false);
+      expect(heeftGeldigeVorm(`${token}x`)).toBe(false);
+    });
+  });
+});

--- a/src/auth/uitnodigingstoken.ts
+++ b/src/auth/uitnodigingstoken.ts
@@ -1,0 +1,72 @@
+import { createHash, randomBytes } from 'node:crypto';
+
+/**
+ * Het token waarmee een uitgenodigde beheerder zijn eerste login koppelt.
+ *
+ * ── Waarom dit bestaat naast survey-token.ts ────────────────────────────────
+ *
+ * Het vormmodel is identiek — 256 bits willekeur, base64url in de link, SHA-256
+ * in de database — en dat is opzet: één bewezen patroon in plaats van twee
+ * varianten die uit elkaar groeien.
+ *
+ * Toch geen hergebruik van `survey-token.ts`, om dezelfde reden als bij
+ * `sessie.ts`: die module draagt het vertrouwensmodel van spoor 2
+ * (accountloze leverancierstoegang, Issue #7) en heeft daar zijn eigen
+ * geldigheidsduur en constraints. Een gedeelde helper zou betekenen dat een
+ * wijziging voor leveranciers stilzwijgend de beheerderuitnodiging raakt.
+ *
+ * ── Wat dit token wél en niet doet ──────────────────────────────────────────
+ *
+ * Het bewijst dat de houder de uitnodiging heeft die de platformbeheerder heeft
+ * uitgegeven. Het is géén authenticatie: wie op de link klikt moet daarna nog
+ * gewoon inloggen bij de identity provider. Het token bepaalt aan wélke
+ * gebruikersrij die login gekoppeld wordt, niet óf iemand binnenkomt.
+ *
+ * Zie drizzle/0024_uitnodigingstoken.sql voor de voorwaarden aan databasekant.
+ */
+
+/** 32 bytes = 256 bits entropie. Raden is rekenkundig onhaalbaar. */
+const TOKEN_BYTES = 32;
+
+/** base64url van 32 bytes levert altijd 43 tekens zonder padding. */
+export const UITNODIGINGSTOKEN_LENGTE = 43;
+
+const TOKEN_PATROON = new RegExp(
+  `^[A-Za-z0-9_-]{${UITNODIGINGSTOKEN_LENGTE}}$`,
+);
+
+/**
+ * Genereert een nieuw uitnodigingstoken.
+ *
+ * `randomBytes` is de veilige generator van Node; `Math.random` is dat
+ * uitdrukkelijk niet en mag hier nooit gebruikt worden.
+ */
+export function genereerUitnodigingstoken(): string {
+  return randomBytes(TOKEN_BYTES).toString('base64url');
+}
+
+/**
+ * Berekent de hash die in `clm.user.uitnodiging_hash` komt.
+ *
+ * Het ruwe token wordt nooit opgeslagen. Wie een databasedump in handen krijgt,
+ * kan daarmee geen openstaande uitnodiging opeisen.
+ *
+ * SHA-256 en niet bcrypt/argon2, net als bij de leverancierstokens: die zijn
+ * traag bij ontwerp omdat mensen korte wachtwoorden kiezen. Hier is de invoer
+ * 256 bits willekeur, dus brute-force is al onhaalbaar en traagheid voegt niets
+ * toe.
+ */
+export function hashUitnodigingstoken(token: string): string {
+  return createHash('sha256').update(token, 'utf8').digest('hex');
+}
+
+/**
+ * Controleert de vorm vóórdat de database geraadpleegd wordt.
+ *
+ * Een verzoek met onzin in de parameter raakt de database dan niet. Dat is hier
+ * extra van belang omdat het token in het pogingcookie meereist: een cookie dat
+ * door iets anders is gevuld hoort af te ketsen op de vorm, niet op een query.
+ */
+export function heeftGeldigeVorm(waarde: unknown): waarde is string {
+  return typeof waarde === 'string' && TOKEN_PATROON.test(waarde);
+}

--- a/src/db/rechten-contract.ts
+++ b/src/db/rechten-contract.ts
@@ -190,7 +190,8 @@ export const DEFINER_FUNCTIES: Readonly<Record<string, FunctieContract>> = {
   // De leverancierstoken-lookup, spoor 2 (0003, herzien in 0006 en 0008).
   resolve_survey_token: DEFINER_STANDAARD,
 
-  // De eerste login van een uitgenodigde beheerder (0023). Koppelt een oid aan
-  // een wachtende gebruikersrij, onder vijf voorwaarden.
+  // De eerste login van een uitgenodigde beheerder (0023, herzien in 0024).
+  // Koppelt een oid aan een wachtende gebruikersrij op vertoon van het
+  // uitnodigingstoken.
   koppel_eerste_login: DEFINER_STANDAARD,
 };

--- a/src/platform/platform.service.ts
+++ b/src/platform/platform.service.ts
@@ -1,6 +1,10 @@
 import { ConflictException, Injectable } from '@nestjs/common';
 import { sql } from 'drizzle-orm';
 
+import {
+  genereerUitnodigingstoken,
+  hashUitnodigingstoken,
+} from '../auth/uitnodigingstoken';
 import { DatabaseService } from '../db/database.service';
 
 /** Hoe lang support-toegang standaard geldig is. */
@@ -28,6 +32,20 @@ export interface TenantOverzicht {
   readonly naam: string;
   readonly aangemaaktOp: Date;
   readonly aantalLeden: number;
+}
+
+/**
+ * Wat het aanmaken oplevert: de tenant plus de uitnodiging voor zijn eerste
+ * beheerder.
+ *
+ * Het ruwe token staat hier één keer in en is daarna nergens meer op te vragen
+ * — de database kent alleen de hash. Raakt het kwijt, dan is opnieuw uitnodigen
+ * de weg, en dat is met opzet: een token dat je kunt navragen is een token dat
+ * een ander kan navragen.
+ */
+export interface NieuweTenantMetUitnodiging extends TenantOverzicht {
+  readonly uitnodigingstoken: string;
+  readonly uitnodigingVerlooptOp: Date;
 }
 
 export interface SupportToegang {
@@ -86,15 +104,27 @@ export class PlatformService {
   constructor(private readonly db: DatabaseService) {}
 
   /**
-   * Maakt een tenant met zijn eerste beheerder.
+   * Maakt een tenant met zijn eerste beheerder, en geeft de uitnodiging uit.
    *
    * De gebruikersrij krijgt géén `external_subject`: die is pas bekend als de
    * persoon voor het eerst inlogt bij Entra. De partiële unieke index op die
    * kolom (migratie 0009, `WHERE external_subject IS NOT NULL`) staat dat
    * uitdrukkelijk toe — precies met deze situatie in gedachten.
+   *
+   * Wat de rij wél krijgt is de hash van een uitnodigingstoken. Dat token is
+   * het bewijs dat deze toegang is toegekend, en zonder dat bewijs koppelt
+   * `clm.koppel_eerste_login()` niets (migratie 0024).
    */
-  async tenantAanmaken(invoer: NieuweTenant): Promise<TenantOverzicht> {
+  async tenantAanmaken(
+    invoer: NieuweTenant,
+  ): Promise<NieuweTenantMetUitnodiging> {
     const tenantId = crypto.randomUUID();
+
+    // Het ruwe token blijft hier, in het geheugen van deze aanroep; alleen de
+    // hash gaat de transactie in. Daarmee is er geen pad waarlangs het token
+    // alsnog in de database, een log of een queryplan belandt.
+    const token = genereerUitnodigingstoken();
+    const tokenHash = hashUitnodigingstoken(token);
 
     return this.db.withTenant(tenantId, async (tx) => {
       // ── Waarom hier geen "bestaat de naam al?"-query staat ─────────────────
@@ -120,15 +150,20 @@ export class PlatformService {
         throw fout;
       }
 
-      // koppelbaar_tot maakt dit een uitnodiging: bij zijn eerste Entra-login
-      // koppelt clm.koppel_eerste_login() de oid aan deze rij (migratie 0023).
-      // Zonder die datum is de rij niet koppelbaar en kan deze admin nooit
-      // inloggen — NULL is daar de veilige stand.
-      const gebruiker = await tx.execute<{ user_id: string }>(
-        sql`INSERT INTO clm."user" (tenant_id, full_name, email, koppelbaar_tot)
+      // Hash en vervaldatum samen maken dit een uitnodiging: bij zijn eerste
+      // Entra-login koppelt clm.koppel_eerste_login() de oid aan deze rij op
+      // vertoon van het token (migratie 0024). Ontbreekt een van beide, dan is
+      // de rij niet koppelbaar — NULL is daar de veilige stand.
+      const gebruiker = await tx.execute<{
+        user_id: string;
+        koppelbaar_tot: Date;
+      }>(
+        sql`INSERT INTO clm."user"
+              (tenant_id, full_name, email, uitnodiging_hash, koppelbaar_tot)
             VALUES (${tenantId}, ${invoer.adminNaam}, ${invoer.adminEmail},
+                    ${tokenHash},
                     now() + ${`${UITNODIGING_GELDIG_DAGEN} days`}::interval)
-            RETURNING user_id`,
+            RETURNING user_id, koppelbaar_tot`,
       );
 
       const userId = gebruiker.rows[0].user_id;
@@ -157,6 +192,8 @@ export class PlatformService {
         naam: invoer.naam,
         aangemaaktOp: rij.rows[0].created_at,
         aantalLeden: 1,
+        uitnodigingstoken: token,
+        uitnodigingVerlooptOp: gebruiker.rows[0].koppelbaar_tot,
       };
     });
   }

--- a/test/eerste-login.e2e-spec.ts
+++ b/test/eerste-login.e2e-spec.ts
@@ -1,10 +1,14 @@
 import { Client } from 'pg';
 
+import {
+  genereerUitnodigingstoken,
+  hashUitnodigingstoken,
+} from '../src/auth/uitnodigingstoken';
 import { verwijderTestdata } from './opruimen';
 import { TEST_IDS } from './test-ids';
 
 /**
- * De eerste login van een uitgenodigde beheerder (migratie 0023).
+ * De eerste login van een uitgenodigde beheerder (migratie 0024).
  *
  * ── Waarom deze suite zwaarder weegt dan hij lijkt ───────────────────────────
  *
@@ -13,15 +17,22 @@ import { TEST_IDS } from './test-ids';
  * iets mis, dan is het gevolg niet "een test faalt" maar een account-overname:
  * iemand anders komt binnen als de beheerder van een klant.
  *
- * De functie kent vijf voorwaarden. Deze suite lokt ze alle vijf uit — niet
- * omdat de code er onbetrouwbaar uitziet, maar omdat een voorwaarde die niet
- * getest is er net zo goed niet kan zijn (§15b).
+ * Elke voorwaarde wordt hier apart uitgelokt — niet omdat de code er
+ * onbetrouwbaar uitziet, maar omdat een voorwaarde die niet getest is er net zo
+ * goed niet kan zijn (§15b).
+ *
+ * ── Wat er veranderde in 0024 ────────────────────────────────────────────────
+ *
+ * De koppeling rustte in 0023 op het kennen van een e-mailadres, met een
+ * idp-claim als waarborg. Die claim toetste de *vorm* van de login en niet wie
+ * er inlogde, en sloot tegelijk elke niet-federatieve inlogmethode uit. Nu is
+ * het uitnodigingstoken de waarborg: het bewijst dat deze toegang is toegekend.
  *
  * ── Wat er NIET getest wordt, en waarom ──────────────────────────────────────
  *
  * De echte Entra-flow. Die is op 2026-08-08 handmatig doorlopen en bewezen
  * (claims-meten.js); hem hier nabootsen zou een mock testen in plaats van de
- * database. Wat hier telt is wat de functie doet met de claims die binnenkomen.
+ * database. Wat hier telt is wat de functie doet met wat er binnenkomt.
  */
 
 const {
@@ -38,27 +49,26 @@ const OID_BESTAAND = `oid-bestaand-${Date.now()}`;
 const EMAIL_UITGENODIGD = `uitgenodigd-${Date.now()}@voorbeeld.nl`;
 const EMAIL_BESTAAND = `bestaand-${Date.now()}@voorbeeld.nl`;
 
-/** Een geloofwaardige idp-claim, zoals Entra hem bij federatie levert. */
-const IDP =
-  'https://login.microsoftonline.com/3ce5523c-cc8b-4422-a310-8bdfa3715168/v2.0';
+/** Het token uit de uitnodigingslink. De database kent alleen de hash. */
+const TOKEN = genereerUitnodigingstoken();
 
 interface Koppeling {
   user_id: string;
   tenant_id: string;
 }
 
-describe('Eerste login koppelen (e2e, migratie 0023)', () => {
+describe('Eerste login koppelen (e2e, migratie 0024)', () => {
   let client: Client;
 
-  /** Roept de functie aan zoals de applicatie dat doet. */
+  /** Roept de functie aan zoals de applicatie dat doet: met de hash. */
   async function koppel(
     oid: string,
     email: string | null,
-    idp: string | null = IDP,
+    token: string | null = TOKEN,
   ): Promise<Koppeling[]> {
     const { rows } = await client.query<Koppeling>(
       'SELECT * FROM clm.koppel_eerste_login($1, $2, $3)',
-      [oid, email, idp],
+      [oid, email, token === null ? null : hashUitnodigingstoken(token)],
     );
     return rows;
   }
@@ -70,9 +80,10 @@ describe('Eerste login koppelen (e2e, migratie 0023)', () => {
     await client.query(
       `UPDATE clm."user"
           SET external_subject = NULL,
-              koppelbaar_tot = now() + ($1 || ' days')::interval
-        WHERE user_id = $2`,
-      [String(dagen), USER_UITGENODIGD],
+              uitnodiging_hash = $1,
+              koppelbaar_tot = now() + ($2 || ' days')::interval
+        WHERE user_id = $3`,
+      [hashUitnodigingstoken(TOKEN), String(dagen), USER_UITGENODIGD],
     );
     await client.query('COMMIT');
   }
@@ -88,11 +99,18 @@ describe('Eerste login koppelen (e2e, migratie 0023)', () => {
       [TENANT, `eerste-login-${Date.now()}`],
     );
 
-    // De uitgenodigde: e-mailadres bekend, oid nog niet.
+    // De uitgenodigde: e-mailadres en tokenhash bekend, oid nog niet.
     await client.query(
-      `INSERT INTO clm."user" (user_id, tenant_id, full_name, email, koppelbaar_tot)
-       VALUES ($1, $2, 'Uitgenodigde Admin', $3, now() + interval '90 days')`,
-      [USER_UITGENODIGD, TENANT, EMAIL_UITGENODIGD],
+      `INSERT INTO clm."user"
+         (user_id, tenant_id, full_name, email, uitnodiging_hash, koppelbaar_tot)
+       VALUES ($1, $2, 'Uitgenodigde Admin', $3, $4,
+               now() + interval '90 days')`,
+      [
+        USER_UITGENODIGD,
+        TENANT,
+        EMAIL_UITGENODIGD,
+        hashUitnodigingstoken(TOKEN),
+      ],
     );
     await client.query(
       `INSERT INTO clm.tenant_membership (user_id, tenant_id, role)
@@ -123,22 +141,25 @@ describe('Eerste login koppelen (e2e, migratie 0023)', () => {
       expect(rijen[0].tenant_id).toBe(TENANT);
     });
 
-    it('sluit de uitnodiging na gebruik', async () => {
-      // koppelbaar_tot op NULL: de rij is niet nóg een keer koppelbaar. Zonder
-      // dit zou een tweede persoon met hetzelfde e-mailadres later alsnog
-      // kunnen proberen.
+    it('sluit de uitnodiging na gebruik — beide sporen tegelijk', async () => {
+      // Hash én vervaldatum op NULL. Alleen de datum wissen zou niet genoeg
+      // zijn: dan blijft er een geldige hash in de database staan, en die is
+      // precies wat een tweede poging nodig heeft.
       await client.query('BEGIN');
       await client.query(`SET LOCAL app.current_tenant_id = '${TENANT}'`);
       const { rows } = await client.query<{
         external_subject: string;
+        uitnodiging_hash: string | null;
         koppelbaar_tot: Date | null;
       }>(
-        'SELECT external_subject, koppelbaar_tot FROM clm."user" WHERE user_id = $1',
+        `SELECT external_subject, uitnodiging_hash, koppelbaar_tot
+           FROM clm."user" WHERE user_id = $1`,
         [USER_UITGENODIGD],
       );
       await client.query('COMMIT');
 
       expect(rows[0].external_subject).toBe(OID_NIEUW);
+      expect(rows[0].uitnodiging_hash).toBeNull();
       expect(rows[0].koppelbaar_tot).toBeNull();
     });
 
@@ -163,7 +184,28 @@ describe('Eerste login koppelen (e2e, migratie 0023)', () => {
       await client.query('COMMIT');
 
       expect(rows).toHaveLength(1);
-      expect(rows[0].new_values.identity_provider).toBe(IDP);
+      expect(rows[0].new_values.via).toBe('uitnodigingstoken');
+    });
+
+    it('bewaart geen sleutelmateriaal in de audit trail', async () => {
+      // De audit trail is voor de tenant leesbaar. Het token hoort daar niet
+      // in, ook niet gehasht: een audit trail hoort te vertellen wát er
+      // gebeurde, niet de sleutel te bewaren waarmee het kon.
+      await client.query('BEGIN');
+      await client.query(`SET LOCAL app.current_tenant_id = '${TENANT}'`);
+      const { rows } = await client.query<{ regel: string }>(
+        `SELECT new_values::text AS regel FROM audit.audit_event
+          WHERE tenant_id = $1
+            AND action_type = 'eerste_login_gekoppeld'
+            AND entity_id = $2
+          ORDER BY created_at DESC
+          LIMIT 1`,
+        [TENANT, USER_UITGENODIGD],
+      );
+      await client.query('COMMIT');
+
+      expect(rows[0].regel).not.toContain(TOKEN);
+      expect(rows[0].regel).not.toContain(hashUitnodigingstoken(TOKEN));
     });
 
     it('laat de gekoppelde gebruiker daarna gewoon inloggen', async () => {
@@ -194,9 +236,18 @@ describe('Eerste login koppelen (e2e, migratie 0023)', () => {
       expect(rijen).toHaveLength(0);
     });
 
-    it('weigert wanneer twee rijen hetzelfde e-mailadres hebben', async () => {
-      // Voorwaarde 1. Gokken zou betekenen dat de uitkomst van volgorde
-      // afhangt — en dan bepaalt toeval wie er binnenkomt.
+    it('koppelt de juiste rij wanneer twee tenants hetzelfde e-mailadres kennen', async () => {
+      // Dit is de situatie die op productie ontstond: één persoon met één
+      // e-mailadres, uitgenodigd in twee tenants. In 0023 was dat een
+      // patstelling — twee kandidaten, dus weigeren — en kwam die persoon
+      // nergens binnen.
+      //
+      // Met een token per uitnodiging is het geen patstelling meer maar een
+      // keuze: het token wijst één rij aan. Dat is niet alleen veiliger, het is
+      // ook het enige dat een platformbeheerder die zelf klant is werkbaar
+      // maakt.
+      const tokenTweede = genereerUitnodigingstoken();
+
       await client.query('BEGIN');
       await client.query(
         `SET LOCAL app.current_tenant_id = '${TENANT_TWEEDE}'`,
@@ -205,18 +256,27 @@ describe('Eerste login koppelen (e2e, migratie 0023)', () => {
         'INSERT INTO clm.tenant (tenant_id, name) VALUES ($1, $2)',
         [TENANT_TWEEDE, `eerste-login-tweede-${Date.now()}`],
       );
-      await client.query(
-        `INSERT INTO clm."user" (tenant_id, full_name, email, koppelbaar_tot)
-         VALUES ($1, 'Dubbel Adres', $2, now() + interval '90 days')`,
-        [TENANT_TWEEDE, EMAIL_UITGENODIGD],
+      const { rows: nieuw } = await client.query<{ user_id: string }>(
+        `INSERT INTO clm."user"
+           (tenant_id, full_name, email, uitnodiging_hash, koppelbaar_tot)
+         VALUES ($1, 'Zelfde Adres', $2, $3, now() + interval '90 days')
+         RETURNING user_id`,
+        [TENANT_TWEEDE, EMAIL_UITGENODIGD, hashUitnodigingstoken(tokenTweede)],
       );
       await client.query('COMMIT');
 
-      const rijen = await koppel(`${OID_NIEUW}-tweede`, EMAIL_UITGENODIGD);
+      // Het token van de tweede tenant wijst de tweede rij aan, niet de eerste.
+      const rijen = await koppel(
+        `${OID_NIEUW}-tweede`,
+        EMAIL_UITGENODIGD,
+        tokenTweede,
+      );
 
-      expect(rijen).toHaveLength(0);
+      expect(rijen).toHaveLength(1);
+      expect(rijen[0].user_id).toBe(nieuw[0].user_id);
+      expect(rijen[0].tenant_id).toBe(TENANT_TWEEDE);
 
-      // Opruimen zodat de volgende test weer één kandidaat heeft.
+      // Opruimen zodat de volgende test weer een schone stand heeft.
       await client.query('BEGIN');
       await client.query(
         `SET LOCAL app.current_tenant_id = '${TENANT_TWEEDE}'`,
@@ -228,6 +288,48 @@ describe('Eerste login koppelen (e2e, migratie 0023)', () => {
         TENANT_TWEEDE,
       ]);
       await client.query('COMMIT');
+    });
+
+    it('laat twee openstaande uitnodigingen niet dezelfde hash delen', async () => {
+      // De unieke index is wat "precies één kandidaat" van een telling in code
+      // naar een eigenschap van de database verplaatst. Deze tegenproef legt
+      // vast dat hij er is: zonder index zou dit slagen en zou één token naar
+      // twee gebruikers wijzen.
+      await client.query('BEGIN');
+      await client.query(`SET LOCAL app.current_tenant_id = '${TENANT}'`);
+
+      await expect(
+        client.query(
+          `INSERT INTO clm."user"
+             (tenant_id, full_name, email, uitnodiging_hash, koppelbaar_tot)
+           VALUES ($1, 'Zelfde Token', $2, $3, now() + interval '90 days')`,
+          [
+            TENANT,
+            `dubbel-token-${Date.now()}@voorbeeld.nl`,
+            hashUitnodigingstoken(TOKEN),
+          ],
+        ),
+      ).rejects.toThrow(/user_uitnodiging_hash_key/);
+
+      await client.query('ROLLBACK');
+    });
+
+    it('weigert een hash die niet de vorm van een hash heeft', async () => {
+      // De CHECK-constraint vangt af wat het meest waarschijnlijke ongeluk is:
+      // het ruwe token opslaan in plaats van de hash.
+      await client.query('BEGIN');
+      await client.query(`SET LOCAL app.current_tenant_id = '${TENANT}'`);
+
+      await expect(
+        client.query(
+          `INSERT INTO clm."user"
+             (tenant_id, full_name, email, uitnodiging_hash, koppelbaar_tot)
+           VALUES ($1, 'Ruw Token', $2, $3, now() + interval '90 days')`,
+          [TENANT, `ruw-${Date.now()}@voorbeeld.nl`, TOKEN],
+        ),
+      ).rejects.toThrow(/user_uitnodiging_hash_format_check/);
+
+      await client.query('ROLLBACK');
     });
 
     it('weigert een verlopen uitnodiging', async () => {
@@ -267,17 +369,49 @@ describe('Eerste login koppelen (e2e, migratie 0023)', () => {
       expect(rijen).toHaveLength(0);
     });
 
-    it('weigert een login zonder federatieve provider', async () => {
-      // Voorwaarde 5. Entra levert geen email_verified; de idp-claim is wat er
-      // wél is, en die zegt dat de gebruiker bij zijn eigen organisatie is
-      // geauthenticeerd.
+    it('weigert een login zonder token', async () => {
+      // De kern van 0024: het e-mailadres alleen is niet genoeg meer. Dit is de
+      // aanval die 0023 als aanvaard restrisico opschreef — wie het adres kent,
+      // komt binnen — en die hier nu op afketst.
       const rijen = await koppel(
-        `${OID_NIEUW}-geen-idp`,
+        `${OID_NIEUW}-geen-token`,
         EMAIL_UITGENODIGD,
         null,
       );
 
       expect(rijen).toHaveLength(0);
+    });
+
+    it('weigert een token dat bij niemand hoort', async () => {
+      const rijen = await koppel(
+        `${OID_NIEUW}-vals-token`,
+        EMAIL_UITGENODIGD,
+        genereerUitnodigingstoken(),
+      );
+
+      expect(rijen).toHaveLength(0);
+    });
+
+    it('weigert een geldig token bij het verkeerde e-mailadres', async () => {
+      // Beide moeten kloppen. Een link die bij de verkeerde persoon belandt is
+      // daarmee waardeloos, ook als die persoon hem eerder opent dan de
+      // geadresseerde.
+      const rijen = await koppel(
+        `${OID_NIEUW}-ander-adres`,
+        `iemand-anders-${Date.now()}@voorbeeld.nl`,
+      );
+
+      expect(rijen).toHaveLength(0);
+    });
+
+    it('werkt precies één keer — na koppelen vindt een tweede poging niets', async () => {
+      // De tegenproef bij "sluit de uitnodiging na gebruik": zonder deze zou
+      // dat een bewering over een kolom blijven in plaats van over gedrag.
+      const eerste = await koppel(`${OID_NIEUW}-eenmalig`, EMAIL_UITGENODIGD);
+      expect(eerste).toHaveLength(1);
+
+      const tweede = await koppel(`${OID_NIEUW}-eenmalig-2`, EMAIL_UITGENODIGD);
+      expect(tweede).toHaveLength(0);
     });
 
     it('weigert een leeg e-mailadres', async () => {


### PR DESCRIPTION
## Waarom

Migratie 0023 eiste bij de eerste login een `idp`-claim. Dat leek een waarborg,
maar toetst de **vorm** van de login en niet wie er inlogt — welke provider het
is, wordt niet gecontroleerd. Wie zich bij een willekeurige federatieve provider
aanmeldt én het uitgenodigde e-mailadres kent, komt binnen.

Dat stond in 0023 zelf al als aanvaard restrisico (regels 49-59), met de
aantekening dat hier een uitnodigingstoken hoort zodra er meer tenants zijn.

Twee dingen brachten dat moment naar voren:

1. **De eis kost meer dan hij oplevert.** Hij sluit elke niet-federatieve
   inlogmethode uit — e-mail met eenmalige code bijvoorbeeld — terwijl hij de
   aanval waar het om gaat niet tegenhoudt.
2. **Hij beantwoordt de verkeerde vraag.** Wat een zakelijke klant vraagt is niet
   "kwam deze login via een federatie" maar "is deze toegang aantoonbaar
   toegekend". Een token dat de platformbeheerder uitgeeft beantwoordt dat.

## Wat er verandert

Hetzelfde patroon als de leverancierstokens (0003): 32 bytes willekeur,
base64url in de link, SHA-256 in de database.

De winst zit in de **unieke partiële index**. In 0023 was "precies één kandidaat"
een telling in de functie — code die kon meetellen wat niet meegeteld had moeten
worden. Nu is het een eigenschap van de database: twee openstaande uitnodigingen
met dezelfde hash kúnnen niet bestaan.

Het e-mailadres blijft als tweede controle staan. Token én adres moeten kloppen,
en ze komen langs verschillende wegen binnen: het adres uit het geverifieerde
ID-token, het token uit de link.

### Het token over de omweg langs de provider

```
/auth/login?uitnodiging=XYZ  →  Entra  →  /auth/callback
      token in het cookie                token uit het cookie
```

Dezelfde weg als `state` en `code_verifier`, geen nieuwe opslag. Het derde veld
is optioneel — een gewone login heeft geen token en mag er niet op stuklopen.
Het token gaat **niet** mee in de URL naar Entra.

## Wat dit oplost dat 0023 niet kon

Op productie staat één persoon (`kees@alingadvies.nl`) in twee tenants:
platformbeheerder én klant. In 0023 was dat een patstelling — twee kandidaten op
hetzelfde e-mailadres, dus weigeren. Met een token per uitnodiging wijst het
token één rij aan. Getest in `koppelt de juiste rij wanneer twee tenants
hetzelfde e-mailadres kennen`.

## Wat bewust níét in deze PR zit

**Federatie per tenant afdwingen.** Een tenant die eist dat alleen zijn eigen AD
toegang geeft, hoort dat bij **elke** login afgedwongen te krijgen — niet globaal
en alleen bij de eerste. Dat is een kolom op `clm.tenant` en een controle in
`sessie_aanmaken()`, te bouwen bij de eerste klant die het vraagt.

Voorwaarde 5 vulde dat gat niet: hij bewaakte alleen de allereerste login.

**De uitnodigingsmail.** `UitnodigingVerzender` is gebouwd voor leveranciers
(`vendorNaam`, `vragenlijstNaam`, surveylink); een beheerder uitnodigen is een
ander bericht. Het token komt nu terug in de response van de platformroute.
Bewuste keuze, apart punt — niet vergeten.

## Verificatie

- 439 tests in 31 suites, `verify:volledig` **GROEN** over de hele keten
- 18 tests in `eerste-login.e2e-spec.ts`, waarvan 8 tegenproeven:
  geen token, vals token, geldig token bij verkeerd adres, tweede poging na
  koppelen, dubbele hash (unieke index), ruw token opslaan (CHECK-constraint),
  geen sleutelmateriaal in de audit trail
- Gedraaid tegen een wegwerpcontainer op 55440; de demo (55450) en productie
  ongemoeid

## Na het mergen — twee stappen

1. **Migratie 0024 naar productie.** Let op deel 3 van de migratie: bestaande
   openstaande uitnodigingen worden op `NULL` gezet. Ze zijn uitgegeven onder de
   oude, zwakkere voorwaarden.
2. **De tenant AlingAdvies verwijderen en opnieuw aanmaken** via de route, zodat
   hij een token krijgt. Afgesproken met de eigenaar; raakt geen andere data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
