### PR TITLE
feat(demo): de voorbeelddata kan naar een bestaande tenant

### DIFF
--- a/scripts/seed-demo-tenant.js
+++ b/scripts/seed-demo-tenant.js
@@ -449,9 +449,29 @@ async function leveranciersAanmaken(db, vendors, gebruikers) {
 function vragenlijstenLaden() {
   const { execFileSync } = require('node:child_process');
 
+  // De doelwitvlaggen doorgeven aan het subproces.
+  //
+  // `seed-vragenlijsten.js` heeft zijn eigen `eisToestemmingBuitenLokaal()` en
+  // kijkt daarvoor naar zijn éígen argv — niet naar die van de aanroeper.
+  // Zonder deze regel stopt het bij een niet-lokaal doelwit terwijl het
+  // hoofdscript al toestemming heeft gekregen, en dan staan de leveranciers er
+  // wél en de vragenlijsten niet.
+  //
+  // Vastgesteld op 2026-08-09 bij het vullen van een tenant op productie: de
+  // seed strandde halverwege. Geen schade — beide scripts zijn idempotent —
+  // maar een halve seed is een verwarrende toestand, en de melding wees naar
+  // het subscript in plaats van naar de ontbrekende doorgifte.
+  const doorgeven = ['--extern', '--ook-beschermd'].filter((vlag) =>
+    process.argv.includes(vlag),
+  );
+
   execFileSync(
     process.execPath,
-    [path.join(__dirname, 'seed-vragenlijsten.js'), DEMO_TENANT_ID],
+    [
+      path.join(__dirname, 'seed-vragenlijsten.js'),
+      DEMO_TENANT_ID,
+      ...doorgeven,
+    ],
     { stdio: 'inherit' },
   );
 }

--- a/scripts/seed-demo-tenant.js
+++ b/scripts/seed-demo-tenant.js
@@ -49,8 +49,59 @@ const {
 // Vast UUID, zodat het script idempotent is en `--verwijder` precies weet wat
 // het weghaalt. Bewust niet 1111.../2222..., die zijn in gebruik bij
 // otap-doorloop.js en de e2e-suites.
-const DEMO_TENANT_ID = 'dededede-0000-4000-8000-000000000001';
-const DEMO_TENANT_NAAM = 'Demo (voorbeelddata)';
+const STANDAARD_TENANT_ID = 'dededede-0000-4000-8000-000000000001';
+const STANDAARD_TENANT_NAAM = 'Demo (voorbeelddata)';
+
+/**
+ * Naar welke tenant deze seed schrijft.
+ *
+ * ── Waarom dit instelbaar is ────────────────────────────────────────────────
+ *
+ * Tot 2026-08-09 stond hier alleen het vaste UUID hierboven, en dat is voor de
+ * demo-database precies goed: één herkenbare tenant die het script zelf
+ * aanmaakt en zelf opruimt.
+ *
+ * Maar de eigenaar wilde dezelfde voorbeelddata in een bestáánde tenant
+ * (AlingAdvies, aangemaakt via de platformroute), om die als demo-omgeving te
+ * gebruiken. Zonder deze vlag zou het script daar een tweede tenant naast
+ * zetten in plaats van de bestaande te vullen.
+ *
+ * ── Wat de vlag NIET doet ───────────────────────────────────────────────────
+ *
+ * Een tenant aanmaken die niet bestaat. Bij `--tenant` moet de tenant er al
+ * zijn: die hoort via de platformroute te ontstaan, met een uitnodiging voor
+ * zijn beheerder. Een seed die stilzwijgend tenants aanmaakt in een echte
+ * omgeving is precies het soort script dat je niet wilt hebben.
+ */
+function leesDoelTenant(argv) {
+  const index = argv.indexOf('--tenant');
+
+  if (index === -1) {
+    return { id: STANDAARD_TENANT_ID, eigen: true };
+  }
+
+  const waarde = argv[index + 1];
+
+  if (!waarde || waarde.startsWith('--')) {
+    console.error('\n--tenant verwacht een tenant-UUID erachter.\n');
+    process.exit(1);
+  }
+
+  if (
+    !/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(
+      waarde,
+    )
+  ) {
+    console.error(`\n'${waarde}' is geen geldig UUID.\n`);
+    process.exit(1);
+  }
+
+  return { id: waarde.toLowerCase(), eigen: false };
+}
+
+const DOEL = leesDoelTenant(process.argv);
+const DEMO_TENANT_ID = DOEL.id;
+const DEMO_TENANT_NAAM = STANDAARD_TENANT_NAAM;
 
 // Herkenbaar niet-echt. Een verzonnen UUID hier zou niet te onderscheiden zijn
 // van een echte Entra-oid: dan kan niemand later nog zien welke gebruikers
@@ -238,6 +289,19 @@ async function tenantAanmaken(db) {
 
       if (bestaand.rows.length > 0) {
         return { nieuw: false, naam: bestaand.rows[0].name };
+      }
+
+      // Met --tenant hoort de tenant al te bestaan: die ontstaat via de
+      // platformroute, met een uitnodiging voor zijn beheerder. Hem hier
+      // alsnog aanmaken zou een tenant opleveren zonder beheerder en zonder
+      // spoor in de audit trail — en bij een typefout in het UUID zou dat
+      // stilzwijgend gebeuren.
+      if (!DOEL.eigen) {
+        throw new Error(
+          `Tenant ${DEMO_TENANT_ID} bestaat niet.\n\n` +
+            'Met --tenant vult dit script een bestáánde tenant. Controleer het\n' +
+            'UUID, of maak de tenant eerst aan via POST /platform/tenants.',
+        );
       }
 
       await tx.execute(
@@ -853,8 +917,20 @@ async function verwijderen(db) {
     sql`DELETE FROM clm.vendor_tag WHERE tenant_id = ${DEMO_TENANT_ID}`,
     sql`DELETE FROM clm.vendor_contact WHERE tenant_id = ${DEMO_TENANT_ID}`,
     sql`DELETE FROM clm.vendor WHERE tenant_id = ${DEMO_TENANT_ID}`,
-    sql`DELETE FROM clm.tenant_membership WHERE tenant_id = ${DEMO_TENANT_ID}`,
-    sql`DELETE FROM clm.user WHERE tenant_id = ${DEMO_TENANT_ID}`,
+    // Alleen de demo-gebruikers, herkenbaar aan hun voorvoegsel.
+    //
+    // Tot 2026-08-09 stond hier `WHERE tenant_id = …` zonder meer, en dat kon
+    // ook: in een tenant die dit script zelf aanmaakt zijn álle gebruikers van
+    // dit script. Met --tenant is dat niet langer waar — daar staat de echte
+    // beheerder tussen, en die mag een opruimactie nooit raken.
+    sql`DELETE FROM clm.tenant_membership
+         WHERE tenant_id = ${DEMO_TENANT_ID}
+           AND user_id IN (SELECT user_id FROM clm.user
+                            WHERE tenant_id = ${DEMO_TENANT_ID}
+                              AND external_subject LIKE ${`${DEMO_SUBJECT_PREFIX}%`})`,
+    sql`DELETE FROM clm.user
+         WHERE tenant_id = ${DEMO_TENANT_ID}
+           AND external_subject LIKE ${`${DEMO_SUBJECT_PREFIX}%`}`,
   ];
 
   await db.transaction(async (tx) =>
@@ -875,9 +951,15 @@ async function verwijderen(db) {
 
       // De tenantrij als laatste, binnen dezelfde context — zie
       // tenantAanmaken() voor waarom dat binnen de context moet.
-      await tx.execute(
-        sql`DELETE FROM clm.tenant WHERE tenant_id = ${DEMO_TENANT_ID}`,
-      );
+      //
+      // Maar alléén wanneer dit script de tenant zelf heeft aangemaakt. Met
+      // --tenant is hij van iemand anders: daar haalt opruimen de voorbeelddata
+      // weg en blijft de omgeving met zijn beheerder staan.
+      if (DOEL.eigen) {
+        await tx.execute(
+          sql`DELETE FROM clm.tenant WHERE tenant_id = ${DEMO_TENANT_ID}`,
+        );
+      }
     }),
   );
 }
@@ -977,7 +1059,12 @@ async function main() {
 
     if (moetVerwijderen) {
       await verwijderen(db);
-      console.log(`Demo-tenant ${DEMO_TENANT_ID} verwijderd.`);
+      console.log(
+        DOEL.eigen
+          ? `Demo-tenant ${DEMO_TENANT_ID} verwijderd.`
+          : `Voorbeelddata uit tenant ${DEMO_TENANT_ID} verwijderd.\n` +
+              'De tenant zelf en zijn eigen gebruikers zijn ongemoeid gebleven.',
+      );
       return;
     }
 

--- a/scripts/seed-vragenlijsten.js
+++ b/scripts/seed-vragenlijsten.js
@@ -59,8 +59,16 @@ function laadValidatie() {
 }
 
 function bestandenUitArgumenten(argumenten) {
-  if (argumenten.length > 0) {
-    return argumenten.map((naam) =>
+  // Vlaggen zijn geen bestandsnamen. Zonder deze regel wordt `--extern` gelezen
+  // als `db/seeds/--extern`, en dan laadt dit script nul vragenlijsten met de
+  // melding dat het bestand niet bestaat — terwijl de aanroeper alleen
+  // toestemming voor een niet-lokaal doelwit gaf.
+  //
+  // Nodig sinds seed-demo-tenant.js zijn doelwitvlaggen doorgeeft (2026-08-09).
+  const bestanden = argumenten.filter((naam) => !naam.startsWith('--'));
+
+  if (bestanden.length > 0) {
+    return bestanden.map((naam) =>
       path.isAbsolute(naam) ? naam : path.join(SEEDMAP, naam),
     );
   }


### PR DESCRIPTION
De eigenaar wil AlingAdvies als demo-omgeving gebruiken, met dezelfde
voorbeelddata die de demo-database heeft. Het tenant-id stond hardgecodeerd, dus
zonder deze vlag zou het script daar een tweede tenant naast zetten in plaats van
de bestaande te vullen.

```
(geen vlag)   → tenant dededede-…, aangemaakt en opgeruimd door dit script
--tenant <id> → een bestaande tenant, die van iemand anders is
```

## Dat verschil bepaalt drie dingen

**1. Met `--tenant` maakt het script géén tenant aan.** Bestaat hij niet, dan
stopt het met een melding. Een tenant hoort via de platformroute te ontstaan, met
een uitnodiging voor zijn beheerder; een seed die er stilzwijgend een aanmaakt
bij een typefout in het UUID is precies wat je niet wilt.

**2. `--verwijder` haalt alleen de demo-gebruikers weg**, herkenbaar aan hun
`demo:`-voorvoegsel. Tot nu toe stond er `DELETE FROM clm.user WHERE tenant_id = …`
zonder meer — in een eigen tenant klopt dat, want daar zijn álle gebruikers van
het script. In een echte tenant zou het de beheerder verwijderen.

**3. `--verwijder` laat de tenantrij staan.** Opruimen haalt de voorbeelddata weg;
de omgeving, zijn instellingen en zijn beheerder blijven.

## De fout die de generale repetitie niet ving

Bij de echte uitvoering strandde de seed halverwege: leveranciers erin,
vragenlijsten niet.

`seed-demo-tenant.js` roept `seed-vragenlijsten.js` aan als subproces, en dat
heeft zijn eigen `eisToestemmingBuitenLokaal()` die naar zijn **eigen** argv
kijkt. Het hoofdscript had toestemming, het subscript niet — dus dat stopte,
terecht.

Niet gevangen in de repetitie omdat die tegen localhost draaide, waar die
controle niet aanslaat. Geen schade — beide scripts zijn idempotent, de tweede
poging maakte het af — maar een halve seed is een verwarrende toestand.

Twee wijzigingen: het hoofdscript geeft `--extern` en `--ook-beschermd` door, en
het subscript filtert vlaggen uit zijn bestandsargumenten (anders wordt
`--extern` gelezen als `db/seeds/--extern`).

## Beproefd vóór productie

Een kopie van de productiestand nagebootst — tenant AlingAdvies met één echte
beheerder — en daarop:

| Stap | Uitkomst |
|---|---|
| Seeden | 21 leveranciers, 2 vragenlijsten, 3 demo-gebruikers |
| Echte beheerder ná seeden | intact, met antwoordadres |
| Opruimen | tenant blijft, beheerder blijft, 0 leveranciers |
| Opnieuw seeden | zelfde uitkomst |
| Onbekend tenant-UUID | weigert met een melding |
| Halve seed afmaken | `Leveranciers: 21 (0 nieuw)`, vragenlijsten erbij |

Die laatste is een aparte proef geweest: verse database, seed met de oude
kapotte doorgifte, daarna de fix erop — precies de situatie die op productie
ontstond.

## Verificatie

464 tests in 34 suites. De bestaande weg zonder vlag levert onveranderd 21
leveranciers en 2 vragenlijsten in de demo-tenant.

## Al uitgevoerd op productie

Tenant AlingAdvies is gevuld: 21 leveranciers, 2 vragenlijsten, 2 rondes, 6
responses (3 pending, 3 submitted), 3 demo-gebruikers naast de echte beheerder.
Teruggelezen uit de database, niet aangenomen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
