### PR TITLE
Stop als het compose-bestand op de server afwijkt van de repository

### DIFF
--- a/docs/runbooks/uitrol-acceptatie-en-productie.md
+++ b/docs/runbooks/uitrol-acceptatie-en-productie.md
@@ -293,6 +293,49 @@ sessie hoort dat **401** te geven:
 
 ---
 
+## ⚠ Het compose-bestand op de server loopt niet vanzelf mee
+
+`deploy.js` gebruikt `/opt/mcm2/docker-compose.omgeving.yml`, maar **brengt dat
+bestand niet mee**. Het komt daar via `deploy:inrichten`, en dat script weigert
+op een server waar al iets draait — terecht, want het zou de
+databasewachtwoorden opnieuw zetten.
+
+Wijzig je het bestand in de repository, dan draait de uitrol dus stilzwijgend
+door op de oude versie.
+
+**Dat is geen theorie.** Op 2026-08-10, bij de eerste uitrol met frontend, stond
+op saxombp nog een versie met `profiles: ["frontend"]` erin terwijl die regel in
+de repository al weg was. Gevolg: de frontend-container werd **niet aangemaakt**
+— geen fout, geen container, alleen een rookproef die faalde met `kreeg 000`.
+Zoeken naar de oorzaak kostte meer tijd dan de uitrol zelf.
+
+**Sindsdien controleert `deploy.js` dit als eerste**, op de inhoud (sha256) en
+niet op de datum. Wijkt het af, dan stopt de uitrol vóórdat er iets is
+aangeraakt, met beide vingerafdrukken en de commando's om het recht te zetten.
+
+Bijwerken doe je met de hand — bewust, want het bestand raakt **beide**
+omgevingen tegelijk, ook productie:
+
+```powershell
+# 1. Kijk eerst wat er verschilt
+ssh root@saxombp "cat /opt/mcm2/docker-compose.omgeving.yml" | diff - deploy/docker-compose.omgeving.yml
+
+# 2. Backup op de server
+ssh root@saxombp "cp /opt/mcm2/docker-compose.omgeving.yml /opt/mcm2/docker-compose.omgeving.yml.bak"
+
+# 3. Kopiëren
+ssh root@saxombp "cat > /opt/mcm2/docker-compose.omgeving.yml" < deploy/docker-compose.omgeving.yml
+
+# 4. Teruglezen — niet de melding geloven
+ssh root@saxombp "sha256sum /opt/mcm2/docker-compose.omgeving.yml"
+```
+
+Een gewijzigd compose-bestand raakt pas aan een draaiende omgeving bij de
+eerstvolgende uitrol daarheen. Rol je alleen acceptatie uit, dan blijft
+productie ongemoeid draaien tot je daar ook uitrolt.
+
+---
+
 ## Wat dit bewijst, en wat niet
 
 **Wel:**

--- a/scripts/deploy.js
+++ b/scripts/deploy.js
@@ -57,6 +57,9 @@
  */
 
 const { spawnSync } = require('node:child_process');
+const { createHash } = require('node:crypto');
+const fs = require('node:fs');
+const path = require('node:path');
 const readline = require('node:readline');
 
 const SERVER = 'root@saxombp';
@@ -315,6 +318,77 @@ function start(omgeving, versie, frontendVersie) {
   return opServer(zet);
 }
 
+/**
+ * Draait de server op hetzelfde compose-bestand als de repository?
+ *
+ * ── Waarom dit bestaat ──────────────────────────────────────────────────────
+ *
+ * Dit script gebruikt `/opt/mcm2/docker-compose.omgeving.yml` op de server,
+ * maar brengt dat bestand niet mee — het komt daar via `deploy:inrichten`, dat
+ * alleen op een lege server draait. Wijzig je het bestand in de repository, dan
+ * draait de uitrol stilzwijgend door op de oude versie.
+ *
+ * Dat is geen theoretisch risico. Op 2026-08-10 stond op saxombp nog een versie
+ * met `profiles: ["frontend"]` erin, terwijl die regel in de repository al weg
+ * was. Gevolg: de frontend-container werd niet aangemaakt — geen fout, geen
+ * container, alleen een rookproef die faalde met "kreeg 000". Zoeken naar de
+ * oorzaak kostte meer tijd dan de uitrol zelf.
+ *
+ * Vergelijken gebeurt op de inhoud en niet op de wijzigingsdatum: een bestand
+ * dat toevallig even oud is, kan nog steeds anders zijn.
+ *
+ * ── Waarom dit stopt en niet zelf kopieert ──────────────────────────────────
+ *
+ * Het bestand overschrijven raakt beide omgevingen tegelijk — ook productie,
+ * die op dat moment kan draaien. Dat hoort een bewuste handeling te zijn, niet
+ * een bijwerking van een uitrol naar acceptatie.
+ */
+function controleerComposeBestand() {
+  const lokaalPad = path.join(
+    __dirname,
+    '..',
+    'deploy',
+    'docker-compose.omgeving.yml',
+  );
+
+  const lokaal = createHash('sha256')
+    .update(fs.readFileSync(lokaalPad))
+    .digest('hex');
+
+  const opDeServer = opServer(
+    `sha256sum ${SERVER_MAP}/docker-compose.omgeving.yml 2>/dev/null | cut -d' ' -f1 || true`,
+    { stil: true },
+  );
+
+  const server = opDeServer.uit.trim();
+
+  if (!server) {
+    stop(
+      `${SERVER_MAP}/docker-compose.omgeving.yml ontbreekt op de server.`,
+      'Richt de server eerst in:\n  npm run deploy:inrichten',
+    );
+  }
+
+  if (server !== lokaal) {
+    stop(
+      'Het compose-bestand op de server wijkt af van dat in de repository.',
+      `  server:      ${server.slice(0, 16)}…\n` +
+        `  repository:  ${lokaal.slice(0, 16)}…\n\n` +
+        'De uitrol zou draaien op een andere opzet dan je hier voor je hebt.\n' +
+        'Precies dat gebeurde op 2026-08-10: de frontend stond op de server nog\n' +
+        'achter een profiel en werd stilzwijgend overgeslagen.\n\n' +
+        'Verschil bekijken:\n' +
+        `  ssh ${SERVER} "cat ${SERVER_MAP}/docker-compose.omgeving.yml" | diff - deploy/docker-compose.omgeving.yml\n\n` +
+        'Bijwerken (raakt BEIDE omgevingen, dus kijk eerst naar het verschil):\n' +
+        `  ssh ${SERVER} "cp ${SERVER_MAP}/docker-compose.omgeving.yml ${SERVER_MAP}/docker-compose.omgeving.yml.bak"\n` +
+        `  ssh ${SERVER} "cat > ${SERVER_MAP}/docker-compose.omgeving.yml" < deploy/docker-compose.omgeving.yml\n\n` +
+        'Er is niets gewijzigd — de draaiende omgeving is niet aangeraakt.',
+    );
+  }
+
+  console.log(`     ${kleur.groen('OK')}   compose-bestand gelijk aan de repository`);
+}
+
 async function main() {
   const doelNaam = process.argv[2];
   const omgeving = OMGEVINGEN[doelNaam];
@@ -360,6 +434,8 @@ async function main() {
       'Richt de server eerst in:\n  npm run deploy:inrichten\n\nZie docs/runbooks/uitrol-acceptatie-en-productie.md.',
     );
   }
+
+  controleerComposeBestand();
 
   const vorige = huidigeVersie(omgeving);
   // Ook de frontend vastleggen, en wel hier — vóór er iets vervangen wordt.


### PR DESCRIPTION
## Gevonden bij de eerste echte uitrol met frontend

Vanavond, direct na het mergen van #128. De uitrol naar acceptatie faalde op de rookproef met `kreeg 000`, en `docker logs` meldde dat de frontend-container **niet bestond**.

## De oorzaak

`deploy.js` gebruikt `/opt/mcm2/docker-compose.omgeving.yml` op de server, maar **brengt dat bestand niet mee**. Het komt daar via `deploy:inrichten`, en dat script weigert op een server waar al iets draait — terecht, want het zou de databasewachtwoorden opnieuw zetten.

Op saxombp stond dus nog een versie met `profiles: ["frontend"]` erin, terwijl die regel in de repository al weg was (#127). Zonder `--profile frontend` slaat compose die dienst over: geen fout, geen container, niets.

**Dit is dezelfde klasse als Issue #86 en de vier fouten van 10-08:** alles meldt succes, en wat er werkelijk draait is iets anders. Het verschil is dat het hier niet in de code zat maar in de afstand tussen repository en server.

## De reparatie

De controle staat in **stap 1**, vóór er iets is aangeraakt, en vergelijkt op **inhoud (sha256)** — niet op wijzigingsdatum, want een bestand dat toevallig even oud is kan nog steeds anders zijn.

**Het script kopieert bewust niet zelf.** Dat bestand raakt beide omgevingen tegelijk, ook productie, die op dat moment kan draaien. Zoiets hoort een bewuste handeling te zijn en geen bijwerking van een uitrol naar acceptatie. De foutmelding geeft de commando's, inclusief de backupstap en een `diff` om eerst te kijken.

## Beide grenzen beproefd op saxombp

**Groen — server gelijk aan de repo:**
```
1/6  Server bereikbaar en ingericht?
     OK   compose-bestand gelijk aan de repository
     OK   nu actief: backend sha-e645e7796489, frontend sha-635ff21150bd
```

**Rood — één regel aan het serverbestand toegevoegd:**
```
GESTOPT: Het compose-bestand op de server wijkt af van dat in de repository.

  server:      30154be06f00fe36…
  repository:  2fcb08b568b2f847…

Er is niets gewijzigd — de draaiende omgeving is niet aangeraakt.
```

Server daarna hersteld en de vingerafdrukken teruggelezen: identiek.

## De uitrol zelf is geslaagd

Na het bijwerken van het compose-bestand draait acceptatie volledig:

```
── ACCEPTATIE ────────────────────────────────────────
   ● frontend   sha-635ff21150bd     Up
   ● api        sha-e645e7796489     Up
   ● db         17.6                 Up (healthy)

   backend  http://saxombp:5011/health   200
   frontend http://saxombp:3010/         200
   frontend → backend                    401
```

**En de nieuwe rookproefcontrole bewees zijn waarde.** Met een opzettelijk verkeerd `API_BASE_URL` op de server:

| Controle | Antwoord |
|---|---|
| frontend serveert een pagina | **200** ← de oude rookproef had dit groen gemeld |
| frontend bereikt de backend | **502** ← de nieuwe controle vangt het |

Zonder die tweede regel had een omgeving met een verkeerd ingesteld adres een geslaagde uitrol opgeleverd.

## Poorten

`format:check`, `lint:check`, `typecheck`, `verify:onderhoud` groen. **383 unittests geslaagd.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)