### PR TITLE
feat(tenant): een beheerder kan zelf het antwoordadres instellen

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -7,6 +7,7 @@ import { HealthModule } from './health/health.module';
 import { MailModule } from './mail/mail.module';
 import { PlatformModule } from './platform/platform.module';
 import { SurveyModule } from './survey/survey.module';
+import { TenantModule } from './tenant/tenant.module';
 import { VendorModule } from './vendor/vendor.module';
 
 @Module({
@@ -18,6 +19,7 @@ import { VendorModule } from './vendor/vendor.module';
     VendorModule,
     MailModule,
     PlatformModule,
+    TenantModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/tenant/tenant-invoer.spec.ts
+++ b/src/tenant/tenant-invoer.spec.ts
@@ -1,0 +1,98 @@
+import { InvoerFout } from '../vendor/vendor-invoer';
+import { leesTenantWijziging } from './tenant-invoer';
+
+describe('leesTenantWijziging', () => {
+  describe('het onderscheid tussen niet-aanraken en wissen', () => {
+    it('geeft een leeg object wanneer het veld ontbreekt', () => {
+      // Zonder dit onderscheid zou een scherm dat straks alleen de tenantnaam
+      // wijzigt het antwoordadres stilzwijgend wissen — precies het soort
+      // stille bijwerking dat pas opvalt als een leverancier antwoordt en
+      // niemand het leest.
+      expect(leesTenantWijziging({})).toEqual({});
+      expect(leesTenantWijziging({ ietsAnders: 'x' })).toEqual({});
+    });
+
+    it.each([
+      ['null', null],
+      ['een lege string', ''],
+      ['alleen spaties', '   '],
+    ])('wist het adres bij %s', (_omschrijving, waarde) => {
+      // Bewust wissen moet kunnen: een tenant die zijn antwoordadres intrekt
+      // krijgt de alternatieve zin in de berichttekst.
+      expect(leesTenantWijziging({ antwoordEmail: waarde })).toEqual({
+        antwoordEmail: null,
+      });
+    });
+  });
+
+  describe('geldige adressen', () => {
+    it('neemt een gewoon adres over', () => {
+      expect(
+        leesTenantWijziging({ antwoordEmail: 'contract@transdev.nl' }),
+      ).toEqual({ antwoordEmail: 'contract@transdev.nl' });
+    });
+
+    it('staat plusadressering toe', () => {
+      // Hierop leunt de testopzet van het mailkanaal: één inbox, meerdere
+      // onderscheidbare adressen.
+      expect(
+        leesTenantWijziging({ antwoordEmail: 'contract+mcm2@transdev.nl' }),
+      ).toEqual({ antwoordEmail: 'contract+mcm2@transdev.nl' });
+    });
+
+    it('haalt witruimte eromheen weg', () => {
+      expect(
+        leesTenantWijziging({ antwoordEmail: '  contract@transdev.nl  ' }),
+      ).toEqual({ antwoordEmail: 'contract@transdev.nl' });
+    });
+  });
+
+  describe('wat geweigerd wordt', () => {
+    it.each([
+      ['zonder apenstaartje', 'geen-adres'],
+      ['zonder domein', 'iemand@'],
+      ['zonder punt in het domein', 'iemand@localhost'],
+      ['met een spatie erin', 'ie mand@transdev.nl'],
+    ])('weigert een adres %s', (_omschrijving, waarde) => {
+      expect(() => leesTenantWijziging({ antwoordEmail: waarde })).toThrow(
+        InvoerFout,
+      );
+    });
+
+    it('weigert een waarde die geen tekst is', () => {
+      expect(() => leesTenantWijziging({ antwoordEmail: 42 })).toThrow(
+        InvoerFout,
+      );
+    });
+
+    it('weigert een adres langer dan 254 tekens', () => {
+      // Zelfde grens als de CHECK-constraint uit migratie 0025. Zou de
+      // applicatie ruimer zijn, dan levert een te lang adres een databasefout
+      // op in plaats van een leesbare melding bij het invoerveld.
+      expect(() =>
+        leesTenantWijziging({
+          antwoordEmail: `${'a'.repeat(250)}@transdev.nl`,
+        }),
+      ).toThrow(InvoerFout);
+    });
+
+    it.each([
+      ['null', null],
+      ['een getal', 42],
+      ['een string', 'geen object'],
+    ])('weigert een body die %s is', (_omschrijving, body) => {
+      expect(() => leesTenantWijziging(body)).toThrow(InvoerFout);
+    });
+
+    it('noemt het veld bij naam in de fout', () => {
+      // Het scherm zet de melding bij het juiste invoerveld; zonder veldnaam
+      // staat de fout bovenaan het formulier en zoekt de gebruiker zelf.
+      try {
+        leesTenantWijziging({ antwoordEmail: 'onzin' });
+        fail('had moeten werpen');
+      } catch (fout) {
+        expect((fout as InvoerFout).veld).toBe('antwoordEmail');
+      }
+    });
+  });
+});

--- a/src/tenant/tenant-invoer.ts
+++ b/src/tenant/tenant-invoer.ts
@@ -1,0 +1,87 @@
+import { isGeldigMailadres } from '../mail/mail-adres';
+import { InvoerFout } from '../vendor/vendor-invoer';
+
+import type { TenantWijziging } from './tenant.service';
+
+/**
+ * Validatie van wat het beheerscherm opstuurt bij het wijzigen van de eigen
+ * tenantinstellingen.
+ *
+ * Zelfde stijl en dezelfde `InvoerFout` als `vendor-invoer.ts` en
+ * `platform-invoer.ts`: handmatig, met `unknown` als invoer.
+ *
+ * ── Waarom hier isGeldigMailadres() en niet een eigen expressie ─────────────
+ *
+ * `platform-invoer.ts` heeft zijn eigen e-mailcontrole, en dat is nu een
+ * verschil te veel: de database (CHECK-constraint uit 0025), het mailkanaal en
+ * dit scherm horen hetzelfde toe te staan. Wijkt er één af, dan is er een adres
+ * dat het ene niveau doorlaat en het andere weigert — en dat blijkt pas bij de
+ * eerste uitvraag.
+ *
+ * `isGeldigMailadres()` is de vorm waar de constraint uit 0025 op is gemodelleerd.
+ */
+
+/** RFC 5321: 64 lokaal + @ + 255 domein. De constraint uit 0025 gebruikt 254. */
+const MAX_EMAIL = 254;
+
+/**
+ * Leest een gedeeltelijke wijziging.
+ *
+ * Drie uitkomsten per veld, en het onderscheid tussen de laatste twee is
+ * wezenlijk:
+ *
+ *   veld ontbreekt        → undefined  → niet aanraken
+ *   veld is leeg of null  → null       → wissen
+ *   veld heeft een waarde → de waarde  → instellen
+ *
+ * Zonder dat onderscheid zou een scherm dat alleen de tenantnaam wijzigt het
+ * antwoordadres stilzwijgend wissen — precies het soort stille bijwerking dat
+ * pas opvalt als een leverancier antwoordt en niemand het leest.
+ */
+export function leesTenantWijziging(body: unknown): TenantWijziging {
+  if (typeof body !== 'object' || body === null) {
+    throw new InvoerFout('body', 'Verwacht een JSON-object.');
+  }
+
+  const invoer = body as Record<string, unknown>;
+
+  if (!('antwoordEmail' in invoer)) {
+    return {};
+  }
+
+  return { antwoordEmail: leesAntwoordEmail(invoer.antwoordEmail) };
+}
+
+function leesAntwoordEmail(waarde: unknown): string | null {
+  const veld = 'antwoordEmail';
+
+  // Bewust wissen: het veld is meegestuurd, maar leeg. Een tenant die zijn
+  // antwoordadres intrekt hoort dat te kunnen — de berichttekst vangt het af
+  // met een andere zin.
+  if (waarde === null || waarde === '') {
+    return null;
+  }
+
+  if (typeof waarde !== 'string') {
+    throw new InvoerFout(veld, 'Het antwoordadres moet tekst zijn.');
+  }
+
+  const schoon = waarde.trim();
+
+  if (schoon === '') {
+    return null;
+  }
+
+  if (schoon.length > MAX_EMAIL) {
+    throw new InvoerFout(
+      veld,
+      `Het antwoordadres mag hoogstens ${MAX_EMAIL} tekens zijn.`,
+    );
+  }
+
+  if (!isGeldigMailadres(schoon)) {
+    throw new InvoerFout(veld, 'Dit is geen geldig e-mailadres.');
+  }
+
+  return schoon;
+}

--- a/src/tenant/tenant.controller.ts
+++ b/src/tenant/tenant.controller.ts
@@ -1,0 +1,71 @@
+import {
+  BadRequestException,
+  Body,
+  Controller,
+  Get,
+  Patch,
+  Req,
+  UseGuards,
+} from '@nestjs/common';
+
+import { RolGuard, VereistRol } from '../auth/rol.guard';
+import {
+  TenantContextGuard,
+  type RequestMetSessie,
+} from '../auth/tenant-context.guard';
+import { InvoerFout } from '../vendor/vendor-invoer';
+import { leesTenantWijziging } from './tenant-invoer';
+import { TenantService } from './tenant.service';
+
+/**
+ * De instellingen van de eigen omgeving.
+ *
+ * ── Waar de tenant vandaan komt ─────────────────────────────────────────────
+ *
+ * Uit de sessie, altijd. Er is geen tenant-parameter in het pad en geen veld in
+ * de body — een beheerder kan hier dus per constructie niet de instellingen van
+ * een andere organisatie opvragen of wijzigen.
+ *
+ * Dat is de gewone regel (§6). `PlatformController` is de uitzondering daarop,
+ * en die woont bewust in een eigen module met een eigen guard ervoor.
+ *
+ * ── Waarom `admin` en niet elke ingelogde gebruiker ─────────────────────────
+ *
+ * Het antwoordadres bepaalt waar vragen van leveranciers van de héle
+ * organisatie heen gaan. Een beoordelaar hoort dat niet te kunnen verleggen.
+ * Backendcontrole met `@VereistRol('admin')`, niet alleen een verborgen
+ * menu-item — een route die alleen in het scherm dicht zit, is niet dicht.
+ *
+ * Lezen mag wél iedereen met een sessie: het scherm toont de instellingen ook
+ * aan wie ze niet mag wijzigen, en dat is beter dan een leeg vlak zonder uitleg.
+ */
+@Controller('tenant')
+@UseGuards(TenantContextGuard, RolGuard)
+export class TenantController {
+  constructor(private readonly tenants: TenantService) {}
+
+  @Get('instellingen')
+  async lezen(@Req() request: RequestMetSessie) {
+    // Veilig: zonder sessie is de guard nooit voorbijgekomen.
+    return this.tenants.lezen(request.sessie!.tenantId);
+  }
+
+  @Patch('instellingen')
+  @VereistRol('admin')
+  async wijzigen(@Req() request: RequestMetSessie, @Body() body: unknown) {
+    try {
+      return await this.tenants.wijzigen(
+        request.sessie!.tenantId,
+        leesTenantWijziging(body),
+      );
+    } catch (fout) {
+      if (fout instanceof InvoerFout) {
+        throw new BadRequestException({
+          veld: fout.veld,
+          melding: fout.message,
+        });
+      }
+      throw fout;
+    }
+  }
+}

--- a/src/tenant/tenant.module.ts
+++ b/src/tenant/tenant.module.ts
@@ -1,0 +1,24 @@
+import { Module } from '@nestjs/common';
+
+import { AuthModule } from '../auth/auth.module';
+import { TenantController } from './tenant.controller';
+import { TenantService } from './tenant.service';
+
+/**
+ * Instellingen van de eigen omgeving.
+ *
+ * `AuthModule` wordt geïmporteerd omdat `TenantContextGuard` en `RolGuard`
+ * daar vandaan komen. Een guard is een gewone provider: zonder die import kent
+ * NestJS hem niet en faalt het opstarten — zichtbaar, niet stil.
+ *
+ * Los van `PlatformModule` met opzet: daar komt de tenant uit de invoer en
+ * staat er een extra guard voor, hier komt hij uit de sessie. Zie de uitleg in
+ * `tenant.controller.ts`.
+ */
+@Module({
+  imports: [AuthModule],
+  controllers: [TenantController],
+  providers: [TenantService],
+  exports: [TenantService],
+})
+export class TenantModule {}

--- a/src/tenant/tenant.service.ts
+++ b/src/tenant/tenant.service.ts
@@ -1,0 +1,147 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { sql } from 'drizzle-orm';
+
+import { DatabaseService } from '../db/database.service';
+
+/**
+ * De instellingen van de eigen tenant.
+ *
+ * ── Waarom dit een eigen module is en niet bij platform hoort ────────────────
+ *
+ * `PlatformService` doet dingen áán een tenant, van buitenaf, als
+ * platformbeheerder. Deze service doet dingen *binnen* de eigen tenant, als
+ * beheerder van die tenant. Het verschil is niet cosmetisch:
+ *
+ *   PlatformController   tenant komt uit de invoer  → PlatformAdminGuard
+ *   TenantController     tenant komt uit de sessie  → de gewone regel (§6)
+ *
+ * Ze in één controller stoppen zou betekenen dat de uitzondering en de regel
+ * naast elkaar wonen, en dan is één vergeten guard genoeg om de tenantgrens
+ * te openen.
+ *
+ * ── Opgezet op uitbreiding ──────────────────────────────────────────────────
+ *
+ * Vandaag staat hier één veld: het antwoordadres (migratie 0025). De vorm is
+ * bewust die van een gedeeltelijke wijziging — `TenantWijziging` met optionele
+ * velden, en een UPDATE die alleen aanraakt wat is meegegeven. Een tweede veld
+ * (tenantnaam, later de instellingen uit #75/#76) past er dan bij zonder dat
+ * deze opzet op de schop hoeft.
+ *
+ * Wat er nog niet is en bewust nog niet: de tenantnaam. Die staat in elke
+ * leveranciersmail, en wijzigen raakt dus wat leveranciers zien. Bovendien
+ * geeft de unieke index een 409 bij een botsing. Doenlijk, maar een eigen
+ * afweging — zie de openstaande punten in de PR.
+ */
+
+export interface TenantInstellingen {
+  readonly tenantId: string;
+  readonly naam: string;
+  /** Waar een antwoord van een leverancier heen gaat. `null` = niet ingesteld. */
+  readonly antwoordEmail: string | null;
+}
+
+/**
+ * Wat een beheerder mag wijzigen.
+ *
+ * Elk veld optioneel: wie alleen het antwoordadres aanpast, hoort de rest niet
+ * te hoeven meesturen. `null` is een geldige waarde en betekent "wissen" —
+ * onderscheiden van `undefined`, dat "niet aanraken" betekent.
+ */
+export interface TenantWijziging {
+  readonly antwoordEmail?: string | null;
+}
+
+@Injectable()
+export class TenantService {
+  constructor(private readonly db: DatabaseService) {}
+
+  /**
+   * De instellingen van de eigen tenant.
+   *
+   * Geen tenantId-parameter uit de invoer: die komt van de aanroeper, die hem
+   * uit de sessie haalt. RLS zou een vreemde tenant sowieso verbergen, maar de
+   * vorm van deze methode maakt het al onmogelijk om er een andere te vragen.
+   */
+  async lezen(tenantId: string): Promise<TenantInstellingen> {
+    return this.db.withTenant(tenantId, async (tx) => {
+      const { rows } = await tx.execute<{
+        tenant_id: string;
+        name: string;
+        antwoord_email: string | null;
+      }>(
+        sql`SELECT tenant_id, name, antwoord_email
+              FROM clm.tenant
+             WHERE tenant_id = ${tenantId}`,
+      );
+
+      // Nul rijen kan hier eigenlijk niet — de sessie verwijst naar deze
+      // tenant, dus hij bestaat. Toch afvangen: een lege lijst stil doorgeven
+      // als lege instellingen zou een verwijderde tenant laten lijken op een
+      // tenant zonder antwoordadres.
+      if (rows.length === 0) {
+        throw new NotFoundException('Deze omgeving bestaat niet meer.');
+      }
+
+      return {
+        tenantId: rows[0].tenant_id,
+        naam: rows[0].name,
+        antwoordEmail: rows[0].antwoord_email,
+      };
+    });
+  }
+
+  /**
+   * Wijzigt de instellingen en geeft de nieuwe stand terug.
+   *
+   * Teruggeven en niet alleen bevestigen: het scherm hoort te tonen wat er nu
+   * werkelijk staat, niet wat het opstuurde. Dat scheelt een tweede aanroep en
+   * maakt zichtbaar wanneer de database iets anders bewaarde dan verwacht —
+   * bijvoorbeeld een adres met witruimte eromheen.
+   */
+  async wijzigen(
+    tenantId: string,
+    wijziging: TenantWijziging,
+  ): Promise<TenantInstellingen> {
+    // Niets meegegeven is geen fout maar een no-op: de huidige stand
+    // teruggeven is precies wat de aanroeper dan wil weten.
+    if (wijziging.antwoordEmail === undefined) {
+      return this.lezen(tenantId);
+    }
+
+    return this.db.withTenant(tenantId, async (tx) => {
+      const { rows } = await tx.execute<{
+        tenant_id: string;
+        name: string;
+        antwoord_email: string | null;
+      }>(
+        sql`UPDATE clm.tenant
+               SET antwoord_email = ${wijziging.antwoordEmail}
+             WHERE tenant_id = ${tenantId}
+         RETURNING tenant_id, name, antwoord_email`,
+      );
+
+      if (rows.length === 0) {
+        throw new NotFoundException('Deze omgeving bestaat niet meer.');
+      }
+
+      // Het antwoordadres bepaalt waar vragen van leveranciers heen gaan.
+      // Wie het wijzigt verlegt dus de post van een hele organisatie, en dat
+      // hoort navolgbaar te zijn (§7.7).
+      await tx.execute(
+        sql`INSERT INTO audit.audit_event
+              (tenant_id, action_type, entity_type, entity_id, new_values)
+            VALUES (${tenantId}, 'tenant_instellingen_gewijzigd', 'tenant',
+                    ${tenantId},
+                    ${JSON.stringify({
+                      antwoordEmail: wijziging.antwoordEmail,
+                    })}::jsonb)`,
+      );
+
+      return {
+        tenantId: rows[0].tenant_id,
+        naam: rows[0].name,
+        antwoordEmail: rows[0].antwoord_email,
+      };
+    });
+  }
+}

--- a/test/geen-echte-mail.e2e-spec.ts
+++ b/test/geen-echte-mail.e2e-spec.ts
@@ -1,0 +1,61 @@
+import { Test } from '@nestjs/testing';
+
+import { LogMailKanaal } from '../src/mail/log-mail-kanaal';
+import { MailKanaal } from '../src/mail/mail-kanaal';
+import { MailModule } from '../src/mail/mail.module';
+
+/**
+ * Een testrun verstuurt geen echte mail.
+ *
+ * ── Aanleiding ───────────────────────────────────────────────────────────────
+ *
+ * Op 2026-08-09 verstuurde `npm run verify:volledig` een echte uitnodigingsmail
+ * naar een bestaand postvak. Twee op zichzelf onschuldige dingen kwamen samen:
+ *
+ *   1. `platform-routes.e2e-spec.ts` gebruikte een bestaand e-mailadres als
+ *      testgegeven — het stond er al maanden, en tot die dag deed de route er
+ *      niets mee.
+ *   2. De e2e-run erft `RESEND_API_KEY` uit `.env` via `jest-e2e.setup.ts`.
+ *
+ * Sinds de platformroute een uitnodiging verstuurt (2026-08-09) betekende dat
+ * samen: post naar een echt adres, bij elke verificatierun.
+ *
+ * ── Waarom een eigen suite en niet alleen een ander adres ────────────────────
+ *
+ * Het adres is aangepast, maar dat beschermt alleen tegen de adressen die
+ * iemand vandaag heeft opgeschreven. De volgende suite die een uitnodiging
+ * verstuurt begint weer bij nul.
+ *
+ * `jest-e2e.setup.ts` wist daarom `RESEND_API_KEY`, en deze suite bewaakt dát.
+ * Zelfde vorm als `jest-e2e.guard.ts` voor de database: niet vertrouwen op wat
+ * er in een test staat, maar het onmogelijk maken — en dan bewijzen dat het
+ * onmogelijk is.
+ *
+ * Deze suite draait bewust géén applicatie op en raakt de database niet. Hij
+ * toetst één ding: welk mailkanaal de module kiest onder testomstandigheden.
+ */
+
+describe('Een testrun verstuurt geen echte mail', () => {
+  it('heeft geen mailsleutel in de omgeving', () => {
+    // De directe controle op wat jest-e2e.setup.ts doet. Zou iemand die regel
+    // weghalen, dan is dit de eerste test die rood wordt — met een melding die
+    // naar de oorzaak wijst in plaats van naar een gevolg.
+    expect(process.env.RESEND_API_KEY).toBeUndefined();
+    expect(process.env.MAIL_AFZENDER_ADRES).toBeUndefined();
+  });
+
+  it('kiest het logkanaal, niet Resend', async () => {
+    // De controle die er werkelijk toe doet. De vorige test toetst een
+    // variabele; deze toetst het gedrag dat eruit volgt — en dat is wat
+    // bepaalt of er post de deur uitgaat.
+    const moduleRef = await Test.createTestingModule({
+      imports: [MailModule],
+    }).compile();
+
+    const kanaal = moduleRef.get<MailKanaal>(MailKanaal);
+
+    expect(kanaal).toBeInstanceOf(LogMailKanaal);
+
+    await moduleRef.close();
+  });
+});

--- a/test/jest-e2e.setup.ts
+++ b/test/jest-e2e.setup.ts
@@ -8,3 +8,27 @@ import 'dotenv/config';
 //
 // Die volgorde is geen detail: dotenv moet vóór de guard draaien, anders leest
 // die een lege DATABASE_URL en slaat hij zichzelf over.
+
+// ── Geen echte mail vanuit een testrun ──────────────────────────────────────
+//
+// Aanleiding: op 2026-08-09 verstuurde `npm run verify:volledig` een echte
+// uitnodigingsmail naar kees@alingadvies.nl. Twee onschuldige dingen kwamen
+// samen: `platform-routes.e2e-spec.ts` gebruikte een bestaand adres als
+// testgegeven, en de e2e-run erft `RESEND_API_KEY` uit `.env` via de import
+// hierboven. Sinds de platformroute een uitnodiging verstuurt (migratie 0025),
+// betekent dat samen: post naar een echt postvak.
+//
+// Het adres in die test is vervangen door voorbeeld.nl, maar dat is de zwakke
+// helft van de oplossing — het beschermt alleen tegen de adressen die iemand
+// vandaag heeft opgeschreven. Deze regel beschermt tegen alle andere.
+//
+// `MailModule` kiest op deze variabele: zonder sleutel wordt het LogMailKanaal
+// en gaat er aantoonbaar niets uit. Zelfde vorm als jest-e2e.guard.ts voor de
+// database: niet vertrouwen op wat er in een test staat, maar het onmogelijk
+// maken.
+//
+// Bewust hier en niet in de guard: `MailModule` leest de sleutel bij het
+// opstarten van de app, en dat gebeurt in `beforeAll` — dus ná
+// setupFilesAfterEnv. Hier is vroeg genoeg, daar zou het te laat kunnen zijn.
+delete process.env.RESEND_API_KEY;
+delete process.env.MAIL_AFZENDER_ADRES;

--- a/test/platform-routes.e2e-spec.ts
+++ b/test/platform-routes.e2e-spec.ts
@@ -208,7 +208,7 @@ describe('Platformroutes (e2e, ADR-015)', () => {
         .send({
           naam: 'AlingAdvies',
           adminNaam: 'Kees',
-          adminEmail: 'kees@alingadvies.nl',
+          adminEmail: 'kees@voorbeeld.nl',
         })
         .expect(201);
 
@@ -248,7 +248,7 @@ describe('Platformroutes (e2e, ADR-015)', () => {
       await client.query('COMMIT');
 
       expect(rows).toHaveLength(1);
-      expect(rows[0].email).toBe('kees@alingadvies.nl');
+      expect(rows[0].email).toBe('kees@voorbeeld.nl');
       expect(rows[0].external_subject).toBeNull();
       expect(rows[0].role).toBe('admin');
     });
@@ -339,7 +339,7 @@ describe('Platformroutes (e2e, ADR-015)', () => {
 
       expect(rows).toHaveLength(1);
       expect(rows[0].new_values.naam).toBe('AlingAdvies');
-      expect(rows[0].new_values.eersteAdmin).toBe('kees@alingadvies.nl');
+      expect(rows[0].new_values.eersteAdmin).toBe('kees@voorbeeld.nl');
     });
 
     it('weigert dezelfde naam met 409', async () => {

--- a/test/tenant-instellingen.e2e-spec.ts
+++ b/test/tenant-instellingen.e2e-spec.ts
@@ -1,0 +1,303 @@
+import { INestApplication } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import cookieParser from 'cookie-parser';
+import { Client } from 'pg';
+import request from 'supertest';
+import type { App } from 'supertest/types';
+
+import { AppModule } from '../src/app.module';
+import { cookieInstellingen } from '../src/auth/sessie';
+import { SessieService } from '../src/auth/sessie.service';
+import { verwijderTestdata } from './opruimen';
+import { TEST_IDS } from './test-ids';
+
+/**
+ * Het beheerscherm voor de eigen omgeving, van buitenaf.
+ *
+ * ── Wat hier bewezen moet worden ─────────────────────────────────────────────
+ *
+ * Niet dat een beheerder zijn antwoordadres kan instellen — dat is het
+ * makkelijke deel. Wél dat de route dichtzit voor wie hem niet hoort te
+ * gebruiken, en dat hij per constructie niet aan een andere tenant kan komen.
+ *
+ * Deze routes zijn de tegenhanger van `PlatformController`: daar komt de tenant
+ * uit de invoer met een extra guard ervoor, hier uit de sessie. Er is geen
+ * tenant-parameter, dus de vraag "kan ik de instellingen van een ander
+ * opvragen" heeft hier geen vorm — en dat is precies wat getest wordt.
+ */
+
+const {
+  tenantA: TENANT_A,
+  tenantB: TENANT_B,
+  adminA: USER_ADMIN_A,
+  reviewerA: USER_REVIEWER_A,
+  adminB: USER_ADMIN_B,
+} = TEST_IDS['tenant-instellingen'];
+
+const SUBJECT_ADMIN_A = `oid-tenantinst-admin-a-${Date.now()}`;
+const SUBJECT_REVIEWER_A = `oid-tenantinst-rev-a-${Date.now()}`;
+const SUBJECT_ADMIN_B = `oid-tenantinst-admin-b-${Date.now()}`;
+
+const ADRES_A = `contract-a-${Date.now()}@voorbeeld.nl`;
+const ADRES_B = `contract-b-${Date.now()}@voorbeeld.nl`;
+
+interface Instellingen {
+  tenantId?: string;
+  naam?: string;
+  antwoordEmail?: string | null;
+  veld?: string;
+}
+
+const body = (res: { body: unknown }) => res.body as Instellingen;
+
+describe('Tenantinstellingen (e2e)', () => {
+  let app: INestApplication<App>;
+  let server: App;
+  let client: Client;
+  let cookieAdminA: string;
+  let cookieReviewerA: string;
+  let cookieAdminB: string;
+
+  beforeAll(async () => {
+    client = new Client({ connectionString: process.env.DATABASE_URL });
+    await client.connect();
+
+    for (const [tenant, naam, adres] of [
+      [TENANT_A, `tenantinst-a-${Date.now()}`, ADRES_A],
+      [TENANT_B, `tenantinst-b-${Date.now()}`, ADRES_B],
+    ] as const) {
+      await client.query('BEGIN');
+      await client.query(`SET LOCAL app.current_tenant_id = '${tenant}'`);
+      await client.query(
+        'INSERT INTO clm.tenant (tenant_id, name, antwoord_email) VALUES ($1, $2, $3)',
+        [tenant, naam, adres],
+      );
+      await client.query('COMMIT');
+    }
+
+    for (const [tenant, user, subject, rol] of [
+      [TENANT_A, USER_ADMIN_A, SUBJECT_ADMIN_A, 'admin'],
+      [TENANT_A, USER_REVIEWER_A, SUBJECT_REVIEWER_A, 'reviewer'],
+      [TENANT_B, USER_ADMIN_B, SUBJECT_ADMIN_B, 'admin'],
+    ] as const) {
+      await client.query('BEGIN');
+      await client.query(`SET LOCAL app.current_tenant_id = '${tenant}'`);
+      await client.query(
+        `INSERT INTO clm."user" (user_id, tenant_id, full_name, email, external_subject)
+         VALUES ($1, $2, $3, $4, $5)`,
+        [user, tenant, rol, `${subject}@voorbeeld.nl`, subject],
+      );
+      await client.query(
+        `INSERT INTO clm.tenant_membership (user_id, tenant_id, role)
+         VALUES ($1, $2, $3)`,
+        [user, tenant, rol],
+      );
+      await client.query('COMMIT');
+    }
+
+    const moduleRef = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleRef.createNestApplication();
+    app.use(cookieParser());
+    await app.init();
+    server = app.getHttpServer();
+
+    const sessies = app.get(SessieService);
+    const cookieNaam = cookieInstellingen().naam;
+
+    const sA = await sessies.aanmaken(SUBJECT_ADMIN_A);
+    const sR = await sessies.aanmaken(SUBJECT_REVIEWER_A);
+    const sB = await sessies.aanmaken(SUBJECT_ADMIN_B);
+    expect(sA).not.toBeNull();
+    expect(sR).not.toBeNull();
+    expect(sB).not.toBeNull();
+
+    cookieAdminA = `${cookieNaam}=${sA!.token}`;
+    cookieReviewerA = `${cookieNaam}=${sR!.token}`;
+    cookieAdminB = `${cookieNaam}=${sB!.token}`;
+  }, 30000);
+
+  afterAll(async () => {
+    await app.close();
+    await verwijderTestdata(TENANT_A, TENANT_B);
+    await client.end();
+  }, 30000);
+
+  describe('de deur', () => {
+    it('weigert lezen zonder sessie met 401', async () => {
+      await request(server).get('/tenant/instellingen').expect(401);
+    });
+
+    it('weigert wijzigen zonder sessie met 401', async () => {
+      await request(server)
+        .patch('/tenant/instellingen')
+        .send({ antwoordEmail: 'kwaad@voorbeeld.nl' })
+        .expect(401);
+    });
+
+    it('weigert wijzigen door een beoordelaar met 403', async () => {
+      // Het antwoordadres bepaalt waar vragen van leveranciers van de héle
+      // organisatie heen gaan. Een beoordelaar hoort dat niet te kunnen
+      // verleggen — en de grens hoort in de backend te zitten, niet alleen in
+      // een verborgen menu-item.
+      await request(server)
+        .patch('/tenant/instellingen')
+        .set('Cookie', cookieReviewerA)
+        .send({ antwoordEmail: 'omgeleid@voorbeeld.nl' })
+        .expect(403);
+    });
+
+    it('laat een beoordelaar wél lezen', async () => {
+      // Bewust ruimer dan wijzigen: het scherm toont de instellingen ook aan
+      // wie ze niet mag aanpassen, en dat is beter dan een leeg vlak.
+      const antwoord = await request(server)
+        .get('/tenant/instellingen')
+        .set('Cookie', cookieReviewerA)
+        .expect(200);
+
+      expect(body(antwoord).antwoordEmail).toBe(ADRES_A);
+    });
+  });
+
+  describe('de tenantgrens', () => {
+    it('toont elke beheerder uitsluitend zijn eigen omgeving', async () => {
+      // Er is geen tenant-parameter in het pad en geen veld in de body, dus
+      // "de instellingen van een ander opvragen" heeft hier geen vorm. Deze
+      // test legt vast dat de route werkelijk uit de sessie leest.
+      const a = await request(server)
+        .get('/tenant/instellingen')
+        .set('Cookie', cookieAdminA)
+        .expect(200);
+
+      const b = await request(server)
+        .get('/tenant/instellingen')
+        .set('Cookie', cookieAdminB)
+        .expect(200);
+
+      expect(body(a).tenantId).toBe(TENANT_A);
+      expect(body(a).antwoordEmail).toBe(ADRES_A);
+      expect(body(b).tenantId).toBe(TENANT_B);
+      expect(body(b).antwoordEmail).toBe(ADRES_B);
+    });
+
+    it('raakt de andere tenant niet bij een wijziging', async () => {
+      await request(server)
+        .patch('/tenant/instellingen')
+        .set('Cookie', cookieAdminA)
+        .send({ antwoordEmail: `nieuw-${Date.now()}@voorbeeld.nl` })
+        .expect(200);
+
+      const b = await request(server)
+        .get('/tenant/instellingen')
+        .set('Cookie', cookieAdminB)
+        .expect(200);
+
+      expect(body(b).antwoordEmail).toBe(ADRES_B);
+    });
+  });
+
+  describe('wijzigen', () => {
+    it('stelt het antwoordadres in en geeft de nieuwe stand terug', async () => {
+      const nieuw = `ingesteld-${Date.now()}@voorbeeld.nl`;
+
+      const antwoord = await request(server)
+        .patch('/tenant/instellingen')
+        .set('Cookie', cookieAdminA)
+        .send({ antwoordEmail: nieuw })
+        .expect(200);
+
+      expect(body(antwoord).antwoordEmail).toBe(nieuw);
+
+      // Teruglezen via een tweede aanroep: het antwoord van een PATCH kan
+      // kloppen terwijl er niets is opgeslagen.
+      const opnieuw = await request(server)
+        .get('/tenant/instellingen')
+        .set('Cookie', cookieAdminA)
+        .expect(200);
+
+      expect(body(opnieuw).antwoordEmail).toBe(nieuw);
+    });
+
+    it('wist het adres bij een lege waarde', async () => {
+      await request(server)
+        .patch('/tenant/instellingen')
+        .set('Cookie', cookieAdminA)
+        .send({ antwoordEmail: '' })
+        .expect(200);
+
+      const antwoord = await request(server)
+        .get('/tenant/instellingen')
+        .set('Cookie', cookieAdminA)
+        .expect(200);
+
+      expect(body(antwoord).antwoordEmail).toBeNull();
+    });
+
+    it('laat het adres met rust wanneer het veld ontbreekt', async () => {
+      // De tegenproef bij "wissen bij een lege waarde": zonder dit onderscheid
+      // zou een scherm dat straks een ander veld wijzigt het antwoordadres
+      // stilzwijgend wissen.
+      const gezet = `blijft-${Date.now()}@voorbeeld.nl`;
+
+      await request(server)
+        .patch('/tenant/instellingen')
+        .set('Cookie', cookieAdminA)
+        .send({ antwoordEmail: gezet })
+        .expect(200);
+
+      await request(server)
+        .patch('/tenant/instellingen')
+        .set('Cookie', cookieAdminA)
+        .send({})
+        .expect(200);
+
+      const antwoord = await request(server)
+        .get('/tenant/instellingen')
+        .set('Cookie', cookieAdminA)
+        .expect(200);
+
+      expect(body(antwoord).antwoordEmail).toBe(gezet);
+    });
+
+    it('weigert een ongeldig adres met 400 en noemt het veld', async () => {
+      const antwoord = await request(server)
+        .patch('/tenant/instellingen')
+        .set('Cookie', cookieAdminA)
+        .send({ antwoordEmail: 'geen-adres' })
+        .expect(400);
+
+      expect(JSON.stringify(antwoord.body)).toContain('antwoordEmail');
+    });
+
+    it('legt de wijziging vast in de audit trail', async () => {
+      // Wie het antwoordadres wijzigt verlegt de post van een hele organisatie.
+      // Dat hoort navolgbaar te zijn (§7.7).
+      const adres = `audit-${Date.now()}@voorbeeld.nl`;
+
+      await request(server)
+        .patch('/tenant/instellingen')
+        .set('Cookie', cookieAdminA)
+        .send({ antwoordEmail: adres })
+        .expect(200);
+
+      await client.query('BEGIN');
+      await client.query(`SET LOCAL app.current_tenant_id = '${TENANT_A}'`);
+      const { rows } = await client.query<{
+        new_values: Record<string, unknown>;
+      }>(
+        `SELECT new_values FROM audit.audit_event
+          WHERE tenant_id = $1
+            AND action_type = 'tenant_instellingen_gewijzigd'
+          ORDER BY created_at DESC
+          LIMIT 1`,
+        [TENANT_A],
+      );
+      await client.query('COMMIT');
+
+      expect(rows).toHaveLength(1);
+      expect(rows[0].new_values.antwoordEmail).toBe(adres);
+    });
+  });
+});

--- a/test/test-ids.ts
+++ b/test/test-ids.ts
@@ -331,6 +331,15 @@ export const TEST_IDS = {
     /** Een tenant zonder — de andere helft van de tegenproef. */
     tenantZonder: id('1e'),
   },
+  'tenant-instellingen': {
+    tenantA: id('1f'),
+    /** Tweede tenant, om cross-tenant zichtbaarheid uit te lokken. */
+    tenantB: id('20'),
+    adminA: id('21'),
+    /** Beoordelaar: mag lezen, niet wijzigen. */
+    reviewerA: id('22'),
+    adminB: id('23'),
+  },
 } as const;
 
 /** Alle uitgedeelde id's, plat. Gebruikt door de bewakingstest. */


### PR DESCRIPTION
Antwoord op de vraag van de eigenaar: *"kan ik niet zelf als beheerder inloggen
om iets in te stellen of te doen?"*

Nee, tot nu toe. Het antwoordadres was alleen te vullen bij het aanmaken van de
omgeving, door de platformbeheerder. Daarna was er geen weg meer — niet in een
scherm en niet in de API. Er bestond geen `PATCH` op de eigen tenant.

## Nieuwe module, bewust los van platform

| | tenant komt uit | guard |
|---|---|---|
| `PlatformController` | de invoer | `PlatformAdminGuard` |
| `TenantController` | de sessie | de gewone regel (§6) |

Ze in één controller stoppen zou betekenen dat de uitzondering en de regel naast
elkaar wonen, en dan is één vergeten guard genoeg om de tenantgrens te openen.

Er is geen tenant-parameter in het pad en geen veld in de body: "de instellingen
van een ander opvragen" heeft hier geen vorm.

## Lezen mag iedereen, wijzigen alleen admin

Het antwoordadres bepaalt waar vragen van leveranciers van de héle organisatie
heen gaan. Een beoordelaar hoort dat niet te kunnen verleggen —
`@VereistRol('admin')` in de backend, niet alleen een verborgen menu-item.

Lezen is bewust ruimer: het scherm toont de instellingen ook aan wie ze niet mag
wijzigen, met de reden erbij. Een uitgegrijsd veld zonder uitleg leest als een
storing.

## Opgezet op uitbreiding

Op verzoek van de eigenaar ("houd rekening met uitbreiding"). `TenantWijziging`
heeft optionele velden en de UPDATE raakt alleen aan wat is meegegeven. Het
onderscheid tussen `null` (wissen) en afwezig (niet aanraken) is daarbij
wezenlijk: zonder dat zou een scherm dat straks de omgevingsnaam wijzigt het
antwoordadres stilzwijgend wissen.

Het scherm is opgebouwd uit secties, zodat een tweede sectie erbij past zonder
herbouw.

## Geen echte mail meer vanuit een testrun

**Dit is het belangrijkste deel van deze PR.**

Vandaag verstuurde `npm run verify:volledig` een echte uitnodigingsmail naar een
bestaand postvak. Twee op zichzelf onschuldige dingen kwamen samen:

1. `platform-routes.e2e-spec.ts` gebruikte een bestaand e-mailadres als
   testgegeven — dat stond er al maanden, en tot vandaag deed de route er niets
   mee.
2. De e2e-run erft `RESEND_API_KEY` uit `.env` via `jest-e2e.setup.ts`.

Sinds PR #114 verstuurt de platformroute een uitnodiging. Samen betekende dat:
post bij elke verificatierun.

Het adres is vervangen door `voorbeeld.nl`, maar dat is de zwakke helft van de
oplossing — het beschermt alleen tegen de adressen die iemand vandaag heeft
opgeschreven. De volgende suite die een uitnodiging verstuurt begint weer bij
nul.

`jest-e2e.setup.ts` wist daarom `RESEND_API_KEY`, en `geen-echte-mail.e2e-spec.ts`
bewaakt dat met twee tests: de variabele is weg, én `MailModule` kiest
aantoonbaar het `LogMailKanaal`. Zelfde vorm als `jest-e2e.guard.ts` voor de
database: niet vertrouwen op wat er in een test staat, maar het onmogelijk maken.

Gemeten, niet aangenomen: `dotenv` levert de echte sleutel wel degelijk aan, en
de setup wist hem.

## Verificatie

- **464 tests in 34 suites**, `verify:volledig` GROEN over de hele keten
- `tenant-instellingen.e2e-spec.ts`: 11 tests, waaronder de tegenproef dat een
  beoordelaar wél mag lezen en niet mag wijzigen, en dat een wijziging in de ene
  tenant de andere niet raakt
- `tenant-invoer.spec.ts`: 17 tests op het onderscheid wissen/niet-aanraken
- Browsertest in de frontend-repo (aparte PR): opslaan, herladen, en de
  oorspronkelijke waarde terugzetten

## Hoort bij

Frontend-PR in `MCM2-frontend`: het scherm `/beheer/instellingen` en het
menu-item. Backend eerst mergen — het scherm heeft de route nodig.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
