### PR TITLE
Migraties automatisch naar staging, met teruglezen (stap 3)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -219,3 +219,118 @@ jobs:
           echo "Gepubliceerd:"
           echo "  $SHA_TAG"
           echo "  $LATEST_TAG"
+
+  # ── Uitrol naar staging ────────────────────────────────────────────────────
+  #
+  # Stap 3 van docs/architectuur/plan-otap-straat-met-staging.md.
+  #
+  # Staging is een tweede Supabase-project (`clm-staging3`). Dat is geen
+  # willekeurige keuze: productie draait Postgres bij AWS in Ierland achter een
+  # connection pooler, en een repetitie in een lokale container bewijst het
+  # verkeerde. De pooler is precies de plek waar het anders gaat — verbindingen
+  # die anders worden vastgehouden, andere timeouts, ander gedrag bij migraties
+  # die een tabel vergrendelen (§1 van het plan).
+  #
+  # ── Wat deze job wél en niet doet ──────────────────────────────────────────
+  #
+  # WEL: migraties draaien tegen staging en TERUGLEZEN of ze geland zijn.
+  # NIET: een applicatie starten en een rookproef doen — dat vraagt toegang tot
+  # saxombp, en GitHub zit niet in dat Tailscale-netwerk. Die helft volgt apart.
+  #
+  # Dat onderscheid is bewust en het is de waardevolste helft: migraties zijn
+  # waar het misgaat. Op 2026-08-07 meldde `migrate:deploy` "Migraties voltooid"
+  # terwijl er niets gebeurde, en in Issue #86 gebeurde het op de verkeerde
+  # database. Beide keren was de melding waar over iets anders.
+  staging:
+    name: Migraties naar staging
+    runs-on: ubuntu-latest
+    needs: [publiceren]
+    # Alleen vanaf main, en alleen als er werkelijk een image is gepubliceerd.
+    # `needs` dekt dat al, maar de expliciete voorwaarde blijft staan: een job
+    # die per ongeluk op een branch draait, migreert een echte database.
+    if: >-
+      github.ref == 'refs/heads/main' &&
+      (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Node.js instellen
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: ".nvmrc"
+          cache: "npm"
+
+      - name: Dependencies installeren
+        run: npm ci
+
+      # ── Vóór ──────────────────────────────────────────────────────────────
+      #
+      # De stand vastleggen voordat er iets gebeurt. Zonder deze meting is
+      # "onveranderd" achteraf niet te onderscheiden van "niets gedaan".
+      - name: Migratiestand vóór de uitrol
+        env:
+          MIGRATION_DATABASE_URL: ${{ secrets.STAGING_MIGRATION_DATABASE_URL }}
+        run: |
+          VOOR=$(node scripts/migratiestand.js | grep -oE '[0-9]+$' | head -1)
+          echo "VOOR=$VOOR" >> "$GITHUB_ENV"
+          echo "Staging stond op $VOOR migraties."
+
+      # `--extern` staat hier expliciet bij de aanroep en niet als
+      # omgevingsvariabele. Het runbook eist dat die vlag een zichtbare,
+      # bewuste uitzondering blijft: hij hoort terug te zien te zijn in de
+      # pipeline. Een `MCM2_EXTERNE_DB=ja` in de omgeving zou hem onzichtbaar
+      # maken voor elke volgende stap — precies wat er niet mag.
+      - name: Migraties draaien tegen staging
+        env:
+          MIGRATION_DATABASE_URL: ${{ secrets.STAGING_MIGRATION_DATABASE_URL }}
+        run: node scripts/migrate.js --extern
+
+      # ── Ná: teruglezen, niet de melding geloven ───────────────────────────
+      #
+      # `--volgens-journal` vergelijkt met drizzle/meta/_journal.json — het
+      # bestand dat migrate() zelf leest. Wat daarin staat is per definitie wat
+      # er na een geslaagde uitrol op de database hoort te staan.
+      #
+      # Een getal in dit bestand zou verouderen bij de volgende migratie, en
+      # dan faalt de controle om de verkeerde reden of blijft hij groen terwijl
+      # er iets ontbreekt.
+      - name: Migratiestand teruglezen en vergelijken met de repository
+        env:
+          MIGRATION_DATABASE_URL: ${{ secrets.STAGING_MIGRATION_DATABASE_URL }}
+        run: node scripts/migratiestand.js --volgens-journal
+
+      # De runtime-rol moet er ook bij kunnen. Slaagt de migratie maar faalt
+      # deze stap, dan staan de rechten verkeerd — en dat merk je anders pas
+      # wanneer de applicatie start en elk scherm een fout geeft.
+      - name: De runtime-rol kan bij zijn eigen gegevens
+        env:
+          DATABASE_URL: ${{ secrets.STAGING_DATABASE_URL }}
+        run: |
+          node -e "
+            const {Client} = require('pg');
+            const c = new Client({
+              connectionString: process.env.DATABASE_URL,
+              ssl: { rejectUnauthorized: false },
+              connectionTimeoutMillis: 30000,
+            });
+            c.connect()
+              .then(() => c.query('SELECT count(*)::int AS n FROM clm.tenant'))
+              .then((r) => {
+                console.log('clm_api_runtime leest clm.tenant: ' + r.rows[0].n + ' rijen');
+                return c.end();
+              })
+              .catch((e) => { console.error('MISLUKT: ' + e.message); process.exit(1); });
+          "
+
+      - name: Samenvatting
+        run: |
+          echo "### Staging bijgewerkt" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "| | |" >> "$GITHUB_STEP_SUMMARY"
+          echo "|---|---|" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Commit | \`${GITHUB_SHA::12}\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Migraties vóór | $VOOR |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Migraties ná | teruggelezen, gelijk aan het journal |" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "Er draait nog geen applicatie tegen staging; dat is een aparte stap." >> "$GITHUB_STEP_SUMMARY"

--- a/scripts/migratiestand.js
+++ b/scripts/migratiestand.js
@@ -1,0 +1,188 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * Leest de migratiestand terug uit een database. Uitsluitend SELECT.
+ *
+ * ── Waarom dit bestaat ───────────────────────────────────────────────────────
+ *
+ * "Migraties voltooid" is geen bewijs. Op 2026-08-07 betekende die melding dat
+ * er niets was gebeurd — de migratie stond niet in `_journal.json` en Drizzle
+ * sloeg hem stil over. In Issue #86 betekende hij dat het op de verkéérde
+ * database was gebeurd. Beide keren klopte de melding over iets anders dan waar
+ * hij over leek te gaan.
+ *
+ * Het runbook eist daarom: lees het resultaat terug uit de database. Dit script
+ * maakt dat uitvoerbaar in een pipeline, waar niemand meekijkt.
+ *
+ * ── Waarom een apart script en geen query in de workflow ─────────────────────
+ *
+ * Een `psql`-aanroep in YAML is niet te testen en niet te lezen. Belangrijker:
+ * de vergelijking hoort ergens te staan waar hij toegelicht kan worden. Een
+ * onveranderd getal ná een migratie is niet altijd fout — bij een uitrol zonder
+ * nieuwe migraties is dat juist correct. Wat wél altijd fout is: nul.
+ *
+ * ── Gebruik ──────────────────────────────────────────────────────────────────
+ *
+ *   node scripts/migratiestand.js                     # print het aantal
+ *   node scripts/migratiestand.js --verwacht 26       # faalt bij afwijking
+ *   node scripts/migratiestand.js --minstens 26       # faalt bij minder
+ *   node scripts/migratiestand.js --volgens-journal   # vergelijkt met de repo
+ *
+ * Die laatste is de bruikbaarste in een pipeline: hij leest het verwachte
+ * aantal uit `drizzle/meta/_journal.json` in plaats van uit een getal dat
+ * iemand in een workflow heeft getypt. Zo'n getal veroudert bij de volgende
+ * migratie, en dan faalt de controle om de verkeerde reden — of erger, hij
+ * blijft groen terwijl er iets ontbreekt.
+ *
+ * Leest MIGRATION_DATABASE_URL. `clm_api_runtime` mag niet bij het
+ * drizzle-schema (ADR-009), dus de migratierol is hier nodig — lezen alleen.
+ */
+
+require('dotenv/config');
+
+const { Client } = require('pg');
+
+const { meldDoelwit } = require('./db-doelwit.js');
+
+const url = process.env.MIGRATION_DATABASE_URL;
+
+if (!url) {
+  console.error(
+    'MIGRATION_DATABASE_URL ontbreekt. De migratietabel staat in het\n' +
+      'drizzle-schema, en clm_api_runtime mag daar niet bij (ADR-009).',
+  );
+  process.exit(1);
+}
+
+/**
+ * Geen `eisToestemmingBuitenLokaal` hier, en dat is een bewuste afwijking van
+ * de andere scripts.
+ *
+ * Die rem beschermt tegen ongewild *schrijven* op een echte database. Dit
+ * script doet uitsluitend `SELECT count(*)`. Een leesquery tegen staging of
+ * productie is precies wat je wilt kunnen doen zonder een vlag die je went
+ * eraan mee te geven — en dat wennen is het echte risico dat het runbook
+ * beschrijft.
+ *
+ * Het doelwit wordt wél altijd gemeld, want een meting op de verkeerde database
+ * is een verkeerde meting. Dat was de fout van 2026-08-10.
+ */
+meldDoelwit(url, 'Migratiestand lezen');
+
+function leesGetal(vlag) {
+  const index = process.argv.indexOf(vlag);
+  if (index === -1) return null;
+
+  const waarde = Number(process.argv[index + 1]);
+  return Number.isInteger(waarde) && waarde >= 0 ? waarde : null;
+}
+
+async function main() {
+  const client = new Client({
+    connectionString: url,
+    // Supabase en RDS eisen TLS. `rejectUnauthorized: false` omdat de
+    // pooler een certificaat aanbiedt dat niet in de standaardketen van Node
+    // zit; dezelfde afweging als in platformbeheerder-inrichten.js.
+    ssl: /supabase|amazonaws|neon/.test(url)
+      ? { rejectUnauthorized: false }
+      : undefined,
+    connectionTimeoutMillis: 30_000,
+  });
+
+  try {
+    await client.connect();
+  } catch (fout) {
+    console.error(`\nGeen verbinding met de database: ${fout.message}\n`);
+    process.exit(1);
+  }
+
+  let aantal;
+
+  try {
+    const uitkomst = await client.query(
+      'SELECT count(*)::int AS aantal FROM drizzle.__drizzle_migrations',
+    );
+    aantal = uitkomst.rows[0].aantal;
+  } catch (fout) {
+    // Een ontbrekende tabel is iets anders dan een verbindingsfout, en de
+    // oorzaak verschilt: nooit gemigreerd, of geen rechten op het schema.
+    console.error(
+      `\nKon de migratietabel niet lezen: ${fout.message}\n` +
+        'Is deze database ooit gemigreerd, en leest dit de migratierol?\n',
+    );
+    await client.end();
+    process.exit(1);
+  }
+
+  await client.end();
+
+  console.log(`Migraties op deze database: ${aantal}`);
+
+  if (aantal === 0) {
+    console.error(
+      '\nNUL migraties. Dat is nooit goed na een uitrol: het betekent dat de\n' +
+        'migratiestap niets heeft gedaan, of tegen een andere database praatte.\n',
+    );
+    process.exit(1);
+  }
+
+  // Het verwachte aantal uit de repository zelf, niet uit een getal dat iemand
+  // heeft ingetypt. `migrate()` leest exact dit bestand; wat erin staat is dus
+  // per definitie wat er na een geslaagde uitrol op de database hoort te staan.
+  if (process.argv.includes('--volgens-journal')) {
+    const journal = JSON.parse(
+      require('node:fs').readFileSync(
+        require('node:path').join(
+          __dirname,
+          '..',
+          'drizzle',
+          'meta',
+          '_journal.json',
+        ),
+        'utf8',
+      ),
+    );
+
+    const verwachtUitJournal = journal.entries.length;
+
+    if (aantal !== verwachtUitJournal) {
+      console.error(
+        `\nDe database staat op ${aantal}, het journal telt ${verwachtUitJournal}.\n` +
+          (aantal < verwachtUitJournal
+            ? 'Er zijn migraties NIET toegepast. Dat is precies de fout die\n' +
+              '"Migraties voltooid" verborg op 2026-08-07.\n'
+            : 'De database loopt vóór op de repository. Draait hier een nieuwere\n' +
+              'versie, of wijst dit naar de verkeerde database?\n'),
+      );
+      process.exit(1);
+    }
+
+    console.log(`Gelijk aan het journal (${verwachtUitJournal}).`);
+  }
+
+  const verwacht = leesGetal('--verwacht');
+
+  if (verwacht !== null && aantal !== verwacht) {
+    console.error(
+      `\nVerwacht ${verwacht}, gevonden ${aantal}.\n` +
+        'Wijkt de stand af, dan is deze database niet gelijk aan de bron.\n',
+    );
+    process.exit(1);
+  }
+
+  const minstens = leesGetal('--minstens');
+
+  if (minstens !== null && aantal < minstens) {
+    console.error(
+      `\nVerwacht minstens ${minstens}, gevonden ${aantal}.\n` +
+        'Er ontbreken migraties op deze database.\n',
+    );
+    process.exit(1);
+  }
+}
+
+main().catch((fout) => {
+  console.error(`\nOnverwachte fout: ${fout.message}\n`);
+  process.exit(1);
+});


### PR DESCRIPTION
## Wat dit doet

Na een geslaagde publicatie op `main` draaien de migraties tegen het Supabase-stagingproject, en wordt **teruggelezen** of ze werkelijk geland zijn.

Dit is de helft van stap 3 die het meeste oplevert en die geen toegang tot saxombp vraagt.

## Waarom staging bij Supabase staat

Geen willekeurige keuze (§1 van het plan): productie draait Postgres bij AWS in Ierland **achter een connection pooler**. Een repetitie in een lokale container bewijst het verkeerde — de pooler is precies de plek waar het anders gaat: verbindingen die anders worden vastgehouden, andere timeouts, ander gedrag bij migraties die een tabel vergrendelen.

## De kern is het teruglezen, niet het migreren

| Datum | Wat de melding zei | Wat er gebeurde |
|---|---|---|
| 2026-08-07 | "Migraties voltooid" | Niets — de migratie stond niet in `_journal.json` |
| Issue #86 | "Migraties voltooid" | Het gebeurde op de **verkeerde database** |

Beide keren klopte de melding over iets anders dan waar hij over leek te gaan.

`scripts/migratiestand.js` leest daarom terug uit de database — uitsluitend `SELECT`. Met `--volgens-journal` vergelijkt hij met `drizzle/meta/_journal.json`, het bestand dat `migrate()` zelf leest. Wat daarin staat is per definitie wat er na een geslaagde uitrol hoort te staan.

> **Waarom niet een getal in de workflow.** Dat veroudert bij de volgende migratie. Dan faalt de controle om de verkeerde reden, of — erger — blijft hij groen terwijl er iets ontbreekt.

## Twee bewuste afwijkingen, beide toegelicht in de code

**Geen `eisToestemmingBuitenLokaal` in het leesscript.** Die rem beschermt tegen ongewild *schrijven*. Een leesquery tegen staging is precies wat je zónder vlag moet kunnen doen — aan die vlag wennen is het echte risico dat het runbook beschrijft. Het doelwit wordt wél altijd gemeld.

**`--extern` staat expliciet bij de migratie-aanroep**, niet als omgevingsvariabele. Het runbook eist dat die vlag zichtbaar blijft in de pipeline; in de omgeving zetten maakt hem onzichtbaar voor elke volgende stap.

## Beproefd tegen het echte stagingproject

```
Migratiestand lezen: aws-1-eu-west-1.pooler.supabase.com:5432/postgres
  als rol 'clm_migrator.ljdldwfylcbubzglxjoa' [NIET-LOKAAL]
Migraties op deze database: 26
Gelijk aan het journal (26).
```

Tegenproeven, **exitcodes zonder pipe gemeten**:

| Aanroep | Exitcode |
|---|---|
| `--volgens-journal` | 0 |
| `--verwacht 99` | 1 — *"Verwacht 99, gevonden 26"* |
| onbereikbare database | 1 |

> Met `| tail` gaf de eerste meting `exitcode 0` — dezelfde valkuil als bij `migrate.js` op 2026-08-10, waar een crash door de pipe naar `tail` als succes werd gelezen. Daarom opnieuw gemeten.

## Ook toegevoegd

Een controle dat `clm_api_runtime` bij `clm.tenant` kan. Slaagt de migratie maar faalt dat, dan staan de rechten verkeerd — en dat merk je anders pas wanneer de applicatie start en elk scherm een fout geeft.

## Wat deze job níét doet

**Geen applicatie starten, geen rookproef.** Dat vraagt toegang tot saxombp, en GitHub Actions zit niet in dat Tailscale-netwerk — er staan daar bovendien geen SSH-sleutels.

Dat volgt apart, met de officiële Tailscale-action. Bewust gescheiden: deze helft werkt vandaag en overleeft een verhuizing naar AWS, de andere helft is er alleen zolang saxombp de uitrolplek is.

## Secrets

`STAGING_MIGRATION_DATABASE_URL` en `STAGING_DATABASE_URL` zijn ingesteld.

## Poorten

`format:check`, `lint:check`, `verify:onderhoud` groen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)