### PR TITLE
docs: staging bestaat — architectuur en onderhoud bijgewerkt

### DIFF
--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -2,17 +2,91 @@
 
 ## Laatst bijgewerkt
 
-**2026-08-10, avond.** De OTAP-keten is af en beproefd: acceptatie en productie
-draaien op `saxombp`, een image promoveert van de ene naar de andere, en
-terugdraaien werkt. Daarnaast: een onderhoudskalender met een poort die faalt als
-hij veroudert, een startscherm in de frontend, en vier documenten bijgewerkt die
-tot twee weken achterliepen.
+**2026-08-10, laat op de avond.** Twee dingen deze dag, en het tweede kwam voort
+uit een fout.
 
-Geen open PR's.
+Overdag: de OTAP-keten op `saxombp` af en beproefd, een onderhoudskalender met
+een poort die faalt als hij veroudert, een startscherm in de frontend.
+
+'s Avonds: vastgesteld dat die keten **niet uitkomt op de database die ertoe
+doet**. Daar is een plan voor geschreven en de eerste stap is uitgevoerd — er is
+nu een **stagingomgeving bij Supabase** die aantoonbaar gelijk is aan productie.
 
 ---
 
-## 🔵 MORGEN BEGINNEN: de frontend promoveerbaar maken (Issue #51)
+## ⚠️ EERST LEZEN: wat er op 10-08 is misgegaan
+
+**De productiedatabase is leeggemaakt op basis van een meetfout.**
+
+Wat er gebeurde: een query op `clm.tenant` zonder tenantcontext gaf nul rijen.
+Dat werd gelezen als "de database is kapot", terwijl RLS gewoon zijn werk deed —
+de tenant AlingAdvies bestond gewoon, hij was alleen niet zichtbaar zonder de
+juiste context. Op die verkeerde meting is een diagnose gebouwd, en op die
+diagnose is toestemming gevraagd om op te ruimen.
+
+**Weg:** tenant AlingAdvies (`c9f2a68a…`), 21 leveranciers, 2 vragenlijsten,
+7 responses, 34 antwoorden, 4 oordelen, 3 notities, 5 gebruikers, 1 bijlage.
+Een gedeeltelijke backup staat in de scratchpad (alleen gebruikers, memberships
+en sessies — niet de leveranciers en antwoorden).
+
+**Wat dit betekent, en waarom het het plan draagt:** de fout was menselijk, maar
+de *gevolgen* waren onmiddellijk omdat er niets tussen zat. Geen goedkeuring,
+geen afgedwongen backup, geen omgeving waar het eerst had moeten gebeuren.
+Zolang de enige weg naar productie een mens met een laptop is, is elke verkeerde
+inschatting direct dataverlies.
+
+Twee lessen die in de code horen:
+
+1. **In een database met RLS betekent nul rijen niet dat er niets staat.** Het
+   betekent dat je niets mag zien. Zet altijd `app.current_tenant_id` voordat je
+   een conclusie trekt over vulling.
+2. **Toon het doelwit, niet alleen de handeling.** Later die avond gaf ik
+   `DATABASE_URL` mee aan `markeer-wegwerp.js`, dat `MIGRATION_DATABASE_URL`
+   leest — het pakte productie uit `.env`. De rem hield het tegen, en de
+   projectreferentie in de melding maakte zichtbaar wat er werkelijk gebeurde.
+
+---
+
+## 🔵 MORGEN BEGINNEN
+
+**Lees eerst:** [`docs/architectuur/plan-otap-straat-met-staging.md`](architectuur/plan-otap-straat-met-staging.md).
+Dat is het plan waar de rest van dit hoofdstuk uit volgt. Stap 2 van de negen is
+gisteren gedaan; morgen begint bij **stap 1 (Issue #51)** en **stap 3**.
+
+### Wat er gisteravond is neergezet: staging
+
+| | Productie | Staging |
+|---|---|---|
+| Project | `clm-enterprise` | `clm-staging3` |
+| Ref | `agojesdovwsupidwlevh` | `ljdldwfylcbubzglxjoa` |
+| Postgres | 17.6 | 17.6 |
+| Regio | eu-west-1 | eu-west-1 |
+| Migraties | 26 | 26 |
+| Tabellen | 23 | 23 |
+| RLS in `clm` | 17/19 | 17/19 |
+| FORCE RLS | 12 | 12 |
+| `clm.omgeving` | `beschermd` | `wegwerp` |
+
+Alles teruggelezen uit beide databases en naast elkaar gelegd — niet aangenomen
+uit een melding die "voltooid" zei.
+
+**Rollen aangemaakt** via `db/roles/bootstrap-roles.sql`: zes stuks, `clm_migrator`
+en `clm_api_runtime` inlogbaar, geen enkele met BYPASSRLS.
+
+**Verbindingsgegevens** staan in de scratchpad van de sessie van 10-08:
+`staging.txt` (postgres), `staging-migrator.txt`, `staging-runtime.txt`. Die
+verdwijnen bij het opruimen van de sessie — ze horen als GitHub secret te
+worden vastgelegd zodra de straat gebouwd wordt. **Is dat nog niet gebeurd en
+zijn ze weg, dan is een wachtwoordreset nodig** (zie waarschuwing hieronder).
+
+> **Val bij Supabase, kost twee uur op 10-08:** een wachtwoord *resetten* komt
+> niet altijd door bij de connection pooler — drie resets, drie keer
+> "password authentication failed", ook na een projectherstart. Het wachtwoord
+> **bij het aanmaken van het project zelf instellen** werkte meteen. Loop je hier
+> weer tegenaan: nieuw project, wachtwoord zelf intypen, niet genereren.
+> Alfanumeriek houden, want `@ : / ? # % &` breken de connectiestring.
+
+### Dan: de frontend promoveerbaar maken (Issue #51)
 
 Dit is de enige plek waar de keten van vandaag nog niet dekt.
 
@@ -156,7 +230,8 @@ handmatig te starten is (PR #122).
 
 | # | Wat | Waarom nu |
 |---|---|---|
-| **#51** | Frontend promoveerbaar maken | Blokkeert de helft van de OTAP-keten — zie bovenaan |
+| — | **Geen geautomatiseerde uitrol naar staging en productie** | De gemeenschappelijke oorzaak onder 04-08, 07-08 en 10-08. Zolang dit ontbreekt, is elke uitrol een mens met een laptop en `.env` wijzend naar productie. Plan: [`plan-otap-straat-met-staging.md`](architectuur/plan-otap-straat-met-staging.md) |
+| **#51** | Frontend promoveerbaar maken | Voorwaarde voor het bovenstaande — zonder verplaatsbaar image is er niets te promoveren |
 | **#46** | Uploads op een containerschijf: weg bij image-vervanging | **Harde datum**: pilot ~1 september. Dit zijn compliance-bewijsstukken |
 | — | Geen bewaking die waarschuwt als een omgeving omvalt | Je zou het merken doordat iemand belt |
 | — | Geen incidentplan | NIS2 kent een meldplicht binnen 24 uur; die klok loopt of je een plan hebt of niet |

--- a/docs/architectuur/plan-otap-straat-met-staging.md
+++ b/docs/architectuur/plan-otap-straat-met-staging.md
@@ -1,0 +1,424 @@
+# Plan — een OTAP-straat met staging, van nul opnieuw doordacht
+
+**Status:** voorstel, nog niet uitgevoerd
+**Datum:** 2026-08-10
+**Eigenaar:** Kees Aling
+**Aanleiding:** de straat die op 09/10-08 op saxombp gebouwd is, loopt niet uit
+op de database die er werkelijk toe doet. Dit plan trekt hem door tot het einde,
+in de volgorde die de eigenaar heeft vastgesteld: **eerst de weg, dan de
+inrichting, dan pas de vulling.**
+
+---
+
+## 0. Waarom dit plan bestaat
+
+Op 10-08 is er in deze sessie een fout gemaakt die de aanleiding voor dit plan
+scherpstelt. Een query op `clm.tenant` zonder tenantcontext gaf nul rijen. Dat
+werd gelezen als "de database is kapot", terwijl RLS gewoon zijn werk deed. Op
+die verkeerde meting is een diagnose gebouwd, en op die diagnose is toestemming
+gevraagd om productiedata te verwijderen. De tenant AlingAdvies met 21
+leveranciers, 7 responses en 34 antwoorden is daarmee weg.
+
+Dat is geen reden voor een strenger protocol op het lezen van databases. Het is
+een reden voor iets anders: **zolang de enige weg naar productie een mens met
+een laptop is, is elke verkeerde inschatting van die mens direct
+productiedataverlies.** Een straat die uitkomt op productie is geen luxe. Het is
+de maatregel die precies dit onmogelijk maakt.
+
+De drie eerdere incidenten wijzen dezelfde kant op:
+
+| Datum | Wat er gebeurde | Wat ontbrak |
+|---|---|---|
+| 2026-08-04 | `clm-enterprise` liep achter, dump miste 9 van 18 tabellen (#25) | Bewijs dat productie op de verwachte stand stond |
+| 2026-08-07 | Vier verzonnen commando's; bijna een migratie op productie | Een weg die het juiste commando afdwingt |
+| 2026-08-10 | Werkende tenant verwijderd op basis van een meetfout | Een weg die handmatig ingrijpen overbodig maakt |
+
+---
+
+## 1. De keuze die alles bepaalt
+
+**Waar draait staging?**
+
+De eigenaar heeft vastgesteld dat er met staging gewerkt wordt, zoals dat bij
+professionele SaaS hoort. Blijft de vraag waar die staging staat. Twee opties,
+en ze sluiten elkaar uit.
+
+### Optie A — staging bij Supabase (aanbevolen)
+
+Een tweede Supabase-project, in dezelfde organisatie KeesOrg.
+
+**Waarom dit wint:** een generale repetitie op ander toneel bewijst weinig.
+Productie draait Postgres bij AWS in Ierland, achter een connection pooler.
+Staging op saxombp draait Postgres in een container op een Ubuntu-machine thuis.
+Dat is niet hetzelfde systeem. De pooler is precies zo'n plek waar het anders
+gaat — verbindingen die anders worden vastgehouden, andere timeouts, ander
+gedrag bij migraties die een tabel vergrendelen.
+
+Staging bij Supabase betekent: dezelfde Postgres-versie, dezelfde pooler,
+dezelfde netwerkweg, dezelfde manier van verbinden. Wat daar werkt, werkt in
+productie.
+
+**Wat het kost:** niets. Het gratis plan geeft twee actieve projecten.
+`clm-enterprise` is er één; er zijn er vier gepauzeerd, en gepauzeerde projecten
+tellen niet mee. Er is dus ruimte.
+
+**De valkuil, en die is echt:** een gratis project pauzeert na 7 dagen zonder
+databaseactiviteit. Staging is bij uitstek de omgeving die je niet elke week
+raakt. Dan faalt een uitrol op een moment dat je denkt dat er iets stuk is,
+terwijl er alleen iets sliep. Dit wordt afgevangen in §4.
+
+### Optie B — staging op saxombp
+
+Hergebruik van wat er al staat: `mcm2-productie` op poort 5021 wordt omgedoopt
+tot staging.
+
+**Waarom dit verliest:** het bewijst het verkeerde. Zie hierboven.
+
+**Wanneer het toch wint:** als de eigenaar geen tweede Supabase-project wil, om
+welke reden dan ook. Dan is staging op saxombp beter dan geen staging. Maar dan
+moet in de documentatie staan wat het níét bewijst, anders geeft het
+schijnzekerheid — en dat is gevaarlijker dan geen repetitie.
+
+### Wat saxombp dan nog doet
+
+Bij optie A verandert de rol van saxombp, maar hij verdwijnt niet:
+
+- **Acceptatie (5011) blijft.** Dit is waar een nieuwe versie het eerst draait,
+  tegen een wegwerpdatabase, met de e2e-suites erop. Snel, gratis, en het mag
+  stuk.
+- **Productie (5021) wordt opgeheven.** Die simuleerde iets dat straks echt
+  bestaat. Twee dingen die "productie" heten is precies de verwarring die op
+  10-08 tot dataverlies leidde.
+- **De machine blijft de plek** waar gereedschap wordt uitgeprobeerd zonder
+  risico. Dat is echte waarde.
+
+De machine heeft ruimte: 7,5 GB geheugen waarvan 6,5 GB vrij, 87 GB schijf vrij,
+2 cores, Ubuntu 22.04.5. De vier huidige containers gebruiken samen minder dan
+1 GB.
+
+---
+
+## 2. Hoe de straat eruit komt te zien
+
+```
+  ┌─────────────┐
+  │   GitHub    │  push naar main
+  └──────┬──────┘
+         │  CI: lint, unit, e2e tegen wegwerpdatabase, build
+         ↓
+  ┌─────────────┐
+  │    GHCR     │  één image, getagd met de commit-SHA
+  └──────┬──────┘
+         │
+         ↓  automatisch
+  ┌─────────────────────────────────┐
+  │  ACCEPTATIE  — saxombp:5011     │  wegwerpdatabase in container
+  │  e2e-suites draaien hier        │  mag stuk, wordt weggegooid
+  └──────┬──────────────────────────┘
+         │
+         ↓  automatisch, dezelfde SHA
+  ┌─────────────────────────────────┐
+  │  STAGING  — Supabase project 2  │  zelfde platform als productie
+  │  gevuld met testdata            │  migraties worden hier eerst gedraaid
+  └──────┬──────────────────────────┘
+         │
+         ↓  ALLEEN NA AKKOORD VAN DE EIGENAAR
+  ┌─────────────────────────────────┐
+  │  PRODUCTIE — clm-enterprise     │  echte data
+  │  backup vooraf, verificatie na  │
+  └─────────────────────────────────┘
+```
+
+**De kern:** één image, vier keer gedraaid, drie keer bewezen voordat het
+productie raakt. Er wordt nergens opnieuw gebouwd. Wat op staging is
+goedgekeurd, is bit voor bit wat naar productie gaat.
+
+**De rem:** de laatste pijl is de enige die niet automatisch is. Een uitrol naar
+productie wacht op een expliciet akkoord. Dat is geen gebrek aan vertrouwen in
+de automatisering — het is de plek waar een mens hoort te kijken, en de enige
+plek.
+
+---
+
+## 3. Fase 1 — de straat werkend krijgen
+
+Dit is de fase die af moet zijn voordat er ook maar één rij data wordt ingevoerd.
+
+### 3.1 Voorwaarde: Issue #51
+
+**Zonder dit werkt de rest niet.** `NEXT_PUBLIC_API_URL` wordt nu tijdens de
+build in de frontend gebakken. Eén image kan dus niet naar meerdere omgevingen —
+en dat is precies wat de straat belooft.
+
+Uit onderzoek op 10-08 (acceptatiecriterium 1 van #51):
+
+- De browser praat nu rechtstreeks cross-origin met de backend, via
+  `credentials: 'include'` in `src/core/api/client.ts`.
+- Dat dwingt `CORS_ORIGIN` af op de backend — met `origin: *` plus credentials
+  weigert elke browser.
+- Er is **geen eis** dat dit cross-origin blijft: geen mobiele app, geen externe
+  consument, frontend en backend rollen samen uit.
+
+**Oplossing:** de Next.js-server wordt een same-origin proxy naar de backend. De
+browser praat alleen met de frontend; de frontend weet waar de backend staat en
+leest dat bij het starten uit een omgevingsvariabele.
+
+**Wat dat extra oplevert** (staat niet in #51, maar is het sterkste argument):
+frontend en backend worden dezelfde herkomst. `CORS_ORIGIN` kan dan wég. Dat is
+één instelling minder die per omgeving goed moet staan — en `deploy-inrichten.js`
+waarschuwt er nu al voor dat een fout hierin "elk beheerscherm een 401 geeft".
+Die hele klasse fouten verdwijnt.
+
+**Wat aandacht vraagt:**
+
+| Onderdeel | Waarom het aandacht vraagt |
+|---|---|
+| `verstuurBestand` (multipart) | De proxy moet de stream doorgeven zonder te bufferen |
+| `Sidebar.tsx` `/auth/login` en `/auth/logout` | Browsernavigaties, geen fetches — moeten óók door de proxy, anders komt het cookie op de verkeerde herkomst |
+| `gebruiktMockData` | Hangt aan een lege `NEXT_PUBLIC_API_URL`; die schakelaar moet blijven werken, alle browsertests leunen erop |
+| 5 al falende browsertests | In `instellingen` (3), `uitnodigen` (1), `vragenlijsten` (1). Eerst vastleggen als nulmeting, anders is niet te zien wat nieuw stuk is |
+
+**Bewijs dat het af is:** hetzelfde image, zonder herbouw, draait tegen twee
+verschillende backends. Dat is acceptatiecriterium 3 van #51 en het is de enige
+maatstaf die telt.
+
+### 3.2 Staging aanmaken
+
+1. Nieuw Supabase-project in KeesOrg, regio **eu-west-1** — dezelfde als
+   productie. Naam: `clm-staging`.
+2. Rollen aanmaken via `db/roles/bootstrap-roles.sql`. Deze staan bewust niet in
+   de migratieketen (ADR-009), dus ze moeten apart.
+3. Alle 26 migraties draaien met `migrate:deploy`.
+4. **Markeren als wat het is.** `clm.omgeving` staat standaard op `beschermd`.
+   Staging bevat geen echte gegevens, dus `wegwerp` is de eerlijke markering —
+   en die maakt seeden en e2e-tests er mogelijk.
+
+**Verificatie, terug te lezen uit de database:** 26 migraties, hetzelfde aantal
+tabellen als productie, RLS actief op dezelfde tabellen. Niet "het commando zei
+dat het goed ging".
+
+### 3.3 De uitrol naar staging automatiseren
+
+Uitbreiding van `.github/workflows/ci.yml`: na een geslaagde acceptatie-uitrol
+gaat dezelfde SHA naar staging.
+
+Stappen, met de rem er al in:
+
+1. Image ophalen uit GHCR op SHA-tag (nooit `latest` — zie §6)
+2. Migraties draaien tegen staging
+3. **Teruglezen** hoeveel migraties er nu staan. Nul of onveranderd = stoppen.
+4. Applicatie starten
+5. Rookproef: `/health` én een route die de database raakt
+
+Stap 5 is een les van 09-08: een backend zonder tabellen antwoordt vrolijk 200
+op `/health` en 401 op beheerroutes. De rookproef moet iets vragen dat alleen
+kan slagen als de database gevuld is.
+
+### 3.4 De uitrol naar productie automatiseren
+
+Dezelfde stappen, plus vier remmen:
+
+| Rem | Waarom |
+|---|---|
+| **Handmatig akkoord** | GitHub Environments met required reviewer. Niets gaat naar productie zonder dat de eigenaar drukt. |
+| **Backup vooraf** | Verplicht, niet optioneel. Faalt de backup, dan gaat de uitrol niet door. |
+| **Migratiestand teruglezen** | Vóór en ná. Wijkt het af van staging, dan stoppen. |
+| **Terugdraaien beproefd** | De vorige SHA moet met één commando terug te zetten zijn. Dit is op 10-08 bewezen op saxombp; het moet opnieuw bewezen op deze weg. |
+
+### 3.5 `.env` ontkoppelen van productie
+
+**Dit is de grootste veiligheidswinst van het hele plan, en hij komt gratis mee.**
+
+Nu wijzen `DATABASE_URL`, `MIGRATION_DATABASE_URL` en `BACKUP_DATABASE_URL` alle
+drie naar Supabase-productie. Elk databasecommando op de laptop raakt de echte
+database. Dat is de gemeenschappelijke oorzaak onder alle drie de incidenten uit
+§0.
+
+Zodra de uitrol via GitHub loopt, hoort de laptop dat adres niet meer te kennen.
+`.env` gaat naar **staging** wijzen. De productiereferenties leven dan alleen nog
+als GitHub secret.
+
+**Wat er dan nog handmatig moet kunnen** — en dus een andere weg krijgt:
+
+- Een noodherstel wanneer de straat zelf stuk is
+- Een leesquery om iets te onderzoeken
+
+Beide via `scripts/with-migration-url.js`, dat het doelwit expliciet maakt in
+plaats van het uit `.env` te halen. Het commando moet zeggen wat het raakt.
+
+---
+
+## 4. Fase 2 — de infrastructuur precies goed inrichten
+
+Pas als fase 1 werkt. Dit gaat over wat er per omgeving moet staan en hoe je
+weet dat het klopt.
+
+### 4.1 Wat er per omgeving hoort te zijn
+
+| | Acceptatie | Staging | Productie |
+|---|---|---|---|
+| Waar | saxombp:5011 | Supabase `clm-staging` | Supabase `clm-enterprise` |
+| Database | container, wegwerp | Supabase eu-west-1 | Supabase eu-west-1 |
+| `clm.omgeving` | `wegwerp` | `wegwerp` | `beschermd` |
+| Rollen | migrator + runtime | migrator + runtime | migrator + runtime |
+| RLS | actief | actief | actief |
+| Backups | nee | nee | dagelijks, met controle |
+| e2e-suites | ja | nee | nooit |
+| Data | wegwerp | testdata | echte data |
+| Wie mag erbij | CI | CI | CI + eigenaar na akkoord |
+
+### 4.2 Het pauzeerprobleem oplossen
+
+Staging pauzeert na 7 dagen stilte. Aanpak:
+
+- Een dagelijkse `SELECT 1` tegen staging, vanuit de Windows-taakplanner die al
+  draait voor de backups.
+- De uitrol naar staging controleert eerst of het project wakker is, en geeft
+  een begrijpelijke melding als het pauzeert — niet een cryptische
+  verbindingsfout.
+
+Verdwijnt dit probleem bij een overstap naar Pro ($25/maand voor de organisatie
+plus $10 voor het tweede project), dan kan de wakkerhouder weg. Tot die tijd is
+hij nodig.
+
+### 4.3 Een controle die de omgevingen vergelijkt
+
+Nieuw: `npm run verify:omgevingen`. Leest van alle drie de omgevingen en
+vergelijkt:
+
+- Migratiestand — moeten gelijk zijn, of staging vooruit op productie
+- Tabellen — zelfde verzameling
+- RLS — actief op dezelfde tabellen
+- Rollen — `clm_api_runtime` zonder BYPASSRLS
+- Markering in `clm.omgeving`
+
+Dit is de controle die op 04-08 had gemeld dat productie 9 tabellen miste, en
+die vandaag had gemeld dat de tenant er wél was. **Alles teruglezen uit de
+database, nooit uit een melding.**
+
+### 4.4 Wat er nog helemaal niet is
+
+Eerlijk benoemen wat dit plan niet oplost:
+
+| Gat | Waarom het telt |
+|---|---|
+| **Geen bewaking** | Valt productie om, dan merkt niemand het. Geen alarm, geen dashboard. |
+| **Geen incidentplan** | Er is geen procedure voor "productie is stuk". ISO27001-verplichting. |
+| **Geen sleutelrotatie** | Het GHCR-token op saxombp verloopt rond **8 november 2026**. Dan stopt elke uitrol. |
+| **Issue #46 — uploads** | Bestanden staan op een containerschijf en verdwijnen bij herstart. Deadline ~1 september. |
+
+Deze horen in fase 3 of later, maar ze horen genoemd te zijn.
+
+---
+
+## 5. Fase 3 — pas dan: vulling en verbindingen
+
+Expliciet als laatste, op verzoek van de eigenaar.
+
+### 5.1 Productie opnieuw opbouwen
+
+De database is op 10-08 leeggemaakt. Wat terug moet:
+
+1. Tenant AlingAdvies **via de platformroute** — dan komt het in de audit trail
+   terecht. De vorige tenant was er buitenom in gezet, en daarom stond er niets
+   over in `audit.audit_event`.
+2. `kees@alingadvies.nl` als admin én platformbeheerder.
+3. Antwoordadres instellen (was `cmaling+transdev@gmail.com`).
+4. Demo-leveranciers via `npm run seed:demo`, als de eigenaar die wil.
+
+**Pas nadat de straat werkt.** Dan gebeurt dit langs de goede weg, met een spoor,
+en is het herhaalbaar.
+
+### 5.2 Testdata voor staging
+
+Staging heeft data nodig, anders bewijst een migratie er niets. Een lege
+database zegt alleen dat de software start.
+
+Regel: **geen echte klantgegevens op staging.** Nu geen probleem — er zijn geen
+betalende klanten — maar het moet vastliggen voordat die er zijn. De seed levert
+verzonnen namen; die blijven verzonnen.
+
+### 5.3 De frontend-backendverbinding
+
+Volgt uit §3.1: same-origin proxy, `API_BASE_URL` bij het starten gelezen,
+`CORS_ORIGIN` weg. Op dat moment is dit al gebouwd; hier wordt het alleen
+vastgelegd als eindtoestand.
+
+---
+
+## 6. Wat dit plan bewust anders doet
+
+### `latest` verdwijnt
+
+Op saxombp draaien de containers nu op `ghcr.io/alingadvies/mcm2/api:latest`.
+Aan de status is dus niet te zien welke code draait. Vanaf nu: **alleen
+SHA-tags in acceptatie, staging en productie.** `latest` blijft bestaan voor
+handmatig gebruik, maar de straat raakt hem niet aan.
+
+### Eén ding heet "productie"
+
+`mcm2-productie` op saxombp wordt opgeheven. Twee dingen die "productie" heten
+is precies de verwarring die op 10-08 tot het verkeerde antwoord op de vraag
+"wat zijn mijn rollen" leidde — en daarmee tot het dataverlies.
+
+### Teruglezen is verplicht, melden is niet genoeg
+
+Elke stap die iets wijzigt, leest terug wat er nu staat. Dit is regel 4 van
+`docs/runbooks/commandos-en-omgeving.md` en het is drie keer bewezen nodig:
+op 04-08 (dump miste tabellen), op 07-08 ("migraties voltooid" terwijl er niets
+gebeurde) en op 10-08 (uitrol meldde succes over een lege database).
+
+---
+
+## 7. Draagbaarheid naar AWS
+
+De eis was: relatief eenvoudig te migreren naar een professionele cloud. Wat dit
+plan oplevert, vertaalt zich zo:
+
+| Nu | Bij AWS | Wat er verandert |
+|---|---|---|
+| Containers via docker compose | ECS of App Runner | Een taakdefinitie in plaats van een compose-bestand |
+| GHCR | ECR | Eén registeradres |
+| Supabase Postgres | RDS Postgres | Eén connectiestring |
+| Instellingen via omgevingsvariabelen | Idem | Niets |
+| GitHub Actions | Idem, of CodePipeline | Niets, als je GitHub houdt |
+
+**Wat er niet in zit, en dat is het punt:** geen enkele functie die alleen bij
+één leverancier bestaat. Dat is vastgelegd in ADR-012 en het is de reden dat de
+overstap van de database naar Neon destijds gratis was.
+
+De uitzondering was de frontend. Issue #51 heft die op, en dat is precies waarom
+het als eerste staat.
+
+---
+
+## 8. Volgorde en beslismomenten
+
+| Stap | Wat | Beslissing nodig? |
+|---|---|---|
+| 1 | Issue #51 — frontend promoveerbaar | Nee, gaat sowieso door |
+| 2 | Staging aanmaken bij Supabase | **Ja — §1, optie A of B** |
+| 3 | Uitrol naar staging automatiseren | Nee |
+| 4 | Uitrol naar productie automatiseren, met akkoordrem | Nee |
+| 5 | `.env` omleiden naar staging | Nee, maar wel melden wanneer |
+| 6 | `mcm2-productie` op saxombp opheffen | **Ja — onomkeerbaar** |
+| 7 | `verify:omgevingen` bouwen | Nee |
+| 8 | Productie opnieuw vullen | Nee |
+| 9 | Testdata op staging | Nee |
+
+**Ruwe inschatting:** stap 1 een halve dag; stappen 2–5 samen twee dagen;
+stappen 6–9 een halve dag. Niet in één sessie, en niet in één dag.
+
+---
+
+## 9. Wat er misgaat als we dit niet doen
+
+- Elke uitrol naar productie blijft een mens met een laptop. De incidenten van
+  04-08, 07-08 en 10-08 herhalen zich, want er is niets veranderd aan de
+  oorzaak.
+- De straat op saxombp blijft bewijzen dat containers werken, maar niet dat
+  *jouw* uitrol werkt.
+- Zodra er een betalende klant is, wordt dataverlies zoals dat van 10-08
+  onherstelbaar in plaats van vervelend.
+- De overstap naar AWS wordt duurder, want de frontend heeft dan een eigen
+  buildpijplijn per omgeving — en dat is permanent in plaats van eenmalig.

--- a/docs/architectuur/plan-otap-straat-met-staging.md
+++ b/docs/architectuur/plan-otap-straat-met-staging.md
@@ -1,7 +1,7 @@
 # Plan — een OTAP-straat met staging, van nul opnieuw doordacht
 
-**Status:** voorstel, nog niet uitgevoerd
-**Datum:** 2026-08-10
+**Status:** in uitvoering — **stap 2 is gedaan** (staging bestaat, zie §8)
+**Datum:** 2026-08-10, bijgewerkt dezelfde avond
 **Eigenaar:** Kees Aling
 **Aanleiding:** de straat die op 09/10-08 op saxombp gebouwd is, loopt niet uit
 op de database die er werkelijk toe doet. Dit plan trekt hem door tot het einde,
@@ -182,20 +182,44 @@ Die hele klasse fouten verdwijnt.
 verschillende backends. Dat is acceptatiecriterium 3 van #51 en het is de enige
 maatstaf die telt.
 
-### 3.2 Staging aanmaken
+### 3.2 Staging aanmaken — ✅ GEDAAN op 2026-08-10
 
-1. Nieuw Supabase-project in KeesOrg, regio **eu-west-1** — dezelfde als
-   productie. Naam: `clm-staging`.
-2. Rollen aanmaken via `db/roles/bootstrap-roles.sql`. Deze staan bewust niet in
-   de migratieketen (ADR-009), dus ze moeten apart.
-3. Alle 26 migraties draaien met `migrate:deploy`.
-4. **Markeren als wat het is.** `clm.omgeving` staat standaard op `beschermd`.
-   Staging bevat geen echte gegevens, dus `wegwerp` is de eerlijke markering —
-   en die maakt seeden en e2e-tests er mogelijk.
+Uitgevoerd. Project `clm-staging3`, ref `ljdldwfylcbubzglxjoa`, KeesOrg,
+regio eu-west-1.
 
-**Verificatie, terug te lezen uit de database:** 26 migraties, hetzelfde aantal
-tabellen als productie, RLS actief op dezelfde tabellen. Niet "het commando zei
-dat het goed ging".
+| Stap | Uitkomst |
+|---|---|
+| Rollen via `db/roles/bootstrap-roles.sql` | 6 rollen; `clm_migrator` en `clm_api_runtime` inlogbaar, geen BYPASSRLS |
+| 26 migraties met `migrate:deploy --extern` | Voltooid |
+| Markeren als `wegwerp` | `clm.omgeving` = `wegwerp`, productie blijft `beschermd` |
+
+**Verificatie, teruggelezen uit beide databases en naast elkaar gelegd:**
+
+| | Productie | Staging |
+|---|---|---|
+| Postgres | 17.6 | 17.6 |
+| Migraties | 26 | 26 |
+| Tabellen | 23 | 23 |
+| RLS in `clm` | 17/19 | 17/19 |
+| FORCE RLS | 12 | 12 |
+
+Geen tabel die alleen in de één voorkomt.
+
+> **Val die twee uur kostte.** Een wachtwoord *resetten* bij Supabase komt niet
+> altijd door bij de connection pooler: drie resets, drie keer
+> `password authentication failed`, ook na een projectherstart. Productie bleef
+> intussen gewoon bereikbaar via dezelfde pooler-host — dus het lag niet aan het
+> netwerk. **Het wachtwoord bij het aanmaken van het project zelf instellen
+> werkte meteen.** Houd het alfanumeriek: `@ : / ? # % &` breken de
+> connectiestring.
+
+> **Tweede bijna-ongeluk, en het bewijst §6.** `markeer-wegwerp.js` leest
+> `MIGRATION_DATABASE_URL`, niet `DATABASE_URL`. Bij het meegeven van de
+> verkeerde variabele pakte het script de waarde uit `.env` — **productie**.
+> Met `--extern` erbij was productie als `wegwerp` gemarkeerd, en dan mogen de
+> e2e-suites hem leegmaken. Wat het tegenhield: de rem die niet-lokale doelwitten
+> weigert, én het feit dat de melding de **projectreferentie** toont. Zonder dat
+> tweede was de fout onzichtbaar geweest.
 
 ### 3.3 De uitrol naar staging automatiseren
 
@@ -397,7 +421,7 @@ het als eerste staat.
 | Stap | Wat | Beslissing nodig? |
 |---|---|---|
 | 1 | Issue #51 — frontend promoveerbaar | Nee, gaat sowieso door |
-| 2 | Staging aanmaken bij Supabase | **Ja — §1, optie A of B** |
+| 2 | ✅ **Staging aanmaken bij Supabase** — gedaan 10-08 | Beslist: optie A |
 | 3 | Uitrol naar staging automatiseren | Nee |
 | 4 | Uitrol naar productie automatiseren, met akkoordrem | Nee |
 | 5 | `.env` omleiden naar staging | Nee, maar wel melden wanneer |

--- a/docs/otap-en-security-voor-eigenaar.md
+++ b/docs/otap-en-security-voor-eigenaar.md
@@ -2,7 +2,7 @@
 
 > Dit document legt in gewone taal uit hoe het ontwikkel- en testproces van MCM2 werkt, en welke bekende NIS2-thema's dit ontwerp raakt. Het is geen juridisch advies en geen compliance-verklaring — het is een eerlijk overzicht van wat er nu staat, wat dat oplevert, en wat nog ontbreekt.
 >
-> Laatst bijgewerkt: 2026-08-10 — acceptatie en productie draaien nu echt (§1), CI heeft vier controles in plaats van twee (§2), en er is een uitrolketen met rollback (§2b). De stand van 27 juli klopte op acht punten niet meer.
+> Laatst bijgewerkt: 2026-08-10, avond — er is een **staging**-omgeving bij Supabase bijgekomen die aantoonbaar gelijk is aan productie (§1). Eerder die dag: acceptatie en productie draaien echt, CI heeft vier controles in plaats van twee (§2), en er is een uitrolketen met rollback (§2b).
 
 ---
 
@@ -19,20 +19,38 @@ Denk aan het als een kwaliteitscontrole in een fabriek: je zet geen product op d
 | **Acceptatie** | De wijziging draait op een testomgeving die op productie lijkt, zodat je het zelf kan proberen vóórdat het "echt" is | Jij, functioneel |
 | **Productie** | De wijziging is live voor echte gebruikers (bijv. Transdev) | — |
 
-**Waar staat MCM2 nu?** Sinds 2026-08-10 bestaan **alle vier de stappen**. Acceptatie en Productie draaien op een aparte machine (`saxombp`, de thuisserver die ook de Saxo-app draait), elk met een eigen database die niets deelt met de ander.
+**Waar staat MCM2 nu?** Sinds 2026-08-10 bestaan **alle vier de stappen**, en
+sinds diezelfde dag is er een **staging**-omgeving bijgekomen die op hetzelfde
+platform draait als productie.
 
 | Omgeving | Waar | Bereikbaar op |
 |---|---|---|
 | Ontwikkel | jouw laptop | `localhost:3000` / `:5001` |
 | Test | jouw laptop, tijdelijk | wegwerpdatabase, verdwijnt na de test |
 | **Acceptatie** | saxombp | `http://saxombp:5011/health` |
-| **Productie** | saxombp | `http://saxombp:5021/health` |
+| **Staging** | Supabase `clm-staging3` | eu-west-1, Postgres 17.6 |
+| **Productie** | Supabase `clm-enterprise` | eu-west-1, Postgres 17.6 |
 
-Alleen bereikbaar via Tailscale — dus vanaf jouw eigen apparaten, niet vanaf internet.
+Acceptatie is alleen bereikbaar via Tailscale — dus vanaf jouw eigen apparaten,
+niet vanaf internet.
 
-> **Wat dit wél en niet is.** Dit is een **procesbewijs**: het toont aan dat dezelfde software die door de controles kwam ook echt draait op een andere machine, dat een nieuwe versie de oude vervangt, en dat terugdraaien werkt. Het is **geen** productieomgeving met garanties — één machine, thuisinternet, geen reservestroom. Voor de Transdev-pilot is een echte cloudomgeving nodig; ADR-011 heeft dat al vastgesteld.
+> **Waarom staging niet op saxombp staat.** Een generale repetitie op een ander
+> toneel bewijst weinig. Productie draait Postgres bij AWS in Ierland, achter een
+> connection pooler; een container op een thuisserver is een ander systeem, met
+> andere timeouts en ander gedrag bij migraties. Staging bij Supabase draait op
+> dezelfde Postgres-versie, dezelfde regio en dezelfde pooler. Wat daar werkt,
+> werkt in productie.
 >
-> Het verschil is belangrijk genoeg om te herhalen: het proces is bewezen, de beschikbaarheid niet.
+> Op 2026-08-10 is dat teruggelezen uit beide databases en naast elkaar gelegd:
+> 26 migraties, 23 tabellen, RLS op 17 van 19 tabellen, `FORCE ROW LEVEL
+> SECURITY` op 12 — in beide identiek.
+
+> **Wat saxombp dan nog is.** Acceptatie: de eerste plek waar een nieuwe versie
+> draait, tegen een wegwerpdatabase, met de e2e-suites erop. Snel, gratis, en het
+> mag stuk. De omgeving die daar "productie" heette is een **procesbewijs**
+> geweest — hij toonde aan dat promoveren en terugdraaien werken — maar hij wordt
+> opgeheven zodra de straat tot Supabase doorloopt. Twee dingen die "productie"
+> heten is precies de verwarring die op 2026-08-10 tot dataverlies leidde.
 
 **Wat is er van de frontend?** De backend doorloopt de volledige keten. De frontend nog niet: die heeft een technisch probleem waardoor één "verpakking" al weet met welke server hij praat (Issue #51). Twee verpakkingen maken — één voor acceptatie, één voor productie — zou dat oplossen, maar breekt het hele uitgangspunt: dan is wat je test niet meer wat je uitrolt. Daarom draait de frontend voorlopig bewust niet mee.
 
@@ -250,7 +268,8 @@ Het belang hiervan: zelfs als er ooit een fout in de applicatiecode zou zitten d
 | Verpakking wordt gebouwd én gestart in CI | ✅ | augustus |
 | Controle dat de documentatie niet veroudert | ✅ | 10-08 |
 | **Acceptatieomgeving** | ✅ Draait op saxombp, eigen database | 10-08 |
-| **Productieomgeving (als procesbewijs)** | ✅ Draait op saxombp, gescheiden data | 10-08 |
+| **Stagingomgeving** | ✅ Supabase, aantoonbaar gelijk aan productie | 10-08 |
+| **Uitrol naar staging en productie** | ❌ Nog met de hand vanaf de laptop | — |
 | **Uitrol met één commando, inclusief terugdraaien** | ✅ Beproefd, niet aangenomen | 10-08 |
 | Frontend doorloopt dezelfde keten | ❌ Nog niet — Issue #51 | — |
 | Wie-ben-ik-echt-verificatie voor gebruikers | ✅ Microsoft Entra, in productie doorlopen | 09-08 |

--- a/docs/runbooks/onderhoudskalender.md
+++ b/docs/runbooks/onderhoudskalender.md
@@ -85,6 +85,8 @@ npm run backup:controle
 | **Bij elke release naar productie** | OTAP-doorloop draaien | Bewijst dat het uitrolbare artefact werkt, niet alleen de code | [otap-doorloop.md](otap-doorloop.md) |
 | **Bij elke release naar productie** | Uitrollen via acceptatie, nooit rechtstreeks | Een versie die niet op acceptatie stond, is niet beproefd | [uitrol-acceptatie-en-productie.md](uitrol-acceptatie-en-productie.md) |
 | **Per kwartaal** | Rollback beproeven op acceptatie | Terugdraaien is het onderdeel dat in de praktijk het vaakst nooit getest is — en dat je nodig hebt op het slechtste moment | [uitrol-acceptatie-en-productie.md](uitrol-acceptatie-en-productie.md) |
+| **Wekelijks** | Staging wakker houden: één query tegen `clm-staging3` | Een gratis Supabase-project pauzeert na 7 dagen zonder databaseactiviteit. Pauzeert staging, dan faalt de eerstvolgende uitrol met een verbindingsfout die naar de verkeerde oorzaak wijst. | — (§5) |
+| **Bij elke migratie** | Eerst op staging draaien, dan pas op productie | Staging draait dezelfde Postgres-versie, regio en pooler als productie. Een migratie die daar slaagt, slaagt in productie — dat is de hele reden dat staging niet op saxombp staat. | — (§5) |
 
 ### Gebeurtenisgebonden — geen ritme, maar een trigger
 
@@ -167,6 +169,8 @@ document dat vertelt hóe.
 | **Logrotatie** | `backup-controle.log` en `backup-taak.log` groeien onbegrensd. Klein probleem, maar het staat nergens. | Laag |
 | **Certificaat- en domeinvervaldata** | Het verzenddomein van het mailkanaal en straks de productie-URL hebben vervaldata die niemand bewaakt. | Middel vanaf de pilotstart |
 | **Uploadopslag** | Certificaten staan op een containerschijf; bij image-vervanging zijn ze weg (Issue #46). Backup daarvan valt buiten ADR-011. | **Hoog** — harde datum, pilot start ~1 september |
+| **Uitrol naar staging en productie** | Staging bestaat sinds 2026-08-10, maar er loopt nog geen geautomatiseerde weg heen. Migraties gaan met de hand vanaf de laptop, met `.env` wijzend naar productie. Dat is de gemeenschappelijke oorzaak onder de incidenten van 04-08, 07-08 en 10-08. Plan: [plan-otap-straat-met-staging.md](../architectuur/plan-otap-straat-met-staging.md) | **Hoog** — elke handmatige uitrol is een kans op dataverlies |
+| **Staging wakker houden** | De wekelijkse taak staat in §2, maar er is nog geen geplande taak die hem uitvoert. Nu dus handwerk, en handwerk dat je vergeet. | Middel — pas pijnlijk bij de eerste uitrol na een stille week |
 
 **Deze lijst hoort korter te worden.** Groeit hij in plaats daarvan, dan is dat
 het signaal dat het onderhoud achterloopt op wat er gebouwd wordt.


### PR DESCRIPTION
## Wat hier in zit

Stap 2 van het OTAP-plan is uitgevoerd. Er is een stagingomgeving bij Supabase
die aantoonbaar gelijk is aan productie — teruggelezen uit beide databases, niet
aangenomen uit een melding.

| | Productie | Staging |
|---|---|---|
| Postgres | 17.6 | 17.6 |
| Regio | eu-west-1 | eu-west-1 |
| Migraties | 26 | 26 |
| Tabellen | 23 | 23 |
| RLS in `clm` | 17/19 | 17/19 |
| FORCE RLS | 12 | 12 |
| `clm.omgeving` | `beschermd` | `wegwerp` |

## Waarom staging niet op saxombp staat

Een repetitie op een ander toneel bewijst weinig. Productie draait Postgres bij
AWS achter een connection pooler; een container op een thuisserver is een ander
systeem. Staging bij Supabase draait op dezelfde versie, regio en pooler.

## Twee vallen die tijd kostten, nu vastgelegd

1. **Een wachtwoordreset bij Supabase komt niet altijd door bij de pooler.**
   Drie resets, drie keer `password authentication failed`, ook na herstart.
   Het wachtwoord bij het aanmaken zelf instellen werkte meteen.

2. **`markeer-wegwerp.js` leest `MIGRATION_DATABASE_URL`, niet `DATABASE_URL`.**
   Bij de verkeerde variabele pakte het script productie uit `.env`. Met
   `--extern` erbij was productie als `wegwerp` gemarkeerd — en dan mogen de
   e2e-suites hem leegmaken. De rem hield het tegen, en de projectreferentie in
   de melding maakte het zichtbaar.

## Ook hierin

STATUS.md beschrijft het dataverlies van 10-08 en de twee lessen die eruit
volgen: in een database met RLS betekent nul rijen niet dat er niets staat, en
een commando hoort zijn doelwit te tonen.

`verify:onderhoud` groen: 9 runbooks, alle geïndexeerd.

🤖 Generated with [Claude Code](https://claude.com/claude-code)