### PR TITLE
feat(platform): antwoordadres per tenant en een uitnodigingsmail voor de beheerder

### DIFF
--- a/drizzle/0025_tenant_antwoordadres.sql
+++ b/drizzle/0025_tenant_antwoordadres.sql
@@ -1,0 +1,70 @@
+-- Waar een leverancier zijn antwoord naartoe stuurt.
+--
+-- ── Het gat ──────────────────────────────────────────────────────────────────
+--
+-- `antwoordAan` bestaat door de hele mailketen — in `UitnodigingGegevens`, in
+-- `MailBericht`, en in `resend-mail-kanaal.ts` als `replyTo`. Alleen: het wordt
+-- nergens gevuld. `UitnodigingContext` kent enkel `tenantNaam` en
+-- `vragenlijstNaam`.
+--
+-- Gevolg: een leverancier die op "Beantwoorden" drukt, stuurt zijn vraag naar
+-- het platformadres. Naar Bizaline dus, niet naar de klant. En de mailtekst
+-- zegt dan letterlijk "Neem contact op met uw contactpersoon bij <klant>" —
+-- zonder te zeggen wie dat is.
+--
+-- De code voorzag dit. In `uitnodiging-bericht.ts` staat bij die regel:
+--
+--     Deze regel voorkomt de mail die anders bij ons terechtkomt en die wij
+--     niet kunnen beantwoorden: alleen de opdrachtgever weet of een leverancier
+--     nog een contract heeft.
+--
+-- De helft was gebouwd, de vulling ontbrak.
+--
+-- ── Waarom een kolom en geen SMTP-instellingen ───────────────────────────────
+--
+-- Issue #76 beschrijft SMTP per tenant: host, poort, gebruikersnaam, een
+-- versleuteld wachtwoord, een testknop. Dat lost hetzelfde probleem op en veel
+-- meer, maar het vraagt een eigen ADR over sleutelbeheer en een write-only
+-- veld dat niemand kan uitlezen.
+--
+-- Besluit van de eigenaar op 2026-08-09: dat is niet nodig zolang de mail
+-- herkenbaar van de klant komt en een antwoord bij de klant belandt. De
+-- weergavenaam doet het eerste al ("<Tenant> via MCM2"); deze kolom doet het
+-- tweede.
+--
+-- Het envelopadres blijft van het platform, en dat is geen tussenoplossing:
+-- versturen vanaf het domein van de klant vraagt SPF- en DKIM-records in hún
+-- DNS. Zonder die records belandt alles in spam. Vandaar dat vrijwel elke SaaS
+-- verstuurt vanaf een eigen geverifieerd domein en de klant in de weergavenaam
+-- en het antwoordadres zet.
+--
+-- ── NULL is een geldige stand ────────────────────────────────────────────────
+--
+-- Niet elke tenant heeft een gedeeld postvak. De berichttekst vangt dat al af
+-- met een alternatieve zin, dus een lege waarde levert geen halve mail op maar
+-- een andere — en dat was er al vóór deze migratie.
+
+ALTER TABLE clm.tenant
+    ADD COLUMN antwoord_email text;--> statement-breakpoint
+
+COMMENT ON COLUMN clm.tenant.antwoord_email IS
+    'Waar een antwoord van een leverancier heen gaat (Reply-To). Van de tenant, niet van het platform: alleen de opdrachtgever kan een vraag over zijn eigen uitvraag beantwoorden. NULL betekent geen antwoordadres; de berichttekst verwijst dan naar de contactpersoon bij de tenant.';--> statement-breakpoint
+
+-- Dezelfde vorm als `isGeldigMailadres()` in src/mail/mail-adres.ts: iets vóór
+-- de @, iets erna, een punt in het domein, geen witruimte.
+--
+-- Bewust ruim en niet RFC 5322-volledig. Een afgewezen geldig adres is erger
+-- dan een doorgelaten ongeldig adres: het eerste betekent dat een beheerder
+-- zijn eigen postvak niet kan invullen, het tweede levert een bounce op. Die
+-- afweging staat uitgeschreven in mail-adres.ts en wordt hier herhaald zodat
+-- database en applicatie hetzelfde toestaan.
+--
+-- Plusadressering (contractmanagement+mcm2@klant.nl) moet werken: daar leunt de
+-- hele testopzet van het mailkanaal op.
+ALTER TABLE clm.tenant
+    ADD CONSTRAINT tenant_antwoord_email_format_check
+    CHECK (
+        antwoord_email IS NULL
+        OR (antwoord_email ~ '^[^[:space:]@]+@[^[:space:]@.]+(\.[^[:space:]@.]+)+$'
+            AND length(antwoord_email) <= 254)
+    );

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -176,6 +176,13 @@
       "when": 1786896000000,
       "tag": "0024_uitnodigingstoken",
       "breakpoints": true
+    },
+    {
+      "idx": 25,
+      "version": "7",
+      "when": 1786982400000,
+      "tag": "0025_tenant_antwoordadres",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -45,6 +45,10 @@ export const tenant = clm.table(
   {
     tenantId: uuid('tenant_id').primaryKey().defaultRandom(),
     name: text('name').notNull(),
+    // Migratie 0025. Waar een antwoord van een leverancier heen gaat: van de
+    // tenant, niet van het platform. NULL is een geldige stand — de
+    // berichttekst verwijst dan naar de contactpersoon bij de tenant.
+    antwoordEmail: text('antwoord_email'),
     createdAt: timestamp('created_at', { withTimezone: true })
       .notNull()
       .defaultNow(),

--- a/src/mail/beheerder-uitnodiging-bericht.spec.ts
+++ b/src/mail/beheerder-uitnodiging-bericht.spec.ts
@@ -1,0 +1,105 @@
+import { stelBeheerderUitnodigingSamen } from './beheerder-uitnodiging-bericht';
+
+const BASIS = {
+  ontvanger: 'beheerder@transdev.nl',
+  beheerderNaam: 'Jan de Vries',
+  tenantNaam: 'Transdev',
+  link: 'https://mcm2.example.nl/auth/login?uitnodiging=abc123',
+  verlooptOp: '2026-11-07T15:47:47.718Z',
+};
+
+describe('beheerder-uitnodigingsbericht', () => {
+  describe('wat de ontvanger moet zien', () => {
+    it('spreekt de beheerder bij naam aan', () => {
+      expect(stelBeheerderUitnodigingSamen(BASIS).tekst).toContain(
+        'Beste Jan de Vries',
+      );
+    });
+
+    it('noemt de organisatie waarvoor de omgeving is aangemaakt', () => {
+      const { tekst, onderwerp } = stelBeheerderUitnodigingSamen(BASIS);
+
+      expect(tekst).toContain('Transdev');
+      expect(onderwerp).toContain('Transdev');
+    });
+
+    it('schrijft de link volledig uit', () => {
+      // Niet achter "klik hier" verstoppen: wie de afzender niet vertrouwt moet
+      // de URL kunnen bekijken zonder te klikken.
+      expect(stelBeheerderUitnodigingSamen(BASIS).tekst).toContain(BASIS.link);
+    });
+
+    it('noemt de uiterste datum in leesbare vorm', () => {
+      // '7 november 2026', niet '07-11-2026': bij een uiterste datum is een
+      // misgelezen dag/maand het verschil tussen op tijd en te laat.
+      expect(stelBeheerderUitnodigingSamen(BASIS).tekst).toContain(
+        '7 november 2026',
+      );
+    });
+
+    it('zegt dat de link eenmalig is', () => {
+      // Wie hem een tweede keer opent krijgt anders een onverklaarbare fout.
+      expect(stelBeheerderUitnodigingSamen(BASIS).tekst).toContain('eenmalig');
+    });
+
+    it('vertelt wat te doen bij een onverwachte uitnodiging', () => {
+      // Zonder deze regel weet iemand die de mail onverwacht krijgt niet wat te
+      // doen — precies het moment waarop een uitnodiging als phishing wordt
+      // gemeld.
+      expect(stelBeheerderUitnodigingSamen(BASIS).tekst).toContain(
+        'Verwacht u deze uitnodiging niet',
+      );
+    });
+  });
+
+  describe('wat er bewust NIET in staat', () => {
+    it('vraagt nergens om een wachtwoord', () => {
+      // Het bekendste phishing-signaal, en juist bij een mail die tot een inlog
+      // leidt het verschil tussen vertrouwd en verdacht.
+      const { tekst, onderwerp } = stelBeheerderUitnodigingSamen(BASIS);
+
+      expect(tekst.toLowerCase()).not.toContain('wachtwoord');
+      expect(onderwerp.toLowerCase()).not.toContain('wachtwoord');
+    });
+
+    it('klopt geen urgentie op', () => {
+      const tekst = stelBeheerderUitnodigingSamen(BASIS).tekst.toLowerCase();
+
+      for (const woord of ['direct', 'onmiddellijk', 'urgent', 'let op!']) {
+        expect(tekst).not.toContain(woord);
+      }
+    });
+
+    it('zet geen Reply-To — dit bericht komt van het platform', () => {
+      // Anders dan de leveranciersmail: de klant heeft nog geen omgeving om
+      // namens te spreken, die wordt hier juist geopend.
+      expect(stelBeheerderUitnodigingSamen(BASIS).antwoordAan).toBeUndefined();
+    });
+  });
+
+  describe('afzender', () => {
+    it('is MCM2 zelf, niet de tenant', () => {
+      expect(stelBeheerderUitnodigingSamen(BASIS).afzenderNaam).toBe('MCM2');
+    });
+
+    it('gaat naar het opgegeven adres', () => {
+      expect(stelBeheerderUitnodigingSamen(BASIS).aan).toBe(
+        'beheerder@transdev.nl',
+      );
+    });
+  });
+
+  describe('randgevallen', () => {
+    it('laat een onleesbare datum staan zoals hij is', () => {
+      // Beter een ruwe waarde in de mail dan 'Invalid Date' of een lege regel:
+      // het eerste is zichtbaar fout, het tweede lijkt bedoeld.
+      const bericht = stelBeheerderUitnodigingSamen({
+        ...BASIS,
+        verlooptOp: 'geen datum',
+      });
+
+      expect(bericht.tekst).toContain('geen datum');
+      expect(bericht.tekst).not.toContain('Invalid Date');
+    });
+  });
+});

--- a/src/mail/beheerder-uitnodiging-bericht.ts
+++ b/src/mail/beheerder-uitnodiging-bericht.ts
@@ -1,0 +1,111 @@
+import type { MailBericht } from './mail-kanaal';
+
+/**
+ * Stelt de mail samen waarmee een nieuwe tenantbeheerder wordt uitgenodigd.
+ *
+ * ── Waarom dit niet `uitnodiging-bericht.ts` hergebruikt ────────────────────
+ *
+ * Beide sturen een link met een token, en daar houdt de overeenkomst op.
+ *
+ * De leveranciersmail gaat naar iemand die MCM2 niet kent, niets heeft
+ * afgesproken en niets hoeft te doen behalve een vragenlijst invullen. Hij moet
+ * vooral overtuigen dat het bericht legitiem is: de opdrachtgever voorop, geen
+ * urgentie, de URL volledig uitgeschreven.
+ *
+ * Deze mail gaat naar iemand die wéét dat hij hem krijgt — de platformbeheerder
+ * heeft met hem afgesproken dat zijn organisatie MCM2 gaat gebruiken. Wat hij
+ * nodig heeft is niet overtuiging maar duidelijkheid: wat is dit, wat moet ik
+ * doen, en wat gebeurt er als ik wacht.
+ *
+ * Eén sjabloon voor beide zou betekenen dat elke wijziging aan de ene tekst de
+ * andere raakt, terwijl ze een verschillend publiek en een verschillend doel
+ * hebben.
+ *
+ * ── Wat deze tekst bewust wél en niet doet ──────────────────────────────────
+ *
+ * Wél: benoemen wie de uitnodiging stuurt en voor welke organisatie, de link
+ * volledig uitschrijven, en zeggen tot wanneer hij werkt.
+ *
+ * Niet: het woord "wachtwoord" gebruiken, of vragen om gegevens in te vullen in
+ * een antwoord op deze mail. Beide zijn phishing-signalen, en juist bij een mail
+ * die tot een inlog leidt is dat het verschil tussen vertrouwd en verdacht.
+ *
+ * Platte tekst, geen HTML — zelfde keuze en zelfde reden als bij de
+ * leveranciersmail.
+ */
+
+export interface BeheerderUitnodigingGegevens {
+  /** Het adres van de nieuwe beheerder. */
+  readonly ontvanger: string;
+  /** Zijn naam, zoals de platformbeheerder die heeft ingevoerd. */
+  readonly beheerderNaam: string;
+  /** De organisatie waarvoor de omgeving is aangemaakt. */
+  readonly tenantNaam: string;
+  /** De volledige uitnodigingslink inclusief token. */
+  readonly link: string;
+  /** Tot wanneer de link werkt (ISO-datum). */
+  readonly verlooptOp: string;
+}
+
+/**
+ * Datum in de vorm die een Nederlandse lezer verwacht: `7 november 2026`.
+ *
+ * Bewust niet `07-11-2026`: bij een uiterste datum is een misgelezen dag/maand
+ * het verschil tussen op tijd en te laat.
+ */
+function leesbareDatum(iso: string): string {
+  const datum = new Date(iso);
+
+  if (Number.isNaN(datum.getTime())) {
+    return iso;
+  }
+
+  return datum.toLocaleDateString('nl-NL', {
+    day: 'numeric',
+    month: 'long',
+    year: 'numeric',
+  });
+}
+
+export function stelBeheerderUitnodigingSamen(
+  gegevens: BeheerderUitnodigingGegevens,
+): MailBericht {
+  const uiterlijk = leesbareDatum(gegevens.verlooptOp);
+
+  const tekst = [
+    `Beste ${gegevens.beheerderNaam},`,
+    ``,
+    `Er is een MCM2-omgeving aangemaakt voor ${gegevens.tenantNaam}, en u bent`,
+    `aangewezen als beheerder.`,
+    ``,
+    `Klik op onderstaande link om uw account te activeren:`,
+    gegevens.link,
+    ``,
+    // Dat de link eenmalig is, staat er niet als waarschuwing maar als uitleg:
+    // wie hem een tweede keer opent krijgt anders een onverklaarbare fout.
+    `U logt daarbij in met uw eigen zakelijke account. De link werkt eenmalig`,
+    `en is geldig tot en met ${uiterlijk}.`,
+    ``,
+    `Daarna beheert u zelf de leveranciers, vragenlijsten en uitvragen van`,
+    `${gegevens.tenantNaam}.`,
+    ``,
+    // Zonder deze regel weet iemand die de mail onverwacht krijgt niet wat te
+    // doen, en dat is precies het moment waarop een uitnodiging als phishing
+    // wordt gemeld.
+    `Verwacht u deze uitnodiging niet? Dan kunt u dit bericht negeren; zonder`,
+    `de link gebeurt er niets.`,
+    ``,
+    `Met vriendelijke groet,`,
+    `MCM2`,
+  ].join('\n');
+
+  return {
+    aan: gegevens.ontvanger,
+    // Geen tenantnaam voorop zoals bij de leveranciersmail: deze uitnodiging
+    // komt van het platform en niet namens de klant. De klant heeft immers nog
+    // geen omgeving om namens te spreken — die wordt hier juist geopend.
+    afzenderNaam: 'MCM2',
+    onderwerp: `Uitnodiging: beheer de MCM2-omgeving van ${gegevens.tenantNaam}`,
+    tekst,
+  };
+}

--- a/src/mail/uitnodiging-verzender.service.ts
+++ b/src/mail/uitnodiging-verzender.service.ts
@@ -1,5 +1,9 @@
 import { Injectable, Logger } from '@nestjs/common';
 
+import {
+  stelBeheerderUitnodigingSamen,
+  type BeheerderUitnodigingGegevens,
+} from './beheerder-uitnodiging-bericht';
 import { MailKanaal, MailVerzendFout } from './mail-kanaal';
 import { stelUitnodigingSamen } from './uitnodiging-bericht';
 
@@ -95,6 +99,53 @@ export class UitnodigingVerzender {
     }
 
     return uitkomsten;
+  }
+
+  /**
+   * Verstuurt de uitnodiging aan de eerste beheerder van een nieuwe tenant.
+   *
+   * Anders dan `verstuurAllemaal()` is dit er altijd precies één, en is de
+   * uitkomst rechtstreeks van belang voor de aanroeper: mislukt hij, dan moet
+   * de platformbeheerder de link met de hand doorgeven. Vandaar één
+   * `VerzendUitkomst` in plaats van een lijst.
+   *
+   * Werpt niet. Een tenant die is aangemaakt blijft aangemaakt, ook als de mail
+   * strandt — hem alsnog laten falen zou betekenen dat een hikkende mailserver
+   * een geslaagde databasehandeling ongedaan lijkt te maken, terwijl hij dat
+   * niet is.
+   */
+  async verstuurAanBeheerder(gegevens: BeheerderUitnodigingGegevens): Promise<{
+    verstuurd: boolean;
+    providerId?: string;
+    fout?: string;
+    tijdelijk?: boolean;
+  }> {
+    try {
+      const { providerId } = await this.mail.verstuur(
+        stelBeheerderUitnodigingSamen(gegevens),
+      );
+
+      this.logger.log(
+        `Uitnodiging voor de beheerder van ${gegevens.tenantNaam} verstuurd.`,
+      );
+
+      return { verstuurd: true, providerId };
+    } catch (err) {
+      const fout = err instanceof MailVerzendFout;
+
+      // Het adres staat bewust niet in de logregel — MCM2-CLAUDE.md §6.
+      this.logger.error(
+        `Uitnodiging voor de beheerder van ${gegevens.tenantNaam} niet verstuurd: ` +
+          (err instanceof Error ? err.message : 'onbekende fout'),
+      );
+
+      return {
+        verstuurd: false,
+        fout:
+          err instanceof Error ? err.message : 'Onbekende fout bij versturen.',
+        tijdelijk: fout ? err.tijdelijk : false,
+      };
+    }
   }
 
   private async verstuurEen(

--- a/src/platform/platform-invoer.spec.ts
+++ b/src/platform/platform-invoer.spec.ts
@@ -1,0 +1,96 @@
+import { InvoerFout } from '../vendor/vendor-invoer';
+import { leesNieuweTenant } from './platform-invoer';
+
+const GELDIG = {
+  naam: 'Transdev',
+  adminNaam: 'Jan de Vries',
+  adminEmail: 'jan@transdev.nl',
+};
+
+describe('leesNieuweTenant', () => {
+  describe('het antwoordadres (migratie 0025)', () => {
+    it('neemt een geldig adres over', () => {
+      const invoer = leesNieuweTenant({
+        ...GELDIG,
+        antwoordEmail: 'contractmanagement@transdev.nl',
+      });
+
+      expect(invoer.antwoordEmail).toBe('contractmanagement@transdev.nl');
+    });
+
+    it('staat plusadressering toe', () => {
+      // Hierop leunt de hele testopzet van het mailkanaal: één inbox, meerdere
+      // onderscheidbare adressen. Een validator die '+' weigert blokkeert niet
+      // een randgeval maar de manier waarop we het systeem aantoonbaar maken.
+      const invoer = leesNieuweTenant({
+        ...GELDIG,
+        antwoordEmail: 'contractmanagement+mcm2@transdev.nl',
+      });
+
+      expect(invoer.antwoordEmail).toBe('contractmanagement+mcm2@transdev.nl');
+    });
+
+    it.each([
+      ['ontbreekt', {}],
+      ['undefined is', { antwoordEmail: undefined }],
+      ['null is', { antwoordEmail: null }],
+      ['een lege string is', { antwoordEmail: '' }],
+      ['alleen spaties bevat', { antwoordEmail: '   ' }],
+    ])('geeft undefined wanneer het veld %s', (_omschrijving, extra) => {
+      // Leeg is een geldige keuze en geen halve invoer: niet elke klant heeft
+      // een gedeeld postvak. Undefined en niet '' — een lege string zou als
+      // "wel ingevuld" door de keten reizen en een leeg Reply-To opleveren.
+      expect(leesNieuweTenant({ ...GELDIG, ...extra }).antwoordEmail).toBe(
+        undefined,
+      );
+    });
+
+    it.each([
+      ['zonder apenstaartje', 'geen-adres'],
+      ['zonder domein', 'iemand@'],
+      ['zonder punt in het domein', 'iemand@localhost'],
+      ['met een spatie', 'ie mand@transdev.nl'],
+    ])('weigert een adres %s', (_omschrijving, waarde) => {
+      expect(() =>
+        leesNieuweTenant({ ...GELDIG, antwoordEmail: waarde }),
+      ).toThrow(InvoerFout);
+    });
+
+    it('weigert een waarde die geen tekst is', () => {
+      expect(() => leesNieuweTenant({ ...GELDIG, antwoordEmail: 42 })).toThrow(
+        InvoerFout,
+      );
+    });
+
+    it('noemt het veld bij naam in de fout', () => {
+      // Het scherm zet de melding bij het juiste invoerveld; zonder veldnaam
+      // staat de fout bovenaan het formulier en zoekt de gebruiker zelf.
+      try {
+        leesNieuweTenant({ ...GELDIG, antwoordEmail: 'onzin' });
+        fail('had moeten werpen');
+      } catch (fout) {
+        expect((fout as InvoerFout).veld).toBe('antwoordEmail');
+      }
+    });
+  });
+
+  describe('de bestaande velden blijven verplicht', () => {
+    it('leest een tenant zonder antwoordadres gewoon in', () => {
+      const invoer = leesNieuweTenant(GELDIG);
+
+      expect(invoer.naam).toBe('Transdev');
+      expect(invoer.adminNaam).toBe('Jan de Vries');
+      expect(invoer.adminEmail).toBe('jan@transdev.nl');
+    });
+
+    it.each(['naam', 'adminNaam', 'adminEmail'])(
+      'weigert een ontbrekende %s',
+      (veld) => {
+        const zonder: Record<string, unknown> = { ...GELDIG };
+        delete zonder[veld];
+
+        expect(() => leesNieuweTenant(zonder)).toThrow(InvoerFout);
+      },
+    );
+  });
+});

--- a/src/platform/platform-invoer.ts
+++ b/src/platform/platform-invoer.ts
@@ -63,7 +63,33 @@ export function leesNieuweTenant(body: unknown): NieuweTenant {
     naam: verplichteTekst(invoer.naam, 'naam', MAX_NAAM),
     adminNaam: verplichteTekst(invoer.adminNaam, 'adminNaam', MAX_NAAM),
     adminEmail: email(invoer.adminEmail, 'adminEmail'),
+    antwoordEmail: optioneelEmail(invoer.antwoordEmail, 'antwoordEmail'),
   };
+}
+
+/**
+ * Het antwoordadres van de tenant — optioneel (migratie 0025).
+ *
+ * Leeg of afwezig is een geldige keuze en geen halve invoer: niet elke klant
+ * heeft een gedeeld postvak, en de berichttekst vangt dat af met een andere
+ * zin. Een lege string wordt daarom `undefined` en geen `''` — dat laatste zou
+ * als "wel ingevuld" door de keten reizen en in de mail een leeg Reply-To
+ * opleveren.
+ */
+function optioneelEmail(waarde: unknown, veld: string): string | undefined {
+  if (waarde === undefined || waarde === null) {
+    return undefined;
+  }
+
+  if (typeof waarde !== 'string') {
+    throw new InvoerFout(veld, `${veld} moet tekst zijn.`);
+  }
+
+  if (waarde.trim() === '') {
+    return undefined;
+  }
+
+  return email(waarde, veld);
 }
 
 /**

--- a/src/platform/platform.controller.ts
+++ b/src/platform/platform.controller.ts
@@ -14,6 +14,7 @@ import {
   TenantContextGuard,
   type RequestMetSessie,
 } from '../auth/tenant-context.guard';
+import { UitnodigingVerzender } from '../mail/uitnodiging-verzender.service';
 import { InvoerFout } from '../vendor/vendor-invoer';
 import { PlatformAdminGuard } from './platform-admin.guard';
 import { leesNieuweTenant, leesSupportReden } from './platform-invoer';
@@ -41,7 +42,10 @@ import { PlatformService } from './platform.service';
 @Controller('platform')
 @UseGuards(TenantContextGuard, PlatformAdminGuard)
 export class PlatformController {
-  constructor(private readonly platform: PlatformService) {}
+  constructor(
+    private readonly platform: PlatformService,
+    private readonly uitnodigingen: UitnodigingVerzender,
+  ) {}
 
   @Post('tenants')
   async tenantAanmaken(@Body() body: unknown) {
@@ -49,14 +53,38 @@ export class PlatformController {
       const invoer = leesNieuweTenant(body);
       const tenant = await this.platform.tenantAanmaken(invoer);
 
+      const link = this.uitnodigingsLink(tenant.uitnodigingstoken);
+
+      // Versturen ná het aanmaken, nooit erin.
+      //
+      // Een verstuurde mail is niet terug te draaien. Zat de verzending in de
+      // transactie en faalde er daarna iets, dan bestond de tenant niet maar
+      // was de uitnodiging wél de deur uit — een link naar niets. Zelfde
+      // volgorde en zelfde reden als bij de leveranciersuitnodigingen.
+      const verzending = await this.uitnodigingen.verstuurAanBeheerder({
+        ontvanger: invoer.adminEmail,
+        beheerderNaam: invoer.adminNaam,
+        tenantNaam: invoer.naam,
+        link,
+        verlooptOp: tenant.uitnodigingVerlooptOp.toISOString(),
+      });
+
       return {
         ...tenant,
-        // De eerste admin kan pas inloggen nadat hij zich bij Entra heeft
-        // gemeld; zijn oid koppelt dan aan deze rij. Het scherm hoort dat te
-        // vertellen, anders lijkt een aangemaakte tenant onbruikbaar.
-        melding:
-          `Tenant aangemaakt. ${invoer.adminNaam} kan inloggen zodra hij zich ` +
-          'met dit e-mailadres bij de identity provider aanmeldt.',
+        // Het token blijft in het antwoord staan, óók als de mail geslaagd is.
+        // Dit is het enige moment waarop het bestaat; er is geen route die het
+        // opnieuw kan tonen. Gaat de mail alsnog verloren, dan is dit de
+        // laatste kans om de link handmatig door te geven. Zelfde afweging als
+        // bij de leverancierstokens.
+        uitnodigingslink: link,
+        mailVerstuurd: verzending.verstuurd,
+        mailFout: verzending.fout,
+        melding: verzending.verstuurd
+          ? `Tenant aangemaakt. ${invoer.adminNaam} heeft een uitnodiging ` +
+            `ontvangen op ${invoer.adminEmail}.`
+          : `Tenant aangemaakt, maar de uitnodiging kon niet verstuurd worden ` +
+            `(${verzending.fout ?? 'onbekende fout'}). Geef de link hierboven ` +
+            'handmatig door.',
       };
     } catch (fout) {
       if (fout instanceof InvoerFout) {
@@ -67,6 +95,25 @@ export class PlatformController {
       }
       throw fout;
     }
+  }
+
+  /**
+   * De URL die de nieuwe beheerder in de mail krijgt.
+   *
+   * Wijst naar **deze backend** en niet naar het portaal: `/auth/login` zet het
+   * token in het pogingcookie en stuurt door naar de identity provider. Het
+   * portaal is de leverancierskant en heeft met deze stroom niets te maken.
+   *
+   * `API_BASIS_URL` en niet `PORTAAL_BASIS_URL`. Ontbreekt de variabele, dan
+   * valt dit terug op de lokale poort — zichtbaar fout in een mail, in plaats
+   * van een lege link waar niemand iets van merkt.
+   */
+  private uitnodigingsLink(token: string): string {
+    const basis = (
+      process.env.API_BASIS_URL ?? 'http://localhost:5001'
+    ).replace(/\/+$/, '');
+
+    return `${basis}/auth/login?uitnodiging=${encodeURIComponent(token)}`;
   }
 
   @Get('tenants/:id')

--- a/src/platform/platform.module.ts
+++ b/src/platform/platform.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common';
 
 import { AuthModule } from '../auth/auth.module';
+import { MailModule } from '../mail/mail.module';
 import { PlatformAdminGuard } from './platform-admin.guard';
 import { PlatformController } from './platform.controller';
 import { PlatformService } from './platform.service';
@@ -12,9 +13,14 @@ import { PlatformService } from './platform.service';
  * hij alleen door deze module gebruikt wordt. Een guard is een gewone
  * provider: zonder registratie kent NestJS hem niet en faalt het opstarten —
  * zichtbaar, niet stil.
+ *
+ * `MailModule` levert UitnodigingVerzender, waarmee de nieuwe beheerder zijn
+ * uitnodigingslink krijgt. Zonder RESEND_API_KEY is dat het logkanaal: de mail
+ * belandt dan in het log en het token staat in het antwoord, dus een omgeving
+ * zonder mailconfiguratie blijft bruikbaar.
  */
 @Module({
-  imports: [AuthModule],
+  imports: [AuthModule, MailModule],
   controllers: [PlatformController],
   providers: [PlatformService, PlatformAdminGuard],
   exports: [PlatformService],

--- a/src/platform/platform.service.ts
+++ b/src/platform/platform.service.ts
@@ -25,6 +25,14 @@ export interface NieuweTenant {
   /** Wordt de eerste admin. Zijn oid volgt bij de eerste login. */
   readonly adminEmail: string;
   readonly adminNaam: string;
+  /**
+   * Waar een antwoord van een leverancier heen gaat (migratie 0025).
+   *
+   * Optioneel: niet elke klant heeft een gedeeld postvak. Blijft hij leeg, dan
+   * verwijst de uitnodigingsmail naar de contactpersoon bij de tenant in plaats
+   * van naar een adres.
+   */
+  readonly antwoordEmail?: string;
 }
 
 export interface TenantOverzicht {
@@ -139,7 +147,9 @@ export class PlatformService {
       // vertalen naar iets wat het scherm kan tonen.
       try {
         await tx.execute(
-          sql`INSERT INTO clm.tenant (tenant_id, name) VALUES (${tenantId}, ${invoer.naam})`,
+          sql`INSERT INTO clm.tenant (tenant_id, name, antwoord_email)
+              VALUES (${tenantId}, ${invoer.naam},
+                      ${invoer.antwoordEmail ?? null})`,
         );
       } catch (fout) {
         if (isUniekeNaamFout(fout)) {
@@ -154,9 +164,14 @@ export class PlatformService {
       // Entra-login koppelt clm.koppel_eerste_login() de oid aan deze rij op
       // vertoon van het token (migratie 0024). Ontbreekt een van beide, dan is
       // de rij niet koppelbaar — NULL is daar de veilige stand.
+      // koppelbaar_tot komt als string terug, niet als Date: drizzle's
+      // execute() geeft de ruwe pg-waarden door zonder de kolomtypen om te
+      // zetten. Het type hier eerlijk houden en één keer converteren is beter
+      // dan een Date beloven die er niet is — dat leverde een 500 op
+      // (`toISOString is not a function`), pas zichtbaar in de e2e-run.
       const gebruiker = await tx.execute<{
         user_id: string;
-        koppelbaar_tot: Date;
+        koppelbaar_tot: string;
       }>(
         sql`INSERT INTO clm."user"
               (tenant_id, full_name, email, uitnodiging_hash, koppelbaar_tot)
@@ -183,17 +198,17 @@ export class PlatformService {
                     })}::jsonb)`,
       );
 
-      const rij = await tx.execute<{ created_at: Date }>(
+      const rij = await tx.execute<{ created_at: string }>(
         sql`SELECT created_at FROM clm.tenant WHERE tenant_id = ${tenantId}`,
       );
 
       return {
         tenantId,
         naam: invoer.naam,
-        aangemaaktOp: rij.rows[0].created_at,
+        aangemaaktOp: new Date(rij.rows[0].created_at),
         aantalLeden: 1,
         uitnodigingstoken: token,
-        uitnodigingVerlooptOp: gebruiker.rows[0].koppelbaar_tot,
+        uitnodigingVerlooptOp: new Date(gebruiker.rows[0].koppelbaar_tot),
       };
     });
   }
@@ -214,7 +229,7 @@ export class PlatformService {
       // Een bestaande support-rij wordt vervangen, niet gedupliceerd: de
       // primaire sleutel is (user_id, tenant_id). Verlengen is hetzelfde als
       // opnieuw toekennen, met een nieuwe reden en een nieuwe einddatum.
-      const rij = await tx.execute<{ verloopt_op: Date }>(
+      const rij = await tx.execute<{ verloopt_op: string }>(
         sql`INSERT INTO clm.tenant_membership
               (user_id, tenant_id, role, verloopt_op, reden, toegekend_door)
             VALUES (${beheerderUserId}, ${tenantId}, 'support',
@@ -240,7 +255,11 @@ export class PlatformService {
                     })}::jsonb)`,
       );
 
-      return { tenantId, verlooptOp: rij.rows[0].verloopt_op, reden };
+      return {
+        tenantId,
+        verlooptOp: new Date(rij.rows[0].verloopt_op),
+        reden,
+      };
     });
   }
 
@@ -261,7 +280,7 @@ export class PlatformService {
       const { rows } = await tx.execute<{
         tenant_id: string;
         name: string;
-        created_at: Date;
+        created_at: string;
         leden: string;
       }>(
         sql`SELECT t.tenant_id, t.name, t.created_at,
@@ -278,7 +297,7 @@ export class PlatformService {
       return {
         tenantId: rows[0].tenant_id,
         naam: rows[0].name,
-        aangemaaktOp: rows[0].created_at,
+        aangemaaktOp: new Date(rows[0].created_at),
         aantalLeden: Number(rows[0].leden),
       };
     });

--- a/src/survey/ronde-beheer.service.ts
+++ b/src/survey/ronde-beheer.service.ts
@@ -82,6 +82,14 @@ export interface Uitnodiging {
 export interface UitnodigingContext {
   tenantNaam: string;
   vragenlijstNaam: string;
+  /**
+   * Waar een antwoord van de leverancier heen gaat (migratie 0025).
+   *
+   * Van de tenant, niet van het platform: alleen de opdrachtgever kan een vraag
+   * over zijn eigen uitvraag beantwoorden. Ontbreekt hij, dan verwijst de
+   * berichttekst naar de contactpersoon bij de tenant.
+   */
+  antwoordAan?: string;
 }
 
 export interface UitnodigingResultaat {
@@ -311,8 +319,10 @@ export class RondeBeheerService {
           status: string;
           template_naam: string;
           tenant_naam: string;
+          antwoord_email: string | null;
         }>(
-          sql`SELECT r.status, t.name AS template_naam, tn.name AS tenant_naam
+          sql`SELECT r.status, t.name AS template_naam, tn.name AS tenant_naam,
+                     tn.antwoord_email
                 FROM clm.survey_run r
                 JOIN clm.survey_template t ON t.template_id = r.template_id
                 JOIN clm.tenant tn ON tn.tenant_id = r.tenant_id
@@ -447,6 +457,11 @@ export class RondeBeheerService {
           context: {
             tenantNaam: ronde.tenant_naam,
             vragenlijstNaam: ronde.template_naam,
+            // Zonder deze regel komt een antwoord van de leverancier bij het
+            // platform terecht in plaats van bij de opdrachtgever. `undefined`
+            // en niet `null`: de mailketen gebruikt de aanwezigheid van dit
+            // veld om te kiezen tussen twee zinnen in de berichttekst.
+            antwoordAan: ronde.antwoord_email ?? undefined,
           },
         };
       },

--- a/test/platform-routes.e2e-spec.ts
+++ b/test/platform-routes.e2e-spec.ts
@@ -213,12 +213,20 @@ describe('Platformroutes (e2e, ADR-015)', () => {
         .expect(201);
 
       const uit = body(antwoord);
+
+      // Vastleggen vóór de asserties, niet erna. Faalt er hierna één, dan is
+      // het id anders nooit vastgelegd en ruimt afterAll de tenant niet op —
+      // waarna elke volgende run strandt op de unieke naamindex. Precies dat
+      // gebeurde op 2026-08-09: een 500 in de eerste test maakte de suite
+      // daarna onherhaalbaar, en de 409 die je dan zag verborg de echte fout.
       expect(uit.tenantId).toBeDefined();
+      aangemaakt.push(uit.tenantId!);
+
       expect(uit.naam).toBe('AlingAdvies');
       expect(uit.aantalLeden).toBe(1);
-      expect(uit.melding).toContain('inloggen');
-
-      aangemaakt.push(uit.tenantId!);
+      // De uitnodiging gaat per mail (migratie 0025). In de e2e-run staat geen
+      // RESEND_API_KEY, dus dit is het logkanaal — dat "verstuurt" en meldt.
+      expect(uit.melding).toContain('uitnodiging');
 
       // De admin bestaat, nog zonder external_subject: die komt bij zijn
       // eerste login. De partiële unieke index staat dat toe (migratie 0009).
@@ -243,6 +251,75 @@ describe('Platformroutes (e2e, ADR-015)', () => {
       expect(rows[0].email).toBe('kees@alingadvies.nl');
       expect(rows[0].external_subject).toBeNull();
       expect(rows[0].role).toBe('admin');
+    });
+
+    it('geeft een bruikbare uitnodigingslink terug', async () => {
+      // Het token staat óók in het antwoord als de mail geslaagd is. Dit is het
+      // enige moment waarop het bestaat; gaat de mail verloren, dan is dit de
+      // laatste kans om de link handmatig door te geven.
+      const antwoord = await request(server)
+        .post('/platform/tenants')
+        .set('Cookie', cookieBeheerder)
+        .send({
+          naam: `Linktest ${Date.now()}`,
+          adminNaam: 'Linkbeheerder',
+          adminEmail: `link-${Date.now()}@voorbeeld.nl`,
+        })
+        .expect(201);
+
+      const uit = body(antwoord) as Record<string, string>;
+      aangemaakt.push(uit.tenantId);
+
+      expect(uit.uitnodigingslink).toContain('/auth/login?uitnodiging=');
+      expect(uit.uitnodigingslink).toContain(uit.uitnodigingstoken);
+      // Naar de backend, niet naar het portaal: /auth/login zet het token in
+      // het pogingcookie. Het portaal is de leverancierskant.
+      expect(uit.uitnodigingslink).not.toContain('/portal/');
+    });
+
+    it('bewaart het antwoordadres van de tenant', async () => {
+      // Migratie 0025. Zonder dit adres komt een antwoord van een leverancier
+      // bij het platform terecht in plaats van bij de opdrachtgever.
+      const adres = `contractmanagement+${Date.now()}@voorbeeld.nl`;
+
+      const antwoord = await request(server)
+        .post('/platform/tenants')
+        .set('Cookie', cookieBeheerder)
+        .send({
+          naam: `Antwoordtest ${Date.now()}`,
+          adminNaam: 'Beheerder',
+          adminEmail: `antwoord-${Date.now()}@voorbeeld.nl`,
+          antwoordEmail: adres,
+        })
+        .expect(201);
+
+      const uit = body(antwoord);
+      aangemaakt.push(uit.tenantId!);
+
+      await client.query('BEGIN');
+      await client.query(
+        `SET LOCAL app.current_tenant_id = '${uit.tenantId!}'`,
+      );
+      const { rows } = await client.query<{ antwoord_email: string | null }>(
+        'SELECT antwoord_email FROM clm.tenant WHERE tenant_id = $1',
+        [uit.tenantId],
+      );
+      await client.query('COMMIT');
+
+      expect(rows[0].antwoord_email).toBe(adres);
+    });
+
+    it('weigert een antwoordadres dat geen adres is', async () => {
+      await request(server)
+        .post('/platform/tenants')
+        .set('Cookie', cookieBeheerder)
+        .send({
+          naam: `Ongeldig ${Date.now()}`,
+          adminNaam: 'Beheerder',
+          adminEmail: `ongeldig-${Date.now()}@voorbeeld.nl`,
+          antwoordEmail: 'geen-adres',
+        })
+        .expect(400);
     });
 
     it('legt het aanmaken vast in de audit trail', async () => {

--- a/test/tenant-antwoordadres.e2e-spec.ts
+++ b/test/tenant-antwoordadres.e2e-spec.ts
@@ -1,0 +1,163 @@
+import { Client } from 'pg';
+
+import { verwijderTestdata } from './opruimen';
+import { TEST_IDS } from './test-ids';
+
+/**
+ * Het antwoordadres van de tenant (migratie 0025).
+ *
+ * ── Waarom deze suite bestaat ────────────────────────────────────────────────
+ *
+ * `antwoordAan` bestond al door de hele mailketen — in `UitnodigingGegevens`,
+ * in `MailBericht`, en als `replyTo` in het Resend-kanaal. Alleen: het werd
+ * nergens gevuld. `UitnodigingContext` kende enkel `tenantNaam` en
+ * `vragenlijstNaam`.
+ *
+ * Elke laag afzonderlijk was getest en groen. De keten als geheel was stuk, en
+ * het gevolg was zichtbaar noch rood: een leverancier die op "Beantwoorden"
+ * drukte kwam bij het platform terecht in plaats van bij de opdrachtgever.
+ *
+ * Dat is precies het soort gat dat unittests niet vinden — ze toetsen elke
+ * schakel, niet of de schakels aan elkaar zitten. Vandaar dat deze suite de
+ * kolom in de database toetst en niet de doorgifte in TypeScript.
+ *
+ * ── Wat hier NIET getest wordt ───────────────────────────────────────────────
+ *
+ * Of de mail werkelijk verstuurd wordt. Dat doet
+ * `uitnodiging-verzender.service.spec.ts` met een testkanaal. Hier gaat het om
+ * de vraag die daar niet gesteld kan worden: staat de waarde in de database, en
+ * komt hij eruit zoals de applicatie hem verwacht.
+ */
+
+const { tenantMet: TENANT_MET, tenantZonder: TENANT_ZONDER } =
+  TEST_IDS['tenant-antwoordadres'];
+
+const ANTWOORDADRES = `contractmanagement+${Date.now()}@voorbeeld.nl`;
+
+describe('Antwoordadres per tenant (e2e, migratie 0025)', () => {
+  let client: Client;
+
+  beforeAll(async () => {
+    client = new Client({ connectionString: process.env.DATABASE_URL });
+    await client.connect();
+
+    await client.query('BEGIN');
+    await client.query(`SET LOCAL app.current_tenant_id = '${TENANT_MET}'`);
+    await client.query(
+      'INSERT INTO clm.tenant (tenant_id, name, antwoord_email) VALUES ($1, $2, $3)',
+      [TENANT_MET, `antwoordadres-met-${Date.now()}`, ANTWOORDADRES],
+    );
+    await client.query('COMMIT');
+
+    await client.query('BEGIN');
+    await client.query(`SET LOCAL app.current_tenant_id = '${TENANT_ZONDER}'`);
+    await client.query(
+      'INSERT INTO clm.tenant (tenant_id, name) VALUES ($1, $2)',
+      [TENANT_ZONDER, `antwoordadres-zonder-${Date.now()}`],
+    );
+    await client.query('COMMIT');
+  }, 30000);
+
+  afterAll(async () => {
+    await verwijderTestdata(TENANT_MET, TENANT_ZONDER);
+    await client.end();
+  }, 30000);
+
+  /** Leest de kolom binnen de tenantcontext, zoals de applicatie dat doet. */
+  async function leesAntwoordadres(tenantId: string): Promise<string | null> {
+    await client.query('BEGIN');
+    await client.query(`SET LOCAL app.current_tenant_id = '${tenantId}'`);
+    const { rows } = await client.query<{ antwoord_email: string | null }>(
+      'SELECT antwoord_email FROM clm.tenant WHERE tenant_id = $1',
+      [tenantId],
+    );
+    await client.query('COMMIT');
+
+    return rows[0]?.antwoord_email ?? null;
+  }
+
+  describe('de kolom', () => {
+    it('bewaart het adres van de tenant', async () => {
+      expect(await leesAntwoordadres(TENANT_MET)).toBe(ANTWOORDADRES);
+    });
+
+    it('staat leeg toe — niet elke klant heeft een gedeeld postvak', async () => {
+      expect(await leesAntwoordadres(TENANT_ZONDER)).toBeNull();
+    });
+  });
+
+  describe('de vormcontrole', () => {
+    it('staat plusadressering toe', async () => {
+      // Hierop leunt de testopzet van het mailkanaal. Een constraint die '+'
+      // weigert blokkeert niet een randgeval maar de manier waarop we het
+      // systeem aantoonbaar maken.
+      await client.query('BEGIN');
+      await client.query(`SET LOCAL app.current_tenant_id = '${TENANT_MET}'`);
+
+      await expect(
+        client.query(
+          'UPDATE clm.tenant SET antwoord_email = $1 WHERE tenant_id = $2',
+          ['beheer+mcm2@voorbeeld.nl', TENANT_MET],
+        ),
+      ).resolves.toBeDefined();
+
+      await client.query('ROLLBACK');
+    });
+
+    it.each([
+      ['zonder apenstaartje', 'geen-adres'],
+      ['zonder punt in het domein', 'iemand@localhost'],
+      ['met een spatie', 'ie mand@voorbeeld.nl'],
+      ['leeg maar niet NULL', ''],
+    ])('weigert een adres %s', async (_omschrijving, waarde) => {
+      // De constraint hoort hetzelfde toe te staan als isGeldigMailadres() in
+      // de applicatie. Zou de database ruimer zijn, dan kan er een waarde in
+      // staan die de mailketen later weigert — en dan faalt de verzending pas
+      // bij de eerste uitvraag.
+      await client.query('BEGIN');
+      await client.query(`SET LOCAL app.current_tenant_id = '${TENANT_MET}'`);
+
+      await expect(
+        client.query(
+          'UPDATE clm.tenant SET antwoord_email = $1 WHERE tenant_id = $2',
+          [waarde, TENANT_MET],
+        ),
+      ).rejects.toThrow(/tenant_antwoord_email_format_check/);
+
+      await client.query('ROLLBACK');
+    });
+
+    it('weigert een adres langer dan 254 tekens', async () => {
+      await client.query('BEGIN');
+      await client.query(`SET LOCAL app.current_tenant_id = '${TENANT_MET}'`);
+
+      await expect(
+        client.query(
+          'UPDATE clm.tenant SET antwoord_email = $1 WHERE tenant_id = $2',
+          [`${'a'.repeat(250)}@voorbeeld.nl`, TENANT_MET],
+        ),
+      ).rejects.toThrow(/tenant_antwoord_email_format_check/);
+
+      await client.query('ROLLBACK');
+    });
+  });
+
+  describe('de tenantgrens', () => {
+    it('toont het adres van een andere tenant niet', async () => {
+      // Het antwoordadres is gewone tenantdata en valt onder dezelfde policy
+      // als de rest van clm.tenant. Deze tegenproef legt vast dat de nieuwe
+      // kolom daar geen uitzondering op is.
+      await client.query('BEGIN');
+      await client.query(
+        `SET LOCAL app.current_tenant_id = '${TENANT_ZONDER}'`,
+      );
+      const { rows } = await client.query(
+        'SELECT antwoord_email FROM clm.tenant WHERE tenant_id = $1',
+        [TENANT_MET],
+      );
+      await client.query('COMMIT');
+
+      expect(rows).toHaveLength(0);
+    });
+  });
+});

--- a/test/test-ids.ts
+++ b/test/test-ids.ts
@@ -325,6 +325,12 @@ export const TEST_IDS = {
     /** Iemand die al een oid heeft — mag nooit overschreven worden. */
     bestaand: id('7f'),
   },
+  'tenant-antwoordadres': {
+    /** Een tenant mét antwoordadres. */
+    tenantMet: id('1d'),
+    /** Een tenant zonder — de andere helft van de tegenproef. */
+    tenantZonder: id('1e'),
+  },
 } as const;
 
 /** Alle uitgedeelde id's, plat. Gebruikt door de bewakingstest. */


### PR DESCRIPTION
Twee gaten die zichtbaar werden bij het aanmaken van de eerste echte tenant.

## 1. Het antwoordadres (migratie 0025)

`antwoordAan` bestond al door de **hele** mailketen — in `UitnodigingGegevens`,
in `MailBericht`, en als `replyTo` in het Resend-kanaal. Alleen: het werd
nergens gevuld. `UitnodigingContext` kende enkel `tenantNaam` en
`vragenlijstNaam`.

Elke laag afzonderlijk was getest en groen. De keten als geheel was stuk, en
het gevolg was zichtbaar noch rood: een leverancier die op "Beantwoorden" drukte
kwam bij het platform terecht in plaats van bij de opdrachtgever. De mailtekst
zei dan *"neem contact op met uw contactpersoon bij <klant>"* — zonder te zeggen
wie dat is.

De code voorzag dit trouwens, in `uitnodiging-bericht.ts`:

> Deze regel voorkomt de mail die anders bij ons terechtkomt en die wij niet
> kunnen beantwoorden: alleen de opdrachtgever weet of een leverancier nog een
> contract heeft.

De helft was gebouwd, de vulling ontbrak.

### Bewust een kolom en geen SMTP per tenant

Issue #76 beschrijft SMTP per tenant met een versleuteld wachtwoord. Besluit van
de eigenaar: dat is niet nodig zolang de mail herkenbaar van de klant komt en
een antwoord bij de klant belandt.

Het envelopadres blijft van het platform, en dat is geen tussenoplossing —
versturen vanaf het klantdomein vraagt SPF- en DKIM-records in hún DNS.

## 2. De uitnodigingsmail

De platformroute gaf het token alleen terug in de response. Bij het aanmaken van
de AlingAdvies-tenant betekende dat: token uit de browserconsole lezen en met de
hand doorsturen.

Nu verstuurt de route een mail met de uitnodigingslink. **Eigen berichtsjabloon**,
niet gedeeld met de leveranciersmail: die gaat naar iemand die MCM2 niet kent en
overtuigd moet worden; deze naar iemand die wéét dat hij hem krijgt en
duidelijkheid nodig heeft.

Versturen ná het aanmaken, nooit erin — zelfde volgorde en reden als bij de
leveranciersuitnodigingen. Het token blijft óók in de response staan: faalt de
mail, dan is dat de laatste kans om de link door te geven.

De link wijst naar `/auth/login?uitnodiging=…` op de **backend**, niet naar het
portaal. Dat laatste is de leverancierskant.

## Twee fouten die de e2e-run blootlegde

**1. Een type dat loog.** `koppelbaar_tot` komt als string terug uit
`tx.execute()`, niet als `Date` — drizzle geeft de ruwe pg-waarden door. Het
type beloofde een `Date`, en dat gaf een 500: `toISOString is not a function`.
Dezelfde onjuiste aanname stond op **drie andere plekken** in deze service
(`created_at` tweemaal, `verloopt_op`); alle vier rechtgezet.

**2. Een test die zichzelf onherhaalbaar maakte.** `aangemaakt.push()` stond ná
de asserties. Faalde er één, dan werd het id nooit vastgelegd, ruimde `afterAll`
de tenant niet op, en strandde elke volgende run op de unieke naamindex — met
een 409 die de echte fout (de 500) verborg. Ik heb daar zelf een halve slag op
verloren voordat ik doorhad dat de 409 een gevolg was.

## Verificatie

- **451 tests in 32 suites**, `verify:volledig` GROEN over de hele keten
- `platform-routes` **twee keer achtereen** groen — de toets op herhaalbaarheid
  die eerder ontbrak
- Nieuwe suite `tenant-antwoordadres.e2e-spec.ts`: 9 tests, waaronder de
  tegenproef dat de kolom onder dezelfde RLS-policy valt als de rest van
  `clm.tenant`
- 12 tests op het berichtsjabloon, waaronder: vraagt nergens om een wachtwoord,
  klopt geen urgentie op, zet geen Reply-To
- Gedraaid tegen een wegwerpcontainer op 55440; demo (55450) en productie
  ongemoeid

## Na het mergen

Migratie 0025 naar productie. De kolom is nullable, dus bestaande tenants
blijven werken zoals ze deden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
