### PR TITLE
fix(mail,auth): geen meldingen meer over dingen die niet gebeurd zijn (#131, #133)

### DIFF
--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -135,12 +135,44 @@ thuisbasis) en `AlingAdvies (acceptatie)`, aangemaakt via de échte route
 `POST /platform/tenants` — met een spoor in `audit.audit_event`. Dat is precies
 wat bij de vorige AlingAdvies-tenant op productie ontbrak.
 
-### Twee dingen die nog aandacht vragen
+### Twee dingen die nog aandacht vroegen — beide opgelost op 11-08
 
-| Issue | Wat | Wanneer het pijn doet |
-|---|---|---|
-| **#131** | `mailVerstuurd: true` terwijl het logkanaal `[niet echt verstuurd]` meldt | Bij de eerste echte klantuitnodiging: je denkt dat hij uitgenodigd is |
-| **#133** | Entra stuurt `"name": "unknown"`; en één persoon kan twee gebruikers worden | Zichtbaar in het scherm en in de audit trail. Blokkeert de straat niet |
+~~**#131**~~ — `mailVerstuurd: true` terwijl het logkanaal `[niet echt
+verstuurd]` meldde. De oorzaak zat op de grens: `LogMailKanaal` gaf een
+resultaat terug dat er precies zo uitzag als dat van een echte verzending, dus
+kon geen enkele aanroeper het verschil zien. `VerzendResultaat` heeft nu een
+verplicht veld `echtVerstuurd`; een implementatie die het vergeet, compileert
+niet. Beide routes — tenantaanmaak én leveranciersuitnodigingen — lezen dat veld
+in plaats van "er ging niets mis".
+
+Bijvangst tijdens het bouwen: mijn eerste versie leidde "geen mailkanaal" af uit
+*nul echte verzendingen*. Dat is óók waar als de provider álles weigert, en dan
+wijst de melding naar de verkeerde oorzaak — dezelfde soort misleiding als de
+fout die hij moest repareren. De toets is nu *geslaagd maar niet echt
+verstuurd*, met een test die dat onderscheid vastlegt.
+
+~~**#133**~~ — de naam `unknown` uit Entra, en één persoon met twee
+gebruikersrijen.
+
+De naam kwam er doorheen omdat de claimlezer alleen *lege* waarden weerde en
+`"unknown"` niet leeg is. Er is nu een korte lijst plaatsvervangers
+(`unknown`, `n/a`, `null`, `-`, …), hoofdletterongevoelig, met een tegenproef
+die bewijst dat een echte naam als `Robert Unknown` ongemoeid blijft. De
+terugval is het e-mailadres — dat zegt wie iemand is, waar
+"Platformbeheerder" alleen zegt wat hij doet.
+
+De dubbele rij is **gemeten** op een wegwerpdatabase, niet beredeneerd:
+`clm.koppel_eerste_login()` geeft **0 rijen** terug wanneer de oid al bestaat,
+en beide rijen blijven staan met de uitnodiging op `open`. Er ontstaat dus geen
+tweede gebruiker en er wordt niets samengevoegd — de uitnodiging doet
+stilzwijgend niets. Die weigering is terecht (koppelen zou accountovername
+zijn); wat ontbrak was zichtbaarheid. `SessieService` waarschuwt nu in beide
+gevallen: bij een mislukte koppeling én wanneer iemand die al binnen is een
+uitnodiging aanbiedt.
+
+**Samenvoegen doen we bewust niet automatisch.** Dat raakt beoordelingen,
+notities en de audit trail, en hoort een beheerhandeling te zijn — geen
+bijverschijnsel van een klik op een link.
 
 ~~**#132**~~ — de uitnodigingslink wees naar `localhost:5001` — **opgelost op
 11-08** (PR #135). De link wordt nu gebouwd op `UITNODIGING_BASIS_URL` en wijst
@@ -431,8 +463,8 @@ handmatig te starten is (PR #122).
 | — | **Geen geautomatiseerde uitrol naar productie** | De gemeenschappelijke oorzaak onder 04-08, 07-08 en 10-08. Staging gaat sinds 11-08 automatisch (migraties + teruglezen); productie nog niet. Dit is **stap 4**. Plan: [`plan-otap-straat-met-staging.md`](architectuur/plan-otap-straat-met-staging.md) |
 | ~~#51~~ | ~~Frontend promoveerbaar maken~~ | ✅ **Gedaan 10-08.** Bewezen: hetzelfde image tegen twee backends, verschillende antwoorden, geen herbouw |
 | ~~#132~~ | ~~Uitnodigingslink wijst naar `localhost`~~ | ✅ **Gedaan 11-08** (PR #135). Twee tests, tegenproef gedraaid |
-| **#131** | `mailVerstuurd: true` terwijl er niets verstuurd is | Vóór de eerste echte klantuitnodiging |
-| **#133** | Naam `unknown` uit Entra; dubbele gebruiker mogelijk | "unknown heeft dit oordeel gegeven" is geen bruikbare audit trail |
+| ~~#131~~ | ~~`mailVerstuurd: true` terwijl er niets verstuurd is~~ | ✅ **Gedaan 11-08.** `echtVerstuurd` op de mailgrens; verplicht veld, dus niet te vergeten |
+| ~~#133~~ | ~~Naam `unknown` uit Entra; dubbele gebruiker mogelijk~~ | ✅ **Gedaan 11-08.** Plaatsvervangers gefilterd; dubbele rij gemeten — geen tweede gebruiker, wél een stille uitnodiging, nu zichtbaar |
 | **#46** | Uploads op een containerschijf: weg bij image-vervanging | **Harde datum**: pilot ~1 september. Dit zijn compliance-bewijsstukken |
 | — | Geen bewaking die waarschuwt als een omgeving omvalt | Je zou het merken doordat iemand belt |
 | — | Geen incidentplan | NIS2 kent een meldplicht binnen 24 uur; die klok loopt of je een plan hebt of niet |

--- a/docs/testaanpak-en-architectuur.md
+++ b/docs/testaanpak-en-architectuur.md
@@ -424,7 +424,9 @@ document maar de reden dat het te vertrouwen is.
 | 2026-08-10 | `pg_isready` meldde "klaar" tijdens de interne herstart van een verse Postgres | twee opeenvolgende **queries**, geen socketcontrole |
 | 2026-08-10 | Frontend met een verkeerd backend-adres gaf **200** op de startpagina | rookproef vraagt óók een beheerroute op via de frontend-poort |
 | 2026-08-10 | `deploy.js` draaide op een compose-bestand dat op de server anders was dan in de repo | sha256-vergelijking als eerste stap van de uitrol |
-| 2026-08-10 | `mailVerstuurd: true` terwijl het logkanaal `[niet echt verstuurd]` meldde | nog open — **Issue #131** |
+| 2026-08-10 | `mailVerstuurd: true` terwijl het logkanaal `[niet echt verstuurd]` meldde | `echtVerstuurd` als **verplicht** veld op `VerzendResultaat` — vergeten kan niet, dat compileert niet |
+| 2026-08-10 | Entra's `"name": "unknown"` belandde als naam in de database — de claimlezer weerde alleen *lege* waarden | lijst plaatsvervangers, mét tegenproef dat `Robert Unknown` blijft staan |
+| 2026-08-11 | Een uitnodiging voor iemand die al een account heeft doet niets, zonder enig spoor | `SessieService` waarschuwt; gemeten op een wegwerpdatabase — **0 rijen**, geen tweede gebruiker |
 | 2026-08-11 | Een migratiescript dat faalt gaf **exitcode 0** door de pipe naar `tail` | exitcodes zonder pipe meten; `scripts/migratiestand.js` faalt aantoonbaar |
 | 2026-08-11 | Compose weigert een héél bestand bij `depends_on` naar een inactief profiel — niet alleen die dienst | overlay `compose.lokale-db.yml`; gemeten met een wegwerp-compose vóór toepassing |
 
@@ -447,6 +449,30 @@ nog open.
 De vierde is een variant van P2: `pg_isready` gaf een antwoord dat waar was op
 het moment van vragen, en onwaar een seconde later. Een controle die maar één
 keer kijkt, meet een momentopname en geen toestand.
+
+### Een testdubbel mag niet vrolijker zijn dan het echte ding
+
+Issue #131 is een nieuwe variant, en hij is leerzaam omdat de opzet er juist
+zorgvuldig uitzag. `LogMailKanaal` is bewust productiecode en geen testhulpje;
+hij valideert adressen even streng als het echte kanaal, en dat is expliciet zo
+opgeschreven — *"zou de testdubbel toegeeflijker zijn dan de echte
+implementatie, dan zijn groene tests geen bewijs"*.
+
+Die regel is toegepast op de **invoer** en vergeten bij de **uitvoer**. Het
+kanaal weigert wat het echte kanaal weigert, maar zijn geslaagde antwoord was
+niet te onderscheiden van een echte verzending. Daardoor was er geen bug in de
+verzendcode én toch een onware melding in het antwoord van de route.
+
+**De les, breder dan mail:** bij een grens met twee implementaties waarvan er
+één niets doet, hoort het verschil in het **resultaattype** te zitten en niet in
+een logregel. Een logregel bereikt alleen wie hem leest; een verplicht veld
+bereikt iedere aanroeper, en een nieuwe implementatie die het vergeet komt langs
+de compiler niet heen.
+
+Dezelfde vraag is te stellen aan elke andere no-op in dit project — bijvoorbeeld
+`scripts/telegram.js`, dat bij ontbrekende configuratie ook stilzwijgend niets
+doet. Daar is de aanroeper een script en niet een route, dus de schade is
+kleiner; het patroon is hetzelfde.
 
 ### Teruglezen als testvorm — nieuw sinds 2026-08-11
 

--- a/scripts/platformbeheerder-inrichten.js
+++ b/scripts/platformbeheerder-inrichten.js
@@ -275,7 +275,15 @@ async function voltooi(code, verifier) {
        RETURNING user_id`,
       [
         PLATFORM_TENANT_ID,
-        identiteit.naam ?? 'Platformbeheerder',
+        // Terugval op het e-mailadres en pas dan op een generieke tekst
+        // (Issue #133). Een adres zegt wie iemand is; "Platformbeheerder" zegt
+        // alleen wat hij doet, en dat is in een audit trail met meer dan één
+        // beheerder onbruikbaar.
+        //
+        // `identiteit.naam` is sinds Issue #133 `undefined` wanneer Entra een
+        // plaatsvervanger als "unknown" meestuurt — die kwam hier vroeger
+        // gewoon doorheen omdat hij niet leeg is.
+        identiteit.naam ?? identiteit.email ?? 'Platformbeheerder',
         identiteit.externalSubject,
         identiteit.email ?? null,
       ],

--- a/src/auth/id-token-verificatie.spec.ts
+++ b/src/auth/id-token-verificatie.spec.ts
@@ -134,6 +134,50 @@ describe('IdTokenVerificateur', () => {
       expect(identiteit.naam).toBeUndefined();
     });
 
+    it('negeert "unknown" als naam (Issue #133)', async () => {
+      // Waargenomen op 2026-08-10: na een echte federatieve login stuurde
+      // Entra `"name": "unknown"` mee, en die tekst belandde als naam in de
+      // database. In de zijbalk stond "unknown / Beheerder"; in de audit trail
+      // zou "unknown heeft dit oordeel gegeven" komen te staan.
+      const identiteit = await verificateur.verifieer(
+        await maakToken({
+          claims: { oid: OID, name: 'unknown', email: 'kees@alingadvies.nl' },
+        }),
+      );
+
+      // `undefined` en geen verzonnen vervanging: de aanroeper kiest zelf zijn
+      // terugval — voor een gebruikersrij is dat het e-mailadres.
+      expect(identiteit.naam).toBeUndefined();
+      expect(identiteit.email).toBe('kees@alingadvies.nl');
+    });
+
+    it('negeert plaatsvervangers ongeacht hoofdletters en spaties', async () => {
+      for (const waarde of ['Unknown', '  UNKNOWN  ', 'n/a', 'null', '-']) {
+        const identiteit = await verificateur.verifieer(
+          await maakToken({ claims: { oid: OID, name: waarde } }),
+        );
+
+        expect(identiteit.naam).toBeUndefined();
+      }
+    });
+
+    it('laat een echte naam ongemoeid', async () => {
+      // De tegenproef. Zou de filter te breed zijn, dan verdwijnen er namen
+      // van echte mensen — en dat is erger dan het probleem dat hij oplost.
+      for (const waarde of [
+        'Kees Aling',
+        'Robert Unknown',
+        'Nancy Ann',
+        'Naomi Nagel',
+      ]) {
+        const identiteit = await verificateur.verifieer(
+          await maakToken({ claims: { oid: OID, name: waarde } }),
+        );
+
+        expect(identiteit.naam).toBe(waarde);
+      }
+    });
+
     it('accepteert een token binnen de klokspeling', async () => {
       // 10 seconden verlopen, speling is 30: nog geldig. Dit bewijst dat de
       // speling werkt en niet per ongeluk 0 is.

--- a/src/auth/id-token-verificatie.ts
+++ b/src/auth/id-token-verificatie.ts
@@ -129,7 +129,7 @@ export class IdTokenVerificateur {
     return {
       externalSubject: oid,
       email: leesTekstClaim(payload, 'email'),
-      naam: leesTekstClaim(payload, 'name'),
+      naam: leesNaamClaim(payload),
       identityTenantId: leesTekstClaim(payload, 'tid'),
       // Bij federatie wijst deze claim naar de identity provider van de
       // gebruiker zelf, niet naar onze CIAM-tenant — voor een AlingAdvies-
@@ -149,4 +149,53 @@ function leesTekstClaim(payload: JWTPayload, naam: string): string | undefined {
   return typeof waarde === 'string' && waarde.trim() !== ''
     ? waarde
     : undefined;
+}
+
+/**
+ * Waarden die Entra invult wanneer hij geen naam heeft (Issue #133).
+ *
+ * Op 2026-08-10 kwam er na een echte federatieve login `"name": "unknown"` uit
+ * de CIAM-tenant, en die tekst belandde als volwaardige naam in de database:
+ * "unknown / Beheerder" linksonder in de zijbalk. `leesTekstClaim()` weerde
+ * alleen lége waarden, en `"unknown"` is niet leeg.
+ *
+ * De oorzaak zit bij de provider — een federatief account bestaat in de
+ * CIAM-tenant alleen als verwijzing naar de eigen organisatie, dus is er geen
+ * profiel om een naam uit te halen. Dat is daar op te lossen, maar dan zijn we
+ * afhankelijk van hoe elke klant zijn tenant inricht. Deze lijst maakt de
+ * applicatie bestand tegen wat er ook binnenkomt.
+ *
+ * Kleinletters en zonder spaties vergeleken, want `"Unknown"` is dezelfde
+ * onzin. Geen brede heuristiek: alleen waarden waarvan is vastgesteld dat een
+ * provider ze als plaatsvervanger gebruikt. Een echte achternaam "Unknown"
+ * bestaat, maar dan als deel van een volledige naam — niet als de hele claim.
+ */
+const NAAM_PLAATSVERVANGERS = new Set([
+  'unknown',
+  'unknown user',
+  'n/a',
+  'na',
+  'null',
+  'undefined',
+  '-',
+]);
+
+/**
+ * De naam uit het token, of `undefined` als er geen bruikbare naam in staat.
+ *
+ * `undefined` en niet een verzonnen vervanging: wie deze functie aanroept weet
+ * zelf wat een goede terugval is. Voor een gebruikersrij is dat het
+ * e-mailadres; voor een scherm iets anders. Hier een keuze maken zou die
+ * afweging weghalen bij wie hem hoort te maken.
+ */
+function leesNaamClaim(payload: JWTPayload): string | undefined {
+  const naam = leesTekstClaim(payload, 'name');
+
+  if (naam === undefined) {
+    return undefined;
+  }
+
+  return NAAM_PLAATSVERVANGERS.has(naam.trim().toLowerCase())
+    ? undefined
+    : naam;
 }

--- a/src/auth/sessie.service.spec.ts
+++ b/src/auth/sessie.service.spec.ts
@@ -1,0 +1,140 @@
+import { Logger } from '@nestjs/common';
+
+import type { DatabaseService } from '../db/database.service';
+import { SessieService } from './sessie.service';
+import { genereerUitnodigingstoken } from './uitnodigingstoken';
+
+/**
+ * Wat er gelogd wordt wanneer een uitnodiging niets doet (Issue #133).
+ *
+ * ── Waarom een logregel het onderwerp van een test is ────────────────────────
+ *
+ * Normaal is een logregel geen gedrag dat je vastlegt. Hier wel, en om dezelfde
+ * reden als bij Issue #131: het gaat om de vraag of een gebeurtenis zichtbaar
+ * is. Op acceptatie bleef een uitgenodigde rij eeuwig wachten terwijl dezelfde
+ * persoon gewoon inlogde als een andere gebruiker — twee rijen, één mens, en
+ * niets wat daar melding van maakte.
+ *
+ * `clm.koppel_eerste_login()` geeft bewust geen reden terug: die zou verklappen
+ * welke uitnodiging bestaat (migratie 0024). Het log is daarmee de énige plek
+ * waar "ik klik en er gebeurt niets" aan een oorzaak te verbinden is. Verdwijnt
+ * die regel, dan is de storing weer onzichtbaar — vandaar deze tests.
+ *
+ * De database is hier een dubbel: wát de functie beslist, is gedekt door
+ * `test/eerste-login.e2e-spec.ts` tegen de echte migratie. Hier gaat het om wat
+ * de service doet met de uitkomst.
+ */
+
+/** Een DatabaseService die teruggeeft wat de test voorschrijft. */
+function dubbel(antwoorden: Array<Array<Record<string, unknown>>>) {
+  const gesteld: string[] = [];
+  let beurt = 0;
+
+  const service = {
+    db: {
+      execute: (query: { queryChunks?: unknown[] }) => {
+        // De SQL zelf doet er hier niet toe; de volgorde van antwoorden wel.
+        gesteld.push(JSON.stringify(query.queryChunks ?? []));
+        return Promise.resolve({ rows: antwoorden[beurt++] ?? [] });
+      },
+    },
+  } as unknown as DatabaseService;
+
+  return { service, gesteld };
+}
+
+const SESSIE = [
+  { sessie_id: 's-1', user_id: 'u-1', tenant_id: 't-1', role: 'admin' },
+];
+
+const UITNODIGING = {
+  email: 'kees@alingadvies.nl',
+  uitnodigingstoken: genereerUitnodigingstoken(),
+};
+
+describe('SessieService — een uitnodiging die niets doet (Issue #133)', () => {
+  let waarschuwingen: string[];
+
+  beforeEach(() => {
+    waarschuwingen = [];
+    jest
+      .spyOn(Logger.prototype, 'warn')
+      .mockImplementation((melding: unknown) => {
+        waarschuwingen.push(String(melding));
+      });
+    jest.spyOn(Logger.prototype, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('waarschuwt wanneer iemand met een account een uitnodiging aanbiedt', async () => {
+    // Dit is de situatie van acceptatie: de platformbeheerder heeft al een oid
+    // en klikt op de uitnodiging voor de rij die op hem wacht. Hij komt gewoon
+    // binnen als zichzelf; de tweede rij blijft staan.
+    const { service } = dubbel([SESSIE]);
+
+    const sessie = await new SessieService(service).aanmaken(
+      'oid-bestaand',
+      UITNODIGING,
+    );
+
+    expect(sessie).not.toBeNull();
+    expect(waarschuwingen.join('\n')).toContain('al een account heeft');
+  });
+
+  it('waarschuwt wanneer de koppeling niet lukt', async () => {
+    // Geen sessie, koppelpoging levert niets op. Vóór Issue #133 gebeurde hier
+    // niets: geen regel, geen onderscheid met "deze persoon hoort er niet bij".
+    const { service } = dubbel([[], []]);
+
+    const sessie = await new SessieService(service).aanmaken(
+      'oid-nieuw',
+      UITNODIGING,
+    );
+
+    expect(sessie).toBeNull();
+    expect(waarschuwingen.join('\n')).toContain('koppeling is niet gelukt');
+  });
+
+  it('zwijgt wanneer de koppeling wél lukt', async () => {
+    // De tegenproef. Zou er altijd gewaarschuwd worden, dan is de waarschuwing
+    // ruis en leest niemand hem meer.
+    const { service } = dubbel([[], [{ user_id: 'u-1' }], SESSIE]);
+
+    const sessie = await new SessieService(service).aanmaken(
+      'oid-nieuw',
+      UITNODIGING,
+    );
+
+    expect(sessie).not.toBeNull();
+    expect(waarschuwingen).toEqual([]);
+  });
+
+  it('zwijgt bij een gewone login zonder uitnodiging', async () => {
+    const { service } = dubbel([SESSIE]);
+
+    await new SessieService(service).aanmaken('oid-bestaand');
+
+    expect(waarschuwingen).toEqual([]);
+  });
+
+  it('doet geen koppelpoging bij een token met een verkeerde vorm', async () => {
+    // De vormcontrole staat vóór de databaseaanroep: een cookie dat door iets
+    // anders gevuld is hoort af te ketsen op zijn vorm.
+    const { service, gesteld } = dubbel([[]]);
+
+    await new SessieService(service).aanmaken('oid-nieuw', {
+      email: 'kees@alingadvies.nl',
+      uitnodigingstoken: 'te-kort',
+    });
+
+    // Eén query: alleen sessie_aanmaken, geen koppel_eerste_login.
+    expect(gesteld).toHaveLength(1);
+    // De "geen membership"-regel komt er wél — die hoort bij het uitblijven
+    // van een sessie en staat los van de uitnodiging. Wat hier niet mag staan,
+    // is een melding over een mislukte koppeling: er is niets geprobeerd.
+    expect(waarschuwingen.join('\n')).not.toContain('koppeling');
+  });
+});

--- a/src/auth/sessie.service.ts
+++ b/src/auth/sessie.service.ts
@@ -105,6 +105,34 @@ export class SessieService {
     // De vormcontrole staat er vóór de query: een token uit een cookie dat door
     // iets anders gevuld is hoort af te ketsen op zijn vorm, niet op een
     // databaseaanroep.
+    // Issue #133: iemand die al binnen is, klikt op een uitnodiging.
+    //
+    // Dan slaagt sessie_aanmaken() en komt de koppeling er niet eens aan te
+    // pas. Hij logt gewoon in, en de uitgenodigde rij blijft wachten op een
+    // login die nooit komt — twee rijen voor één persoon, precies wat er op
+    // acceptatie stond. Niemand merkt er iets van.
+    //
+    // Koppelen is hier geen optie: de oid zit al aan een andere rij vast, en
+    // migratie 0024 weigert dat terecht (dat zou accountovername zijn). Het
+    // samenvoegen van twee gebruikersrijen raakt beoordelingen, notities en de
+    // audit trail, en hoort dus een bewuste beheerhandeling te zijn — geen
+    // bijverschijnsel van een klik op een link.
+    //
+    // Wat hier wél moet: het zichtbaar maken, zodat de platformbeheerder de
+    // openstaande uitnodiging kan intrekken in plaats van hem te laten staan.
+    if (
+      resultaat.rows.length > 0 &&
+      uitnodiging?.email &&
+      heeftGeldigeUitnodigingsVorm(uitnodiging.uitnodigingstoken)
+    ) {
+      this.logger.warn(
+        'Uitnodigingstoken aangeboden door iemand die al een account heeft. ' +
+          'De uitnodiging blijft openstaan en er is niets gekoppeld; deze ' +
+          'persoon logt in als zijn bestaande gebruiker. Trek de openstaande ' +
+          'uitnodiging in of voeg de gebruikers samen.',
+      );
+    }
+
     if (
       resultaat.rows.length === 0 &&
       uitnodiging?.email &&
@@ -123,6 +151,21 @@ export class SessieService {
 
         resultaat = await this.db.db.execute<SessieRij>(
           sql`SELECT * FROM clm.sessie_aanmaken(${hash}, ${externalSubject}, ${GELDIGHEID_INTERVAL}::interval)`,
+        );
+      } else {
+        // Issue #133: hier gebeurde niets, en dat was niet te zien.
+        //
+        // De functie geeft bewust geen reden terug — die zou verklappen welke
+        // uitnodiging bestaat (migratie 0024). Maar dat er een koppeling is
+        // geprobeerd én mislukt, mag wél in het log: dat is de enige plek waar
+        // een beheerder "ik klik op de link en er gebeurt niets" kan verbinden
+        // aan een oorzaak. Zonder deze regel is een verlopen token niet te
+        // onderscheiden van een verkeerd adres of van een oid die al bestaat.
+        this.logger.warn(
+          'Uitnodigingstoken aangeboden, maar de koppeling is niet gelukt. ' +
+            'Mogelijke oorzaken: de uitnodiging is verlopen of al gebruikt, ' +
+            'het e-mailadres wijkt af, of dit account is al aan een andere ' +
+            'gebruiker gekoppeld. Zie clm.koppel_eerste_login (migratie 0024).',
         );
       }
     }

--- a/src/mail/log-mail-kanaal.spec.ts
+++ b/src/mail/log-mail-kanaal.spec.ts
@@ -38,6 +38,16 @@ describe('LogMailKanaal', () => {
     expect(resultaat.providerId.length).toBeGreaterThan(10);
   });
 
+  it('zegt in het resultaat dat er niets echt verstuurd is (Issue #131)', async () => {
+    // Tot Issue #131 zat die wetenschap alleen in de logregel. Het resultaat
+    // zag er precies zo uit als dat van een echte verzending, dus kon de
+    // aanroeper het verschil niet zien — en meldde `mailVerstuurd: true` voor
+    // een mail die nooit bestond.
+    const resultaat = await kanaal.verstuur(BERICHT);
+
+    expect(resultaat.echtVerstuurd).toBe(false);
+  });
+
   it('geeft elk bericht een eigen providerId', async () => {
     // Het providerId is de sleutel waarmee een latere statusmelding gekoppeld
     // wordt (ontwerp §4). Twee berichten met hetzelfde id zouden betekenen dat

--- a/src/mail/log-mail-kanaal.ts
+++ b/src/mail/log-mail-kanaal.ts
@@ -72,7 +72,10 @@ export class LogMailKanaal extends MailKanaal {
         `onderwerp="${bericht.onderwerp}"`,
     );
 
-    return Promise.resolve({ providerId });
+    // `echtVerstuurd: false` is het hele punt van Issue #131. De logregel
+    // hierboven zei het al, maar alleen tegen wie het log leest; nu loopt het
+    // door tot in het antwoord van de route.
+    return Promise.resolve({ providerId, echtVerstuurd: false });
   }
 
   /** Alles wat dit kanaal heeft "verstuurd", in volgorde. */

--- a/src/mail/mail-kanaal.ts
+++ b/src/mail/mail-kanaal.ts
@@ -67,6 +67,30 @@ export interface MailBericht {
  */
 export interface VerzendResultaat {
   readonly providerId: string;
+
+  /**
+   * Waar of er werkelijk een bericht het netwerk op is gegaan.
+   *
+   * ── Waarom dit veld bestaat (Issue #131) ──────────────────────────────────
+   *
+   * `LogMailKanaal` verstuurt niets en zegt dat ook — in zijn logregel. Maar
+   * zijn `VerzendResultaat` zag er tot Issue #131 precies zo uit als dat van
+   * een echte verzending, dus kon geen enkele aanroeper het verschil zien.
+   * Gevolg op acceptatie: `"mailVerstuurd": true` en de melding "heeft een
+   * uitnodiging ontvangen", terwijl het log in dezelfde seconde
+   * `[niet echt verstuurd]` zei.
+   *
+   * Dat is dezelfde klasse als Issue #86: een geruststellende melding over
+   * iets dat niet gebeurd is. Op acceptatie onschuldig, op productie niet —
+   * je denkt dat de klant is uitgenodigd en merkt pas na een week dat er
+   * niets uit is gegaan.
+   *
+   * Het veld staat hier en niet bij de aanroeper omdat alleen het kanaal het
+   * weet. Verplicht, niet optioneel: een nieuwe implementatie die het vergeet
+   * te zetten, compileert dan niet — in plaats van stilzwijgend `undefined`
+   * terug te geven, wat als "niet echt" zou lezen terwijl er wél mail uitging.
+   */
+  readonly echtVerstuurd: boolean;
 }
 
 /**

--- a/src/mail/resend-mail-kanaal.ts
+++ b/src/mail/resend-mail-kanaal.ts
@@ -113,7 +113,7 @@ export class ResendMailKanaal extends MailKanaal {
       );
     }
 
-    return { providerId: data.id };
+    return { providerId: data.id, echtVerstuurd: true };
   }
 
   /**

--- a/src/mail/uitnodiging-verzender.service.spec.ts
+++ b/src/mail/uitnodiging-verzender.service.spec.ts
@@ -52,7 +52,13 @@ class FalendKanaal extends MailKanaal {
       );
     }
     this.verstuurd.push(bericht.aan);
-    return Promise.resolve({ providerId: `id-${this.verstuurd.length}` });
+    // Dit kanaal staat voor een échte provider — vandaar `true`. Het logkanaal
+    // is de enige met `false`, en het verschil tussen die twee is de kern van
+    // Issue #131.
+    return Promise.resolve({
+      providerId: `id-${this.verstuurd.length}`,
+      echtVerstuurd: true,
+    });
   }
 }
 
@@ -256,6 +262,94 @@ describe('UitnodigingVerzender', () => {
         [],
       );
       expect(kanaal.verzonden).toHaveLength(0);
+    });
+  });
+
+  /**
+   * Issue #131: zonder mailkanaal is er niets misgegaan én is er niets
+   * aangekomen. Dat zijn twee verschillende dingen en ze hadden één veld.
+   */
+  describe('zonder mailkanaal — er gaat niets uit', () => {
+    it('meldt de leveranciersuitnodiging als niet echt verstuurd', async () => {
+      const verzender = new UitnodigingVerzender(new LogMailKanaal());
+
+      const [uitkomst] = await verzender.verstuurAllemaal(
+        [uitnodiging(1)],
+        CONTEXT,
+      );
+
+      // Niets misgegaan...
+      expect(uitkomst.verstuurd).toBe(true);
+      expect(uitkomst.fout).toBeUndefined();
+      // ...maar er is ook niets aangekomen.
+      expect(uitkomst.echtVerstuurd).toBe(false);
+    });
+
+    it('meldt de beheerdersuitnodiging als niet echt verstuurd', async () => {
+      // Dit is de waarneming uit de issue: op acceptatie gaf de route
+      // `mailVerstuurd: true` terwijl het log `[niet echt verstuurd]` zei.
+      const verzender = new UitnodigingVerzender(new LogMailKanaal());
+
+      const uitkomst = await verzender.verstuurAanBeheerder({
+        ontvanger: 'kees@alingadvies.nl',
+        beheerderNaam: 'Kees Aling',
+        tenantNaam: 'AlingAdvies (acceptatie)',
+        link: 'https://mcm2.example.nl/api/backend/auth/login?uitnodiging=abc',
+        verlooptOp: '2026-09-01T12:00:00.000Z',
+      });
+
+      expect(uitkomst.verstuurd).toBe(true);
+      expect(uitkomst.echtVerstuurd).toBe(false);
+    });
+  });
+
+  describe('met een echt kanaal', () => {
+    it('meldt de uitnodiging als echt verstuurd', async () => {
+      // De tegenproef: zou `echtVerstuurd` altijd `false` zijn, dan is het
+      // veld waardeloos en meldt een geslaagde verzending straks ten onrechte
+      // dat er niets uitging.
+      const verzender = new UitnodigingVerzender(new FalendKanaal(new Set()));
+
+      const [uitkomst] = await verzender.verstuurAllemaal(
+        [uitnodiging(1)],
+        CONTEXT,
+      );
+
+      expect(uitkomst.echtVerstuurd).toBe(true);
+    });
+
+    it('meldt een mislukte verzending niet als echt verstuurd', async () => {
+      const verzender = new UitnodigingVerzender(
+        new FalendKanaal(new Set(['contact+vendor1@gmail.com'])),
+      );
+
+      const [uitkomst] = await verzender.verstuurAllemaal(
+        [uitnodiging(1)],
+        CONTEXT,
+      );
+
+      expect(uitkomst.verstuurd).toBe(false);
+      expect(uitkomst.echtVerstuurd).toBe(false);
+    });
+
+    it('houdt een geweigerde verzending apart van een ontbrekend mailkanaal', async () => {
+      // Beide leveren `echtVerstuurd: false` op, en het onderscheid zit in
+      // `verstuurd`. Wie die twee door elkaar haalt, meldt "geen mailkanaal
+      // ingesteld" terwijl de provider gewoon weigerde — precies de soort
+      // misleiding die Issue #131 aan de kaak stelt.
+      const geweigerd = await new UitnodigingVerzender(
+        new FalendKanaal(new Set(['contact+vendor1@gmail.com'])),
+      ).verstuurAllemaal([uitnodiging(1)], CONTEXT);
+
+      const stil = await new UitnodigingVerzender(
+        new LogMailKanaal(),
+      ).verstuurAllemaal([uitnodiging(1)], CONTEXT);
+
+      expect(geweigerd[0]).toMatchObject({
+        verstuurd: false,
+        echtVerstuurd: false,
+      });
+      expect(stil[0]).toMatchObject({ verstuurd: true, echtVerstuurd: false });
     });
   });
 });

--- a/src/mail/uitnodiging-verzender.service.ts
+++ b/src/mail/uitnodiging-verzender.service.ts
@@ -54,8 +54,23 @@ export interface VerzendUitkomst {
   readonly responseId: string;
   readonly vendorNaam: string;
   readonly ontvanger?: string;
-  /** Waar of de mail bij de provider is aangenomen. */
+  /**
+   * Waar of de verzending is gelukt — dus: er is niets misgegaan.
+   *
+   * Let op het verschil met `echtVerstuurd`. Draait het logkanaal, dan is dit
+   * `true` en `echtVerstuurd` `false`: er is niets fout gegaan, maar er is ook
+   * niets aangekomen. Wie een mens iets wil melden moet naar `echtVerstuurd`
+   * kijken; wie wil weten of er ingegrepen moet worden, naar `fout`.
+   */
   readonly verstuurd: boolean;
+  /**
+   * Waar of er werkelijk mail is uitgegaan (Issue #131).
+   *
+   * `false` bij het logkanaal — dan is er geen sleutel ingesteld en belandt de
+   * uitnodiging alleen in het log. De link moet dan met de hand doorgegeven
+   * worden, en dat moet de aanroeper kunnen zien zonder het log te lezen.
+   */
+  readonly echtVerstuurd: boolean;
   /** Alleen bij succes: de sleutel voor een latere statusmelding. */
   readonly providerId?: string;
   /** Alleen bij mislukking: wat er misging, in lezersvorm. */
@@ -90,12 +105,30 @@ export class UitnodigingVerzender {
 
     const mislukt = uitkomsten.filter((u) => !u.verstuurd).length;
 
+    // "verstuurd" alleen zeggen als er ook werkelijk iets uit is gegaan
+    // (Issue #131). Zonder mailkanaal was deze regel de laatste plek waar het
+    // nog geruststellend klonk.
+    //
+    // De toets is *geslaagd maar niet echt verstuurd*, niet simpelweg "nul
+    // echte verzendingen". Dat laatste is óók waar als álles mislukte, en dan
+    // wijst deze regel de lezer naar een ontbrekend mailkanaal terwijl de
+    // provider gewoon weigerde — dezelfde soort misleiding als de fout die
+    // deze wijziging repareert.
+    const geslaagdMaarStil = uitkomsten.some(
+      (u) => u.verstuurd && !u.echtVerstuurd,
+    );
+    const staart = geslaagdMaarStil
+      ? ' Let op: er is geen mailkanaal ingesteld, er ging niets de deur uit.'
+      : '';
+
     if (mislukt > 0) {
       this.logger.warn(
-        `${uitkomsten.length - mislukt} van de ${uitkomsten.length} uitnodigingen verstuurd; ${mislukt} mislukt.`,
+        `${uitkomsten.length - mislukt} van de ${uitkomsten.length} uitnodigingen verstuurd; ${mislukt} mislukt.${staart}`,
       );
     } else {
-      this.logger.log(`${uitkomsten.length} uitnodiging(en) verstuurd.`);
+      this.logger.log(
+        `${uitkomsten.length} uitnodiging(en) verstuurd.${staart}`,
+      );
     }
 
     return uitkomsten;
@@ -116,20 +149,27 @@ export class UitnodigingVerzender {
    */
   async verstuurAanBeheerder(gegevens: BeheerderUitnodigingGegevens): Promise<{
     verstuurd: boolean;
+    echtVerstuurd: boolean;
     providerId?: string;
     fout?: string;
     tijdelijk?: boolean;
   }> {
     try {
-      const { providerId } = await this.mail.verstuur(
+      const { providerId, echtVerstuurd } = await this.mail.verstuur(
         stelBeheerderUitnodigingSamen(gegevens),
       );
 
+      // De logregel zegt nu wát er gebeurd is. Vóór Issue #131 stond hier
+      // "verstuurd" ook als het logkanaal draaide — en dat is precies de
+      // geruststellende melding waar het misging.
       this.logger.log(
-        `Uitnodiging voor de beheerder van ${gegevens.tenantNaam} verstuurd.`,
+        echtVerstuurd
+          ? `Uitnodiging voor de beheerder van ${gegevens.tenantNaam} verstuurd.`
+          : `Uitnodiging voor de beheerder van ${gegevens.tenantNaam} NIET verstuurd: ` +
+              'er is geen mailkanaal ingesteld. Geef de link handmatig door.',
       );
 
-      return { verstuurd: true, providerId };
+      return { verstuurd: true, echtVerstuurd, providerId };
     } catch (err) {
       const fout = err instanceof MailVerzendFout;
 
@@ -141,6 +181,7 @@ export class UitnodigingVerzender {
 
       return {
         verstuurd: false,
+        echtVerstuurd: false,
         fout:
           err instanceof Error ? err.message : 'Onbekende fout bij versturen.',
         tijdelijk: fout ? err.tijdelijk : false,
@@ -169,13 +210,14 @@ export class UitnodigingVerzender {
       return {
         ...basis,
         verstuurd: false,
+        echtVerstuurd: false,
         fout: 'Geen e-mailadres bekend bij deze leverancier.',
         tijdelijk: false,
       };
     }
 
     try {
-      const { providerId } = await this.mail.verstuur(
+      const { providerId, echtVerstuurd } = await this.mail.verstuur(
         stelUitnodigingSamen({
           ontvanger: uitnodiging.ontvanger,
           vendorNaam: uitnodiging.vendorNaam,
@@ -187,7 +229,7 @@ export class UitnodigingVerzender {
         }),
       );
 
-      return { ...basis, verstuurd: true, providerId };
+      return { ...basis, verstuurd: true, echtVerstuurd, providerId };
     } catch (err) {
       const fout = err instanceof MailVerzendFout;
 
@@ -200,6 +242,7 @@ export class UitnodigingVerzender {
       return {
         ...basis,
         verstuurd: false,
+        echtVerstuurd: false,
         fout:
           err instanceof Error ? err.message : 'Onbekende fout bij versturen.',
         tijdelijk: fout ? err.tijdelijk : false,

--- a/src/platform/platform.controller.ts
+++ b/src/platform/platform.controller.ts
@@ -77,14 +77,21 @@ export class PlatformController {
         // laatste kans om de link handmatig door te geven. Zelfde afweging als
         // bij de leverancierstokens.
         uitnodigingslink: link,
-        mailVerstuurd: verzending.verstuurd,
+        // `echtVerstuurd` en niet `verstuurd` (Issue #131).
+        //
+        // Draait het logkanaal — geen RESEND_API_KEY — dan is `verstuurd`
+        // true (er ging niets mis) maar `echtVerstuurd` false (er ging ook
+        // niets uit). Op acceptatie stond hier `"mailVerstuurd": true` en
+        // "heeft een uitnodiging ontvangen", terwijl het log in dezelfde
+        // seconde `[niet echt verstuurd]` zei. Dat is precies de faalvorm
+        // die dit project elders bestrijdt.
+        mailVerstuurd: verzending.echtVerstuurd,
         mailFout: verzending.fout,
-        melding: verzending.verstuurd
-          ? `Tenant aangemaakt. ${invoer.adminNaam} heeft een uitnodiging ` +
-            `ontvangen op ${invoer.adminEmail}.`
-          : `Tenant aangemaakt, maar de uitnodiging kon niet verstuurd worden ` +
-            `(${verzending.fout ?? 'onbekende fout'}). Geef de link hierboven ` +
-            'handmatig door.',
+        melding: this.meldingOverVerzending(
+          verzending,
+          invoer.adminNaam,
+          invoer.adminEmail,
+        ),
       };
     } catch (fout) {
       if (fout instanceof InvoerFout) {
@@ -95,6 +102,47 @@ export class PlatformController {
       }
       throw fout;
     }
+  }
+
+  /**
+   * De zin die de platformbeheerder op zijn scherm krijgt.
+   *
+   * ── Drie uitkomsten, geen twee (Issue #131) ───────────────────────────────
+   *
+   * Hier stond een ternary op `verstuurd`: gelukt of mislukt. Die derde
+   * uitkomst — niets misgegaan, maar er is ook niets verstuurd — viel daardoor
+   * onder "gelukt" en leverde de zin "heeft een uitnodiging ontvangen" op voor
+   * een mail die nooit bestond.
+   *
+   * De middelste zin noemt de oorzaak (geen mailkanaal) én de handeling (geef
+   * de link door). Zonder die twee is "niet verstuurd" een mededeling waar de
+   * lezer niets mee kan.
+   */
+  private meldingOverVerzending(
+    verzending: { verstuurd: boolean; echtVerstuurd: boolean; fout?: string },
+    adminNaam: string,
+    adminEmail: string,
+  ): string {
+    if (verzending.echtVerstuurd) {
+      return (
+        `Tenant aangemaakt. ${adminNaam} heeft een uitnodiging ` +
+        `ontvangen op ${adminEmail}.`
+      );
+    }
+
+    if (verzending.verstuurd) {
+      return (
+        'Tenant aangemaakt, maar er is GEEN mail verstuurd: deze omgeving ' +
+        'heeft geen mailkanaal ingesteld. Geef de link hierboven handmatig ' +
+        `door aan ${adminNaam}.`
+      );
+    }
+
+    return (
+      `Tenant aangemaakt, maar de uitnodiging kon niet verstuurd worden ` +
+      `(${verzending.fout ?? 'onbekende fout'}). Geef de link hierboven ` +
+      'handmatig door.'
+    );
   }
 
   /**

--- a/src/survey/vragenlijst-beheer.controller.ts
+++ b/src/survey/vragenlijst-beheer.controller.ts
@@ -544,12 +544,25 @@ export class VragenlijstBeheerController {
         const uitkomst = perResponse.get(u.responseId);
         return {
           ...u,
-          verstuurd: uitkomst?.verstuurd ?? false,
+          // `echtVerstuurd` en niet `verstuurd` — zelfde reden als bij
+          // `PlatformController` (Issue #131). Zonder mailkanaal ging er niets
+          // uit, en dan mag hier geen vinkje staan dat zegt van wel.
+          verstuurd: uitkomst?.echtVerstuurd ?? false,
           verzendFout: uitkomst?.fout,
         };
       }),
-      verzonden: verzending.filter((v) => v.verstuurd).length,
+      verzonden: verzending.filter((v) => v.echtVerstuurd).length,
       mislukt: verzending.filter((v) => !v.verstuurd).length,
+      // Staat dit op `true`, dan is `verzonden` nul zonder dat er iets fout is:
+      // de tokens zijn geldig, maar de links moeten met de hand doorgegeven
+      // worden. Het scherm kan dat dan zeggen in plaats van "0 verstuurd" te
+      // tonen bij een ronde waar niets mis mee is.
+      //
+      // De toets is *geslaagd maar niet echt verstuurd*. Zou hier
+      // `every(v => !v.echtVerstuurd)` staan, dan is dit ook `true` wanneer de
+      // provider álles weigerde — en dan wijst het scherm naar een ontbrekend
+      // mailkanaal terwijl er een heel ander probleem is.
+      geenMailkanaal: verzending.some((v) => v.verstuurd && !v.echtVerstuurd),
     };
   }
 

--- a/test/platform-routes.e2e-spec.ts
+++ b/test/platform-routes.e2e-spec.ts
@@ -38,6 +38,9 @@ interface TenantAntwoord {
   naam?: string;
   aantalLeden?: number;
   melding?: string;
+  /** Sinds Issue #131: alleen `true` als er werkelijk mail is uitgegaan. */
+  mailVerstuurd?: boolean;
+  uitnodigingslink?: string;
   verlooptOp?: string;
   reden?: string;
   veld?: string;
@@ -225,8 +228,18 @@ describe('Platformroutes (e2e, ADR-015)', () => {
       expect(uit.naam).toBe('AlingAdvies');
       expect(uit.aantalLeden).toBe(1);
       // De uitnodiging gaat per mail (migratie 0025). In de e2e-run staat geen
-      // RESEND_API_KEY, dus dit is het logkanaal — dat "verstuurt" en meldt.
-      expect(uit.melding).toContain('uitnodiging');
+      // RESEND_API_KEY, dus draait het logkanaal en gaat er níéts uit.
+      //
+      // Sinds Issue #131 zegt het antwoord dat ook. Deze test verwachtte
+      // eerder het woord "uitnodiging" in de melding — dat stond er, in de zin
+      // "heeft een uitnodiging ontvangen", en die zin was onwaar. De melding
+      // hoort nu de oorzaak te noemen én wat de lezer moet doen.
+      expect(uit.melding).toContain('GEEN mail verstuurd');
+      expect(uit.melding).toContain('handmatig door');
+      expect(uit.mailVerstuurd).toBe(false);
+      // De link staat in het antwoord: dat is het enige moment waarop het
+      // token bestaat, en zonder mail de enige manier om hem door te geven.
+      expect(uit.uitnodigingslink).toContain('uitnodiging=');
 
       // De admin bestaat, nog zonder external_subject: die komt bij zijn
       // eerste login. De partiële unieke index staat dat toe (migratie 0009).

--- a/test/ronde-beheer-routes.e2e-spec.ts
+++ b/test/ronde-beheer-routes.e2e-spec.ts
@@ -69,8 +69,11 @@ interface Uitnodiging {
 
 interface UitnodigingAntwoord {
   uitnodigingen: Uitnodiging[];
+  /** Alleen échte verzendingen — sinds Issue #131. */
   verzonden: number;
   mislukt: number;
+  /** Waar wanneer er geen mailkanaal is: de links moeten met de hand door. */
+  geenMailkanaal: boolean;
 }
 
 interface RondeAntwoord {
@@ -399,13 +402,24 @@ describe('Ronde-beheerroutes (e2e)', () => {
 
     const body = antwoord.body as UitnodigingAntwoord;
 
-    expect(body.verzonden).toBe(1);
+    // Sinds Issue #131 telt `verzonden` alleen échte verzendingen. Hier stond
+    // `1`, en die één was de leverancier die het logkanaal "verstuurde" — een
+    // mail die nooit bestond. Nul is het eerlijke antwoord.
+    expect(body.verzonden).toBe(0);
+    // `mislukt` blijft 1: dat is VENDOR_2, zonder e-mailadres. Er is een
+    // verschil tussen "niet verstuurd omdat er geen kanaal is" en "niet
+    // verstuurd omdat deze leverancier geen adres heeft", en dat verschil
+    // hoort zichtbaar te blijven.
     expect(body.mislukt).toBe(1);
+    // Het vlaggetje dat het scherm nodig heeft om "0 verstuurd" uit te leggen
+    // bij een ronde waar niets mis mee is.
+    expect(body.geenMailkanaal).toBe(true);
 
     const eerste = body.uitnodigingen.find((u) => u.vendorId === VENDOR_1);
     const tweede = body.uitnodigingen.find((u) => u.vendorId === VENDOR_2);
 
-    expect(eerste?.verstuurd).toBe(true);
+    // Er ging niets uit, dus geen vinkje — ook al ging er niets fout.
+    expect(eerste?.verstuurd).toBe(false);
     expect(eerste?.verzendFout).toBeUndefined();
 
     // Zonder e-mailadres geen uitnodiging — en dat staat er met reden bij.


### PR DESCRIPTION
Sluit #131 en #133. Twee issues van dezelfde soort: het systeem meldde iets geruststellends over iets dat niet had plaatsgevonden.

## #131 — `mailVerstuurd: true` zonder mail

`LogMailKanaal` wist dat het niets verstuurde en zei dat ook — in zijn logregel. Zijn `VerzendResultaat` zag er alleen precies zo uit als dat van een echte verzending, dus kon geen enkele aanroeper het verschil zien.

`VerzendResultaat` krijgt daarom een **verplicht** veld `echtVerstuurd`. Niet optioneel: een nieuwe implementatie die het vergeet compileert dan niet, in plaats van stilzwijgend `undefined` terug te geven — wat als "niet echt" zou lezen terwijl er wél mail uitging.

Beide routes lezen dat veld nu, en de melding bij tenantaanmaak kent drie uitkomsten waar er twee waren:

| Situatie | Melding |
|---|---|
| mail verstuurd | "heeft een uitnodiging ontvangen op …" |
| geen mailkanaal | "er is **GEEN** mail verstuurd … geef de link handmatig door" |
| verzending mislukt | "kon niet verstuurd worden (reden) … geef de link handmatig door" |

Die middelste viel eerder onder "gelukt".

**Bijvangst.** Mijn eerste versie leidde "geen mailkanaal" af uit *nul echte verzendingen*. Dat is óók waar als de provider álles weigert, en dan wijst de melding naar de verkeerde oorzaak — dezelfde soort misleiding als de fout die hij repareert. De toets is nu *geslaagd maar niet echt verstuurd*, met een test die dat onderscheid vastlegt.

## #133 — naam `unknown` en twee rijen voor één persoon

**De naam.** De claimlezer weerde alleen *lege* waarden, en `"unknown"` is niet leeg. Er is nu een korte lijst plaatsvervangers (`unknown`, `n/a`, `null`, `-`, …), hoofdletterongevoelig, met een tegenproef dat een echte naam als `Robert Unknown` ongemoeid blijft. De terugval bij het inrichten is het e-mailadres — dat zegt wie iemand is, waar "Platformbeheerder" alleen zegt wat hij doet.

**De dubbele rij is gemeten**, niet beredeneerd. Op een wegwerpdatabase de situatie van acceptatie nagespeeld:

```
koppelpoging levert rijen op: 0

 full_name  |        email        |     oid      | uitnodiging
------------+---------------------+--------------+-------------
 Kees Aling | kees@alingadvies.nl | (geen)       | open
 unknown    | kees@alingadvies.nl | oid-ee89a3d3 | geen
```

Er ontstaat dus **geen tweede gebruiker** en er wordt **niets samengevoegd** — de uitnodiging doet stilzwijgend niets, en blijft er `open` bij staan alsof hij nog geldig is.

Die weigering is terecht: koppelen zou accountovername zijn (migratie 0024). Wat ontbrak was zichtbaarheid. `SessieService` waarschuwt nu in beide gevallen: bij een mislukte koppeling, én wanneer iemand die al binnen is een uitnodiging aanbiedt.

**Automatisch samenvoegen doen we bewust niet.** Dat raakt beoordelingen, notities en de audit trail, en hoort een beheerhandeling te zijn — geen bijverschijnsel van een klik op een link.

## Twee e2e-tests legden het oude gedrag vast

- `platform-routes` verwachtte het woord "uitnodiging" in de melding. Dat stond er — in de onware zin "heeft een uitnodiging ontvangen".
- `ronde-beheer-routes` verwachtte `verzonden: 1` voor een mail die nooit bestond.

Beide beschreven in hun eigen commentaar al dat er niets over het netwerk ging.

## Gemeten

`npm run verify:volledig` groen tot en met de browsertest: **397 unittests, 471 e2e, 66 browsertests**. Tegen een eigen wegwerpcontainer op 55440; de demo (55450) is niet aangeraakt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)