### PR TITLE
feat(otap): stap 4 — uitrol naar productie met vier remmen

### DIFF
--- a/.github/workflows/productie.yml
+++ b/.github/workflows/productie.yml
@@ -1,0 +1,227 @@
+name: Uitrol naar productie
+
+# ── Waarom dit een eigen workflow is en geen job in ci.yml ────────────────────
+#
+# De stagingjob draait bij elke merge op main. Voor productie mag dat niet: dan
+# staat er na elke merge een akkoordverzoek te wachten, en een akkoord dat je
+# tien keer per week wegklikt is geen rem meer — dat is een knop die in de weg
+# zit. Precies zo verdwijnt de aandacht die deze stap juist moet hebben.
+#
+# Vandaar: uitsluitend handmatig starten. Uitrollen naar productie is een
+# besluit, en het hoort te beginnen met iemand die dat besluit neemt.
+#
+# ── De vier remmen van §3.4 ──────────────────────────────────────────────────
+#
+#   1. handmatig akkoord      GitHub Environment `productie`, required reviewer
+#   2. backup vooraf          productie-poort.js leest het backup-bewijs
+#   3. migratiestand          vóór, ná, én vergeleken met staging
+#   4. terugdraaien           de vorige versie staat in de samenvatting
+#
+# Rem 2 en 3 zitten in de poort-job, die draait VÓÓR het akkoord. Dat is opzet:
+# een akkoordverzoek voor een uitrol die toch geblokkeerd wordt, is een vraag om
+# aandacht voor niets.
+#
+# ── Wat deze workflow NIET doet ──────────────────────────────────────────────
+#
+# De applicatie op saxombp starten. Dat blijft één commando met de hand, om
+# dezelfde reden als bij staging: een CI-runner krijgt onvermijdelijk een
+# Tailscale-label, en gelabelde apparaten kunnen niet via SSH bij een apparaat
+# met een gebruikersidentiteit. Zie de toelichting onderaan de stagingjob in
+# ci.yml.
+#
+# Dat is minder erg dan het klinkt. De migraties zijn de helft waar het misgaat
+# (2026-08-07, Issue #86), en dat is de helft die hier geautomatiseerd is.
+
+on:
+  workflow_dispatch:
+    inputs:
+      versie:
+        description: "Backend-image, bijv. sha-abc123def456 (leeg = laatste van main)"
+        required: false
+        default: ""
+      frontend_versie:
+        description: "Frontend-image, bijv. sha-987fed654321 (leeg = latest)"
+        required: false
+        default: ""
+      reden:
+        description: "Waarom rol je uit? Komt in de samenvatting en het akkoordverzoek."
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+  # ── Rem 2 en 3 ─────────────────────────────────────────────────────────────
+  #
+  # Draait vóór het akkoord. Blokkeert deze job, dan is er niemand lastiggevallen
+  # met een vraag die toch nergens toe kon leiden.
+  poort:
+    name: Poort — backup en migratiestanden
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Node.js instellen
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: ".nvmrc"
+          cache: "npm"
+
+      - name: Dependencies installeren
+        run: npm ci
+
+      # Leest uitsluitend. Beide URL's zijn `clm_migrator`, want de migratietabel
+      # staat in het drizzle-schema en clm_api_runtime mag daar niet bij
+      # (ADR-009).
+      - name: De drie automatische remmen
+        env:
+          STAGING_MIGRATION_DATABASE_URL: ${{ secrets.STAGING_MIGRATION_DATABASE_URL }}
+          PRODUCTIE_MIGRATION_DATABASE_URL: ${{ secrets.PRODUCTIE_MIGRATION_DATABASE_URL }}
+        run: node scripts/productie-poort.js
+
+      # De stand van productie vastleggen vóórdat er iets gebeurt. Zonder deze
+      # meting is "onveranderd" achteraf niet te onderscheiden van "niets
+      # gedaan" — de fout van 2026-08-07.
+      - name: Migratiestand van productie vóór de uitrol
+        id: voor
+        env:
+          MIGRATION_DATABASE_URL: ${{ secrets.PRODUCTIE_MIGRATION_DATABASE_URL }}
+        run: |
+          VOOR=$(node scripts/migratiestand.js | grep -oE '[0-9]+$' | head -1)
+          echo "aantal=$VOOR" >> "$GITHUB_OUTPUT"
+          echo "Productie stond op $VOOR migraties."
+    outputs:
+      voor: ${{ steps.voor.outputs.aantal }}
+
+  # ── Rem 1: het akkoord ─────────────────────────────────────────────────────
+  #
+  # De `environment`-regel is de hele rem. GitHub pauzeert deze job en stuurt
+  # een verzoek naar de reviewers van de Environment `productie`. Zonder die
+  # instelling in de repository draait deze job gewoon door — de rem zit in
+  # GitHub, niet in dit bestand. Zie het runbook voor het inrichten.
+  uitrollen:
+    name: Migraties naar productie
+    runs-on: ubuntu-latest
+    needs: [poort]
+    environment: productie
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Node.js instellen
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: ".nvmrc"
+          cache: "npm"
+
+      - name: Dependencies installeren
+        run: npm ci
+
+      # De poort draaide vóór het akkoord. Tussen dat moment en nu kan er tijd
+      # zitten — een akkoord kan een dag blijven wachten. In die tijd kan er van
+      # alles gebeurd zijn: een tweede merge, een migratie met de hand, een
+      # backup die verlopen is.
+      #
+      # Opnieuw toetsen kost seconden en sluit uit dat het akkoord ergens anders
+      # over ging dan wat er nu gebeurt.
+      - name: De remmen opnieuw, ná het akkoord
+        env:
+          STAGING_MIGRATION_DATABASE_URL: ${{ secrets.STAGING_MIGRATION_DATABASE_URL }}
+          PRODUCTIE_MIGRATION_DATABASE_URL: ${{ secrets.PRODUCTIE_MIGRATION_DATABASE_URL }}
+        run: node scripts/productie-poort.js
+
+      # `--extern` staat expliciet bij de aanroep en niet als omgevingsvariabele.
+      # Het runbook eist dat die vlag een zichtbare, bewuste uitzondering blijft:
+      # in de omgeving zou hij onzichtbaar doorwerken naar elke volgende stap.
+      - name: Migraties draaien tegen productie
+        env:
+          MIGRATION_DATABASE_URL: ${{ secrets.PRODUCTIE_MIGRATION_DATABASE_URL }}
+        run: node scripts/migrate.js --extern
+
+      # Teruglezen, niet de melding geloven. "Migraties voltooid" betekende op
+      # 2026-08-07 dat er niets gebeurd was, en in Issue #86 dat het op de
+      # verkeerde database gebeurd was.
+      - name: Migratiestand teruglezen en vergelijken met de repository
+        env:
+          MIGRATION_DATABASE_URL: ${{ secrets.PRODUCTIE_MIGRATION_DATABASE_URL }}
+        run: node scripts/migratiestand.js --volgens-journal
+
+      # Slaagt de migratie maar faalt dit, dan staan de rechten verkeerd — en dat
+      # merk je anders pas wanneer de applicatie start en elk scherm een fout
+      # geeft.
+      - name: De runtime-rol kan bij zijn eigen gegevens
+        env:
+          DATABASE_URL: ${{ secrets.PRODUCTIE_DATABASE_URL }}
+        run: |
+          node -e "
+            const {Client} = require('pg');
+            const c = new Client({
+              connectionString: process.env.DATABASE_URL,
+              ssl: { rejectUnauthorized: false },
+              connectionTimeoutMillis: 30000,
+            });
+            c.connect()
+              .then(() => c.query('SELECT count(*)::int AS n FROM clm.tenant'))
+              .then((r) => {
+                console.log('clm_api_runtime leest clm.tenant: ' + r.rows[0].n + ' rijen');
+                return c.end();
+              })
+              .catch((e) => { console.error('MISLUKT: ' + e.message); process.exit(1); });
+          "
+
+      # ── Rem 4: terugdraaien ────────────────────────────────────────────────
+      #
+      # De samenvatting draagt beide commando's: het startcommando en de weg
+      # terug. Dat is bewust één plek: op het moment dat je moet terugdraaien,
+      # ben je aan het zoeken en niet aan het lezen.
+      #
+      # `if: always()` omdat juist een MISLUKTE run die weg terug moet tonen.
+      - name: Samenvatting
+        if: always()
+        env:
+          VERSIE: ${{ inputs.versie }}
+          FRONTEND: ${{ inputs.frontend_versie }}
+          REDEN: ${{ inputs.reden }}
+          VOOR: ${{ needs.poort.outputs.voor }}
+        run: |
+          VERSIE_UIT="${VERSIE:-sha-${GITHUB_SHA::12}}"
+          FRONTEND_ARG=""
+          if [ -n "$FRONTEND" ]; then
+            FRONTEND_ARG=" --frontend-versie $FRONTEND"
+          fi
+
+          {
+            echo "### Productie — migraties bijgewerkt"
+            echo ""
+            echo "| | |"
+            echo "|---|---|"
+            echo "| Reden | $REDEN |"
+            echo "| Commit | \`${GITHUB_SHA::12}\` |"
+            echo "| Migraties vóór | $VOOR |"
+            echo "| Migraties ná | teruggelezen, gelijk aan het journal |"
+            echo ""
+            echo "**De applicatie is nog niet vervangen.** Dat gebeurt met de hand:"
+            echo ""
+            echo '```powershell'
+            echo "npm run deploy:productie -- --versie $VERSIE_UIT$FRONTEND_ARG"
+            echo '```'
+            echo ""
+            echo "#### Als het misgaat"
+            echo ""
+            echo "\`deploy.js\` draait zelf een rookproef en zet de vorige versie terug"
+            echo "als die faalt. Terugdraaien is **geen apart script** maar dezelfde"
+            echo "uitrol met de vorige tag — die staat in het slotbericht van de"
+            echo "vorige uitrol, en anders vraag je hem op:"
+            echo ""
+            echo '```powershell'
+            echo "npm run deploy:status          # welke versie draait waar"
+            echo "npm run deploy:productie -- --versie sha-<vorige>"
+            echo '```'
+            echo ""
+            echo "> Let op: een teruggedraaide **applicatie** draait tegen een database"
+            echo "> die de nieuwe migraties al heeft. Dat gaat goed zolang migraties"
+            echo "> achterwaarts verdraagzaam zijn — kolommen toevoegen wel, kolommen"
+            echo "> verwijderen niet. Staat er een verwijderende migratie in, dan is"
+            echo "> terugzetten van de backup de weg, niet de rollback."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -2,11 +2,8 @@
 
 ## Laatst bijgewerkt
 
-**2026-08-11, middag.** **Stap 3 van het OTAP-plan is af.** Na elke merge op
-`main` draaien de migraties automatisch tegen de Supabase-stagingdatabase, en
-wordt teruggelezen of ze werkelijk geland zijn. Er draait bovendien een
-applicatie tegen die database — **voor het eerst gaat MCM2 over een connection
-pooler**, precies waarvoor staging bestaat.
+**2026-08-11, avond.** **Stap 3 én stap 4 van het OTAP-plan zijn af.** De keten
+loopt nu van een merge tot aan productie, met vier remmen ervoor.
 
 ```
 merge op main
@@ -16,14 +13,42 @@ merge op main
   → migratiestand teruggelezen, vergeleken met het journal   ← automatisch
   ──────────────────────────────────────────────────────────
   → npm run deploy:staging -- --versie sha-…                 ← één commando
+
+Actions → "Uitrol naar productie" (handmatig, met reden)
+  → poort: backup vers? staging op stand? productie niet vóór?
+  → JOUW AKKOORD                                             ← de run staat stil
+  → poort opnieuw (er kan tijd overheen zijn gegaan)
+  → migraties naar Supabase-productie
+  → teruggelezen + rechtencontrole                           ← automatisch
+  ──────────────────────────────────────────────────────────
+  → npm run deploy:productie -- --versie sha-…               ← één commando
 ```
+
+**De vier remmen** — drie in `productie-poort.js`, één op GitHub:
+
+| Rem | Houdt tegen |
+|---|---|
+| Backup vooraf | geen bewijs, ouder dan 36 uur, of de controle meldde problemen |
+| Staging beproefd | staging staat niet op de stand van de repository |
+| Productie niet vóór | productie telt méér migraties dan het journal |
+| Handmatig akkoord | Environment `productie`, required reviewer |
+
+Beproefd op zeven uitkomsten, exitcodes zonder pipe gemeten. Terugdraaien is
+heen-en-terug gedraaid op acceptatie.
+
+**De backuprem was het lastigste stuk**, want CI kan nooit bij de backup op de
+laptop. Opgelost door de omkering: `backup-controle.js` schrijft een bewijs in
+de repository, en de poort leest dat. Bewust uit de *controle* en niet uit
+`backup-dump.js` — op 2026-08-04 waren alle dumps vers en misten er negen van de
+achttien tabellen.
 
 Vandaag gemerged: **#135** (uitnodigingslink wees naar `localhost`), **#136**
 (migraties naar staging), **#137** (applicatie tegen Supabase), **#139/#140**
-(time-outs, en de Tailscale-stappen er weer uit).
+(time-outs, en de Tailscale-stappen er weer uit), **#142** (#131 en #133).
 
-**Van de negen stappen zijn 1, 2, 2b en 3 af.** Volgende is stap 4: uitrol naar
-productie met een akkoordrem.
+**Van de negen stappen zijn 1, 2, 2b, 3 en 4 af.** Volgende is stap 5: `.env`
+omleiden naar staging — de grootste veiligheidswinst van het plan, want dan
+wijst de laptop niet meer standaard naar de productiedatabase.
 
 ### Waarom het starten van de applicatie handwerk blijft
 
@@ -460,7 +485,8 @@ handmatig te starten is (PR #122).
 
 | # | Wat | Waarom nu |
 |---|---|---|
-| — | **Geen geautomatiseerde uitrol naar productie** | De gemeenschappelijke oorzaak onder 04-08, 07-08 en 10-08. Staging gaat sinds 11-08 automatisch (migraties + teruglezen); productie nog niet. Dit is **stap 4**. Plan: [`plan-otap-straat-met-staging.md`](architectuur/plan-otap-straat-met-staging.md) |
+| — | ~~**Geen geautomatiseerde uitrol naar productie**~~ | ✅ **Gedaan 11-08** (stap 4). Migraties gaan achter vier remmen langs; de applicatie starten blijft één commando. De remmen zijn op zeven uitkomsten beproefd |
+| — | **`.env` wijst nog naar productie** | Nu de uitrol via GitHub loopt, hoeft de laptop dat adres niet meer te kennen. Dit is **stap 5**, en de grootste veiligheidswinst van het plan — de gemeenschappelijke oorzaak onder 04-08, 07-08 en 10-08 |
 | ~~#51~~ | ~~Frontend promoveerbaar maken~~ | ✅ **Gedaan 10-08.** Bewezen: hetzelfde image tegen twee backends, verschillende antwoorden, geen herbouw |
 | ~~#132~~ | ~~Uitnodigingslink wijst naar `localhost`~~ | ✅ **Gedaan 11-08** (PR #135). Twee tests, tegenproef gedraaid |
 | ~~#131~~ | ~~`mailVerstuurd: true` terwijl er niets verstuurd is~~ | ✅ **Gedaan 11-08.** `echtVerstuurd` op de mailgrens; verplicht veld, dus niet te vergeten |

--- a/docs/architectuur/plan-otap-straat-met-staging.md
+++ b/docs/architectuur/plan-otap-straat-met-staging.md
@@ -471,16 +471,84 @@ erger dan geen stap: dan wordt elke run rood en leer je rode runs negeren.
 De samenvatting van elke CI-run drukt het vervolgcommando af met de juiste SHA
 erin, zodat het niet samengesteld hoeft te worden.
 
-### 3.4 De uitrol naar productie automatiseren
+### 3.4 De uitrol naar productie automatiseren — ✅ gedaan 2026-08-11
 
 Dezelfde stappen, plus vier remmen:
 
-| Rem | Waarom |
+| Rem | Waarom | Waar hij zit |
+|---|---|---|
+| **Handmatig akkoord** | GitHub Environments met required reviewer. Niets gaat naar productie zonder dat de eigenaar drukt. | Environment `productie`, teruggelezen: `required_reviewers` → `cmalinghotmail` |
+| **Backup vooraf** | Verplicht, niet optioneel. Faalt de backup, dan gaat de uitrol niet door. | `productie-poort.js`, leest `docs/runbooks/backup-bewijs.json` |
+| **Migratiestand teruglezen** | Vóór en ná. Wijkt het af van staging, dan stoppen. | `productie-poort.js` + `migratiestand.js --volgens-journal` |
+| **Terugdraaien beproefd** | De vorige SHA moet met één commando terug te zetten zijn. | Heen en terug gedraaid op acceptatie, 11-08 |
+
+**De workflow is `.github/workflows/productie.yml`, en hij staat bewust los van
+`ci.yml`.** De stagingjob draait bij elke merge op main; voor productie mag dat
+niet. Dan wacht er na elke merge een akkoordverzoek, en een akkoord dat je tien
+keer per week wegklikt is geen rem meer maar een knop die in de weg zit.
+Uitrollen naar productie begint daarom met iemand die dat besluit neemt:
+`workflow_dispatch`, met een verplicht veld `reden`.
+
+**De poort draait twee keer: vóór het akkoord en erna.** De eerste keer zodat er
+niemand om aandacht wordt gevraagd voor een uitrol die toch geblokkeerd wordt.
+De tweede omdat een akkoord een dag kan blijven wachten, en in die tijd kan er
+een tweede merge zijn geweest of een backup verlopen.
+
+#### Hoe de backuprem werkt zonder dat CI bij de backup kan
+
+Dit was het lastigste stuk. De backup ligt op de laptop van de eigenaar; een
+CI-runner kan daar nooit bij. De runner kan dus niet zelf vaststellen dat er een
+bruikbare dump is.
+
+Vandaar de omkering: **niet de runner gaat kijken, maar de backupcontrole laat
+een spoor achter.** `backup-controle.js` — die tóch al dagelijks draait —
+schrijft `docs/runbooks/backup-bewijs.json`, en dat bestand gaat mee in de
+repository. De poort leest het.
+
+Het bewijs komt uit de *controle* en niet uit `backup-dump.js`, en dat verschil
+is de hele les van 2026-08-04: alle dumps waren toen keurig vers en misten al
+maanden negen van de achttien tabellen. Een dump die bestaat is geen dump die
+deugt. Het bestand zegt daarom niet "er is een backup" maar "de controle is
+gedraaid en dit vond hij" — inclusief welke lagen er gedraaid hebben, want
+zonder `--volledig` is de herstelbaarheid niet getoetst.
+
+Er staat bewust géén pad, mapnaam of hostnaam in: het bestand wordt gecommit en
+is dus zo openbaar als de repository, en `BACKUP_DIR` wijst naar een
+OneDrive-map met de naam van de eigenaar erin.
+
+#### Beproefd op zeven uitkomsten
+
+Exitcodes zonder pipe gemeten — de fout van 2026-08-10 en 11-08.
+
+| Situatie | Uitkomst |
 |---|---|
-| **Handmatig akkoord** | GitHub Environments met required reviewer. Niets gaat naar productie zonder dat de eigenaar drukt. |
-| **Backup vooraf** | Verplicht, niet optioneel. Faalt de backup, dan gaat de uitrol niet door. |
-| **Migratiestand teruglezen** | Vóór en ná. Wijkt het af van staging, dan stoppen. |
-| **Terugdraaien beproefd** | De vorige SHA moet met één commando terug te zetten zijn. Dit is op 10-08 bewezen op saxombp; het moet opnieuw bewezen op deze weg. |
+| geen bewijsbestand | geblokkeerd, exitcode 1 |
+| bewijs 50 uur oud | geblokkeerd, 1 |
+| bewijs meldt problemen (`goed: false`) | geblokkeerd, 1 |
+| alles gelijk | **DOOR**, 0 |
+| staging loopt achter op de repository | geblokkeerd, 1 |
+| productie loopt vóór op de repository | geblokkeerd, 1 |
+| database onbereikbaar | geblokkeerd, 1 |
+
+De vier migratiegevallen zijn gemeten met twee wegwerpcontainers (55480, 55481)
+waarvan de migratietabel met de hand uit elkaar is getrokken.
+
+#### Wat de poort níét doet
+
+De applicatie starten. Dat blijft `npm run deploy:productie -- --versie …`, om
+dezelfde Tailscale-reden als bij staging (§3.3c). De samenvatting van de
+workflow draagt dat commando, en de weg terug.
+
+#### Bijvangst: een rollbackcommando dat niet bestond
+
+`deploy.js` verwees op twee plekken naar `npm run rollback:<omgeving>`. Dat
+script staat niet in `package.json` en heeft er nooit in gestaan. Eén ervan was
+een docstring — vervelend. De andere stond in de foutmelding die verschijnt
+wanneer de containers niet starten, dus precies op het moment dat je hem nodig
+hebt en een "Missing script"-melding het laatste is wat je kunt gebruiken.
+
+Terugdraaien is in dit project geen apart script maar dezelfde uitrol met de
+vorige tag. Die melding draagt nu die regel, samengesteld uit wat er draaide.
 
 ### 3.5 `.env` ontkoppelen van productie
 
@@ -669,7 +737,7 @@ het als eerste staat.
 | 2 | ✅ **Staging aanmaken bij Supabase** — gedaan 10-08 | Beslist: optie A |
 | 2b | ✅ **Frontend-image publiceren, frontend in de uitrol** — gedaan 10-08 | Beslist: twee versies, zie hieronder |
 | 3 | ✅ **Uitrol naar staging automatiseren** — gedaan 11-08 | Beslist: applicatie start met de hand, zie §3.3c |
-| 4 | Uitrol naar productie automatiseren, met akkoordrem | Nee |
+| 4 | ✅ **Uitrol naar productie automatiseren, met akkoordrem** — gedaan 11-08 | Beslist: backup blijft bij de eigenaar, CI controleert; applicatie start met de hand |
 | 5 | `.env` omleiden naar staging | Nee, maar wel melden wanneer |
 | 6 | `mcm2-productie` op saxombp opheffen | **Ja — onomkeerbaar** |
 | 7 | `verify:omgevingen` bouwen | Nee |

--- a/docs/runbooks/backup-bewijs.json
+++ b/docs/runbooks/backup-bewijs.json
@@ -1,0 +1,16 @@
+{
+  "gecontroleerdOp": "2026-08-11T13:54:44.791Z",
+  "dumpGemaaktOp": "2026-08-11T05:00:09.219Z",
+  "dumpNaam": "mcm2-2026-08-11_05-00-02.dump",
+  "dumpBytes": 110307,
+  "lagen": [
+    "A",
+    "B"
+  ],
+  "goed": true,
+  "problemen": [],
+  "bevindingen": [
+    "Laatste dump: mcm2-2026-08-11_05-00-02.dump (8 uur oud)",
+    "Compleet: 23 tabellen"
+  ]
+}

--- a/docs/runbooks/commandos-en-omgeving.md
+++ b/docs/runbooks/commandos-en-omgeving.md
@@ -125,6 +125,15 @@ Volledige lijst uit `package.json`. Er is **geen** `npm run migrate`, **geen**
 | `npm run verify:snel` | Idem, e2e overgeslagen (zegt dat er ook bij) | Nee |
 | `npm run verify:schema` | Schemaconformiteit: draait `test/schema-conformiteit.e2e-spec.ts` | Ja |
 | `npm run verify:onderhoud` | Runbooks geïndexeerd en niet verouderd; `backup-verwachting.json` bij de migratiestand | Nee |
+| `npm run productie:poort` | De drie automatische remmen vóór een uitrol naar productie: is de backup vers en goed, staat staging op de stand van de repository, loopt productie niet vóór | Leest staging én productie |
+
+`productie:poort` **schrijft nergens** — uitsluitend `SELECT count(*)`. Hij
+draait ook vanzelf in de workflow *Uitrol naar productie*, twee keer: vóór het
+akkoord en erna. Los draaien is handig om te kijken of alles klaarstaat.
+
+Verwacht `STAGING_MIGRATION_DATABASE_URL` en `PRODUCTIE_MIGRATION_DATABASE_URL`.
+Ontbreken die, dan blokkeert hij — hij gaat niet stilletjes terugvallen op
+`.env`, want dan zou hij productie met zichzelf vergelijken.
 
 `verify.js` **weigert** te draaien als `DATABASE_URL` niet naar een lokale host
 wijst. Die bescherming werkt; laat hem staan.

--- a/docs/runbooks/onderhoudskalender.md
+++ b/docs/runbooks/onderhoudskalender.md
@@ -39,7 +39,7 @@ dat je de meldingen leest.
 | Wanneer | Taak | Wat het doet | Runbook |
 |---|---|---|---|
 | Dagelijks 07:00 | `MCM2 databasebackup` | `pg_dump` van productie naar OneDrive, 14 dagen retentie | [backupcontrole.md](backupcontrole.md) |
-| Dagelijks 07:30 | `MCM2 backupcontrole` | Laag A (is er een dump?) en B (zit alles erin?) | [backupcontrole.md](backupcontrole.md) |
+| Dagelijks 07:30 | `MCM2 backupcontrole` | Laag A (is er een dump?) en B (zit alles erin?), en schrijft `backup-bewijs.json` | [backupcontrole.md](backupcontrole.md) |
 | Maandag 07:45 | `MCM2 backupcontrole volledig` | Idem, plus laag C: echte restore in een wegwerpcontainer | [backupcontrole.md](backupcontrole.md) |
 
 Nagaan of ze nog bestaan en wanneer ze laatst draaiden:
@@ -84,7 +84,7 @@ npm run backup:controle
 | **Per kwartaal** | ADR's op geldigheid nalopen, met name ADR-011 en ADR-002 | Fase-overgangen veranderen de norm, niet het document | — (§5) |
 | **Bij elke release naar productie** | OTAP-doorloop draaien | Bewijst dat het uitrolbare artefact werkt, niet alleen de code | [otap-doorloop.md](otap-doorloop.md) |
 | **Bij elke release naar productie** | Uitrollen via acceptatie, nooit rechtstreeks | Een versie die niet op acceptatie stond, is niet beproefd | [uitrol-acceptatie-en-productie.md](uitrol-acceptatie-en-productie.md) |
-| **Per kwartaal** | Rollback beproeven op acceptatie | Terugdraaien is het onderdeel dat in de praktijk het vaakst nooit getest is — en dat je nodig hebt op het slechtste moment | [uitrol-acceptatie-en-productie.md](uitrol-acceptatie-en-productie.md) |
+| **Per kwartaal** | Rollback beproeven op acceptatie (laatst: **11-08-2026**, heen en terug, alle rookproeven groen) | Terugdraaien is het onderdeel dat in de praktijk het vaakst nooit getest is — en dat je nodig hebt op het slechtste moment | [uitrol-acceptatie-en-productie.md](uitrol-acceptatie-en-productie.md) |
 | **Wekelijks** | Staging wakker houden: één query tegen `clm-staging3` | Een gratis Supabase-project pauzeert na 7 dagen zonder databaseactiviteit. Pauzeert staging, dan faalt de eerstvolgende uitrol met een verbindingsfout die naar de verkeerde oorzaak wijst. | — (§5) |
 | **Bij elke migratie** | Eerst op staging draaien, dan pas op productie | Staging draait dezelfde Postgres-versie, regio en pooler als productie. Een migratie die daar slaagt, slaagt in productie — dat is de hele reden dat staging niet op saxombp staat. | — (§5) |
 
@@ -93,6 +93,7 @@ npm run backup:controle
 | Trigger | Taak | Waarom het niet mag wachten |
 |---|---|---|
 | **Migratie die een tabel toevoegt of hernoemt** | [backup-verwachting.json](backup-verwachting.json) bijwerken, inclusief `bijgewerkt` en `migratiestand` | Vergeet je dit, dan meldt de controle "compleet" over een lijst die de nieuwe tabellen niet kent. Op 2026-08-10 stond de lijst twaalf migraties achter en misten er vijf tabellen. |
+| **Vóór een uitrol naar productie** | `docs/runbooks/backup-bewijs.json` committen | De poort weigert bij een bewijs ouder dan 36 uur. Het bestand wordt dagelijks geschreven door de backupcontrole, maar committen doet niemand vanzelf — en dan blokkeert de uitrol op een backup die er wél is |
 | **Nieuw runbook geschreven** | Regel toevoegen in [README.md](README.md) | Een runbook dat niet in de index staat, vindt niemand |
 | **Nieuwe terugkerende taak afgesproken** | Regel toevoegen in dit document | Anders staat hij over een maand weer in één losse spec |
 | **Major dependency-update** (NestJS, Drizzle, TypeScript) | Korte impact-analyse vóór merge, nooit blind updaten | De Prisma 7-episode in dit project is het directe bewijs |

--- a/docs/runbooks/uitrol-acceptatie-en-productie.md
+++ b/docs/runbooks/uitrol-acceptatie-en-productie.md
@@ -158,13 +158,77 @@ versie en beproeft die opnieuw. Je krijgt dan `TERUGGEDRAAID naar <versie>`.
 
 ## Stap 3 — Promoveren naar productie
 
+**Sinds 2026-08-11 (stap 4 van het OTAP-plan) loopt dit via GitHub, niet meer
+rechtstreeks vanaf de laptop.** De migraties gaan achter vier remmen langs; het
+starten van de applicatie blijft één commando met de hand.
+
+### 3a. Vooraf: zorg dat de backup vers is
+
+De poort weigert een uitrol als de backupcontrole ouder is dan 36 uur.
+
+Meestal hoef je niets te doen: de geplande taken draaien dagelijks om 07:00 en
+07:30, en de controle van 07:30 schrijft `docs/runbooks/backup-bewijs.json`.
+**Wat je wél moet doen is dat bestand committen** — het is het enige wat een
+CI-runner over jouw backup te weten kan komen.
+
+Is de taak overgeslagen (Docker stond uit), haal hem dan in:
+
 ```powershell
-npm run deploy:productie
+& "C:\DEV\Work\MCM2\scripts\backup-taak.cmd"   # niet: npm run backup:dump
+npm run backup:controle
 ```
 
-**Verwacht resultaat:** het script vraagt bevestiging. Typ `ja`.
+> **Gebruik het `.cmd`, niet het npm-script.** `BACKUP_DIR` staat alleen in
+> `backup-taak.cmd`. Los gedraaid schrijft `npm run backup:dump` naar `backups/`
+> in de projectmap: de dump slaagt, de controle ziet hem niet, en de retentie
+> raakt hem niet.
 
-**Het waarschuwt als deze versie niet op acceptatie staat:**
+Je kunt de poort ook los draaien om te kijken of alles klaarstaat:
+
+```powershell
+npm run productie:poort
+```
+
+### 3b. De uitrol starten
+
+Actions → **Uitrol naar productie** → *Run workflow*. Drie velden:
+
+| Veld | Wat |
+|---|---|
+| `versie` | backend-tag, bijv. `sha-5428bb954884`. Leeg = de laatste van main |
+| `frontend_versie` | frontend-tag. Leeg = `latest` |
+| `reden` | **verplicht.** Komt in de samenvatting te staan |
+
+> **De tag is twaalf tekens.** `sha-ffd27dc9` bestaat niet, `sha-ffd27dc9472f`
+> wel. Dat is twee keer misgegaan (10-08 en 11-08); beide keren hield de rem het
+> tegen met *"Er is niets gewijzigd"*. Kijk ze op met
+> `ssh root@saxombp "docker images | grep mcm2/api"`.
+
+### 3c. Wat er dan gebeurt
+
+1. **De poort draait** — backup, staging op de stand van de repository,
+   productie niet vóór. Blokkeert dit, dan is er niemand lastiggevallen met een
+   akkoordverzoek voor niets.
+2. **Jij krijgt een akkoordverzoek** van de Environment `productie`. De run staat
+   stil tot je drukt.
+3. **De poort draait opnieuw** — een akkoord kan een dag wachten, en in die tijd
+   kan de wereld veranderd zijn.
+4. **Migraties, teruglezen, rechtencontrole** — precies zoals bij staging.
+5. **De samenvatting draagt het startcommando**, plus de weg terug.
+
+### 3d. De applicatie starten
+
+Dat doet CI niet, om dezelfde reden als bij staging: een CI-runner krijgt
+onvermijdelijk een Tailscale-label, en gelabelde apparaten kunnen niet via SSH
+bij een apparaat met een gebruikersidentiteit. Kopieer de regel uit de
+samenvatting:
+
+```powershell
+npm run deploy:productie -- --versie sha-<versie> --frontend-versie sha-<frontend>
+```
+
+Dat script vraagt nog steeds bevestiging, en waarschuwt als deze versie niet op
+acceptatie draait:
 
 ```
 LET OP: op acceptatie draait sha-abc123, niet sha-def456.
@@ -174,6 +238,19 @@ Deze versie is daar dus niet beproefd.
 Dat blokkeert niet. Soms is er een gegronde reden — maar hij moet zichtbaar
 zijn, want dit is precies de stap die OTAP voorschrijft en die onder tijdsdruk
 wordt overgeslagen.
+
+### De vier remmen, en waar ze zitten
+
+| Rem | Waar | Wat hem tegenhoudt |
+|---|---|---|
+| Backup vooraf | `productie-poort.js` | geen bewijs, ouder dan 36 uur, of de controle meldde problemen |
+| Staging beproefd | `productie-poort.js` | staging staat niet op de stand van de repository |
+| Productie niet vóór | `productie-poort.js` | productie telt méér migraties dan het journal |
+| Handmatig akkoord | GitHub Environment | jij drukt niet |
+
+De eerste drie zijn beproefd op alle uitkomsten (11-08), exitcodes zonder pipe
+gemeten. De vierde is een instelling op GitHub, geen code: staat `productie`
+daar niet met een required reviewer, dan draait de job gewoon door.
 
 ---
 
@@ -193,6 +270,26 @@ gemigreerd. **Let op:** migraties draaien niet terug. Bevatte de slechte versie
 een migratie, dan blijft die staan — dat is opzet (geen destructieve migraties
 zonder schema-debt issue), maar het betekent dat "terug naar de vorige versie"
 het schema niet terugdraait.
+
+**Je hoeft de regel niet zelf samen te stellen.** Elke geslaagde uitrol drukt
+hem af, met beide versies erin:
+
+```
+  vorige versie was sha-5428bb954884 met frontend sha-635ff21150bd
+  terugdraaien:  npm run deploy:acceptatie -- --versie sha-5428bb954884 --frontend-versie sha-635ff21150bd
+```
+
+**Beproefd op 2026-08-11**, op acceptatie: heen naar `sha-ffd27dc9472f`, terug
+naar `sha-5428bb954884` met de afgedrukte regel. Beide keren alle vier de
+rookproeven groen, en de omgeving stond daarna teruggelezen exact zoals hij
+stond. Acceptatie en niet productie, omdat `mcm2-productie` op saxombp een
+lokale database heeft en niet de Supabase-productiedatabase — dezelfde weg,
+zonder risico voor echte gegevens.
+
+> **Er is géén `npm run rollback:…`.** Dat commando bestaat niet en heeft nooit
+> bestaan, maar het stond wél in de foutmelding die je kreeg als de containers
+> niet startten — dus juist op het moment dat je het nodig had. Hersteld op
+> 11-08; die melding draagt nu de echte regel.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "deploy:staging": "node scripts/deploy.js staging",
     "deploy:productie": "node scripts/deploy.js productie",
     "deploy:status": "node scripts/deploy-status.js",
+    "productie:poort": "node scripts/productie-poort.js",
     "verify": "node scripts/verify.js",
     "verify:onderhoud": "node scripts/verify-onderhoud.js",
     "verify:schema": "node scripts/verify-schema.js",

--- a/scripts/backup-controle.js
+++ b/scripts/backup-controle.js
@@ -274,6 +274,50 @@ function controleerHerstelbaarheid(dump) {
   }
 }
 
+// ── Het bewijsbestand ───────────────────────────────────────────────────────
+//
+// Waar het staat: `docs/runbooks/backup-bewijs.json`, náást de
+// verwachtingslijst waar het bij hoort. In de repository, want de lezer is een
+// CI-runner die alleen de repository heeft.
+//
+// ── Wat er NIET in staat, en waarom dat telt ────────────────────────────────
+//
+// Geen pad, geen mapnaam, geen hostnaam. Het bestand wordt gecommit en is dus
+// zo openbaar als de repository. `backupDir` wijst naar een OneDrive-map met de
+// naam van de eigenaar erin; die hoort daar niet in te belanden.
+//
+// De bestandsnaam van de dump is wél veilig: `mcm2-<tijdstempel>.dump` bevat
+// niets persoonlijks, en zonder die naam is niet na te gaan wélke dump het
+// akkoord droeg.
+const bewijsPad = path.join(PROJECT_DIR, 'docs', 'runbooks', 'backup-bewijs.json');
+
+function schrijfBewijs({ dump, problemen, regels, modus }) {
+  const bewijs = {
+    // Wanneer de controle draaide — niet wanneer de dump gemaakt is. Dat
+    // onderscheid is precies waar het op 2026-08-04 misging: de dumps waren
+    // dagelijks vers en al maanden incompleet.
+    gecontroleerdOp: new Date().toISOString(),
+    dumpGemaaktOp: new Date(dump.tijd).toISOString(),
+    dumpNaam: dump.naam,
+    dumpBytes: dump.grootte,
+    // Welke lagen er gedraaid hebben. Zonder `--volledig` is de
+    // herstelbaarheid niet getoetst, en dat mag het bewijs niet verzwijgen.
+    lagen: modus === '--volledig' ? ['A', 'B', 'C'] : ['A', 'B'],
+    goed: problemen.length === 0,
+    problemen: problemen.map((p) => p.sleutel),
+    bevindingen: regels,
+  };
+
+  try {
+    fs.writeFileSync(bewijsPad, JSON.stringify(bewijs, null, 2) + '\n', 'utf8');
+  } catch (err) {
+    // Niet fataal: de backupcontrole zelf is belangrijker dan zijn bewijs.
+    // Wél zichtbaar, want zonder dit bestand blokkeert de productie-uitrol en
+    // is de oorzaak anders niet te vinden.
+    console.error(`Bewijsbestand niet geschreven: ${err.message}`);
+  }
+}
+
 // ── Hoofdprogramma ──────────────────────────────────────────────────────────
 async function main() {
   const modus = process.argv[2] || '';
@@ -385,6 +429,30 @@ async function main() {
       `✅ MCM2 backup — weekcheck ${stempel}\n\n${regels.join('\n')}\nBewaard: ${aantal} dump(s)`,
     );
   }
+
+  // ── Het bewijsbestand voor de productie-uitrol ────────────────────────────
+  //
+  // Stap 4 van het OTAP-plan eist een backup vóór elke uitrol naar productie,
+  // en die eis moet AFDWINGBAAR zijn — niet een zin in een runbook.
+  //
+  // Het probleem: de backup ligt hier, op deze laptop, en de uitrol wordt
+  // gestart door een CI-runner die daar nooit bij kan. De runner kan dus niet
+  // zelf vaststellen of er een bruikbare dump is.
+  //
+  // Vandaar deze omkering. Niet de runner gaat kijken; de controle die hier
+  // tóch al draait laat een spoor achter in de repository, en de runner leest
+  // dat. `productie-poort.js` weigert de uitrol als het te oud is.
+  //
+  // ── Waarom het uit DEZE controle komt en niet uit backup-dump.js ──────────
+  //
+  // Een dump die bestaat is geen dump die deugt. Op 2026-08-04 waren alle
+  // dumps precies 21.683 bytes en misten er negen van de achttien tabellen —
+  // `backup-dump.js` meldde al die tijd succes. Laag B hierboven is de enige
+  // die dát vaststelt, dus het bewijs hoort daarachter te zitten.
+  //
+  // Het bestand zegt daarom niet "er is een backup" maar "de controle is
+  // gedraaid en dit vond hij". Staat er een probleem in, dan weigert de poort.
+  schrijfBewijs({ dump, problemen, regels, modus });
 
   // Console-uitvoer voor handmatig gebruik en het taaklog.
   console.log(`${new Date().toISOString()} — ${problemen.length} probleem(en)`);

--- a/scripts/deploy.js
+++ b/scripts/deploy.js
@@ -42,7 +42,14 @@
  *   npm run deploy:productie               vraagt bevestiging
  *   npm run deploy:productie -- --versie sha-abc123def456
  *   npm run deploy:status                  wat draait waar
- *   npm run rollback:acceptatie            vorige versie terug
+ *
+ * Terugdraaien is géén apart script. Het is dezelfde uitrol met de vorige tag:
+ *
+ *   npm run deploy:acceptatie -- --versie sha-<vorige>
+ *
+ * Hier stond `npm run rollback:acceptatie`, en dat bestaat niet — niet in
+ * package.json en nergens anders. Het slotbericht van elke uitrol drukt de
+ * juiste regel af, met beide versies erin.
  *
  * Backend en frontend zijn aparte repositories met eigen SHA's. De frontend
  * krijgt een eigen vlag; laat je hem weg, dan wordt dat `:latest`:
@@ -731,9 +738,25 @@ async function main() {
   const gestart = start(omgeving, versie, frontendVersie);
 
   if (!gestart.ok) {
+    // Hier stond `npm run rollback:<omgeving>` — een script dat niet bestaat.
+    // Dat is niet zomaar een verkeerde verwijzing: deze regel verschijnt op het
+    // moment dat de uitrol al mislukt is, en dan is een commando dat "Missing
+    // script" antwoordt het laatste wat je kunt gebruiken.
+    //
+    // Terugdraaien is in dit project geen apart script maar dezelfde uitrol met
+    // de vorige tag. Die staat hier expliciet in, samengesteld uit wat er
+    // draaide — net als in het slotbericht van een geslaagde uitrol.
+    //
+    // Gevonden op 2026-08-11, bij het bouwen van stap 4.
     stop(
       'De containers konden niet gestart worden.',
-      `${gestart.fout}\n\nTerugdraaien:\n  npm run rollback:${omgeving.naam}`,
+      `${gestart.fout}\n\nTerugdraaien:\n  ` +
+        (vorige
+          ? `npm run deploy:${omgeving.naam} -- --versie ${vorige}` +
+            (FRONTEND_MEE && vorigeFrontend
+              ? ` --frontend-versie ${vorigeFrontend}`
+              : '')
+          : 'er draaide hier nog niets — er is geen vorige versie om naar terug te vallen.'),
     );
   }
 

--- a/scripts/productie-poort.js
+++ b/scripts/productie-poort.js
@@ -1,0 +1,314 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * De poort vóór een uitrol naar productie. Weigert, of laat door.
+ *
+ * ── Waarom een poort en geen checklist ───────────────────────────────────────
+ *
+ * Stap 4 van het OTAP-plan noemt vier remmen. Drie ervan zijn af te dwingen
+ * vóórdat er iets gebeurt, en dit script is die drie:
+ *
+ *   1. er is een gecontroleerde, actuele backup
+ *   2. staging draait op dezelfde migratiestand als de repository
+ *   3. productie loopt niet vóór op staging
+ *
+ * De vierde — een handmatig akkoord — kan een script niet geven; dat is een
+ * GitHub Environment met een required reviewer.
+ *
+ * Een checklist in een runbook wordt overgeslagen op precies de dag dat het
+ * ertoe doet. Dit script staat in de weg.
+ *
+ * ── Waarom staging hier meedoet ──────────────────────────────────────────────
+ *
+ * "Wat op staging is goedgekeurd, is bit voor bit wat naar productie gaat" (§2
+ * van het plan). Dat is een bewering, en tot nu toe controleerde niets hem.
+ * Staat staging niet op de stand van de repository, dan is er dus niets
+ * beproefd op de database die op productie lijkt — en dan is de belangrijkste
+ * reden dat staging bestaat weggevallen.
+ *
+ * ── Gebruik ──────────────────────────────────────────────────────────────────
+ *
+ *   node scripts/productie-poort.js
+ *
+ * Verwacht in de omgeving:
+ *   STAGING_MIGRATION_DATABASE_URL     lezen — de stand van staging
+ *   PRODUCTIE_MIGRATION_DATABASE_URL   lezen — de stand van productie
+ *
+ * Beide uitsluitend voor `SELECT count(*)`. Dit script schrijft nergens.
+ *
+ * Vlaggen:
+ *   --backup-max-uren <n>   hoe oud de backupcontrole mag zijn (standaard 36)
+ *   --zonder-backup         sla de backuprem over; eist een reden
+ *
+ * Zie docs/architectuur/plan-otap-straat-met-staging.md §3.4 en
+ * docs/runbooks/uitrol-acceptatie-en-productie.md.
+ */
+
+require('dotenv/config');
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const { Client } = require('pg');
+
+const BEWIJS_PAD = path.join(
+  __dirname,
+  '..',
+  'docs',
+  'runbooks',
+  'backup-bewijs.json',
+);
+
+const JOURNAL_PAD = path.join(
+  __dirname,
+  '..',
+  'drizzle',
+  'meta',
+  '_journal.json',
+);
+
+/** Standaard even ruim als backup-controle.js: één overgeslagen dag mag. */
+const STANDAARD_MAX_UREN = 36;
+
+function leesVlag(naam) {
+  const index = process.argv.indexOf(naam);
+  return index === -1 ? null : (process.argv[index + 1] ?? null);
+}
+
+/**
+ * Rem 1 — is er een gecontroleerde, actuele backup?
+ *
+ * Let op wat hier getoetst wordt: niet of er een dumpbestand bestaat, maar of
+ * de *controle* gedraaid heeft en niets gevonden heeft. Dat onderscheid is de
+ * les van 2026-08-04, toen alle dumps keurig vers waren en al maanden negen van
+ * de achttien tabellen misten.
+ *
+ * Het bewijs komt uit `backup-controle.js` op de machine van de eigenaar. Een
+ * CI-runner kan niet bij die backup, dus de controle laat een spoor achter in
+ * de repository en de runner leest dat.
+ */
+function toetsBackup(maxUren) {
+  if (!fs.existsSync(BEWIJS_PAD)) {
+    return {
+      goed: false,
+      regel: 'Backup: GEEN BEWIJS',
+      uitleg:
+        'Er staat geen backup-bewijs in de repository.\n\n' +
+        'Draai op de machine met de backups:\n' +
+        '  npm run backup:controle\n\n' +
+        'en commit docs/runbooks/backup-bewijs.json.',
+    };
+  }
+
+  let bewijs;
+
+  try {
+    bewijs = JSON.parse(fs.readFileSync(BEWIJS_PAD, 'utf8'));
+  } catch (fout) {
+    return {
+      goed: false,
+      regel: 'Backup: BEWIJS ONLEESBAAR',
+      uitleg: `Het bewijsbestand is geen geldige JSON: ${fout.message}`,
+    };
+  }
+
+  const gecontroleerd = Date.parse(bewijs.gecontroleerdOp);
+
+  if (Number.isNaN(gecontroleerd)) {
+    return {
+      goed: false,
+      regel: 'Backup: BEWIJS ZONDER DATUM',
+      uitleg:
+        'Het bewijsbestand heeft geen bruikbare `gecontroleerdOp`. ' +
+        'Draai de backupcontrole opnieuw.',
+    };
+  }
+
+  const uren = (Date.now() - gecontroleerd) / 3_600_000;
+
+  if (uren > maxUren) {
+    return {
+      goed: false,
+      regel: `Backup: TE OUD (${Math.round(uren)} uur)`,
+      uitleg:
+        `De laatste backupcontrole was ${Math.round(uren)} uur geleden; ` +
+        `de grens staat op ${maxUren}.\n\n` +
+        'Draai op de machine met de backups:\n' +
+        '  npm run backup:dump && npm run backup:controle\n\n' +
+        'en commit het bijgewerkte bewijs.',
+    };
+  }
+
+  // Een bewijs dat problemen meldt is geen groen licht. Dit is het geval waar
+  // het echt om gaat: de backup bestaat, is vers, en deugt niet.
+  if (bewijs.goed !== true) {
+    return {
+      goed: false,
+      regel: 'Backup: CONTROLE MELDDE PROBLEMEN',
+      uitleg:
+        'De backupcontrole is recent gedraaid en vond problemen:\n' +
+        `  ${(bewijs.problemen ?? []).join(', ') || '(niet gespecificeerd)'}\n\n` +
+        'Los die eerst op. Een uitrol zonder werkend vangnet is precies wat\n' +
+        'deze rem moet tegenhouden.',
+    };
+  }
+
+  return {
+    goed: true,
+    regel:
+      `Backup: OK (${Math.round(uren)} uur oud, lagen ` +
+      `${(bewijs.lagen ?? []).join('+')}, ${bewijs.dumpNaam})`,
+  };
+}
+
+/** Het aantal migraties dat de repository voorschrijft. */
+function journalStand() {
+  const journal = JSON.parse(fs.readFileSync(JOURNAL_PAD, 'utf8'));
+  return journal.entries.length;
+}
+
+/** Leest `count(*)` uit de migratietabel. Uitsluitend SELECT. */
+async function migratiestand(url, wat) {
+  const client = new Client({
+    connectionString: url,
+    ssl: /supabase|amazonaws|neon/.test(url)
+      ? { rejectUnauthorized: false }
+      : undefined,
+    connectionTimeoutMillis: 30_000,
+  });
+
+  try {
+    await client.connect();
+    const uitkomst = await client.query(
+      'SELECT count(*)::int AS aantal FROM drizzle.__drizzle_migrations',
+    );
+    return { aantal: uitkomst.rows[0].aantal };
+  } catch (fout) {
+    return { fout: `${wat}: ${fout.message}` };
+  } finally {
+    await client.end().catch(() => {});
+  }
+}
+
+async function main() {
+  const maxUren = Number(leesVlag('--backup-max-uren') ?? STANDAARD_MAX_UREN);
+  const zonderBackup = process.argv.includes('--zonder-backup');
+
+  console.log('');
+  console.log('Poort vóór de uitrol naar productie');
+  console.log('─'.repeat(70));
+
+  const bevindingen = [];
+  const blokkades = [];
+
+  // ── Rem 1: de backup ──────────────────────────────────────────────────────
+  if (zonderBackup) {
+    // Overslaan mag, maar niet stilzwijgend. Dit is de ontsnappingsklep voor
+    // een noodherstel — en die hoort in het log te staan, zodat achteraf
+    // navolgbaar is dat er zonder vangnet is uitgerold.
+    bevindingen.push('Backup: OVERGESLAGEN (--zonder-backup)');
+    console.log(
+      '\n  LET OP: de backuprem is bewust overgeslagen. Dit hoort alleen bij\n' +
+        '  een noodherstel, en het staat nu in het log van deze run.\n',
+    );
+  } else {
+    const backup = toetsBackup(maxUren);
+    bevindingen.push(backup.regel);
+    if (!backup.goed) blokkades.push(backup.uitleg);
+  }
+
+  // ── Rem 2 en 3: de migratiestanden ────────────────────────────────────────
+  const verwacht = journalStand();
+  bevindingen.push(`Repository: ${verwacht} migraties in het journal`);
+
+  const stagingUrl = process.env.STAGING_MIGRATION_DATABASE_URL;
+  const productieUrl = process.env.PRODUCTIE_MIGRATION_DATABASE_URL;
+
+  if (!stagingUrl || !productieUrl) {
+    blokkades.push(
+      'STAGING_MIGRATION_DATABASE_URL en/of PRODUCTIE_MIGRATION_DATABASE_URL\n' +
+        'ontbreken. Zonder beide is er niets te vergelijken.',
+    );
+  } else {
+    const staging = await migratiestand(stagingUrl, 'staging');
+    const productie = await migratiestand(productieUrl, 'productie');
+
+    if (staging.fout) {
+      bevindingen.push('Staging: ONBEREIKBAAR');
+      blokkades.push(`Staging niet te lezen — ${staging.fout}`);
+    } else {
+      bevindingen.push(`Staging: ${staging.aantal} migraties`);
+
+      // Staging moet op de stand van de repository staan. Staat hij lager, dan
+      // is deze versie daar nooit gedraaid en bewijst "goedgekeurd op staging"
+      // niets. Staat hij hoger, dan draait daar iets nieuwers dan wat je nu
+      // uitrolt — en dan rol je een oudere versie naar productie.
+      if (staging.aantal !== verwacht) {
+        blokkades.push(
+          `Staging staat op ${staging.aantal}, de repository op ${verwacht}.\n` +
+            (staging.aantal < verwacht
+              ? 'Deze versie is nooit op staging gedraaid. Er is dus niets\n' +
+                'beproefd op een database die op productie lijkt.'
+              : 'Staging loopt vóór op deze code. Rol je nu uit, dan gaat er een\n' +
+                'oudere versie naar productie dan wat er beproefd is.'),
+        );
+      }
+    }
+
+    if (productie.fout) {
+      bevindingen.push('Productie: ONBEREIKBAAR');
+      blokkades.push(`Productie niet te lezen — ${productie.fout}`);
+    } else {
+      bevindingen.push(`Productie: ${productie.aantal} migraties`);
+
+      // Productie mag achterlopen — dat is normaal vlak vóór een uitrol. Wat
+      // niet mag: productie vóór op de repository. Dan draait daar iets dat
+      // niet uit deze code komt, en overschrijven is dan geen uitrol maar
+      // verlies.
+      if (productie.aantal > verwacht) {
+        blokkades.push(
+          `Productie staat op ${productie.aantal}, de repository op ${verwacht}.\n` +
+            'Productie loopt VÓÓR op deze code. Dat hoort niet te kunnen:\n' +
+            'draait daar iets dat hier niet in zit, of wijst dit naar de\n' +
+            'verkeerde database?',
+        );
+      }
+    }
+  }
+
+  // ── Uitkomst ──────────────────────────────────────────────────────────────
+  console.log('');
+  for (const regel of bevindingen) console.log(`  ${regel}`);
+  console.log('');
+
+  if (blokkades.length > 0) {
+    console.error('─'.repeat(70));
+    console.error('');
+    console.error(`GEBLOKKEERD — ${blokkades.length} reden(en):`);
+    console.error('');
+    for (const blokkade of blokkades) {
+      console.error(
+        blokkade
+          .split('\n')
+          .map((r) => `  ${r}`)
+          .join('\n'),
+      );
+      console.error('');
+    }
+    process.exit(1);
+  }
+
+  console.log('─'.repeat(70));
+  console.log('');
+  console.log('  DOOR — de drie automatische remmen geven groen licht.');
+  console.log('');
+  console.log('  De vierde rem is een mens: het akkoord op de GitHub');
+  console.log('  Environment `productie`.');
+  console.log('');
+}
+
+main().catch((fout) => {
+  console.error(`\nOnverwachte fout in de poort: ${fout.message}\n`);
+  process.exit(1);
+});


### PR DESCRIPTION
Stap 4 van [`plan-otap-straat-met-staging.md`](docs/architectuur/plan-otap-straat-met-staging.md). De keten loopt nu van een merge tot aan productie.

```
Actions → "Uitrol naar productie" (handmatig, met verplichte reden)
  → poort: backup vers? staging op stand? productie niet vóór?
  → JOUW AKKOORD                              ← de run staat stil
  → poort opnieuw (er kan tijd overheen zijn)
  → migraties naar Supabase-productie
  → teruggelezen + rechtencontrole            ← automatisch
  ────────────────────────────────────────────
  → npm run deploy:productie -- --versie sha-… ← één commando
```

## De vier remmen

| Rem | Waar | Houdt tegen |
|---|---|---|
| Backup vooraf | `productie-poort.js` | geen bewijs, ouder dan 36 uur, of de controle meldde problemen |
| Staging beproefd | `productie-poort.js` | staging staat niet op de stand van de repository |
| Productie niet vóór | `productie-poort.js` | productie telt méér migraties dan het journal |
| Handmatig akkoord | GitHub Environment | jij drukt niet |

De Environment `productie` is aangemaakt en teruggelezen: `required_reviewers` → `cmalinghotmail`. De twee `PRODUCTIE_*`-secrets staan in de repository.

## De backuprem is een omkering

Dit was het lastigste stuk. De backup ligt op de laptop; een CI-runner kan daar nooit bij en kan dus niet zelf vaststellen dat er een bruikbare dump is.

Daarom gaat de runner niet kijken — **de backupcontrole laat een spoor achter.** `backup-controle.js` schrijft `docs/runbooks/backup-bewijs.json`, dat meegaat in de repository, en de poort leest het.

Het bewijs komt uit de **controle** en niet uit `backup-dump.js`. Dat verschil is de les van 2026-08-04: alle dumps waren toen vers en misten al maanden negen van de achttien tabellen. Het bestand zegt daarom niet "er is een backup" maar "de controle is gedraaid en dit vond hij" — inclusief wélke lagen, want zonder `--volledig` is de herstelbaarheid niet getoetst.

Er staat bewust geen pad, mapnaam of hostnaam in: het bestand wordt gecommit, en `BACKUP_DIR` wijst naar een OneDrive-map met de naam van de eigenaar erin.

## Waarom een eigen workflow, niet een job in ci.yml

De stagingjob draait bij elke merge op main. Voor productie mag dat niet: dan wacht er na elke merge een akkoordverzoek, en **een akkoord dat je tien keer per week wegklikt is geen rem meer maar een knop die in de weg zit.**

De poort draait twee keer — vóór het akkoord, zodat er niemand om aandacht wordt gevraagd voor een uitrol die toch geblokkeerd wordt, en erna, omdat een akkoord een dag kan blijven wachten.

## Beproefd op zeven uitkomsten

Exitcodes zonder pipe gemeten.

| Situatie | Uitkomst |
|---|---|
| geen bewijsbestand | geblokkeerd, 1 |
| bewijs 50 uur oud | geblokkeerd, 1 |
| bewijs meldt problemen | geblokkeerd, 1 |
| alles gelijk | **DOOR**, 0 |
| staging loopt achter | geblokkeerd, 1 |
| productie loopt vóór | geblokkeerd, 1 |
| database onbereikbaar | geblokkeerd, 1 |

De vier migratiegevallen met twee wegwerpcontainers (55480, 55481) waarvan de migratietabel met de hand uit elkaar is getrokken.

**Terugdraaien:** heen naar `sha-ffd27dc9472f`, terug naar `sha-5428bb954884` met de regel die `deploy.js` zelf afdrukt. Beide keren alle vier de rookproeven groen; acceptatie stond daarna teruggelezen exact zoals hij stond. Op acceptatie en niet op productie, omdat `mcm2-productie` op saxombp een lokale database heeft — stap 6 heft dat verschil op.

## Bijvangst: een rollbackcommando dat niet bestond

`deploy.js` verwees op twee plekken naar `npm run rollback:<omgeving>`. Dat script staat niet in `package.json` en heeft er nooit in gestaan. Eén was een docstring; **de andere stond in de foutmelding die verschijnt wanneer de containers niet starten** — precies wanneer je hem nodig hebt en "Missing script" het laatste is wat je kunt gebruiken.

Terugdraaien is geen apart script maar dezelfde uitrol met de vorige tag. Die melding draagt nu die regel, samengesteld uit wat er draaide.

## Gemeten

`npm run verify` groen (397 unittests, 471 e2e), `format:check`, `lint:check` en `verify:onderhoud` groen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)