### PR TITLE
Stand na stap 3 — staging draait, migraties gaan automatisch

### DIFF
--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -2,12 +2,52 @@
 
 ## Laatst bijgewerkt
 
-**2026-08-10, nacht.** De dag begon met een leeggemaakte productiedatabase en
-eindigde met een **volledig werkende acceptatieomgeving waar je met je
-Microsoft-account op inlogt** — frontend, backend en database, uitgerold vanaf
-een image dat door de kwaliteitspoorten kwam.
+**2026-08-11, middag.** **Stap 3 van het OTAP-plan is af.** Na elke merge op
+`main` draaien de migraties automatisch tegen de Supabase-stagingdatabase, en
+wordt teruggelezen of ze werkelijk geland zijn. Er draait bovendien een
+applicatie tegen die database — **voor het eerst gaat MCM2 over een connection
+pooler**, precies waarvoor staging bestaat.
 
-Zes PR's, alle gemerged:
+```
+merge op main
+  → CI: lint, tests, build
+  → image naar GHCR (SHA-tag)
+  → migraties naar Supabase-staging
+  → migratiestand teruggelezen, vergeleken met het journal   ← automatisch
+  ──────────────────────────────────────────────────────────
+  → npm run deploy:staging -- --versie sha-…                 ← één commando
+```
+
+Vandaag gemerged: **#135** (uitnodigingslink wees naar `localhost`), **#136**
+(migraties naar staging), **#137** (applicatie tegen Supabase), **#139/#140**
+(time-outs, en de Tailscale-stappen er weer uit).
+
+**Van de negen stappen zijn 1, 2, 2b en 3 af.** Volgende is stap 4: uitrol naar
+productie met een akkoordrem.
+
+### Waarom het starten van de applicatie handwerk blijft
+
+Bewust, niet uit onvermogen. CI kan niet bij saxombp — de machine staat thuis
+achter een router, en buiten Tailscale bestaat het adres niet eens. De officiële
+Tailscale-action loste dat op en de runner kwám in het netwerk, maar de
+SSH-verbinding liep op een harde regel:
+
+> *"Devices with a tag-based identity can only SSH into other tagged devices."*
+
+Een CI-runner krijgt onvermijdelijk een label, saxombp heeft er geen. De enige
+oplossing zou zijn saxombp óók te labelen, en dat verwijdert de gebruiker als
+eigenaar — met gevolgen voor de HTTPS-opzet die de inlog draagt.
+
+Afgewogen en verworpen (eigenaar, 11-08): het levert één ding op, en juist dat
+verdwijnt bij een verhuizing naar AWS. Details in §3.3c van het plan.
+
+<details>
+<summary><strong>Wat er op 2026-08-10 gebeurde</strong> — de dag ervoor</summary>
+
+De dag begon met een leeggemaakte productiedatabase en eindigde met een
+**volledig werkende acceptatieomgeving waar je met je Microsoft-account op
+inlogt** — frontend, backend en database, uitgerold vanaf een image dat door de
+kwaliteitspoorten kwam.
 
 | | Wat |
 |---|---|
@@ -19,9 +59,11 @@ Zes PR's, alle gemerged:
 Plus, niet in een PR maar op de server: **HTTPS op acceptatie** via
 `tailscale serve`, waardoor de cookie-verzwakking eruit kon.
 
-**De opbrengst zit niet in de PR's maar in wat de eerste echte uitrol
-blootlegde.** Die faalde, en drie van de vier oorzaken waren stille fouten die
-geen enkele test ving. Zie "Wat de uitrol leerde" hieronder.
+De opbrengst zat niet in de PR's maar in wat de eerste echte uitrol blootlegde.
+Die faalde, en drie van de vier oorzaken waren stille fouten die geen enkele
+test ving. Zie "Wat de uitrol leerde" hieronder.
+
+</details>
 
 ---
 
@@ -61,11 +103,22 @@ Twee lessen die in de code horen:
 ## 🔵 MORGEN BEGINNEN
 
 **Lees eerst:** [`docs/architectuur/plan-otap-straat-met-staging.md`](architectuur/plan-otap-straat-met-staging.md).
-Van de negen stappen zijn **1, 2 en 2b gedaan**. Morgen begint bij **stap 3**:
-de uitrol naar staging automatiseren.
+Van de negen stappen zijn **1, 2, 2b en 3 gedaan**. Volgende is **stap 4**: de
+uitrol naar productie, met vier remmen erin.
 
-Dat was tot gisteren geblokkeerd door twee dingen die nu weg zijn — de frontend
-was niet promoveerbaar (#51) en zijn image werd nergens gepubliceerd (2b).
+| Rem | Waarom |
+|---|---|
+| Handmatig akkoord | Niets naar productie zonder dat de eigenaar drukt |
+| Backup vooraf | Verplicht. Faalt de backup, dan gaat de uitrol niet door |
+| Migratiestand vergelijken met staging | Wijkt het af, dan stoppen |
+| Terugdraaien beproefd | Op deze weg, niet alleen op saxombp |
+
+De derde is nu goedkoop geworden: `scripts/migratiestand.js` bestaat en is
+beproefd op alle drie de uitkomsten.
+
+**Let op bij stap 4.** Productie draait nu nog op `latest` zonder frontend en
+zonder `OIDC_*` — inloggen kan daar niet. Het compose-bestand raakt beide
+omgevingen, dus een uitrol daarheen is een aparte, bewuste handeling.
 
 ### Waar je meteen naar kunt kijken
 
@@ -82,26 +135,34 @@ thuisbasis) en `AlingAdvies (acceptatie)`, aangemaakt via de échte route
 `POST /platform/tenants` — met een spoor in `audit.audit_event`. Dat is precies
 wat bij de vorige AlingAdvies-tenant op productie ontbrak.
 
-### Drie dingen die morgen aandacht vragen
-
-Alle drie gevonden bij de eerste echte uitrol, alle drie vastgelegd:
+### Twee dingen die nog aandacht vragen
 
 | Issue | Wat | Wanneer het pijn doet |
 |---|---|---|
 | **#131** | `mailVerstuurd: true` terwijl het logkanaal `[niet echt verstuurd]` meldt | Bij de eerste echte klantuitnodiging: je denkt dat hij uitgenodigd is |
-| **#132** | De uitnodigingslink wees naar `localhost:5001` — een adres dat op die omgeving niet bestaat | Bij de eerste tenant die via een uitnodiging in gebruik wordt genomen |
 | **#133** | Entra stuurt `"name": "unknown"`; en één persoon kan twee gebruikers worden | Zichtbaar in het scherm en in de audit trail. Blokkeert de straat niet |
 
-#131 en #132 zijn samen erger dan apart: de melding zegt dat de uitnodiging
-verstuurd is (niet waar), en de link die je als terugval krijgt is onbruikbaar.
+~~**#132**~~ — de uitnodigingslink wees naar `localhost:5001` — **opgelost op
+11-08** (PR #135). De link wordt nu gebouwd op `UITNODIGING_BASIS_URL` en wijst
+naar de frontend, want sinds Issue #51 loopt de inlog via het doorgeefluik. Een
+link naar de backend-poort zou het pogingcookie op de verkeerde herkomst zetten.
 
-### Wat productie nog niet heeft
+`PORTAAL_BASIS_URL` ontbrak net zo goed en is meegenomen; die was nooit
+opgevallen omdat er nog geen leverancier is uitgenodigd.
 
-Acceptatie is bijgewerkt, productie niet. Daar draait nog `latest` zonder
-frontend, zonder `OIDC_*` en zonder HTTPS. Inloggen kan daar dus niet.
+### De omgevingen op saxombp
 
-Dat is geen achterstand maar een keuze: het compose-bestand raakt beide
-omgevingen, en een uitrol naar productie hoort een aparte, bewuste handeling te
+Teruggelezen op 2026-08-11:
+
+| | Backend | Frontend | Database |
+|---|---|---|---|
+| acceptatie | `sha-5428bb95` | `sha-635ff211` | container 55460 |
+| **staging** | `sha-ffd27dc9` | `sha-635ff211` | **Supabase `clm-staging3`** |
+| productie | `latest` | — | container 55470 |
+
+**Productie loopt bewust achter.** Daar draait nog `latest` zonder frontend,
+zonder `OIDC_*` en zonder HTTPS — inloggen kan daar dus niet. Dat is stap 4, en
+het compose-bestand raakt beide omgevingen, dus het hoort een aparte handeling te
 zijn.
 
 ### Wat er gisteravond is neergezet: staging
@@ -171,6 +232,60 @@ dan bouwen, dan opnieuw meten. Het verschil is de regressie.
 
 Daarna kan `FRONTEND_MEE` in `scripts/deploy.js` op `true` en de regel
 `profiles:` uit `deploy/docker-compose.omgeving.yml`. Verder verandert er niets.
+
+---
+
+## Wat er op 2026-08-11 is gebouwd
+
+### Stap 3 — migraties automatisch naar staging (#136)
+
+`scripts/migratiestand.js` leest de stand terug uit de database en vergelijkt
+met `drizzle/meta/_journal.json`. Beproefd op alle drie de uitkomsten, met
+**exitcodes zonder pipe gemeten**:
+
+| Toestand | Antwoord |
+|---|---|
+| gelijk | `Gelijk aan het journal (26)` — exitcode 0 |
+| 11 achter | *"De database staat op 15, het journal telt 26"* — exitcode 1 |
+| onbereikbaar | exitcode 1 |
+
+Met `| tail` gaf de eerste meting exitcode 0 — dezelfde valkuil als bij
+`migrate.js` op 10-08.
+
+### Stap 3b — de applicatie tegen Supabase (#137)
+
+Voor het eerst praat MCM2 over een **connection pooler**. Bewezen aan de
+Supabase-kant: `clm_api_runtime: 1` actieve verbinding, terwijl de applicatie op
+saxombp draaide.
+
+Drie dingen moesten instelbaar worden, en het derde was een verrassing: Compose
+weigert een **héél** compose-bestand zodra een service `depends_on` een dienst
+achter een inactief profiel — *"invalid compose project"*, en dan start er
+niets. Gemeten met een wegwerp-compose vóór toepassing, net als de oplossing
+(`compose.lokale-db.yml` als overlay).
+
+Regressietest: acceptatie opnieuw uitgerold met het gewijzigde compose-bestand,
+vier rookproeven groen.
+
+### #132 — de uitnodigingslink (#135)
+
+De link werd gebouwd op `API_BASIS_URL`, een variabele die in geen enkel
+voorbeeldbestand stond en dus nooit gezet werd. Elke uitgerolde omgeving gaf een
+link naar `localhost:5001`.
+
+Hij wijst nu naar de frontend, want sinds Issue #51 loopt de inlog via het
+doorgeefluik. **De aanname eerst gemeten** voordat ik bouwde: een uitnodiging via
+`/api/backend/auth/login` geeft 302 naar Microsoft en zet het token in het
+pogingcookie — 44 tekens langer dan zonder token.
+
+> Die meting ging bijna fout. Mijn eerste poging gebruikte een token van 12
+> tekens en gaf geen verschil, waaruit ik bijna concludeerde dat het token niet
+> meereist. `heeftGeldigeVorm()` eist er 43, dus het werd terecht genegeerd.
+
+### Wat er níét gebouwd is, en waarom
+
+De uitrol naar saxombp automatiseren (#138, teruggedraaid in #140). Zie
+"Waarom het starten van de applicatie handwerk blijft" bovenaan.
 
 ---
 
@@ -313,9 +428,9 @@ handmatig te starten is (PR #122).
 
 | # | Wat | Waarom nu |
 |---|---|---|
-| — | **Geen geautomatiseerde uitrol naar staging en productie** | De gemeenschappelijke oorzaak onder 04-08, 07-08 en 10-08. Acceptatie is sinds 10-08 wél volledig uitgerold, maar met de hand gestart. Dit is **stap 3** en de eerstvolgende taak. Plan: [`plan-otap-straat-met-staging.md`](architectuur/plan-otap-straat-met-staging.md) |
+| — | **Geen geautomatiseerde uitrol naar productie** | De gemeenschappelijke oorzaak onder 04-08, 07-08 en 10-08. Staging gaat sinds 11-08 automatisch (migraties + teruglezen); productie nog niet. Dit is **stap 4**. Plan: [`plan-otap-straat-met-staging.md`](architectuur/plan-otap-straat-met-staging.md) |
 | ~~#51~~ | ~~Frontend promoveerbaar maken~~ | ✅ **Gedaan 10-08.** Bewezen: hetzelfde image tegen twee backends, verschillende antwoorden, geen herbouw |
-| **#132** | Uitnodigingslink wijst naar `localhost` op een uitgerolde omgeving | Het token bestaat maar één keer; een verkeerde link is niet opnieuw uit te geven |
+| ~~#132~~ | ~~Uitnodigingslink wijst naar `localhost`~~ | ✅ **Gedaan 11-08** (PR #135). Twee tests, tegenproef gedraaid |
 | **#131** | `mailVerstuurd: true` terwijl er niets verstuurd is | Vóór de eerste echte klantuitnodiging |
 | **#133** | Naam `unknown` uit Entra; dubbele gebruiker mogelijk | "unknown heeft dit oordeel gegeven" is geen bruikbare audit trail |
 | **#46** | Uploads op een containerschijf: weg bij image-vervanging | **Harde datum**: pilot ~1 september. Dit zijn compliance-bewijsstukken |

--- a/docs/architectuur/exit-route-hosting.md
+++ b/docs/architectuur/exit-route-hosting.md
@@ -217,6 +217,39 @@ load balancer leveren zelf TLS — maar tot die tijd hangt de inlog op acceptati
 geldig certificaat nodig, niet als goede gewoonte maar omdat Entra het afdwingt. Dat is een
 eis die eerder onzichtbaar was, en hij geldt voor elke cloudkeuze.
 
+### 2026-08-11: staging praat met Supabase over de pooler — en dat is de AWS-vorm
+
+Er draait sinds vandaag een applicatie op saxombp tegen het Supabase-stagingproject.
+**Compute en database staan daarmee voor het eerst los van elkaar**, en dat is precies hoe het
+bij AWS werkt: een container in App Runner of ECS, een database in RDS, verbonden door één
+connectiestring.
+
+| Onderdeel | Nu | Bij AWS | Wat verandert |
+|---|---|---|---|
+| Compute | container op saxombp | App Runner / ECS | een taakdefinitie in plaats van compose |
+| Database | Supabase over de pooler | RDS Postgres | één connectiestring |
+
+Wat dit **meet** en niet alleen belooft: het gedrag van de applicatie achter een connection
+pooler. Verbindingen worden daar anders vastgehouden dan bij een lokale Postgres, timeouts
+zijn anders, en een migratie die een tabel vergrendelt gedraagt zich anders. Elk probleem dat
+daar zit, kwam anders pas op productie boven.
+
+Bewezen door aan de Supabase-kant te tellen: `clm_api_runtime: 1` actieve verbinding, terwijl
+de applicatie op saxombp draaide.
+
+### Wat de mislukte Tailscale-poging opleverde voor dit document
+
+De uitrol naar saxombp is bewust niet geautomatiseerd (§3.3c van het OTAP-plan). Bij het
+uitzoeken bleek iets dat hier hoort:
+
+**`tailscale serve` is geen leveranciersafhankelijkheid die vrijblijvend is.** Het draagt de
+inlog van acceptatie, en het zit vast aan de identiteit van de machine — een apparaat labelen
+verwijdert de gebruiker als eigenaar, met gevolgen voor die opzet. Dat maakt het minder los
+dan de tabel hierboven suggereert: vervangen kan, maar niet zonder de inlog te raken.
+
+Bij AWS verdwijnt die hele knoop: een load balancer levert TLS en er is geen SSH nodig om
+uit te rollen.
+
 ---
 
 ## 4. De enige echte blokkade: bestandsopslag

--- a/docs/architectuur/plan-otap-straat-met-staging.md
+++ b/docs/architectuur/plan-otap-straat-met-staging.md
@@ -1,6 +1,7 @@
 # Plan — een OTAP-straat met staging, van nul opnieuw doordacht
 
-**Status:** in uitvoering — **stap 1 en 2 zijn gedaan** (§3.1 en §3.2)
+**Status:** in uitvoering — **stap 1, 2, 2b en 3 zijn gedaan**. Volgende: stap 4
+(uitrol naar productie met een akkoordrem)
 **Datum:** 2026-08-10, bijgewerkt dezelfde avond
 **Eigenaar:** Kees Aling
 **Aanleiding:** de straat die op 09/10-08 op saxombp gebouwd is, loopt niet uit
@@ -363,22 +364,112 @@ Geen tabel die alleen in de één voorkomt.
 > weigert, én het feit dat de melding de **projectreferentie** toont. Zonder dat
 > tweede was de fout onzichtbaar geweest.
 
-### 3.3 De uitrol naar staging automatiseren
+### 3.3 De uitrol naar staging automatiseren — ✅ GEDAAN op 2026-08-11
 
-Uitbreiding van `.github/workflows/ci.yml`: na een geslaagde acceptatie-uitrol
-gaat dezelfde SHA naar staging.
+Uitbreiding van `.github/workflows/ci.yml`. Wat er nu draait na elke merge op
+`main`:
 
-Stappen, met de rem er al in:
+```
+CI: lint, tests, build
+  → image naar GHCR (SHA-tag, nooit `latest` — §6)
+  → migraties tegen Supabase-staging
+  → migratiestand TERUGGELEZEN en vergeleken met het journal
+  ────────────────────────────────────────────────────────
+  → npm run deploy:staging -- --versie sha-…     met de hand
+```
 
-1. Image ophalen uit GHCR op SHA-tag (nooit `latest` — zie §6)
-2. Migraties draaien tegen staging
-3. **Teruglezen** hoeveel migraties er nu staan. Nul of onveranderd = stoppen.
-4. Applicatie starten
-5. Rookproef: `/health` én een route die de database raakt
+**Het teruglezen is de kern, niet het migreren.** `scripts/migratiestand.js`
+leest de stand uit de database — uitsluitend `SELECT` — en vergelijkt met
+`drizzle/meta/_journal.json`, het bestand dat `migrate()` zelf leest. Wat daarin
+staat is per definitie wat er na een geslaagde uitrol hoort te staan.
 
-Stap 5 is een les van 09-08: een backend zonder tabellen antwoordt vrolijk 200
-op `/health` en 401 op beheerroutes. De rookproef moet iets vragen dat alleen
-kan slagen als de database gevuld is.
+Een getal in de workflow zou verouderen bij de volgende migratie: dan faalt de
+controle om de verkeerde reden, of blijft hij groen terwijl er iets ontbreekt.
+
+**Beproefd, niet aangenomen:**
+
+| Proef | Uitkomst |
+|---|---|
+| Tegen het echte stagingproject | `Migraties op deze database: 26 — Gelijk aan het journal (26)`, exitcode 0 |
+| Database die 11 migraties achterliep | *"De database staat op 15, het journal telt 26 — er zijn migraties NIET toegepast"*, exitcode 1 |
+| Onbereikbare database | exitcode 1 |
+
+Die exitcodes zijn **zonder pipe** gemeten. Met `| tail` gaf de eerste meting 0 —
+dezelfde valkuil als bij `migrate.js` op 10-08, waar een crash door de pipe als
+succes werd gelezen.
+
+**Twee bewuste afwijkingen**, beide toegelicht in de code:
+
+- Geen `eisToestemmingBuitenLokaal` in het leesscript. Die rem beschermt tegen
+  ongewild *schrijven*; aan een vlag wennen voor een leesquery is het echte
+  risico dat het runbook beschrijft. Het doelwit wordt wél altijd gemeld.
+- `--extern` staat expliciet bij de migratie-aanroep, niet als
+  omgevingsvariabele. In de omgeving zetten maakt hem onzichtbaar voor elke
+  volgende stap.
+
+### 3.3b De applicatie tegen Supabase — ✅ GEDAAN, en dit was het punt
+
+Er draait nu een applicatie op saxombp die praat met het Supabase-stagingproject.
+**Voor het eerst gaat MCM2 over een connection pooler.** Dat is de hele reden dat
+staging bij Supabase staat en niet in een container (§1).
+
+Bewezen aan de Supabase-kant:
+
+```
+Actieve verbindingen op de Supabase-stagingdatabase:
+  clm_api_runtime: 1     ← de applicatie op saxombp
+  clm_migrator: 1        ← de leesquery van de meting
+```
+
+**Drie dingen moesten instelbaar worden**, en het derde was een verrassing:
+
+1. `DATABASE_URL` stond vast in het compose-bestand, opgebouwd uit
+   `DB_WACHTWOORD`. Nu een variabele.
+2. De databaseservice staat achter het profiel `lokale-db`. Staging heeft er geen.
+3. `depends_on: db` kon **niet** blijven staan. Compose weigert een heel
+   compose-bestand zodra een service verwijst naar een dienst achter een inactief
+   profiel: *"service api depends on undefined service db: invalid compose
+   project"*. Niet alleen de api start dan niet — er start niets.
+
+Dat derde punt is gemeten met een wegwerp-compose vóórdat het werd toegepast, en
+de oplossing (`deploy/compose.lokale-db.yml` als overlay) op dezelfde manier.
+
+**Regressietest:** acceptatie opnieuw uitgerold met het gewijzigde
+compose-bestand — vier rookproeven groen. Dat was de risicovolle kant.
+
+### 3.3c Waarom het starten van de applicatie handwerk blijft
+
+De uitrol naar saxombp is bewust **niet** geautomatiseerd. Dat is geen
+onvermogen maar een besluit (eigenaar, 2026-08-11), en de reden hoort hier
+vastgelegd.
+
+CI kan niet bij saxombp: de machine staat thuis achter een router, en buiten
+Tailscale bestaat `saxombp.tail4b29b.ts.net` niet eens — een publieke DNS-server
+geeft "non-existent domain".
+
+De officiële Tailscale-action lost dat op, en werkte ook: de runner was
+aantoonbaar in het netwerk zichtbaar. Maar de SSH-verbinding liep op een harde
+regel van Tailscale:
+
+> *"Devices with a tag-based identity can only SSH into other tagged devices;
+> they cannot SSH into devices with a user-based identity."*
+
+Een CI-runner krijgt onvermijdelijk een label; saxombp heeft er geen. Er bestáát
+dus geen geldige regel die dit toestaat — drie pogingen
+(`autogroup:self`, `autogroup:tagged`, een gebruiker als bestemming) waren alle
+drie ongeldig, en de laatste werd door het invoerscherm zelf geweigerd.
+
+De enige oplossing zou zijn saxombp óók te labelen. Dat *"removes the user
+account"* en raakt daarmee de `tailscale serve`-opzet die het HTTPS-adres van
+acceptatie draagt — de enige weg naar de inlog.
+
+**Afgewogen en verworpen.** Het levert één ding op: dat één commando vanzelf
+gaat. En juist dat commando verdwijnt bij een verhuizing naar AWS, waar je een
+image duwt en de dienst het zelf ophaalt. Een stap die altijd faalt is bovendien
+erger dan geen stap: dan wordt elke run rood en leer je rode runs negeren.
+
+De samenvatting van elke CI-run drukt het vervolgcommando af met de juiste SHA
+erin, zodat het niet samengesteld hoeft te worden.
 
 ### 3.4 De uitrol naar productie automatiseren
 
@@ -421,17 +512,29 @@ weet dat het klopt.
 
 ### 4.1 Wat er per omgeving hoort te zijn
 
+*Bijgewerkt 2026-08-11 naar wat er werkelijk staat; teruggelezen, niet gepland.*
+
 | | Acceptatie | Staging | Productie |
 |---|---|---|---|
-| Waar | saxombp:5011 | Supabase `clm-staging` | Supabase `clm-enterprise` |
-| Database | container, wegwerp | Supabase eu-west-1 | Supabase eu-west-1 |
+| Applicatie | saxombp `:5011` / `:3010` | saxombp `:5031` / `:3030` | saxombp `:5021` (procesbewijs) |
+| Database | container 55460 | **Supabase `clm-staging3`** | Supabase `clm-enterprise` |
+| Migraties door | `deploy:acceptatie` | **CI, automatisch** | met de hand — stap 4 |
 | `clm.omgeving` | `wegwerp` | `wegwerp` | `beschermd` |
 | Rollen | migrator + runtime | migrator + runtime | migrator + runtime |
-| RLS | actief | actief | actief |
+| RLS | actief | **actief — geverifieerd** | actief |
 | Backups | nee | nee | dagelijks, met controle |
 | e2e-suites | ja | nee | nooit |
-| Data | wegwerp | testdata | echte data |
-| Wie mag erbij | CI | CI | CI + eigenaar na akkoord |
+| Data | wegwerp | leeg | echte data |
+| Inloggen | ja, via HTTPS | nee — vraagt eigen redirect-URI | nee |
+
+**Dat staging draait, is de applicatie op saxombp; de database staat bij
+Supabase.** Die scheiding is opzet en het is de AWS-vorm: compute los van
+database, elk apart te verhuizen.
+
+> **RLS op staging is niet aangenomen maar gemeten.** Een poging om een tenant
+> in te voegen als `clm_migrator` werd geweigerd met *"new row violates
+> row-level security policy for table tenant"*. Dat is precies wat er hoort te
+> gebeuren zonder tenantcontext.
 
 ### 4.2 Het pauzeerprobleem oplossen
 
@@ -565,7 +668,7 @@ het als eerste staat.
 | 1 | ✅ **Issue #51 — frontend promoveerbaar** — gedaan 10-08 | Nee, ging sowieso door |
 | 2 | ✅ **Staging aanmaken bij Supabase** — gedaan 10-08 | Beslist: optie A |
 | 2b | ✅ **Frontend-image publiceren, frontend in de uitrol** — gedaan 10-08 | Beslist: twee versies, zie hieronder |
-| 3 | Uitrol naar staging automatiseren | Nee |
+| 3 | ✅ **Uitrol naar staging automatiseren** — gedaan 11-08 | Beslist: applicatie start met de hand, zie §3.3c |
 | 4 | Uitrol naar productie automatiseren, met akkoordrem | Nee |
 | 5 | `.env` omleiden naar staging | Nee, maar wel melden wanneer |
 | 6 | `mcm2-productie` op saxombp opheffen | **Ja — onomkeerbaar** |

--- a/docs/testaanpak-en-architectuur.md
+++ b/docs/testaanpak-en-architectuur.md
@@ -425,6 +425,8 @@ document maar de reden dat het te vertrouwen is.
 | 2026-08-10 | Frontend met een verkeerd backend-adres gaf **200** op de startpagina | rookproef vraagt óók een beheerroute op via de frontend-poort |
 | 2026-08-10 | `deploy.js` draaide op een compose-bestand dat op de server anders was dan in de repo | sha256-vergelijking als eerste stap van de uitrol |
 | 2026-08-10 | `mailVerstuurd: true` terwijl het logkanaal `[niet echt verstuurd]` meldde | nog open — **Issue #131** |
+| 2026-08-11 | Een migratiescript dat faalt gaf **exitcode 0** door de pipe naar `tail` | exitcodes zonder pipe meten; `scripts/migratiestand.js` faalt aantoonbaar |
+| 2026-08-11 | Compose weigert een héél bestand bij `depends_on` naar een inactief profiel — niet alleen die dienst | overlay `compose.lokale-db.yml`; gemeten met een wegwerp-compose vóór toepassing |
 
 **De regels van 10 augustus zijn varianten van P3**, en dat is geen toeval. Elk
 ervan zag eruit als succes: een groene controle, een geslaagde uitrol, een
@@ -445,6 +447,40 @@ nog open.
 De vierde is een variant van P2: `pg_isready` gaf een antwoord dat waar was op
 het moment van vragen, en onwaar een seconde later. Een controle die maar één
 keer kijkt, meet een momentopname en geen toestand.
+
+### Teruglezen als testvorm — nieuw sinds 2026-08-11
+
+De poorten hierboven draaien vóór een uitrol. Sinds stap 3 van het OTAP-plan is
+er een controle die erná draait, in de pipeline, waar niemand meekijkt:
+`scripts/migratiestand.js`.
+
+Hij leest de migratiestand uit de database — uitsluitend `SELECT` — en
+vergelijkt met `drizzle/meta/_journal.json`. Dat is bewust **niet** een getal in
+de workflow: zo'n getal veroudert bij de volgende migratie, en dan faalt de
+controle om de verkeerde reden of blijft hij groen terwijl er iets ontbreekt.
+Het journal is het bestand dat `migrate()` zelf leest, dus wat daarin staat is
+per definitie wat er hoort te staan.
+
+**Waarom dit een testvorm is en geen logregel.** De drie eerdere gevallen —
+2026-08-07 ("Migraties voltooid" over niets), Issue #86 (de verkeerde database),
+2026-08-10 (exitcode 0 na een crash) — hadden allemaal een geruststellende
+melding. Geen ervan had een meting die daarnaast lag.
+
+**Beproefd op alle drie de uitkomsten**, met exitcodes zonder pipe gemeten:
+
+| Toestand | Antwoord |
+|---|---|
+| gelijk aan het journal | `Gelijk aan het journal (26)` — exitcode 0 |
+| 11 migraties achter | *"De database staat op 15, het journal telt 26"* — exitcode 1 |
+| onbereikbaar | exitcode 1 met de verbindingsfout |
+
+Die tweede is gemaakt door een database op te bouwen met een tijdelijk ingekort
+journal — de aanpak uit `docs/runbooks/commandos-en-omgeving.md`, met de `trap`
+die het journal altijd terugzet.
+
+**De grens die dit níét dekt:** het toetst dat migraties gelánd zijn, niet dat ze
+het júíste doen. Een migratie die een verkeerde kolom toevoegt telt gewoon mee.
+Daarvoor is `verify:schema` er, en die draait niet tegen staging.
 
 ---
 


### PR DESCRIPTION
## Wat er is vastgelegd

Stap 3 van het OTAP-plan is af. Deze PR brengt de documentatie in lijn met wat er werkelijk draait.

## Per document

**`STATUS.md`** — de kop herschreven naar wat er nu geldt. De dag van 10-08 is ingeklapt in een `<details>`; die stond boven het actuele nieuws. Een sectie *"Wat er op 2026-08-11 is gebouwd"* erbij, en de openstaandtabel bijgewerkt: **#132 doorgestreept**, en de regel over de uitrol gaat nu over **productie** in plaats van over staging.

Het startpuntblok wijst naar **stap 4** en noemt de vier remmen. Eén daarvan — de migratiestand vergelijken — is goedkoop geworden nu `scripts/migratiestand.js` bestaat en beproefd is.

**`plan-otap-straat-met-staging.md`** — drie secties:

| | |
|---|---|
| §3.3 | Afgevinkt, met de metingen erbij |
| §3.3b | Nieuw — de applicatie tegen Supabase, met het bewijs aan de Supabase-kant |
| §3.3c | Nieuw, en de belangrijkste — **waarom het starten van de applicatie handwerk blijft** |

Dat laatste besluit hoort vastgelegd, inclusief de drie SSH-regels die niet konden werken en waarom.

De omgevingstabel in §4.1 is bijgewerkt naar wat er **werkelijk staat**, teruggelezen. Hij beschreef een plan; nu beschrijft hij de toestand — inclusief dat staging als enige geen eigen databasecontainer heeft, en dat RLS daar **gemeten** is:

> Een insert als `clm_migrator` werd geweigerd met *"new row violates row-level security policy for table tenant"*. Precies wat er hoort te gebeuren zonder tenantcontext.

**`testaanpak-en-architectuur.md`** — twee regels bij de tabel met stille fouten:

| Datum | Wat |
|---|---|
| 2026-08-11 | Een falend script gaf **exitcode 0** door de pipe naar `tail` |
| 2026-08-11 | Compose weigert een **héél** bestand bij `depends_on` naar een inactief profiel |

Plus een nieuwe sectie over **teruglezen als testvorm**. Die hoort daar: de poorten draaien vóór een uitrol, deze controle draait erná — in een pipeline waar niemand meekijkt. Met de grens erbij: *het toetst dat migraties geland zijn, niet dat ze het juiste doen.*

**`exit-route-hosting.md`** — compute en database staan sinds vandaag los van elkaar, en dat is de AWS-vorm. Plus een eerlijke kanttekening bij `tailscale serve`: dat zit **vaster** dan de tabel suggereerde, want het hangt aan de identiteit van de machine.

**`onderhoudskalender.md`** — de Tailscale-sleutel eruit bij de sleutelrotatie (niet meer in gebruik, secret verwijderd), de GitHub-secrets voor staging erbij.

## Geheugen

Startpunt bijgewerkt naar 11-08, plus een notitie over waarom CI niet bij saxombp kan — zodat dat niet opnieuw voorgesteld wordt zonder dat er iets veranderd is.

## Poorten

`format:check`, `lint:check`, `verify:onderhoud` groen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)