### PR TITLE
Uitnodigingslink wijst naar de frontend (#132)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -173,3 +173,24 @@ MAIL_AFZENDER_ADRES=
 # http://localhost:3000, wat in een echte mail zichtbaar fout is in plaats van
 # stil verkeerd.
 PORTAAL_BASIS_URL=http://localhost:3000
+
+# Waar de uitnodiging voor een nieuwe TENANTBEHEERDER heen wijst (Issue #132).
+# Ook dit is de FRONTEND, maar om een andere reden dan hierboven: de link gaat
+# naar /api/backend/auth/login -- het doorgeefluik van de frontend naar deze
+# API. Die route zet het uitnodigingstoken in het pogingcookie en stuurt door
+# naar Microsoft.
+#
+# Waarom niet rechtstreeks naar deze API: sinds Issue #51 praat de browser
+# alleen nog met de frontend. Een link naar de API-poort zet het pogingcookie op
+# een andere herkomst dan waar de callback terugkomt, en dan mislukt elke login
+# op een ontbrekende state. Zelfde valkuil als bij OIDC_REDIRECT_URI.
+#
+# Meestal gelijk aan PORTAAL_BASIS_URL -- het is dezelfde frontend. Twee
+# variabelen omdat het twee verschillende stromen zijn: de leverancier gaat naar
+# het portaal, de beheerder naar de inlog.
+#
+# Hier stond eerder API_BASIS_URL, met het adres van deze API. Die variabele
+# stond in geen enkel voorbeeldbestand en werd dus nooit gezet: elke uitgerolde
+# omgeving gaf een link naar localhost. Gevonden op 2026-08-10, bij de eerste
+# tenant die op acceptatie werd aangemaakt.
+UITNODIGING_BASIS_URL=http://localhost:3000

--- a/deploy/docker-compose.omgeving.yml
+++ b/deploy/docker-compose.omgeving.yml
@@ -118,6 +118,16 @@ services:
       # staat.
       NA_LOGIN_URL: ${NA_LOGIN_URL}
       NA_LOGOUT_URL: ${NA_LOGOUT_URL}
+      #
+      # Waar links naartoe wijzen die een ontvanger in zijn browser opent
+      # (Issue #132). Beide de frontend: het portaal voor de leverancier, het
+      # doorgeefluik naar /auth/login voor een nieuwe tenantbeheerder.
+      #
+      # Ontbraken tot 2026-08-10. Elke uitgerolde omgeving gaf daardoor een
+      # uitnodigingslink naar localhost — en zo'n token bestaat maar één keer,
+      # dus die link is niet te repareren.
+      PORTAAL_BASIS_URL: ${PORTAAL_BASIS_URL}
+      UITNODIGING_BASIS_URL: ${UITNODIGING_BASIS_URL}
     ports:
       - "${API_POORT}:5001"
     depends_on:

--- a/docs/runbooks/uitrol-acceptatie-en-productie.md
+++ b/docs/runbooks/uitrol-acceptatie-en-productie.md
@@ -324,6 +324,7 @@ opzet: het script kent het client-secret niet en hoort het niet uit een lokale
 | `OIDC_ISSUER`, `OIDC_TOKEN_ENDPOINT`, `OIDC_JWKS_URI`, `OIDC_CLIENT_ID` | `.env.example` §Identity |
 | `OIDC_CLIENT_SECRET` | de lokale `.env` — nooit in git |
 | `OIDC_REDIRECT_URI` | vooringevuld op de frontend-poort |
+| `PORTAAL_BASIS_URL`, `UITNODIGING_BASIS_URL` | vooringevuld op de frontend-poort. Zie hieronder — dit ging op 10-08 mis |
 | `NA_LOGIN_URL`, `NA_LOGOUT_URL` | vooringevuld; zonder deze valt de backend terug op `/`, en dat is de backend-poort waar geen scherm staat |
 
 ### En dan de stap die niet in code zit
@@ -338,8 +339,41 @@ die lijst:
 | Omgeving | Redirect-URI |
 |---|---|
 | lokaal | `http://localhost:5001/auth/callback` |
-| acceptatie | `http://saxombp:3010/api/backend/auth/callback` |
-| productie | `http://saxombp:3020/api/backend/auth/callback` |
+| acceptatie | `https://saxombp.tail4b29b.ts.net/api/backend/auth/callback` |
+| productie | nog niet ingericht — vraagt eerst HTTPS |
+
+> **Let op de `https`.** Entra accepteert **geen** `http`-adres, behalve op
+> `localhost`. Dat is geen instelling die je omzeilt: het invoerveld weigert de
+> waarde met *"Must start with HTTPS or http://localhost"*.
+>
+> Daarom draait acceptatie sinds 2026-08-10 via `tailscale serve` op
+> `https://saxombp.tail4b29b.ts.net`. Productie heeft dat nog niet, en kan
+> daarom nog geen inlog hebben.
+
+### Waar links naartoe wijzen (Issue #132)
+
+Twee variabelen, allebei het adres van de **frontend**, allebei op 10-08 gemist:
+
+| Variabele | Waarvoor | Pad dat de code erachter zet |
+|---|---|---|
+| `PORTAAL_BASIS_URL` | de leverancier die een vragenlijst invult | `/portal/survey/<token>` |
+| `UITNODIGING_BASIS_URL` | een nieuwe tenantbeheerder | `/api/backend/auth/login?uitnodiging=<token>` |
+
+**Waarom de tweede niet naar de API wijst.** Die link komt uit op `/auth/login`,
+en die route zet het uitnodigingstoken in het pogingcookie. Sinds Issue #51
+praat de browser alleen nog met de frontend; een link naar de API-poort zou dat
+cookie op een andere herkomst zetten dan waar de callback terugkomt, en dan
+mislukt de login op een ontbrekende state. Zelfde valkuil als bij
+`OIDC_REDIRECT_URI`.
+
+**Wat er misging op 10-08.** De code las `API_BASIS_URL` — een variabele die in
+geen enkel voorbeeldbestand stond en dus nooit gezet werd. De eerste tenant op
+acceptatie kreeg daardoor een uitnodigingslink naar `http://localhost:5001`, een
+adres dat op die server niet bestaat.
+
+**Dat is niet te repareren achteraf.** Het token bestaat alleen op het moment
+van aanmaken; er is geen route die het opnieuw toont. Een verkeerde link
+betekent: tenant aangemaakt, beheerder kan er niet in, opnieuw beginnen.
 
 Controleren wat de backend werkelijk meestuurt — niet wat er in het bestand
 staat:

--- a/scripts/deploy-inrichten.js
+++ b/scripts/deploy-inrichten.js
@@ -301,6 +301,20 @@ function main() {
       `NA_LOGIN_URL=http://saxombp:${o.frontendPoort}/beheer`,
       `NA_LOGOUT_URL=http://saxombp:${o.frontendPoort}/`,
       '',
+      '# ── Waar links naartoe wijzen (Issue #132) ────────────────────────────',
+      '#',
+      '# Beide de FRONTEND, want beide zijn adressen die een ontvanger in zijn',
+      '# browser opent. PORTAAL_BASIS_URL is de leverancierskant',
+      '# (/portal/survey/<token>), UITNODIGING_BASIS_URL de beheerderskant',
+      '# (/api/backend/auth/login?uitnodiging=<token>).',
+      '#',
+      '# Ontbraken tot 2026-08-10 allebei in dit script. Gevolg: elke uitgerolde',
+      '# omgeving gaf een uitnodigingslink naar localhost — een adres dat daar',
+      '# niet bestaat. Het token bestaat maar één keer en is niet opnieuw uit te',
+      '# geven, dus zo’n link is niet te repareren.',
+      `PORTAAL_BASIS_URL=http://saxombp:${o.frontendPoort}`,
+      `UITNODIGING_BASIS_URL=http://saxombp:${o.frontendPoort}`,
+      '',
     ].join('\n');
 
     const schrijf = spawnSync(

--- a/src/platform/platform.controller.ts
+++ b/src/platform/platform.controller.ts
@@ -100,20 +100,39 @@ export class PlatformController {
   /**
    * De URL die de nieuwe beheerder in de mail krijgt.
    *
-   * Wijst naar **deze backend** en niet naar het portaal: `/auth/login` zet het
-   * token in het pogingcookie en stuurt door naar de identity provider. Het
-   * portaal is de leverancierskant en heeft met deze stroom niets te maken.
+   * Wijst naar `/auth/login` en niet naar het portaal: die route zet het token
+   * in het pogingcookie en stuurt door naar de identity provider. Het portaal
+   * is de leverancierskant en heeft met deze stroom niets te maken.
    *
-   * `API_BASIS_URL` en niet `PORTAAL_BASIS_URL`. Ontbreekt de variabele, dan
-   * valt dit terug op de lokale poort — zichtbaar fout in een mail, in plaats
-   * van een lege link waar niemand iets van merkt.
+   * ── Sinds Issue #51 loopt dat via de frontend (Issue #132) ────────────────
+   *
+   * Hier stond `API_BASIS_URL`, met het adres van de backend. Dat klopte zolang
+   * de browser daar rechtstreeks mee praatte; sinds het doorgeefluik doet hij
+   * dat niet meer. Een link naar de backend-poort zou het pogingcookie op de
+   * verkeerde herkomst zetten, en dan is het bij de callback niet meer te
+   * lezen — dezelfde valkuil als bij `OIDC_REDIRECT_URI`.
+   *
+   * `UITNODIGING_BASIS_URL` is daarom het adres van de **frontend**. Het pad
+   * `/api/backend` ervoor is het doorgeefluik.
+   *
+   * ── Waarom de terugval blijft, en waarom hij localhost is ─────────────────
+   *
+   * Ontbreekt de variabele, dan valt dit terug op de lokale frontend. Dat is
+   * zichtbaar fout in een mail naar een klant, in plaats van een lege link waar
+   * niemand iets van merkt. Op 2026-08-10 was dat precies wat er gebeurde: de
+   * variabele bestond nergens, de tenant werd aangemaakt, en de beheerder kreeg
+   * een link naar een adres dat op die server niet bestaat.
+   *
+   * Dat de terugval bestaat is dus geen vangnet maar een leesbare fout. De
+   * echte oplossing is dat `deploy-inrichten.js` deze variabele per omgeving
+   * neerzet — daar volgt hij uit het poortnummer.
    */
   private uitnodigingsLink(token: string): string {
     const basis = (
-      process.env.API_BASIS_URL ?? 'http://localhost:5001'
+      process.env.UITNODIGING_BASIS_URL ?? 'http://localhost:3000'
     ).replace(/\/+$/, '');
 
-    return `${basis}/auth/login?uitnodiging=${encodeURIComponent(token)}`;
+    return `${basis}/api/backend/auth/login?uitnodiging=${encodeURIComponent(token)}`;
   }
 
   @Get('tenants/:id')

--- a/test/platform-routes.e2e-spec.ts
+++ b/test/platform-routes.e2e-spec.ts
@@ -272,9 +272,56 @@ describe('Platformroutes (e2e, ADR-015)', () => {
 
       expect(uit.uitnodigingslink).toContain('/auth/login?uitnodiging=');
       expect(uit.uitnodigingslink).toContain(uit.uitnodigingstoken);
-      // Naar de backend, niet naar het portaal: /auth/login zet het token in
+      // Naar /auth/login, niet naar het portaal: die route zet het token in
       // het pogingcookie. Het portaal is de leverancierskant.
       expect(uit.uitnodigingslink).not.toContain('/portal/');
+
+      // Via het doorgeefluik van de frontend (Issue #132). Deze regel is de
+      // hele reden dat de test bestaat: de link wees tot 2026-08-10 naar de
+      // backend-poort, en dan zet /auth/login het pogingcookie op een andere
+      // herkomst dan waar de callback terugkomt. Elke login mislukt dan op een
+      // ontbrekende state — een fout die pas opvalt bij de eerste beheerder die
+      // zijn uitnodiging gebruikt.
+      expect(uit.uitnodigingslink).toContain('/api/backend/auth/login');
+    });
+
+    it('bouwt de link op UITNODIGING_BASIS_URL, niet op een vast adres', async () => {
+      // De aanleiding voor Issue #132: er bestond een variabele (API_BASIS_URL)
+      // die nergens gedocumenteerd stond en dus nooit gezet werd. Elke
+      // uitgerolde omgeving gaf daardoor een link naar localhost — een adres
+      // dat daar niet bestaat.
+      //
+      // Deze test faalt zodra iemand het adres opnieuw hardcodeert of de naam
+      // van de variabele wijzigt zonder erbij na te denken.
+      const oud = process.env.UITNODIGING_BASIS_URL;
+      process.env.UITNODIGING_BASIS_URL = 'https://acceptatie.voorbeeld.nl/';
+
+      try {
+        const antwoord = await request(server)
+          .post('/platform/tenants')
+          .set('Cookie', cookieBeheerder)
+          .send({
+            naam: `Basisurltest ${Date.now()}`,
+            adminNaam: 'Linkbeheerder',
+            adminEmail: `basis-${Date.now()}@voorbeeld.nl`,
+          })
+          .expect(201);
+
+        const uit = body(antwoord) as Record<string, string>;
+        aangemaakt.push(uit.tenantId);
+
+        // De afsluitende schuine streep uit de variabele hoort weg te vallen;
+        // anders staat er een dubbele in de link.
+        expect(uit.uitnodigingslink).toMatch(
+          /^https:\/\/acceptatie\.voorbeeld\.nl\/api\/backend\/auth\/login\?uitnodiging=/,
+        );
+      } finally {
+        if (oud === undefined) {
+          delete process.env.UITNODIGING_BASIS_URL;
+        } else {
+          process.env.UITNODIGING_BASIS_URL = oud;
+        }
+      }
     });
 
     it('bewaart het antwoordadres van de tenant', async () => {


### PR DESCRIPTION
## Wat er misging

De link voor een nieuwe tenantbeheerder werd gebouwd op `API_BASIS_URL` — een variabele die in **geen enkel voorbeeldbestand** stond en dus nooit gezet werd. De enige verwijzing ernaar stond in `platform.controller.ts` zelf.

De eerste tenant op acceptatie kreeg daardoor:

```
http://localhost:5001/auth/login?uitnodiging=1NjlfxeI…
```

Een adres dat op die server niet bestaat.

**Dat is niet achteraf te repareren.** Het uitnodigingstoken bestaat alleen op het moment van aanmaken; er is geen route die het opnieuw toont. Een verkeerde link betekent: tenant aangemaakt, beheerder kan er niet in, opnieuw beginnen.

## De link moet naar de frontend

De toelichting in de code redeneerde nog vanuit de situatie vóór Issue #51:

> *"Wijst naar deze backend en niet naar het portaal: `/auth/login` zet het token in het pogingcookie."*

Het tweede deel klopt nog. Het eerste niet meer: sinds het doorgeefluik praat de browser alleen nog met de frontend. Een link naar de API-poort zou dat pogingcookie op een andere herkomst zetten dan waar de callback terugkomt — en dan mislukt de login op een ontbrekende state. Precies de valkuil die bij `OIDC_REDIRECT_URI` is vermeden.

`UITNODIGING_BASIS_URL` is daarom het adres van de **frontend**; de code zet `/api/backend/auth/login` erachter.

## De aanname eerst getoetst

Dat de uitnodigingsroute via het doorgeefluik werkt, was niet vanzelfsprekend. Gemeten tegen de draaiende acceptatieomgeving vóór het bouwen:

```
GET /api/backend/auth/login?uitnodiging=<43 tekens>
  → 302 naar ciamlogin.com
  → __Host-mcm2_inlog gezet, 131 tekens
zonder token: 87 tekens
```

Het verschil van 44 tekens bewijst dat het token werkelijk in het cookie belandt.

> **Eén meting die faalde om de verkeerde reden.** Mijn eerste poging gebruikte een token van 12 tekens en gaf geen verschil — waaruit ik bijna concludeerde dat het token niet meereist. Fout: `heeftGeldigeVorm()` eist er 43, dus het werd terecht genegeerd. Met een geldig token bleek het wél te werken.

## Tests

Twee, en ze dekken een ander stuk:

1. de link bevat `/api/backend/auth/login`
2. de link wordt gebouwd op `UITNODIGING_BASIS_URL` — de test overschrijft de variabele en toetst de volledige link, inclusief het wegvallen van een dubbele schuine streep

**Tegenproef gedraaid** met een hardgecodeerd backend-adres:

```
● bouwt de link op UITNODIGING_BASIS_URL, niet op een vast adres
  Expected pattern: /^https:\/\/acceptatie\.voorbeeld\.nl\/api\/backend\/auth\/login\?uitnodiging=/
  Received string:  "http://localhost:5001/api/backend/auth/login?uitnodiging=…"
```

Test 1 bleef daarbij groen — ze meten dus werkelijk iets anders.

## Ook meegenomen

`deploy-inrichten.js` zet nu **`PORTAAL_BASIS_URL` én `UITNODIGING_BASIS_URL`** neer, vooringevuld op de frontend-poort. Beide ontbraken; de eerste is nooit opgevallen omdat er op acceptatie nog geen leverancier is uitgenodigd.

De redirect-tabel in het runbook stond nog op `http` voor acceptatie — achterhaald sinds gisteravond, want Entra weigert dat. Gecorrigeerd naar `https://saxombp.tail4b29b.ts.net`.

## Poorten

**471 e2e-tests** (34 suites, volledige run — de stap die botsingen tussen suites vindt), 383 unittests, `format:check`, `lint:check`, `typecheck`, `verify:onderhoud`. Alles groen.

Closes #132

🤖 Generated with [Claude Code](https://claude.com/claude-code)