### PR TITLE
Harde tijdslimieten op de bereikbaarheidsstap

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -366,14 +366,31 @@ jobs:
       #
       # Anders is een mislukte uitrol niet te onderscheiden van een netwerk dat
       # niet tot stand kwam, en die twee vragen een heel ander onderzoek.
+      #
+      # ── Waarom hier drie tijdslimieten op staan ────────────────────────────
+      #
+      # `ConnectTimeout` dekt alleen het OPENEN van de verbinding, niet de
+      # authenticatie erna. Op 2026-08-11 bleef deze stap daardoor hangen: de
+      # runner zat aantoonbaar in het Tailscale-netwerk (zichtbaar als
+      # `github-runnervmvrwv9`), maar de SSH-sessie kwam nooit tot stand en er
+      # verscheen geen enkele poging in het log van saxombp.
+      #
+      # Zonder limiet loopt zo'n stap door tot GitHub's maximum van zes uur.
+      # Vandaar `timeout-minutes` op de stap, `timeout 60` op het commando, en
+      # `ServerAliveInterval` zodat een stille verbinding zichzelf opgeeft.
       - name: Is saxombp bereikbaar?
+        timeout-minutes: 3
         run: |
-          ssh -o StrictHostKeyChecking=no -o BatchMode=yes \
-              -o ConnectTimeout=20 root@saxombp \
-              "echo bereikbaar; docker --version" || {
-            echo "::error::saxombp is niet bereikbaar via Tailscale. Staat de auth-key nog geldig, en laat het SSH-beleid deze node toe?"
-            exit 1
-          }
+          timeout 60 ssh \
+            -o StrictHostKeyChecking=no \
+            -o BatchMode=yes \
+            -o ConnectTimeout=20 \
+            -o ServerAliveInterval=5 \
+            -o ServerAliveCountMax=3 \
+            root@saxombp "echo bereikbaar; docker --version" || {
+              echo "::error::saxombp is niet bereikbaar via Tailscale SSH. Zit de runner in het netwerk (stap hierboven), en laat het SSH-beleid van het tailnet deze node toe? Een node zonder tag valt onder de standaardregels; die staan een CI-machine niet altijd toe."
+              exit 1
+            }
 
       # `deploy.js` doet de rest: image ophalen, containers vervangen,
       # rookproef, en bij een falende rookproef terugdraaien naar de vorige


### PR DESCRIPTION
## Wat er misging

De eerste automatische uitrol (PR #138) bleef hangen op *"Is saxombp bereikbaar?"*. `ConnectTimeout` dekt alleen het **openen** van de verbinding, niet de authenticatie erna — en juist daar zat het vast. Zonder limiet loopt zo'n stap door tot GitHub's maximum van zes uur.

Nu drie remmen: `timeout-minutes` op de stap, `timeout 60` op het commando, en `ServerAliveInterval` zodat een stille verbinding zichzelf opgeeft.

## Wat de hangende run opleverde — de eigenlijke diagnose

Uit het log van saxombp:

```
ssh-conn-…: handling conn: 100.104.208.10:55040->root@100.99.51.53:22
```

De CI-machine **bereikte saxombp wél**. De Tailscale-stap werkte: de runner was zichtbaar in het netwerk als `github-runnervmvrwv9`, van dezelfde gebruiker.

Maar daarna volgt niets — geen `starting session`, geen `access granted`, geen weigering. De verbinding bleef hangen op de extra verificatie die Tailscale SSH kan eisen:

> *"Tailscale SSH requires an additional check — visit login.tailscale.com/…"*

Die vraag is voor een mens te beantwoorden en voor een CI-machine niet.

## Wat er inmiddels aan de andere kant is aangepast

Het toegangsbeleid van het tailnet had één SSH-regel: `autogroup:member` → `autogroup:self`, **with check mode**. Daar is een tweede regel naast gezet:

```json
{
    "src":    ["autogroup:tagged"],
    "dst":    ["autogroup:self"],
    "users":  ["root"],
    "action": "accept"
}
```

Apparaten **met een label** slaan de bevestiging over; de laptop van de eigenaar heeft geen label en houdt zijn tweede slot. De auth-key is opnieuw aangemaakt mét tag, anders zou de runner ongelabeld binnenkomen en alsnog onder de oude regel vallen.

Die wijziging zit in het Tailscale-beheerscherm, niet in deze repository — vandaar dat hij hier alleen beschreven staat.

## Poorten

`format:check` groen. De echte proef is de eerste run na de merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)