### PR TITLE
feat(survey): route voor de uitvragen van één leverancier

### DIFF
--- a/scripts/seed-demo-tenant.js
+++ b/scripts/seed-demo-tenant.js
@@ -449,9 +449,29 @@ async function leveranciersAanmaken(db, vendors, gebruikers) {
 function vragenlijstenLaden() {
   const { execFileSync } = require('node:child_process');
 
+  // De doelwitvlaggen doorgeven aan het subproces.
+  //
+  // `seed-vragenlijsten.js` heeft zijn eigen `eisToestemmingBuitenLokaal()` en
+  // kijkt daarvoor naar zijn éígen argv — niet naar die van de aanroeper.
+  // Zonder deze regel stopt het bij een niet-lokaal doelwit terwijl het
+  // hoofdscript al toestemming heeft gekregen, en dan staan de leveranciers er
+  // wél en de vragenlijsten niet.
+  //
+  // Vastgesteld op 2026-08-09 bij het vullen van een tenant op productie: de
+  // seed strandde halverwege. Geen schade — beide scripts zijn idempotent —
+  // maar een halve seed is een verwarrende toestand, en de melding wees naar
+  // het subscript in plaats van naar de ontbrekende doorgifte.
+  const doorgeven = ['--extern', '--ook-beschermd'].filter((vlag) =>
+    process.argv.includes(vlag),
+  );
+
   execFileSync(
     process.execPath,
-    [path.join(__dirname, 'seed-vragenlijsten.js'), DEMO_TENANT_ID],
+    [
+      path.join(__dirname, 'seed-vragenlijsten.js'),
+      DEMO_TENANT_ID,
+      ...doorgeven,
+    ],
     { stdio: 'inherit' },
   );
 }

--- a/scripts/seed-demo-tenant.js
+++ b/scripts/seed-demo-tenant.js
@@ -49,8 +49,59 @@ const {
 // Vast UUID, zodat het script idempotent is en `--verwijder` precies weet wat
 // het weghaalt. Bewust niet 1111.../2222..., die zijn in gebruik bij
 // otap-doorloop.js en de e2e-suites.
-const DEMO_TENANT_ID = 'dededede-0000-4000-8000-000000000001';
-const DEMO_TENANT_NAAM = 'Demo (voorbeelddata)';
+const STANDAARD_TENANT_ID = 'dededede-0000-4000-8000-000000000001';
+const STANDAARD_TENANT_NAAM = 'Demo (voorbeelddata)';
+
+/**
+ * Naar welke tenant deze seed schrijft.
+ *
+ * ── Waarom dit instelbaar is ────────────────────────────────────────────────
+ *
+ * Tot 2026-08-09 stond hier alleen het vaste UUID hierboven, en dat is voor de
+ * demo-database precies goed: één herkenbare tenant die het script zelf
+ * aanmaakt en zelf opruimt.
+ *
+ * Maar de eigenaar wilde dezelfde voorbeelddata in een bestáánde tenant
+ * (AlingAdvies, aangemaakt via de platformroute), om die als demo-omgeving te
+ * gebruiken. Zonder deze vlag zou het script daar een tweede tenant naast
+ * zetten in plaats van de bestaande te vullen.
+ *
+ * ── Wat de vlag NIET doet ───────────────────────────────────────────────────
+ *
+ * Een tenant aanmaken die niet bestaat. Bij `--tenant` moet de tenant er al
+ * zijn: die hoort via de platformroute te ontstaan, met een uitnodiging voor
+ * zijn beheerder. Een seed die stilzwijgend tenants aanmaakt in een echte
+ * omgeving is precies het soort script dat je niet wilt hebben.
+ */
+function leesDoelTenant(argv) {
+  const index = argv.indexOf('--tenant');
+
+  if (index === -1) {
+    return { id: STANDAARD_TENANT_ID, eigen: true };
+  }
+
+  const waarde = argv[index + 1];
+
+  if (!waarde || waarde.startsWith('--')) {
+    console.error('\n--tenant verwacht een tenant-UUID erachter.\n');
+    process.exit(1);
+  }
+
+  if (
+    !/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(
+      waarde,
+    )
+  ) {
+    console.error(`\n'${waarde}' is geen geldig UUID.\n`);
+    process.exit(1);
+  }
+
+  return { id: waarde.toLowerCase(), eigen: false };
+}
+
+const DOEL = leesDoelTenant(process.argv);
+const DEMO_TENANT_ID = DOEL.id;
+const DEMO_TENANT_NAAM = STANDAARD_TENANT_NAAM;
 
 // Herkenbaar niet-echt. Een verzonnen UUID hier zou niet te onderscheiden zijn
 // van een echte Entra-oid: dan kan niemand later nog zien welke gebruikers
@@ -238,6 +289,19 @@ async function tenantAanmaken(db) {
 
       if (bestaand.rows.length > 0) {
         return { nieuw: false, naam: bestaand.rows[0].name };
+      }
+
+      // Met --tenant hoort de tenant al te bestaan: die ontstaat via de
+      // platformroute, met een uitnodiging voor zijn beheerder. Hem hier
+      // alsnog aanmaken zou een tenant opleveren zonder beheerder en zonder
+      // spoor in de audit trail — en bij een typefout in het UUID zou dat
+      // stilzwijgend gebeuren.
+      if (!DOEL.eigen) {
+        throw new Error(
+          `Tenant ${DEMO_TENANT_ID} bestaat niet.\n\n` +
+            'Met --tenant vult dit script een bestáánde tenant. Controleer het\n' +
+            'UUID, of maak de tenant eerst aan via POST /platform/tenants.',
+        );
       }
 
       await tx.execute(
@@ -853,8 +917,20 @@ async function verwijderen(db) {
     sql`DELETE FROM clm.vendor_tag WHERE tenant_id = ${DEMO_TENANT_ID}`,
     sql`DELETE FROM clm.vendor_contact WHERE tenant_id = ${DEMO_TENANT_ID}`,
     sql`DELETE FROM clm.vendor WHERE tenant_id = ${DEMO_TENANT_ID}`,
-    sql`DELETE FROM clm.tenant_membership WHERE tenant_id = ${DEMO_TENANT_ID}`,
-    sql`DELETE FROM clm.user WHERE tenant_id = ${DEMO_TENANT_ID}`,
+    // Alleen de demo-gebruikers, herkenbaar aan hun voorvoegsel.
+    //
+    // Tot 2026-08-09 stond hier `WHERE tenant_id = …` zonder meer, en dat kon
+    // ook: in een tenant die dit script zelf aanmaakt zijn álle gebruikers van
+    // dit script. Met --tenant is dat niet langer waar — daar staat de echte
+    // beheerder tussen, en die mag een opruimactie nooit raken.
+    sql`DELETE FROM clm.tenant_membership
+         WHERE tenant_id = ${DEMO_TENANT_ID}
+           AND user_id IN (SELECT user_id FROM clm.user
+                            WHERE tenant_id = ${DEMO_TENANT_ID}
+                              AND external_subject LIKE ${`${DEMO_SUBJECT_PREFIX}%`})`,
+    sql`DELETE FROM clm.user
+         WHERE tenant_id = ${DEMO_TENANT_ID}
+           AND external_subject LIKE ${`${DEMO_SUBJECT_PREFIX}%`}`,
   ];
 
   await db.transaction(async (tx) =>
@@ -875,9 +951,15 @@ async function verwijderen(db) {
 
       // De tenantrij als laatste, binnen dezelfde context — zie
       // tenantAanmaken() voor waarom dat binnen de context moet.
-      await tx.execute(
-        sql`DELETE FROM clm.tenant WHERE tenant_id = ${DEMO_TENANT_ID}`,
-      );
+      //
+      // Maar alléén wanneer dit script de tenant zelf heeft aangemaakt. Met
+      // --tenant is hij van iemand anders: daar haalt opruimen de voorbeelddata
+      // weg en blijft de omgeving met zijn beheerder staan.
+      if (DOEL.eigen) {
+        await tx.execute(
+          sql`DELETE FROM clm.tenant WHERE tenant_id = ${DEMO_TENANT_ID}`,
+        );
+      }
     }),
   );
 }
@@ -977,7 +1059,12 @@ async function main() {
 
     if (moetVerwijderen) {
       await verwijderen(db);
-      console.log(`Demo-tenant ${DEMO_TENANT_ID} verwijderd.`);
+      console.log(
+        DOEL.eigen
+          ? `Demo-tenant ${DEMO_TENANT_ID} verwijderd.`
+          : `Voorbeelddata uit tenant ${DEMO_TENANT_ID} verwijderd.\n` +
+              'De tenant zelf en zijn eigen gebruikers zijn ongemoeid gebleven.',
+      );
       return;
     }
 

--- a/scripts/seed-vragenlijsten.js
+++ b/scripts/seed-vragenlijsten.js
@@ -59,8 +59,16 @@ function laadValidatie() {
 }
 
 function bestandenUitArgumenten(argumenten) {
-  if (argumenten.length > 0) {
-    return argumenten.map((naam) =>
+  // Vlaggen zijn geen bestandsnamen. Zonder deze regel wordt `--extern` gelezen
+  // als `db/seeds/--extern`, en dan laadt dit script nul vragenlijsten met de
+  // melding dat het bestand niet bestaat — terwijl de aanroeper alleen
+  // toestemming voor een niet-lokaal doelwit gaf.
+  //
+  // Nodig sinds seed-demo-tenant.js zijn doelwitvlaggen doorgeeft (2026-08-09).
+  const bestanden = argumenten.filter((naam) => !naam.startsWith('--'));
+
+  if (bestanden.length > 0) {
+    return bestanden.map((naam) =>
       path.isAbsolute(naam) ? naam : path.join(SEEDMAP, naam),
     );
   }

--- a/src/survey/vragenlijst-beheer.controller.ts
+++ b/src/survey/vragenlijst-beheer.controller.ts
@@ -352,6 +352,29 @@ export class VragenlijstBeheerController {
     return { werkvoorraad, scope: heleOrganisatie ? 'organisatie' : 'mij' };
   }
 
+  /**
+   * De uitvragen van één leverancier — de databron voor het paneel op zijn
+   * detailpagina.
+   *
+   * Geen `@VereistRol`: dit is lezen, en een beoordelaar mag zien wat er bij
+   * een leverancier loopt. Dezelfde afweging als bij `runs` en `templates`.
+   *
+   * De vendorId komt uit het pad, de tenant uit de sessie. RLS zorgt dat een
+   * vendorId uit een andere tenant hier niets oplevert — geen 403 maar een lege
+   * lijst, want het bestaan van die leverancier is zelf al informatie.
+   */
+  @Get('vendors/:id/uitvragen')
+  async uitvragenVanVendor(
+    @Req() request: RequestMetSessie,
+    @Param('id') id: string,
+  ) {
+    const sessie = request.sessie!;
+
+    const uitvragen = await this.beheer.uitvragenVanVendor(sessie.tenantId, id);
+
+    return { uitvragen };
+  }
+
   /** Wie er aan deze vragenlijst gekoppeld zijn als beoordelaar. */
   @Get('templates/:id/reviewers')
   async reviewers(@Req() request: RequestMetSessie, @Param('id') id: string) {

--- a/src/survey/vragenlijst-beheer.service.ts
+++ b/src/survey/vragenlijst-beheer.service.ts
@@ -91,6 +91,28 @@ export interface RondeSamenvatting {
   aantalIngediend: number;
 }
 
+/**
+ * Eén uitvraag zoals hij op de leverancierspagina getoond wordt.
+ *
+ * Bewust vanuit de leverancier gezien en niet vanuit de ronde: wat een
+ * contractmanager wil weten is "wat loopt er bij Siemens", niet "wie zat er in
+ * ronde 3". Vandaar dat de respons hier de hoofdzaak is en de ronde de context.
+ */
+export interface VendorUitvraag {
+  responseId: string;
+  runId: string;
+  templateNaam: string;
+  /** `pending`, `submitted` of `revoked`. */
+  status: string;
+  isTest: boolean;
+  startedAt: string | null;
+  verlooptOp: string | null;
+  ingediendOp: string | null;
+  /** Waar de hele ronde is ingetrokken; dan telt deze uitvraag niet meer. */
+  rondeIngetrokken: boolean;
+  aantalBeoordelingen: number;
+}
+
 /** Eén deelnemer aan een ronde. */
 export interface DeelnemerSamenvatting {
   responseId: string;
@@ -452,6 +474,87 @@ export class VragenlijstBeheerService {
         );
 
         return resultaat.rows.map((r) => this.naarRonde(r));
+      },
+      'medewerker',
+    );
+  }
+
+  /**
+   * De uitvragen van één leverancier, nieuwste eerst.
+   *
+   * ── Waarom deze route bestaat ───────────────────────────────────────────────
+   *
+   * Op 2026-08-09 nodigde de eigenaar een leverancier uit, kreeg de mail,
+   * vulde de vragenlijst in en diende hem in — en kon in de app nergens
+   * terugvinden dát hij hem had uitgestuurd, laat staan dat er antwoord was.
+   *
+   * De data stond er wel. Alleen: wie wil weten hoe het met één leverancier
+   * staat, moet bij Rondes zijn en daar de juiste ronde zoeken. Dat is de
+   * omgekeerde vraag van wat een contractmanager stelt — die kijkt naar de
+   * leverancier, niet naar de ronde.
+   *
+   * MVM_V2 lost dat op met een `VendorSurveyPanel` op de leverancierspagina
+   * (src/shared/components/VendorSurveyPanel.tsx). Deze methode is de
+   * databron daarvoor.
+   *
+   * ── Wat er bewust niet in zit ───────────────────────────────────────────────
+   *
+   * Scores. MVM_V2 toont er een (`4.2 / 5` met een trendpijl), maar dat vraagt
+   * een scoreberekening die MCM2 niet heeft. Liever tonen wat er is —
+   * uitgenodigd, ingediend, beoordeeld — dan een getal dat nergens op rust.
+   */
+  async uitvragenVanVendor(
+    tenantId: string,
+    vendorId: string,
+  ): Promise<VendorUitvraag[]> {
+    return this.db.withTenant(
+      tenantId,
+      async (tx) => {
+        const { rows } = await tx.execute<{
+          response_id: string;
+          run_id: string;
+          template_naam: string;
+          status: string;
+          is_test: boolean;
+          started_at: Date | null;
+          expires_at: Date | null;
+          submitted_at: Date | null;
+          run_status: string;
+          revoked_at: Date | null;
+          aantal_beoordelingen: string;
+        }>(
+          sql`SELECT resp.response_id,
+                     run.run_id,
+                     t.name          AS template_naam,
+                     resp.status,
+                     run.is_test,
+                     run.started_at,
+                     resp.expires_at,
+                     resp.submitted_at,
+                     run.status      AS run_status,
+                     run.revoked_at,
+                     (SELECT count(*) FROM clm.survey_review rev
+                       WHERE rev.response_id = resp.response_id
+                         AND rev.deleted_at IS NULL) AS aantal_beoordelingen
+                FROM clm.survey_response resp
+                JOIN clm.survey_run run ON run.run_id = resp.run_id
+                JOIN clm.survey_template t ON t.template_id = run.template_id
+               WHERE resp.vendor_id = ${vendorId}
+               ORDER BY run.started_at DESC NULLS LAST, t.name`,
+        );
+
+        return rows.map((r) => ({
+          responseId: r.response_id,
+          runId: r.run_id,
+          templateNaam: r.template_naam,
+          status: r.status,
+          isTest: r.is_test,
+          startedAt: iso(r.started_at),
+          verlooptOp: iso(r.expires_at),
+          ingediendOp: iso(r.submitted_at),
+          rondeIngetrokken: r.revoked_at !== null,
+          aantalBeoordelingen: getal(r.aantal_beoordelingen),
+        }));
       },
       'medewerker',
     );

--- a/test/vragenlijst-beheer-routes.e2e-spec.ts
+++ b/test/vragenlijst-beheer-routes.e2e-spec.ts
@@ -562,6 +562,87 @@ describe('Vragenlijst-beheerroutes (e2e)', () => {
     });
   });
 
+  describe('de uitvragen van één leverancier', () => {
+    /**
+     * ── Waarom deze route bestaat ─────────────────────────────────────────
+     *
+     * Op 2026-08-09 nodigde de eigenaar een leverancier uit, kreeg de mail,
+     * vulde de vragenlijst in en diende hem in — en kon in de app nergens
+     * terugvinden dát hij hem had uitgestuurd. De data stond er wel, maar
+     * alleen te vinden via Rondes, en dat is de omgekeerde vraag van wat een
+     * contractmanager stelt.
+     */
+    it('toont wat er bij deze leverancier loopt', async () => {
+      const antwoord = await request(server)
+        .get(`/admin/survey/vendors/${VENDOR_A}/uitvragen`)
+        .set('Cookie', cookieA)
+        .expect(200);
+
+      const { uitvragen } = antwoord.body as {
+        uitvragen: Array<Record<string, unknown>>;
+      };
+
+      expect(uitvragen).toHaveLength(1);
+      expect(uitvragen[0].responseId).toBe(RESPONSE_A);
+      expect(uitvragen[0].runId).toBe(RUN_A);
+      expect(uitvragen[0].status).toBe('pending');
+      expect(uitvragen[0].ingediendOp).toBeNull();
+      expect(uitvragen[0].templateNaam).toBeTruthy();
+    });
+
+    it('lekt het token niet', async () => {
+      // Het paneel toont de status van een uitvraag, niet de sleutel ernaartoe.
+      // Zou de hash meekomen, dan staat sleutelmateriaal in een scherm dat
+      // iedereen met een sessie mag openen.
+      const antwoord = await request(server)
+        .get(`/admin/survey/vendors/${VENDOR_A}/uitvragen`)
+        .set('Cookie', cookieA)
+        .expect(200);
+
+      const ruw = JSON.stringify(antwoord.body);
+
+      expect(ruw).not.toContain(TOKEN_HASH);
+      expect(ruw).not.toContain('token');
+    });
+
+    it('laat een reviewer meekijken', async () => {
+      // Lezen mag: wie beoordeelt, hoort te zien wat er bij een leverancier
+      // loopt. Dezelfde afweging als bij rondes en vragenlijsten.
+      await request(server)
+        .get(`/admin/survey/vendors/${VENDOR_A}/uitvragen`)
+        .set('Cookie', cookieReviewer)
+        .expect(200);
+    });
+
+    it('geeft een lege lijst voor een leverancier van een andere tenant', async () => {
+      // Geen 403 maar niets: dat een vendorId elders bestaat is zelf al
+      // informatie. RLS doet het werk, de route hoeft niets te weten.
+      const antwoord = await request(server)
+        .get(`/admin/survey/vendors/${VENDOR_A}/uitvragen`)
+        .set('Cookie', cookieB)
+        .expect(200);
+
+      expect((antwoord.body as { uitvragen: unknown[] }).uitvragen).toEqual([]);
+    });
+
+    it('geeft een lege lijst voor een onbekende leverancier', async () => {
+      const antwoord = await request(server)
+        .get(
+          '/admin/survey/vendors/00000000-0000-0000-0000-00000000dead/uitvragen',
+        )
+        .set('Cookie', cookieA)
+        .expect(200);
+
+      expect((antwoord.body as { uitvragen: unknown[] }).uitvragen).toEqual([]);
+    });
+
+    it('weigert zonder sessie', async () => {
+      await request(server)
+        .get(`/admin/survey/vendors/${VENDOR_A}/uitvragen`)
+        .expect(401);
+    });
+  });
+
   describe('onbekende id’s', () => {
     it('geeft 404 op een niet-bestaande vragenlijst', async () => {
       await request(server)


### PR DESCRIPTION
De eigenaar nodigde een leverancier uit, kreeg de mail, vulde de vragenlijst in
en diende hem in — en kon in de app nergens terugvinden dát hij hem had
uitgestuurd, laat staan dat er antwoord was.

**De data stond er wel.** Teruggelezen uit productie: response `submitted`, 8
antwoorden, ronde met 1 van 1 ingediend. Maar ze was uitsluitend te vinden via
Rondes, en dat is de omgekeerde vraag van wat een contractmanager stelt. Die
kijkt naar de leverancier, niet naar de ronde.

## De route

`GET /admin/survey/vendors/:id/uitvragen` levert per leverancier zijn uitvragen,
nieuwste eerst: welke vragenlijst, wanneer uitgestuurd, wanneer ingediend, en of
er al beoordeeld is.

Naar het voorbeeld van `VendorSurveyPanel` in MVM_V2, dat dezelfde plek invult.
Eén verschil: MVM_V2 toont een score (`4.2 / 5` met trendpijl). Dat vraagt een
scoreberekening die MCM2 niet heeft — liever tonen wat er is dan een getal dat
nergens op rust.

## Rechten en grenzen

**Geen `@VereistRol`.** Lezen mag een reviewer ook, net als bij `runs` en
`templates`. Wie beoordeelt, hoort te zien wat er bij een leverancier loopt.

**De vendorId komt uit het pad, de tenant uit de sessie.** Een vendorId uit een
andere tenant levert een lege lijst op, geen 403 — dat een leverancier elders
bestaat is zelf al informatie. RLS doet het werk; de route hoeft niets te weten.

## Zes tests

Waaronder twee tegenproeven die ertoe doen:

- **het token lekt niet mee** — het paneel toont de status van een uitvraag,
  niet de sleutel ernaartoe. Zou de hash meekomen, dan staat sleutelmateriaal in
  een scherm dat iedereen met een sessie mag openen.
- **een leverancier van een andere tenant geeft een lege lijst**, niet een fout.

## Verificatie

470 tests in 34 suites, `verify:volledig` GROEN over de hele keten inclusief 60
browsertests.

## Hoort bij

Frontend-PR in `MCM2-frontend`: het paneel op de leverancierspagina. Backend
eerst mergen — het paneel heeft de route nodig.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
