### PR TITLE
Frontend rolt mee in de uitrol, met een eigen versie naast de backend

### DIFF
--- a/docs/architectuur/plan-otap-straat-met-staging.md
+++ b/docs/architectuur/plan-otap-straat-met-staging.md
@@ -182,10 +182,59 @@ melding. Geen stil terugvallen op voorbeelddata.
    is dat `http://api:5001`. Dat is het spiegelbeeld van `CORS_ORIGIN`, en die
    twee zijn makkelijk te verwarren.
 
-**Wat dit níét oplost, en wat stap 3 nu blokkeert:** de frontend-image wordt
-nergens gepubliceerd. De CI bouwt hem en controleert dat hij start, maar duwt
-hem niet naar GHCR. `FRONTEND_MEE` in `scripts/deploy.js` staat daarom nog op
-`false` — geen ontwerpprobleem meer, wel een ontbrekende publicatiestap.
+**Wat dit níét oploste:** de frontend-image werd nergens gepubliceerd. Dat is
+stap 2b geworden, hieronder.
+
+### 3.1b Frontend publiceren en meenemen in de uitrol — ✅ GEDAAN op 2026-08-10
+
+Kwam boven bij stap 1 en blokkeerde stap 3: de CI van MCM2-frontend bouwde het
+image en controleerde dat het start, maar duwde het niet naar GHCR.
+`FRONTEND_IMAGE` verwees dus naar iets dat niet bestond.
+
+**Uitgevoerd.** De frontend publiceert nu naar
+`ghcr.io/alingadvies/mcm2-frontend/web`, met dezelfde tagstructuur en dezelfde
+`workflow_dispatch`-terugval als de backend. `FRONTEND_MEE` staat op `true`.
+
+**Het besluit dat hier viel: twee versies, samen vastgelegd.**
+
+Backend en frontend zitten in aparte repositories, dus hun commit-SHA's zijn
+nooit gelijk. `deploy.js` gebruikte één versietag voor beide — dat zou een
+frontend-image zoeken met de SHA van de backend, en dat bestaat niet.
+
+Afgewogen (besluit eigenaar 2026-08-10):
+
+| Optie | Waarom niet |
+|---|---|
+| Frontend volgt `:latest` | Aan een draaiende omgeving is dan niet te zien welke schermcode erin zit, en terugdraaien werkt alleen voor de backend. In strijd met §6 |
+| Frontend onder de backend-SHA publiceren | Kan niet — de frontend-CI kent de backend-commit niet |
+| **Twee versies, apart meegegeven** | **Gekozen** |
+
+```powershell
+npm run deploy:productie -- --versie sha-abc123def456 --frontend-versie sha-987fed654321
+```
+
+**Eén afwijking van wat oorspronkelijk was voorgesteld, en het is een
+verbetering.** Het idee was de combinatie weg te schrijven in een bestand op de
+server. Dat is niet gebeurd: `deploy.js` leest de draaiende versies terug uit de
+containers zelf. Een bestand kan afwijken van de werkelijkheid zodra iemand met
+de hand ingrijpt, en wijst dan de verkeerde kant op precies wanneer je het nodig
+hebt. Dat is regel 4 van het runbook — teruglezen, niet aannemen.
+
+**Wat er verder bij kwam:**
+
+- **Rollback zet beide onderdelen samen terug.** Alleen de backend terugdraaien
+  laat een frontend achter die bij een andere versie hoort; die toestand is
+  nergens beproefd.
+- **De promotiecontrole vergelijkt beide.** Alleen de backend controleren zou
+  een onbeproefde frontend stilzwijgend laten meepromoveren.
+- **De rookproef toetst of de frontend de backend bereikt**, niet alleen of hij
+  een pagina serveert. Dat is een aparte schakel met een misleidende faalvorm.
+  Ook toegevoegd aan `deploy:status`.
+- **Een CI-poort die Issue #51 bewaakt.** Herintroductie van
+  `NEXT_PUBLIC_API_URL` is stil: het werkt lokaal en gaat pas mis bij de
+  promotie. De poort toetst de bron én het gebouwde image — twee containers uit
+  hetzelfde image met een verschillend adres moeten beide een 502 geven, en
+  zonder adres een 500. Tegenproef gedraaid: de poort wordt aantoonbaar rood.
 
 Uit onderzoek op 10-08 (acceptatiecriterium 1 van #51):
 
@@ -459,7 +508,7 @@ het als eerste staat.
 |---|---|---|
 | 1 | ✅ **Issue #51 — frontend promoveerbaar** — gedaan 10-08 | Nee, ging sowieso door |
 | 2 | ✅ **Staging aanmaken bij Supabase** — gedaan 10-08 | Beslist: optie A |
-| 2b | **Frontend-image publiceren naar GHCR** — kwam boven bij stap 1 | Nee. Voorwaarde voor stap 3 |
+| 2b | ✅ **Frontend-image publiceren, frontend in de uitrol** — gedaan 10-08 | Beslist: twee versies, zie hieronder |
 | 3 | Uitrol naar staging automatiseren | Nee |
 | 4 | Uitrol naar productie automatiseren, met akkoordrem | Nee |
 | 5 | `.env` omleiden naar staging | Nee, maar wel melden wanneer |

--- a/docs/runbooks/uitrol-acceptatie-en-productie.md
+++ b/docs/runbooks/uitrol-acceptatie-en-productie.md
@@ -230,29 +230,66 @@ verhuizing naar een echte cloud met TLS moet die regel weg uit `productie.env`.*
 
 ---
 
-## Bekende beperking — de frontend rolt nog niet mee
+## De frontend rolt mee — met een eigen versie
 
-**De oude blokkade is weg.** `NEXT_PUBLIC_API_URL` werd bij de build in de
-bundel gebakken, waardoor één frontend-image al wist met welke backend het
-praatte. Sinds Issue #51 leest de frontend dat adres bij het **starten**, uit
-`API_BASE_URL`. Hetzelfde image is daarmee bruikbaar op elke omgeving, en
-`profiles:` is uit `deploy/docker-compose.omgeving.yml` verdwenen.
+Sinds 2026-08-10 draait de frontend mee in deze keten. Twee blokkades zijn
+achtereenvolgens weggenomen: het ingebakken backend-adres (Issue #51) en het
+ontbreken van een gepubliceerd image.
 
-**Wat nu nog ontbreekt is eenvoudiger.** De frontend-image wordt nergens
-gepubliceerd: de CI van MCM2-frontend bouwt hem en controleert dat hij start,
-maar duwt hem niet naar GHCR. `FRONTEND_IMAGE` zou dus verwijzen naar iets dat
-niet bestaat, en de uitrol zou stranden op een `docker pull`.
+### Twee repositories, twee versies
 
-Daarom staat `FRONTEND_MEE` in `scripts/deploy.js` nog op `false`. Zodra de
-frontend naar `ghcr.io/…/mcm2-frontend/web` publiceert met dezelfde SHA-tag als
-de backend, kan die vlag op `true` — verder verandert er niets.
+**Dit is het enige dat je hier echt moet onthouden.** Backend en frontend zitten
+in aparte repositories, dus hun commit-SHA's zijn nooit gelijk. De uitrol vraagt
+ze allebei:
 
-> **Let op bij het instellen:** `API_BASE_URL` wordt aangeroepen door de
-> frontend-*container*, niet door de browser. Daarbinnen is `localhost` de
-> container zelf; gebruik de servicenaam (`http://api:5001`). Dat is het
-> spiegelbeeld van `CORS_ORIGIN`, dat juist een adres is dat de browser
-> gebruikt. Staat het verkeerd, dan geeft de frontend een 502 met een leesbare
-> melding — geen stil scherm op voorbeelddata.
+```powershell
+npm run deploy:acceptatie -- --versie sha-abc123def456 --frontend-versie sha-987fed654321
+```
+
+Laat je een van beide weg, dan wordt dat `:latest`. Voor acceptatie is dat
+prima. **Voor productie niet**: dan is aan de omgeving niet te zien welke code
+er draait, en dat is precies wat §6 van het OTAP-plan uitsluit.
+
+Het slotbericht van een geslaagde uitrol drukt de terugdraairegel af met beide
+versies erin, zodat je die niet zelf hoeft samen te stellen:
+
+```
+  vorige versie was sha-25ffdf847ce0 met frontend sha-f850fc0d4e5f
+  terugdraaien:  npm run deploy:acceptatie -- --versie sha-25ffdf847ce0 --frontend-versie sha-f850fc0d4e5f
+```
+
+**Bij een rollback gaan beide onderdelen samen terug** naar de combinatie die er
+stond. Alleen de backend terugdraaien zou een frontend achterlaten die bij een
+andere versie hoort — een toestand die nergens beproefd is.
+
+**De promotiecontrole kijkt naar allebei.** Rol je naar productie uit met een
+combinatie die niet op acceptatie stond, dan meldt het script dat per onderdeel.
+Het blokkeert niet: soms is er een gegronde reden, maar hij moet zichtbaar zijn.
+
+### Wat er nu extra gecontroleerd wordt
+
+De rookproef controleerde of de frontend een pagina serveert. Dat bewijst niet
+dat hij de backend bereikt — sinds #51 loopt dat via een doorgeefluik dat
+`API_BASE_URL` bij het starten leest, en dat is een aparte schakel die apart
+stuk kan. Staat die variabele verkeerd, dan draait de frontend gewoon door en
+blijft elk beheerscherm leeg.
+
+Daarom vraagt de rookproef nu ook een beheerroute op via poort 3000. Zonder
+sessie hoort dat **401** te geven:
+
+| Antwoord | Wat het betekent |
+|---|---|
+| 401 | goed — de aanroep bereikte de backend en werd geweigerd |
+| 502 | het doorgeefluik vindt de backend niet — `API_BASE_URL` wijst verkeerd |
+| 500 | `API_BASE_URL` is helemaal niet gezet |
+
+`npm run deploy:status` toont dezelfde controle.
+
+> **`API_BASE_URL` is géén browseradres.** Het wordt aangeroepen door de
+> frontend-*container*, en daarbinnen is `localhost` de container zelf. Gebruik
+> de servicenaam: `http://api:5001`. Dat is het spiegelbeeld van `CORS_ORIGIN`,
+> dat juist wél een adres is dat de browser gebruikt — die twee zijn makkelijk
+> te verwarren.
 
 ---
 

--- a/scripts/deploy-status.js
+++ b/scripts/deploy-status.js
@@ -21,10 +21,14 @@ const SERVER = 'root@saxombp';
  * Draait de frontend mee? Gelijk aan de vlag in deploy.js.
  *
  * Staat dit op false, dan wordt de frontend niet als storing gemeld — hij hoort
- * er dan niet te zijn (Issue #51). Een rood bolletje voor iets dat bewust niet
- * draait, leert je rode bolletjes negeren.
+ * er dan niet te zijn. Een rood bolletje voor iets dat bewust niet draait,
+ * leert je rode bolletjes negeren.
+ *
+ * Sinds 2026-08-10 op true: het backend-adres komt uit `API_BASE_URL` (Issue
+ * #51) en het image wordt gepubliceerd naar GHCR. Deze vlag hoort gelijk te
+ * blijven aan die in deploy.js.
  */
-const FRONTEND_MEE = false;
+const FRONTEND_MEE = true;
 
 const OMGEVINGEN = [
   { naam: 'acceptatie', project: 'mcm2-acceptatie', api: 5011, frontend: 3010 },
@@ -114,9 +118,35 @@ function main() {
       console.log(
         `   frontend http://saxombp:${omgeving.frontend}/         ${web.uit === '200' ? kleur.groen('200') : kleur.rood(web.uit)}`,
       );
+
+      // Een pagina serveren is niet hetzelfde als de backend bereiken. Sinds
+      // Issue #51 loopt dat via een doorgeefluik dat `API_BASE_URL` bij het
+      // starten leest; staat die verkeerd, dan draait de frontend gewoon door
+      // en blijft elk beheerscherm leeg. Zonder deze regel zou dit overzicht
+      // twee groene bolletjes tonen bij een omgeving die niet werkt.
+      //
+      // 401 is het goede antwoord: de aanroep bereikte de backend en die
+      // weigerde hem zonder sessie. 502 betekent dat het doorgeefluik de
+      // backend niet vindt, 500 dat `API_BASE_URL` niet gezet is.
+      const doorgeefluik = opServer(
+        `curl -s -o /dev/null -w '%{http_code}' --max-time 8 http://localhost:${omgeving.frontend}/api/backend/admin/survey/templates || echo geen`,
+      );
+      const goed = doorgeefluik.uit === '401';
+      console.log(
+        `   frontend → backend                       ${goed ? kleur.groen('401') : kleur.rood(doorgeefluik.uit)}` +
+          (goed
+            ? ''
+            : kleur.rood(
+                doorgeefluik.uit === '502'
+                  ? '  ← doorgeefluik vindt de backend niet (API_BASE_URL)'
+                  : doorgeefluik.uit === '500'
+                    ? '  ← API_BASE_URL is niet gezet'
+                    : '  ← verwacht 401',
+              )),
+      );
     } else {
       console.log(
-        kleur.grijs('   frontend draait bewust niet mee — Issue #51'),
+        kleur.grijs('   frontend draait bewust niet mee — image ontbreekt'),
       );
     }
 

--- a/scripts/deploy.js
+++ b/scripts/deploy.js
@@ -37,12 +37,21 @@
  *
  * ── Gebruik ─────────────────────────────────────────────────────────────────
  *
- *   npm run deploy:acceptatie              laatste main-image
+ *   npm run deploy:acceptatie              laatste main-images
  *   npm run deploy:acceptatie -- sha-abc123def456
  *   npm run deploy:productie               vraagt bevestiging
  *   npm run deploy:productie -- --versie sha-abc123def456
  *   npm run deploy:status                  wat draait waar
  *   npm run rollback:acceptatie            vorige versie terug
+ *
+ * Backend en frontend zijn aparte repositories met eigen SHA's. De frontend
+ * krijgt een eigen vlag; laat je hem weg, dan wordt dat `:latest`:
+ *
+ *   npm run deploy:productie -- --versie sha-abc123def456 \
+ *                               --frontend-versie sha-987fed654321
+ *
+ * Het slotbericht van een geslaagde uitrol drukt de terugdraairegel af met
+ * beide versies erin, zodat je die niet zelf hoeft samen te stellen.
  *
  * Zie docs/runbooks/uitrol-acceptatie-en-productie.md.
  */
@@ -56,24 +65,33 @@ const SERVER_MAP = '/opt/mcm2';
 /**
  * Draait de frontend mee?
  *
- * Nog niet, maar om een ándere reden dan voorheen. De oude blokkade — het
- * ingebakken backend-adres uit Issue #51 — is weg: de frontend leest dat adres
- * sinds die wijziging bij het starten uit `API_BASE_URL`, en `profiles:` is
- * daarom al uit docker-compose.omgeving.yml verdwenen.
+ * Ja, sinds 2026-08-10. Twee blokkades zijn achtereenvolgens weggenomen:
  *
- * Wat nu nog ontbreekt is eenvoudiger en concreter: **de frontend-image wordt
- * nergens gepubliceerd.** De CI van MCM2-frontend bouwt hem en controleert dat
- * hij start, maar duwt hem niet naar GHCR. `FRONTEND_IMAGE` zou dus verwijzen
- * naar iets dat niet bestaat, en de uitrol zou stranden op een `docker pull`.
+ *   1. Issue #51 — het backend-adres werd bij de build ingebakken, waardoor
+ *      één image al wist met welke backend het praatte. Dat adres komt nu uit
+ *      `API_BASE_URL`, gelezen bij het starten.
+ *   2. Het frontend-image werd nergens gepubliceerd. De CI van MCM2-frontend
+ *      duwt hem nu naar `ghcr.io/alingadvies/mcm2-frontend/web`, met dezelfde
+ *      tagstructuur als de backend.
  *
- * Liever een keten die alleen de backend dekt en dat eerlijk zegt, dan een die
- * er compleet uitziet en struikelt op een ontbrekend image.
+ * ── Twee versies, en waarom dat geen omissie is ─────────────────────────────
  *
- * Zodra de frontend naar `ghcr.io/…/mcm2-frontend/web` publiceert met dezelfde
- * SHA-tag als de backend: deze vlag op `true`. Verder verandert er niets in dit
- * script — het compose-bestand is er al klaar voor.
+ * Backend en frontend zitten in aparte repositories, dus hun commit-SHA's zijn
+ * nooit gelijk. Deze uitrol vraagt ze allebei:
+ *
+ *   npm run deploy:acceptatie -- --versie sha-abc123def456 \
+ *                                --frontend-versie sha-987fed654321
+ *
+ * Zonder argument valt elk terug op `:latest`. Wat er drááit wordt altijd
+ * teruggelezen uit de containers zelf — niet uit een bestand dat een vorige
+ * uitrol heeft weggeschreven, want zo'n bestand kan afwijken van de
+ * werkelijkheid zodra iemand met de hand ingrijpt.
+ *
+ * Bij een rollback gaan beide onderdelen samen terug naar de combinatie die er
+ * stond. Alleen de backend terugdraaien laat een frontend achter die bij een
+ * andere versie hoort, en die toestand is nergens beproefd.
  */
-const FRONTEND_MEE = false;
+const FRONTEND_MEE = true;
 
 /**
  * De omgevingen. Poorten liggen ver uit elkaar zodat een typefout in een
@@ -160,10 +178,45 @@ function bepaalVersie(argumenten) {
   return los || 'latest';
 }
 
-/** Wat er op dit moment draait, of null wanneer er niets draait. */
-function huidigeVersie(omgeving) {
+/**
+ * Stelt vast welk frontend-image uitgerold wordt.
+ *
+ * ── Waarom dit een aparte versie is ─────────────────────────────────────────
+ *
+ * Backend en frontend zitten in twee repositories, dus hun commit-SHA's zijn
+ * nooit gelijk. Eén versietag voor beide zou een frontend-image zoeken met de
+ * SHA van de backend, en dat bestaat niet — de uitrol zou stranden op een
+ * `docker pull` met een melding die naar de verkeerde oorzaak wijst.
+ *
+ * De alternatieven zijn afgewogen (besluit eigenaar 2026-08-10): de frontend
+ * `:latest` laten volgen is eenvoudiger, maar dan is aan een draaiende omgeving
+ * niet te zien welke schermcode erin zit en werkt terugdraaien alleen voor de
+ * backend. Dat gaat in tegen §6 van het OTAP-plan.
+ *
+ * Zonder argument valt dit terug op `:latest`, net als de backend.
+ */
+function bepaalFrontendVersie(argumenten) {
+  const index = argumenten.indexOf('--frontend-versie');
+  if (index !== -1 && argumenten[index + 1]) return argumenten[index + 1];
+
+  return 'latest';
+}
+
+/**
+ * Wat er op dit moment draait, of null wanneer er niets draait.
+ *
+ * Teruggelezen uit de draaiende container en niet uit een bestand dat de vorige
+ * uitrol heeft weggeschreven. Dat is bewust: zo'n bestand kan afwijken van de
+ * werkelijkheid zodra iemand met de hand ingrijpt, en dan wijst het de
+ * verkeerde kant op precies wanneer je het nodig hebt (runbook, regel 4).
+ *
+ * `dienst` is 'api' of 'frontend'. Draait de frontend niet mee, dan geeft
+ * `docker inspect` niets terug en is het antwoord null — dat is geen fout maar
+ * de juiste beschrijving van de toestand.
+ */
+function huidigeVersie(omgeving, dienst = 'api') {
   const res = opServer(
-    `docker inspect --format '{{.Config.Image}}' ${omgeving.project}-api-1 2>/dev/null || true`,
+    `docker inspect --format '{{.Config.Image}}' ${omgeving.project}-${dienst}-1 2>/dev/null || true`,
     { stil: true },
   );
 
@@ -193,6 +246,23 @@ function rookproef(omgeving) {
             wat: 'frontend serveert een pagina',
             commando: `curl -s -o /dev/null -w '%{http_code}' --max-time 10 http://localhost:${omgeving.frontendPoort}/`,
             verwacht: (uit) => uit === '200',
+          },
+          {
+            // Een pagina serveren bewijst niet dat de frontend de backend
+            // bereikt: sinds Issue #51 loopt dat via een doorgeefluik dat
+            // `API_BASE_URL` bij het starten leest, en dat is een aparte
+            // schakel die apart stuk kan. Staat die variabele verkeerd, dan
+            // draait de frontend vrolijk door en geeft elk beheerscherm "kon
+            // niet worden opgehaald" — precies zoals bij een backend die niet
+            // draait.
+            //
+            // Dezelfde aanroep als de controle hierboven, maar via poort 3000.
+            // Zonder sessie hoort dat 401 te geven; een 502 betekent dat het
+            // doorgeefluik de backend niet vindt, een 500 dat de variabele
+            // helemaal niet gezet is.
+            wat: 'frontend bereikt de backend (401 via het doorgeefluik)',
+            commando: `curl -s -o /dev/null -w '%{http_code}' --max-time 10 http://localhost:${omgeving.frontendPoort}/api/backend/admin/survey/templates`,
+            verwacht: (uit) => uit === '401',
           },
         ]
       : []),
@@ -225,11 +295,12 @@ function rookproef(omgeving) {
 }
 
 /** Start een omgeving met een bepaalde versie. */
-function start(omgeving, versie) {
-  // Het profiel `frontend` staat in het compose-bestand en is standaard uit.
-  // Zonder `--profile frontend` blijft die dienst dus buiten beschouwing —
-  // ook zijn ontbrekende image levert dan geen fout op.
-  const profiel = FRONTEND_MEE ? '--profile frontend ' : '';
+function start(omgeving, versie, frontendVersie) {
+  // Draait de frontend niet mee, dan wordt die dienst geschaald naar nul in
+  // plaats van uit het compose-bestand geweerd. `profiles:` is daar weg sinds
+  // de frontend promoveerbaar is (Issue #51); wat nu nog ontbreekt is dat het
+  // image gepubliceerd wordt, en dat is een tijdelijke toestand.
+  const schaal = FRONTEND_MEE ? '' : '--scale frontend=0 ';
 
   const zet = [
     `cd ${SERVER_MAP}`,
@@ -237,8 +308,8 @@ function start(omgeving, versie) {
     // Ook zetten wanneer de frontend niet meedraait: docker compose
     // waarschuwt anders over een lege variabele, en zo'n waarschuwing in de
     // uitvoer van een uitrol leidt af van meldingen die er wél toe doen.
-    `export FRONTEND_IMAGE=$(grep '^GHCR_FRONTEND=' ${omgeving.naam}.env | cut -d= -f2):${versie}`,
-    `docker compose --env-file ${omgeving.naam}.env -p ${omgeving.project} ${profiel}-f docker-compose.omgeving.yml up -d`,
+    `export FRONTEND_IMAGE=$(grep '^GHCR_FRONTEND=' ${omgeving.naam}.env | cut -d= -f2):${frontendVersie}`,
+    `docker compose --env-file ${omgeving.naam}.env -p ${omgeving.project} -f docker-compose.omgeving.yml up -d ${schaal}`.trim(),
   ].join(' && ');
 
   return opServer(zet);
@@ -257,11 +328,17 @@ async function main() {
 
   const argumenten = process.argv.slice(3);
   const versie = bepaalVersie(argumenten);
+  const frontendVersie = bepaalFrontendVersie(argumenten);
 
   console.log('');
   console.log(`Uitrol naar ${kleur.geel(omgeving.naam.toUpperCase())}`);
   console.log(kleur.grijs(`  server:  ${SERVER}`));
-  console.log(kleur.grijs(`  versie:  ${versie}`));
+  console.log(kleur.grijs(`  backend:  ${versie}`));
+  console.log(
+    kleur.grijs(
+      `  frontend: ${FRONTEND_MEE ? frontendVersie : '(rolt nog niet mee)'}`,
+    ),
+  );
   console.log(
     kleur.grijs(
       `  poorten: api ${omgeving.apiPoort}, frontend ${omgeving.frontendPoort}`,
@@ -285,8 +362,17 @@ async function main() {
   }
 
   const vorige = huidigeVersie(omgeving);
+  // Ook de frontend vastleggen, en wel hier — vóór er iets vervangen wordt.
+  // Bij een falende rookproef moeten beide onderdelen samen terug; alleen de
+  // backend terugdraaien laat een frontend achter die bij een andere versie
+  // hoort, en dat is een toestand die nergens beproefd is.
+  const vorigeFrontend = huidigeVersie(omgeving, 'frontend');
+
   console.log(
-    `     ${kleur.groen('OK')}   ${vorige ? `nu actief: ${vorige}` : 'er draait nog niets'}`,
+    `     ${kleur.groen('OK')}   ${vorige ? `nu actief: backend ${vorige}` : 'er draait nog niets'}` +
+      (vorige && FRONTEND_MEE
+        ? `, frontend ${vorigeFrontend || '(geen)'}`
+        : ''),
   );
 
   // ── 2. Bevestiging bij productie ────────────────────────────────────────
@@ -297,13 +383,18 @@ async function main() {
     // Een uitrol naar productie die niet eerst op acceptatie stond, is precies
     // de stap die OTAP overslaat. Melden, niet blokkeren: soms is er een
     // gegronde reden, maar hij moet zichtbaar zijn.
+    //
+    // Beide onderdelen worden vergeleken. Alleen de backend controleren zou
+    // betekenen dat een onbeproefde frontend stilzwijgend meepromoveert — en
+    // juist omdat de versies uit twee repositories komen, is dat makkelijk om
+    // over het hoofd te zien.
     const opAcceptatie = huidigeVersie(OMGEVINGEN.acceptatie);
 
     if (opAcceptatie !== versie) {
       console.log('');
       console.log(
         kleur.geel(
-          `     LET OP: op acceptatie draait ${opAcceptatie || '(niets)'}, niet ${versie}.`,
+          `     LET OP: op acceptatie draait als backend ${opAcceptatie || '(niets)'}, niet ${versie}.`,
         ),
       );
       console.log(
@@ -311,6 +402,24 @@ async function main() {
           '     Deze versie is daar dus niet beproefd. Dat is de stap die OTAP juist voorschrijft.',
         ),
       );
+    }
+
+    if (FRONTEND_MEE) {
+      const feOpAcceptatie = huidigeVersie(OMGEVINGEN.acceptatie, 'frontend');
+
+      if (feOpAcceptatie !== frontendVersie) {
+        console.log('');
+        console.log(
+          kleur.geel(
+            `     LET OP: op acceptatie draait als frontend ${feOpAcceptatie || '(niets)'}, niet ${frontendVersie}.`,
+          ),
+        );
+        console.log(
+          kleur.geel(
+            '     Het is de combinatie die beproefd wordt, niet elk onderdeel apart.',
+          ),
+        );
+      }
     }
 
     console.log('');
@@ -342,7 +451,7 @@ async function main() {
       `docker pull $(grep '^GHCR_API=' ${omgeving.naam}.env | cut -d= -f2):${versie}`,
       ...(FRONTEND_MEE
         ? [
-            `docker pull $(grep '^GHCR_FRONTEND=' ${omgeving.naam}.env | cut -d= -f2):${versie}`,
+            `docker pull $(grep '^GHCR_FRONTEND=' ${omgeving.naam}.env | cut -d= -f2):${frontendVersie}`,
           ]
         : []),
     ].join(' && '),
@@ -350,9 +459,21 @@ async function main() {
   );
 
   if (!ophalen.ok) {
+    // Twee images, twee registers, twee mogelijke tikfouten. De melding noemt
+    // ze allebei: uit de foutuitvoer alleen is niet af te leiden welk van de
+    // twee niet bestond, en zoeken in het verkeerde register kost tijd.
     stop(
-      `Kon image '${versie}' niet ophalen.`,
-      `${ophalen.fout}\n\nBestaat die tag? Kijk op:\n  https://github.com/AlingAdvies/MCM2/pkgs/container/mcm2%2Fapi\n\nEr is niets gewijzigd — de draaiende omgeving is niet aangeraakt.`,
+      FRONTEND_MEE
+        ? `Kon image '${versie}' (backend) of '${frontendVersie}' (frontend) niet ophalen.`
+        : `Kon image '${versie}' niet ophalen.`,
+      `${ophalen.fout}\n\nBestaan die tags? Kijk op:\n` +
+        `  https://github.com/AlingAdvies/MCM2/pkgs/container/mcm2%2Fapi\n` +
+        (FRONTEND_MEE
+          ? `  https://github.com/AlingAdvies/MCM2-frontend/pkgs/container/mcm2-frontend%2Fweb\n`
+          : '') +
+        `\nLet op: backend en frontend zijn aparte repositories, dus hun SHA's\n` +
+        `verschillen. De frontendversie geef je mee met --frontend-versie.\n\n` +
+        `Er is niets gewijzigd — de draaiende omgeving is niet aangeraakt.`,
     );
   }
 
@@ -472,7 +593,7 @@ async function main() {
   console.log('');
   console.log('5/6  Containers vervangen');
 
-  const gestart = start(omgeving, versie);
+  const gestart = start(omgeving, versie, frontendVersie);
 
   if (!gestart.ok) {
     stop(
@@ -499,8 +620,15 @@ async function main() {
     console.log(kleur.rood(`De rookproef faalde op ${mislukt.length} punt(en).`));
 
     if (vorige && vorige !== versie) {
-      console.log(`Terugdraaien naar ${vorige}…`);
-      const terug = start(omgeving, vorige);
+      // Beide onderdelen samen terug naar de combinatie die er stond. Draait de
+      // frontend niet mee, dan is `vorigeFrontend` null en valt hij terug op
+      // `latest` — dat is dan een lege variabele die niets start.
+      console.log(
+        `Terugdraaien naar ${vorige}` +
+          (FRONTEND_MEE ? ` met frontend ${vorigeFrontend || 'latest'}` : '') +
+          '…',
+      );
+      const terug = start(omgeving, vorige, vorigeFrontend || 'latest');
 
       if (terug.ok) {
         opServer('sleep 6', { stil: true });
@@ -537,7 +665,11 @@ async function main() {
   // ── Klaar ───────────────────────────────────────────────────────────────
   console.log('');
   console.log(
-    kleur.groen(`UITGEROLD — ${omgeving.naam} draait op ${versie}.`),
+    kleur.groen(
+      `UITGEROLD — ${omgeving.naam} draait op ${versie}` +
+        (FRONTEND_MEE ? ` met frontend ${frontendVersie}` : '') +
+        '.',
+    ),
   );
   console.log('');
   console.log(`  backend:   http://saxombp:${omgeving.apiPoort}/health`);
@@ -547,17 +679,29 @@ async function main() {
   } else {
     console.log(
       kleur.grijs(
-        `  frontend:  draait niet mee — nog niet promoveerbaar (Issue #51)`,
+        `  frontend:  draait niet mee — image wordt nog niet gepubliceerd`,
       ),
     );
   }
 
   if (vorige && vorige !== versie) {
     console.log('');
-    console.log(kleur.grijs(`  vorige versie was ${vorige}`));
     console.log(
       kleur.grijs(
-        `  terugdraaien:  npm run deploy:${omgeving.naam} -- --versie ${vorige}`,
+        `  vorige versie was ${vorige}` +
+          (FRONTEND_MEE
+            ? ` met frontend ${vorigeFrontend || '(geen)'}`
+            : ''),
+      ),
+    );
+    // De hele combinatie in één regel, zodat terugdraaien geen puzzel is: met
+    // twee repositories is de frontendversie precies het stuk dat je vergeet.
+    console.log(
+      kleur.grijs(
+        `  terugdraaien:  npm run deploy:${omgeving.naam} -- --versie ${vorige}` +
+          (FRONTEND_MEE && vorigeFrontend
+            ? ` --frontend-versie ${vorigeFrontend}`
+            : ''),
       ),
     );
   }


### PR DESCRIPTION
## Samenhang

Hoort samen met **[MCM2-frontend #13](https://github.com/AlingAdvies/MCM2-frontend/pull/13)**, die het frontend-image naar GHCR publiceert. **Die eerst mergen** — deze PR zet `FRONTEND_MEE` op `true` en heeft dat image nodig.

Samen zijn dit stap 2b van het OTAP-plan, de voorwaarde voor stap 3.

## Het kernprobleem dat hierbij boven kwam

`deploy.js` gebruikte **één versietag voor beide images**. Backend en frontend zitten in aparte repositories, dus hun commit-SHA's zijn nooit gelijk. Zodra de frontend meedraaide zou de uitrol een frontend-image zoeken met de SHA van de backend — en stranden op een `docker pull` met een melding die naar de verkeerde oorzaak wijst.

**Besluit eigenaar 2026-08-10: twee versies, apart meegegeven.**

| Optie | Waarom niet |
|---|---|
| Frontend volgt `:latest` | Aan een draaiende omgeving is dan niet te zien welke schermcode erin zit, en terugdraaien werkt alleen voor de backend. In strijd met §6 van het plan |
| Frontend onder de backend-SHA publiceren | Kan niet — de frontend-CI kent de backend-commit niet |
| **Twee versies, apart meegegeven** | **Gekozen** |

```powershell
npm run deploy:productie -- --versie sha-abc123def456 --frontend-versie sha-987fed654321
```

Zonder argument valt elk terug op `:latest`.

## Eén afwijking van wat was voorgesteld — en het is een verbetering

Het voorstel was de combinatie **weg te schrijven** in een bestand op de server. Dat is niet gebeurd: `deploy.js` leest de draaiende versies **terug** uit de containers zelf.

Een bestand kan afwijken van de werkelijkheid zodra iemand met de hand ingrijpt, en wijst dan de verkeerde kant op precies wanneer je het nodig hebt. Dat is regel 4 van het runbook — teruglezen, niet aannemen. Het bestaande `huidigeVersie()` deed dat al voor de backend; het is uitgebreid met een `dienst`-parameter.

## Wat er verder bij komt, elk om een eigen reden

**Rollback zet beide onderdelen samen terug** naar de combinatie die er stond. Alleen de backend terugdraaien laat een frontend achter die bij een andere versie hoort — een toestand die nergens beproefd is. De vorige frontendversie wordt vastgelegd *vóór* de vervanging.

**De promotiecontrole vergelijkt beide.** Alleen de backend controleren zou een onbeproefde frontend stilzwijgend laten meepromoveren, en juist omdat de versies uit twee repo's komen is dat makkelijk te missen. Melden, niet blokkeren — zoals de bestaande controle.

**De rookproef toetst of de frontend de backend *bereikt*,** niet alleen of hij een pagina serveert. Het doorgeefluik uit #51 is een aparte schakel met een misleidende faalvorm: staat `API_BASE_URL` verkeerd, dan draait de frontend gewoon door en blijft elk beheerscherm leeg.

| Antwoord | Betekenis |
|---|---|
| 401 | goed — bereikte de backend, geweigerd zonder sessie |
| 502 | het doorgeefluik vindt de backend niet |
| 500 | `API_BASE_URL` is niet gezet |

Dezelfde controle in `deploy:status`, waar anders **twee groene bolletjes** zouden staan bij een omgeving die niet werkt.

**Het slotbericht drukt de terugdraairegel af met beide versies erin**, zodat je die niet zelf hoeft samen te stellen — met twee repositories is de frontendversie precies het stuk dat je vergeet.

## Wat hier níét gebeurd is

**Er is niet uitgerold naar saxombp.** Dat is een uitrol en geen codewijziging; de eerste echte uitrol is de proef. Wat er in deze PR bewezen is, is dat de scripts laden en dat alle poorten groen zijn.

## Poorten

`format:check`, `lint:check`, `typecheck`, `verify:onderhoud` groen. **383 unittests geslaagd.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)