### PR TITLE
Staging draait tegen Supabase over de pooler (stap 3b)

### DIFF
--- a/deploy/compose.lokale-db.yml
+++ b/deploy/compose.lokale-db.yml
@@ -1,0 +1,34 @@
+# Overlay voor omgevingen met een eigen databasecontainer.
+#
+# ── Waarom dit een apart bestand is ────────────────────────────────────────
+#
+# Acceptatie draait tegen een Postgres-container op saxombp; staging praat met
+# een Supabase-project. Dat verschil is niet toevallig — het is de reden dat
+# staging bestaat. Productie draait Postgres bij AWS in Ierland achter een
+# connection pooler, en een repetitie in een lokale container bewijst het
+# verkeerde (§1 van het OTAP-plan).
+#
+# De databaseservice staat in `docker-compose.omgeving.yml` achter het profiel
+# `lokale-db`. Maar een profiel alleen is niet genoeg: Compose weigert een heel
+# compose-bestand zodra een service `depends_on` een dienst achter een inactief
+# profiel — "invalid compose project", en dan start er niets. Gemeten op
+# 2026-08-11, niet aangenomen.
+#
+# Vandaar deze overlay. Wie de lokale database wil, legt hem erover:
+#
+#   docker compose --profile lokale-db \
+#     -f docker-compose.omgeving.yml -f compose.lokale-db.yml up -d
+#
+# `scripts/deploy.js` doet dat zelf, op basis van de omgeving.
+#
+# ── Wat hier NIET in hoort ─────────────────────────────────────────────────
+#
+# Alleen de afhankelijkheid. Elke instelling die per omgeving verschilt hoort
+# in het `.env`-bestand op de server — anders lopen acceptatie en staging
+# ongemerkt uiteen, en dan bewijst een groene acceptatie niets meer.
+
+services:
+  api:
+    depends_on:
+      db:
+        condition: service_healthy

--- a/deploy/docker-compose.omgeving.yml
+++ b/deploy/docker-compose.omgeving.yml
@@ -30,7 +30,22 @@
 name: ${COMPOSE_PROJECT_NAME}
 
 services:
+  # ── De lokale database — niet elke omgeving heeft er een ──────────────────
+  #
+  # Acceptatie draait tegen deze container. Staging niet: die praat met een
+  # Supabase-project, en dat is de hele reden dat staging bestaat. Productie
+  # draait Postgres bij AWS in Ierland achter een connection pooler, en een
+  # repetitie in een lokale container bewijst het verkeerde — de pooler is
+  # precies waar het anders gaat (§1 van het OTAP-plan).
+  #
+  # Vandaar het profiel. `docker compose --profile lokale-db` start hem;
+  # zonder dat profiel bestaat de service niet en start er ook geen container.
+  #
+  # Waarom een profiel en niet `--scale db=0`: schalen naar nul laat de
+  # afhankelijkheid in `depends_on` staan, en dan wacht de api op een
+  # healthcheck die nooit komt.
   db:
+    profiles: ["lokale-db"]
     image: postgres:17.6
     environment:
       POSTGRES_PASSWORD: ${DB_WACHTWOORD}
@@ -56,7 +71,14 @@ services:
   api:
     image: ${API_IMAGE}
     environment:
-      DATABASE_URL: postgresql://clm_api_runtime:${DB_WACHTWOORD}@db:5432/postgres
+      # Waar de database staat. Vóór 2026-08-11 stond hier een vaste
+      # connectiestring naar de `db`-service hierboven; dat kon niet meer toen
+      # staging erbij kwam, want die praat met Supabase.
+      #
+      # De omgevingsbestanden van acceptatie en productie vullen dit met
+      # precies de oude waarde — `deploy-inrichten.js` schrijft hem — dus voor
+      # die twee verandert er niets. Staging krijgt de Supabase-URL.
+      DATABASE_URL: ${DATABASE_URL}
       PORT: "5001"
       CORS_ORIGIN: ${FRONTEND_URL}
       # Het sessiecookie draagt standaard de __Host--prefix en Secure; dat
@@ -130,9 +152,17 @@ services:
       UITNODIGING_BASIS_URL: ${UITNODIGING_BASIS_URL}
     ports:
       - "${API_POORT}:5001"
-    depends_on:
-      db:
-        condition: service_healthy
+    # GEEN `depends_on: db` hier, en dat is geen omissie.
+    #
+    # Docker Compose weigert een heel compose-bestand als een service verwijst
+    # naar een dienst achter een inactief profiel: "service api depends on
+    # undefined service db: invalid compose project". Niet alleen de api start
+    # dan niet — het hele project is ongeldig. Gemeten op 2026-08-11.
+    #
+    # Voor omgevingen mét een lokale database staat de afhankelijkheid in
+    # `compose.lokale-db.yml`, dat er als tweede `-f` overheen gelegd wordt.
+    # Staging heeft die overlay niet: daar staat de database bij Supabase en is
+    # er niets om op te wachten.
     restart: unless-stopped
 
   # ── De frontend, promoveerbaar sinds Issue #51 ────────────────────────────

--- a/docs/runbooks/uitrol-acceptatie-en-productie.md
+++ b/docs/runbooks/uitrol-acceptatie-en-productie.md
@@ -30,10 +30,23 @@ lopen.
 | **O** ontwikkel | laptop | 3000 | 5001 | container 55450 |
 | **T** test | laptop, tijdelijk | — | — | wegwerp 55441 |
 | **A** acceptatie | `saxombp` | 3010 | 5011 | 55460 (127.0.0.1) |
+| **S** staging | `saxombp` | 3030 | 5031 | **Supabase `clm-staging3`** |
 | **P** productie | `saxombp` | 3020 | 5021 | 55470 (127.0.0.1) |
 
-Bereikbaar via Tailscale: `http://saxombp:3010` en `http://saxombp:3020`. Niet
-vanaf internet — alleen vanaf je eigen apparaten.
+Bereikbaar via Tailscale. Acceptatie ook op
+`https://saxombp.tail4b29b.ts.net`; niet vanaf internet — alleen vanaf je eigen
+apparaten.
+
+> **Staging is de enige omgeving zonder eigen databasecontainer**, en dat is de
+> reden dat hij bestaat. Productie draait Postgres bij AWS in Ierland achter een
+> connection pooler; een repetitie in een lokale container bewijst het verkeerde
+> (§1 van het OTAP-plan). De pooler is precies waar het anders gaat —
+> verbindingen die anders worden vastgehouden, andere timeouts, ander gedrag bij
+> migraties die een tabel vergrendelen.
+>
+> **De migraties van staging draaien vanuit CI**, niet vanaf een laptop. Zie de
+> job `staging` in `.github/workflows/ci.yml`; `npm run deploy:staging` slaat
+> die stap over en zegt dat ook.
 
 **Op dezelfde server draait de Saxo-app** onder PM2, op poort 8080 en 8081.
 Die is geen onderdeel van MCM2 en mag nooit geraakt worden. Zowel

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "test:e2e": "jest --config ./test/jest-e2e.json",
     "deploy:inrichten": "node scripts/deploy-inrichten.js",
     "deploy:acceptatie": "node scripts/deploy.js acceptatie",
+    "deploy:staging": "node scripts/deploy.js staging",
     "deploy:productie": "node scripts/deploy.js productie",
     "deploy:status": "node scripts/deploy-status.js",
     "verify": "node scripts/verify.js",

--- a/scripts/deploy-inrichten.js
+++ b/scripts/deploy-inrichten.js
@@ -49,6 +49,22 @@ const OMGEVINGEN = [
     project: 'mcm2-acceptatie',
   },
   {
+    // Staging heeft GEEN dbPoort: de database staat bij Supabase
+    // (`clm-staging3`). Dat is de reden dat staging bestaat — productie draait
+    // Postgres bij AWS in Ierland achter een connection pooler, en een
+    // repetitie in een lokale container bewijst het verkeerde (§1 van het
+    // OTAP-plan).
+    //
+    // Gevolg: `DATABASE_URL` en `MIGRATION_DATABASE_URL` staan hier niet
+    // vooringevuld. Die connectiestrings zijn geheimen en horen niet uit een
+    // script te komen — zelfde afweging als bij OIDC_CLIENT_SECRET.
+    naam: 'staging',
+    apiPoort: 5031,
+    frontendPoort: 3030,
+    dbPoort: null,
+    project: 'mcm2-staging',
+  },
+  {
     naam: 'productie',
     apiPoort: 5021,
     frontendPoort: 3020,
@@ -241,6 +257,12 @@ function main() {
       continue;
     }
 
+    // Eén keer genereren en hergebruiken: het wachtwoord staat zowel los in
+    // DB_WACHTWOORD (voor de databasecontainer) als in DATABASE_URL (voor de
+    // applicatie). Twee aanroepen zouden twee verschillende wachtwoorden
+    // opleveren, en dan start de api met een string die nergens op slaat.
+    const dbWachtwoord = o.dbPoort === null ? null : wachtwoord();
+
     const inhoud = [
       `# Omgeving: ${o.naam.toUpperCase()} — aangemaakt ${new Date().toISOString().slice(0, 10)}`,
       '#',
@@ -250,8 +272,30 @@ function main() {
       '# de omgeving niet meer bij zijn eigen data.',
       '',
       `COMPOSE_PROJECT_NAME=${o.project}`,
-      `DB_WACHTWOORD=${wachtwoord()}`,
-      `DB_POORT=${o.dbPoort}`,
+      ...(o.dbPoort === null
+        ? [
+            '# Deze omgeving heeft GEEN eigen databasecontainer — de database',
+            '# staat bij Supabase. DATABASE_URL hieronder moet met de hand',
+            '# ingevuld worden met de runtime-connectiestring; dat is een',
+            '# geheim en hoort niet uit dit script te komen.',
+            '#',
+            '# DB_WACHTWOORD en DB_POORT staan er leeg bij omdat het',
+            '# compose-bestand ze noemt. Zonder die regels waarschuwt docker',
+            '# compose over lege variabelen, en zo n waarschuwing leidt af van',
+            '# meldingen die er wel toe doen.',
+            'DB_WACHTWOORD=',
+            'DB_POORT=',
+            'DATABASE_URL=',
+          ]
+        : [
+            `DB_WACHTWOORD=${dbWachtwoord}`,
+            `DB_POORT=${o.dbPoort}`,
+            '',
+            '# De runtime-rol tegen de eigen databasecontainer. Zelfde',
+            '# wachtwoord als hierboven; alleen omgevingen met een externe',
+            '# database wijken hiervan af.',
+            `DATABASE_URL=postgresql://clm_api_runtime:${dbWachtwoord}@db:5432/postgres`,
+          ]),
       `API_POORT=${o.apiPoort}`,
       `FRONTEND_POORT=${o.frontendPoort}`,
       '',

--- a/scripts/deploy.js
+++ b/scripts/deploy.js
@@ -107,6 +107,25 @@ const OMGEVINGEN = {
     apiPoort: 5011,
     frontendPoort: 3010,
     bevestiging: false,
+    // Een Postgres-container op deze machine. Mag stuk, wordt weggegooid.
+    lokaleDatabase: true,
+  },
+  staging: {
+    naam: 'staging',
+    project: 'mcm2-staging',
+    apiPoort: 5031,
+    frontendPoort: 3030,
+    bevestiging: false,
+    // GEEN lokale database: staging praat met het Supabase-project
+    // `clm-staging3`. Dat is de hele reden dat staging bestaat — productie
+    // draait Postgres bij AWS in Ierland achter een connection pooler, en een
+    // repetitie in een container bewijst het verkeerde (§1 van het plan).
+    //
+    // De migraties gaan hier niet vanaf deze machine maar vanuit CI; zie de
+    // job `staging` in .github/workflows/ci.yml. Deze uitrol start alleen de
+    // applicatie.
+    lokaleDatabase: false,
+    migratiesOverslaan: true,
   },
   productie: {
     naam: 'productie',
@@ -116,6 +135,7 @@ const OMGEVINGEN = {
     // Productie krijgt nooit een stille uitrol. Ook niet als het "maar een
     // kleine wijziging" is — juist dan.
     bevestiging: true,
+    lokaleDatabase: true,
   },
 };
 
@@ -305,6 +325,16 @@ function start(omgeving, versie, frontendVersie) {
   // image gepubliceerd wordt, en dat is een tijdelijke toestand.
   const schaal = FRONTEND_MEE ? '' : '--scale frontend=0 ';
 
+  // Omgevingen met een eigen databasecontainer krijgen het profiel én de
+  // overlay die de afhankelijkheid legt. Zonder de overlay start de api
+  // voordat Postgres klaar is; zonder het profiel bestaat de container niet.
+  //
+  // Staging krijgt geen van beide: die praat met Supabase. Zie
+  // deploy/compose.lokale-db.yml voor waarom dat twee losse dingen zijn.
+  const db = omgeving.lokaleDatabase
+    ? '--profile lokale-db -f docker-compose.omgeving.yml -f compose.lokale-db.yml'
+    : '-f docker-compose.omgeving.yml';
+
   const zet = [
     `cd ${SERVER_MAP}`,
     `export API_IMAGE=$(grep '^GHCR_API=' ${omgeving.naam}.env | cut -d= -f2):${versie}`,
@@ -312,7 +342,7 @@ function start(omgeving, versie, frontendVersie) {
     // waarschuwt anders over een lege variabele, en zo'n waarschuwing in de
     // uitvoer van een uitrol leidt af van meldingen die er wél toe doen.
     `export FRONTEND_IMAGE=$(grep '^GHCR_FRONTEND=' ${omgeving.naam}.env | cut -d= -f2):${frontendVersie}`,
-    `docker compose --env-file ${omgeving.naam}.env -p ${omgeving.project} -f docker-compose.omgeving.yml up -d ${schaal}`.trim(),
+    `docker compose --env-file ${omgeving.naam}.env -p ${omgeving.project} ${db} up -d ${schaal}`.trim(),
   ].join(' && ');
 
   return opServer(zet);
@@ -575,9 +605,22 @@ async function main() {
   // verzwakken — daar verandert niets aan, en een handmatige
   // `npm run migrate:deploy` op je laptop weigert nog steeds gewoon.
   console.log('');
-  console.log('4/6  Migraties op de database van deze omgeving');
+  console.log(
+    omgeving.migratiesOverslaan
+      ? '4/6  Migraties — overgeslagen'
+      : '4/6  Migraties op de database van deze omgeving',
+  );
 
-  const migreren = opServer(
+  // Staging migreert niet vanaf deze machine. Dat gebeurt in CI, tegen
+  // Supabase, met het teruglezen erin — zie de job `staging` in
+  // .github/workflows/ci.yml.
+  //
+  // Ze hier nóg een keer draaien zou betekenen dat een laptop schrijft naar een
+  // database die de pipeline beheert. Dat is precies de gewoonte die dit plan
+  // probeert af te leren: `.env` op een laptop wijzend naar iets echts.
+  const migreren = omgeving.migratiesOverslaan
+    ? { ok: true, uit: '', fout: '' }
+    : opServer(
     [
       `cd ${SERVER_MAP}`,
       // API_IMAGE en FRONTEND_IMAGE moeten gezet zijn, óók nu we alleen `db`
@@ -644,15 +687,29 @@ async function main() {
   //
   // Dat is dezelfde faalvorm als Issue #86 en migratie 0017: een geruststellende
   // melding over iets dat niet gebeurd is. De enige remedie is teruglezen.
-  const migratiestand = opServer(
-    `docker exec ${omgeving.project}-db-1 psql -U postgres -tAc ` +
-      `"SELECT count(*) FROM drizzle.__drizzle_migrations" 2>/dev/null || echo 0`,
-    { stil: true },
-  );
+  const migratiestand = omgeving.migratiesOverslaan
+    ? { uit: '' }
+    : opServer(
+        `docker exec ${omgeving.project}-db-1 psql -U postgres -tAc ` +
+          `"SELECT count(*) FROM drizzle.__drizzle_migrations" 2>/dev/null || echo 0`,
+        { stil: true },
+      );
 
   const aantalMigraties = Number(migratiestand.uit.trim()) || 0;
 
-  if (aantalMigraties === 0) {
+  // Teruglezen is de kern van deze stap, dus overslaan vraagt een reden. Die
+  // is er: staging heeft geen containerdatabase om in te kijken, en de
+  // CI-job die daar migreert leest de stand zelf terug — met
+  // `scripts/migratiestand.js --volgens-journal`, dat vergelijkt met het
+  // journal in plaats van met een getal dat veroudert.
+  //
+  // Wat hier dus NIET gebeurt: aannemen dat het goed is. Het bewijs staat
+  // ergens anders, en deze melding zegt waar.
+  if (omgeving.migratiesOverslaan) {
+    console.log(
+      `     ${kleur.grijs('teruglezen gebeurt in CI, tegen Supabase')}`,
+    );
+  } else if (aantalMigraties === 0) {
     stop(
       'De migraties meldden succes, maar de database is leeg.',
       `In drizzle.__drizzle_migrations staan ${aantalMigraties} migraties.\n\n` +
@@ -661,9 +718,11 @@ async function main() {
     );
   }
 
-  console.log(
-    `     ${kleur.groen('OK')}   ${aantalMigraties} migraties op de database (teruggelezen, niet aangenomen)`,
-  );
+  if (!omgeving.migratiesOverslaan) {
+    console.log(
+      `     ${kleur.groen('OK')}   ${aantalMigraties} migraties op de database (teruggelezen, niet aangenomen)`,
+    );
+  }
 
   // ── 5. Containers vervangen ─────────────────────────────────────────────
   console.log('');


### PR DESCRIPTION
## Wat dit doet

Er draait nu een applicatie op saxombp die praat met het Supabase-stagingproject. **Voor het eerst gaat MCM2 over een connection pooler** — en dat is precies waarvoor staging bestaat.

## Bewezen aan de Supabase-kant, niet aangenomen

```
Actieve verbindingen op de Supabase-stagingdatabase:
  clm_api_runtime: 1     ← de applicatie op saxombp
  clm_migrator: 1        ← mijn eigen leesquery
```

De keten is compleet: image uit GHCR → container op saxombp → connection pooler → Supabase in Ierland.

Rookproef vier keer groen, inclusief *"beheerroute weigert zonder sessie (401, geen 500)"* — een 500 zou betekenen dat de verbinding faalt.

## Drie dingen moesten instelbaar worden

**1. `DATABASE_URL`** stond vast in het compose-bestand, opgebouwd uit `DB_WACHTWOORD`. Nu een variabele; acceptatie en productie krijgen exact dezelfde waarde als voorheen.

**2. De databaseservice** staat achter het profiel `lokale-db`. Staging heeft er geen.

**3. `depends_on: db` kon niet blijven staan** — en dat was een verrassing:

```
service "api" depends on undefined service "db": invalid compose project
```

Docker Compose weigert het **hele** compose-bestand zodra een service verwijst naar een dienst achter een inactief profiel. Niet alleen de api start niet — er start niets.

> Gemeten met een wegwerp-compose vóórdat ik het toepaste, niet ontdekt tijdens een uitrol. De oplossing (`deploy/compose.lokale-db.yml` als overlay) is op dezelfde manier getoetst: zonder overlay start de api meteen, met overlay wacht hij netjes op de healthcheck.

## Staging migreert niet vanaf een laptop

`deploy.js` kent staging met `migratiesOverslaan`. De migraties draaien vanuit CI tegen Supabase, met het teruglezen erin (PR #136).

Ze hier nóg eens draaien zou betekenen dat een laptop schrijft naar een database die de pipeline beheert — precies de gewoonte die dit plan afleert. De melding zegt expliciet waar het bewijs dan wél staat:

```
4/6  Migraties — overgeslagen
     teruglezen gebeurt in CI, tegen Supabase
```

## Regressietest

**Acceptatie opnieuw uitgerold** met het gewijzigde compose-bestand — vier rookproeven groen. Dat was de risicovolle kant van deze wijziging: als het compose-bestand breekt, breekt het overal.

## Eén eigen fout, en de rem hield hem tegen

Ik gaf `sha-5428bb9d33a6` op in plaats van de SHA op te zoeken. Die bestaat niet — het is `5428bb954884`.

```
GESTOPT: Kon image 'sha-5428bb9d33a6' niet ophalen.
Er is niets gewijzigd — de draaiende omgeving is niet aangeraakt.
```

Dezelfde les als CLAUDE.md punt 2 (*"verzin nooit een commando — en ook geen kolomnaam of route"*), en de tweede keer vandaag. De rem werkte.

## Omgevingen na deze PR

| | Waar | Frontend | Backend | Database |
|---|---|---|---|---|
| **A** acceptatie | saxombp | 3010 | 5011 | container 55460 |
| **S** staging | saxombp | 3030 | 5031 | **Supabase `clm-staging3`** |
| **P** productie | saxombp | 3020 | 5021 | container 55470 |

`npm run deploy:staging` toegevoegd, tussen acceptatie en productie — zelfde volgorde als de straat zelf.

## Poorten

383 unittests, `format:check`, `lint:check`, `typecheck`, `verify:onderhoud`. Alles groen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)