### PR TITLE
feat(otap): stap 5 — .env wijst naar staging, rem kijkt naar clm.omgeving

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,10 +1,53 @@
 # dotenv print anders willekeurige "tip"-regels (soms met externe URL's) naar de console bij elke .config()-aanroep.
 DOTENV_CONFIG_QUIET=true
 
-# Database (Supabase Session Pooler). Gebruik de runtime-rol (clm_api_runtime),
-# nooit de postgres-beheerrol — die heeft BYPASSRLS en omzeilt tenant-isolatie.
+# ═══════════════════════════════════════════════════════════════════════════
+#  DIT BESTAND WIJST NAAR STAGING — NIET NAAR PRODUCTIE
+# ═══════════════════════════════════════════════════════════════════════════
+#
+# Sinds stap 5 van het OTAP-plan (2026-08-11) staat hier het adres van het
+# Supabase-project `clm-staging3`, de oefendatabase.
+#
+# ── Waarom dat de belangrijkste verandering van het hele plan is ────────────
+#
+# Elk databasecommando dat je typt zonder zelf een adres mee te geven, pakt de
+# waarden hieronder op. Wees daar de productiedatabase, dan raakte élk commando
+# de echte klantgegevens — niet omdat je dat koos, maar omdat het de standaard
+# was.
+#
+# Dat is de gemeenschappelijke oorzaak onder alle drie de incidenten:
+#   2026-08-04  productie liep achter, dump miste 9 van 18 tabellen (#25)
+#   2026-08-06  migrate:deploy draaide tegen productie (Issue #86)
+#   2026-08-07  vier verzonnen commando's; bijna een migratie op productie
+#
+# Nu de uitrol via GitHub loopt (stappen 3 en 4), hoeft deze machine het
+# productieadres niet meer te kennen. Het leeft nog als GitHub-secret, waar de
+# workflow erbij kan.
+#
+# ── Waar productie dan nog vandaan komt ────────────────────────────────────
+#
+# Zie NOOD_PRODUCTIE_URL onderaan dit bestand. Géén enkel script leest die
+# naam, dus geen commando komt er per ongeluk uit — je moet hem bewust
+# meegeven.
+#
+# ── De rem die hierbij hoort ───────────────────────────────────────────────
+#
+# De schrijvende scripts vragen de database zélf of hij beschermd is
+# (`clm.omgeving`, migratie 0019). Staging is `wegwerp` en mag dus zonder
+# vlag; productie is `beschermd` en eist `--extern`.
+#
+# Vóór stap 5 keek die rem naar de hostnaam, en dan gaat hij bij élk
+# stagingcommando af — staging staat immers óók bij Supabase. Dan went
+# `--extern`, en een waarschuwing die altijd afgaat is geen waarschuwing meer.
+#
+# ───────────────────────────────────────────────────────────────────────────
+
+# De runtime-rol (clm_api_runtime), nooit de postgres-beheerrol — die heeft
+# BYPASSRLS en omzeilt tenant-isolatie.
 # Zie docs/STATUS.md (P0) en docs/adr/ADR-008-clm-admin-rechten.md.
-DATABASE_URL="postgresql://clm_api_runtime.PROJECT_REF:PASSWORD@aws-1-eu-west-1.pooler.supabase.com:5432/postgres?schema=public"
+#
+# STAGING: het projectref hieronder is dat van `clm-staging3`.
+DATABASE_URL="postgresql://clm_api_runtime.STAGING_PROJECT_REF:PASSWORD@aws-1-eu-west-1.pooler.supabase.com:5432/postgres?schema=public"
 
 # Uitsluitend voor `npm run migrate:deploy` en `npm run db:generate` — nooit door de
 # applicatie zelf gebruikt. clm_migrator is eigenaar van clm/ref/audit en
@@ -17,10 +60,12 @@ DATABASE_URL="postgresql://clm_api_runtime.PROJECT_REF:PASSWORD@aws-1-eu-west-1.
 # 2026-08-06 mis en is de aanleiding voor Issue #86.
 #
 # Sinds die issue weigeren migrate:deploy en de seeds te draaien tegen een
-# database die niet op deze machine staat. Is dat wél de bedoeling, geef dan
-# expliciet `-- --extern` mee. De scripts drukken bovendien vóór elke
-# schrijfactie af tegen welke host ze praten.
-MIGRATION_DATABASE_URL="postgresql://clm_migrator.PROJECT_REF:PASSWORD@aws-1-eu-west-1.pooler.supabase.com:5432/postgres?schema=public"
+# BESCHERMDE database (stap 5; daarvóór: tegen een niet-lokale host). Is dat
+# wél de bedoeling, geef dan expliciet `-- --extern` mee. De scripts drukken
+# bovendien vóór elke schrijfactie af tegen welke host ze praten.
+#
+# STAGING: het projectref hieronder is dat van `clm-staging3`.
+MIGRATION_DATABASE_URL="postgresql://clm_migrator.STAGING_PROJECT_REF:PASSWORD@aws-1-eu-west-1.pooler.supabase.com:5432/postgres?schema=public"
 
 # Backupdump — een rol die ALLE rijen ziet.
 #
@@ -37,7 +82,18 @@ MIGRATION_DATABASE_URL="postgresql://clm_migrator.PROJECT_REF:PASSWORD@aws-1-eu-
 #
 # Leeg laten op omgevingen zonder FORCE RLS (verse containers, CI): dan valt
 # backup-dump.js terug op MIGRATION_DATABASE_URL.
-BACKUP_DATABASE_URL="postgresql://postgres.PROJECT_REF:PASSWORD@aws-1-eu-west-1.pooler.supabase.com:5432/postgres"
+#
+# ── DEZE BLIJFT NAAR PRODUCTIE WIJZEN (stap 5) ─────────────────────────────
+#
+# De andere twee variabelen zijn omgezet naar staging; deze niet, en dat is
+# opzet. Een backup van de oefendatabase beschermt niets. De dagelijkse taak
+# om 07:00 dumpt productie, en de controle om 07:30 schrijft daar het bewijs
+# van dat de productie-uitrol vraagt (zie docs/runbooks/backup-bewijs.json).
+#
+# Dit is dus de enige plek in .env waar het productieadres nog staat. Dat is
+# een bewuste uitzondering: hij wordt alleen gelezen door backup-dump.js en
+# backup-controle.js, en die schrijven niets naar de database.
+BACKUP_DATABASE_URL="postgresql://postgres.PRODUCTIE_PROJECT_REF:PASSWORD@aws-1-eu-west-1.pooler.supabase.com:5432/postgres"
 
 # API
 PORT=5001
@@ -194,3 +250,34 @@ PORTAAL_BASIS_URL=http://localhost:3000
 # omgeving gaf een link naar localhost. Gevonden op 2026-08-10, bij de eerste
 # tenant die op acceptatie werd aangemaakt.
 UITNODIGING_BASIS_URL=http://localhost:3000
+
+# ═══════════════════════════════════════════════════════════════════════════
+#  NOODTOEGANG TOT PRODUCTIE — geen enkel script leest deze naam
+# ═══════════════════════════════════════════════════════════════════════════
+#
+# Sinds stap 5 wijzen DATABASE_URL en MIGRATION_DATABASE_URL naar staging. Dat
+# is de bedoeling: geen enkel commando komt dan per ongeluk bij productie uit.
+#
+# Maar soms moet je er wél bij:
+#   - een leesquery om iets te onderzoeken
+#   - een noodherstel wanneer de straat zelf stuk is
+#
+# Daarvoor staat het adres hier, onder een naam die NERGENS in de code
+# voorkomt. Dat is de hele bescherming: `dotenv` laadt hem wel, maar geen
+# script vraagt ernaar. Je moet hem bewust doorgeven:
+#
+#   $env:MIGRATION_DATABASE_URL=$env:NOOD_PRODUCTIE_URL
+#   node scripts/migratiestand.js
+#
+# Of, voor één commando (PowerShell):
+#
+#   $p = (Get-Content .env | Select-String '^NOOD_PRODUCTIE_URL=').Line -replace '^NOOD_PRODUCTIE_URL=',''
+#   $env:MIGRATION_DATABASE_URL = $p.Trim('"')
+#
+# Let op: de schrijvende scripts weigeren dan alsnog, want productie is
+# `beschermd` in clm.omgeving. Je hebt óók `--extern` nodig. Dat is twee keer
+# bewust kiezen voordat je een echte database wijzigt, en dat is precies genoeg.
+#
+# Vergeet niet je terminal daarna te sluiten of de variabele leeg te maken —
+# hij blijft anders gelden voor élk volgend commando in dezelfde sessie.
+NOOD_PRODUCTIE_URL="postgresql://clm_migrator.PRODUCTIE_PROJECT_REF:PASSWORD@aws-1-eu-west-1.pooler.supabase.com:5432/postgres?schema=public"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,9 +22,19 @@ terugkeert en wanneer, staat in **`docs/runbooks/onderhoudskalender.md`**.
 `MCM2-CLAUDE.md`. Reden: op 2026-08-07 werden in één sessie vier commando's
 aangeroepen die niet bestaan (`npm run migrate`, `migrate:status`,
 `verify:migratieketen`, `node scripts/db-doelwit.js`) en scheelde het weinig of
-er was een migratie tegen de Supabase-productiedatabase gedraaid. Dat komt
-doordat `.env` daarheen wijst. Architectuurregels lezen helpt niet als het
-eerste commando al het verkeerde doelwit raakt.
+er was een migratie tegen de Supabase-productiedatabase gedraaid — `.env` wees
+daarheen. Architectuurregels lezen helpt niet als het eerste commando al het
+verkeerde doelwit raakt.
+
+> Sinds stap 5 (2026-08-11) wijst `.env` naar **staging**, en de rem leest
+> `clm.omgeving` in plaats van de hostnaam. Dat verkleint dit risico maar heft
+> het niet op: het verzinnen van commando's is er niet mee opgelost.
+
+**`docs/runbooks/devops-handleiding.md` is niet voor jou maar voor de
+eigenaar.** Hij typt zelf geen commando's; hij vraagt ze in de chat. Die
+handleiding beschrijft wát hij doet — akkoord geven op GitHub, reageren op een
+Telegram-melding, Docker starten. Verwijs ernaar als hij vraagt hoe iets werkt,
+en houd hem bij wanneer een handeling van hem verandert.
 
 ---
 
@@ -32,18 +42,31 @@ eerste commando al het verkeerde doelwit raakt.
 
 Volledig uitgelegd in het runbook; hier alleen zodat je ze niet mist.
 
-**1. `.env` wijst naar Supabase — de echte database.**
-Elk databasecommando zonder overschreven variabele raakt productie. Zet een
-wegwerpcontainer op (`-p 127.0.0.1:55440:5432`, niet `0.0.0.0`) en overschrijf
-`MIGRATION_DATABASE_URL` / `DATABASE_URL` binnen het commando. Nooit `.env`
-aanpassen.
+**1. `.env` wijst naar STAGING — sinds stap 5 (2026-08-11).**
+Een databasecommando zonder eigen adres komt op de oefendatabase uit, niet meer
+op productie. Voor e2e-werk zet je nog steeds een eigen wegwerpcontainer op
+(`-p 127.0.0.1:55440:5432`, niet `0.0.0.0`) en overschrijf je
+`MIGRATION_DATABASE_URL` / `DATABASE_URL` binnen het commando.
+
+Productie leeft nog als `NOOD_PRODUCTIE_URL` in `.env` — **geen enkel script
+leest die naam**. Erbij komen kost twee bewuste stappen: het adres meegeven én
+`--extern`, want productie is `beschermd`.
 
 **1b. Elke database is `beschermd` tot hij zich als wegwerp meldt.**
-Sinds migratie 0019 staat dat in `clm.omgeving`, en de e2e-suites weigeren te
-draaien tegen alles wat niet `wegwerp` is. Na het opzetten van je eigen
-container: `node scripts/markeer-wegwerp.js "waarvoor"`. **Markeer nooit de
-demo (poort 55450) of Supabase.** Aanleiding: op 2026-08-07 wisten de e2e-tests
-de demo-database leeg omdat `DATABASE_URL` naar 55450 wees.
+Sinds migratie 0019 staat dat in `clm.omgeving`. De e2e-suites weigeren tegen
+alles wat niet `wegwerp` is, en sinds stap 5 geldt dat ook voor de schrijvende
+scripts: `eisOnbeschermdeDatabase()` leest die markering in plaats van de
+hostnaam. Na het opzetten van je eigen container:
+`node scripts/markeer-wegwerp.js "waarvoor"`.
+
+**Markeer nooit de demo (poort 55450) of een Supabase-productiedatabase.**
+Aanleiding: op 2026-08-07 wisten de e2e-tests de demo-database leeg omdat
+`DATABASE_URL` naar 55450 wees.
+
+> Eén uitzondering, bewust: een **lokale** database zonder `clm.omgeving` mag
+> door. Die tabel ontstaat pas bij migratie 0019, dus een verse container zou
+> anders blokkeren op precies het commando dat hem moet vullen. Niet-lokaal
+> zonder markering blijft geblokkeerd.
 
 **2. Verzin nooit een commando — en ook geen kolomnaam of route.**
 Staat het niet in `package.json`, dan bestaat het niet:

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -46,9 +46,40 @@ Vandaag gemerged: **#135** (uitnodigingslink wees naar `localhost`), **#136**
 (migraties naar staging), **#137** (applicatie tegen Supabase), **#139/#140**
 (time-outs, en de Tailscale-stappen er weer uit), **#142** (#131 en #133).
 
-**Van de negen stappen zijn 1, 2, 2b, 3 en 4 af.** Volgende is stap 5: `.env`
-omleiden naar staging — de grootste veiligheidswinst van het plan, want dan
-wijst de laptop niet meer standaard naar de productiedatabase.
+### Stap 5 is ook af: de laptop wijst niet meer naar productie
+
+**Dit is de grootste veiligheidswinst van het hele plan.** Tot vanmiddag wezen
+`DATABASE_URL` en `MIGRATION_DATABASE_URL` naar de echte klantendatabase. Elk
+databasecommando raakte die — niet omdat iemand dat koos, maar omdat het de
+standaard was. Dat is de gemeenschappelijke oorzaak onder 04-08, 07-08 en 10-08.
+
+| Variabele | Wijst nu naar |
+|---|---|
+| `DATABASE_URL` | **staging** |
+| `MIGRATION_DATABASE_URL` | **staging** |
+| `BACKUP_DATABASE_URL` | productie — bewust, een backup van de oefendatabase beschermt niets |
+| `NOOD_PRODUCTIE_URL` | productie — **geen enkel script leest deze naam** |
+
+**De rem moest mee, en dat was het echte werk.** Hij kende `localhost` en "de
+rest". Maar staging staat óók bij Supabase, dus hij zou bij élk stagingcommando
+afgaan — en dan went `--extern`. Een waarschuwing die altijd afgaat is geen
+waarschuwing meer.
+
+De rem vraagt nu de database zélf wat hij is (`clm.omgeving`, migratie 0019):
+`wegwerp` mag door, `beschermd` eist de vlag. Beproefd op vier doelwitten,
+exitcodes zonder pipe gemeten.
+
+Twee dingen kwamen alleen boven door het te draaien: een verse container
+blokkeerde op het commando dat hem moet vullen, en de doorloopstack op poort
+55500 werd nergens gemarkeerd. Beide opgelost.
+
+**Van de negen stappen zijn 1, 2, 2b, 3, 4 en 5 af.** Volgende is stap 6:
+`mcm2-productie` op saxombp opheffen, zodat er nog maar één ding "productie"
+heet. Dat is de eerste onomkeerbare stap van het plan.
+
+Nieuw: **[`docs/runbooks/devops-handleiding.md`](runbooks/devops-handleiding.md)**
+— uitrollen, terugdraaien, status opvragen en wat er misgaat, geschreven vanuit
+de handeling in plaats van vanuit de techniek.
 
 ### Waarom het starten van de applicatie handwerk blijft
 
@@ -486,7 +517,8 @@ handmatig te starten is (PR #122).
 | # | Wat | Waarom nu |
 |---|---|---|
 | — | ~~**Geen geautomatiseerde uitrol naar productie**~~ | ✅ **Gedaan 11-08** (stap 4). Migraties gaan achter vier remmen langs; de applicatie starten blijft één commando. De remmen zijn op zeven uitkomsten beproefd |
-| — | **`.env` wijst nog naar productie** | Nu de uitrol via GitHub loopt, hoeft de laptop dat adres niet meer te kennen. Dit is **stap 5**, en de grootste veiligheidswinst van het plan — de gemeenschappelijke oorzaak onder 04-08, 07-08 en 10-08 |
+| — | ~~**`.env` wijst nog naar productie**~~ | ✅ **Gedaan 11-08** (stap 5). Wijst nu naar staging; de rem kijkt naar `clm.omgeving` in plaats van naar de hostnaam |
+| — | **Twee dingen heten "productie"** | `mcm2-productie` op saxombp draait op een eigen lokale database, niet op Supabase. Dat is verwarrend op precies het verkeerde moment. **Stap 6**, en de eerste onomkeerbare stap |
 | ~~#51~~ | ~~Frontend promoveerbaar maken~~ | ✅ **Gedaan 10-08.** Bewezen: hetzelfde image tegen twee backends, verschillende antwoorden, geen herbouw |
 | ~~#132~~ | ~~Uitnodigingslink wijst naar `localhost`~~ | ✅ **Gedaan 11-08** (PR #135). Twee tests, tegenproef gedraaid |
 | ~~#131~~ | ~~`mailVerstuurd: true` terwijl er niets verstuurd is~~ | ✅ **Gedaan 11-08.** `echtVerstuurd` op de mailgrens; verplicht veld, dus niet te vergeten |

--- a/docs/architectuur/plan-otap-straat-met-staging.md
+++ b/docs/architectuur/plan-otap-straat-met-staging.md
@@ -563,13 +563,72 @@ Zodra de uitrol via GitHub loopt, hoort de laptop dat adres niet meer te kennen.
 `.env` gaat naar **staging** wijzen. De productiereferenties leven dan alleen nog
 als GitHub secret.
 
-**Wat er dan nog handmatig moet kunnen** — en dus een andere weg krijgt:
+### ✅ Uitgevoerd 2026-08-11
 
-- Een noodherstel wanneer de straat zelf stuk is
-- Een leesquery om iets te onderzoeken
+| Variabele | Wijst nu naar | Waarom |
+|---|---|---|
+| `DATABASE_URL` | **staging** | de oefendatabase is het nieuwe standaarddoelwit |
+| `MIGRATION_DATABASE_URL` | **staging** | idem |
+| `BACKUP_DATABASE_URL` | productie | **bewust** — een backup van de oefendatabase beschermt niets |
+| `NOOD_PRODUCTIE_URL` | productie | nieuw; **geen enkel script leest deze naam** |
 
-Beide via `scripts/with-migration-url.js`, dat het doelwit expliciet maakt in
-plaats van het uit `.env` te halen. Het commando moet zeggen wat het raakt.
+**Waarom de noodtoegang in `.env` staat en niet alleen bij GitHub.** De
+bescherming zit niet in "onvindbaar" maar in "geen enkel script pakt het
+automatisch op". `dotenv` laadt de variabele wel, maar niets vraagt ernaar — je
+moet hem bewust doorgeven. Het verschil met een GitHub-secret is alleen hoe snel
+je erbij kunt wanneer er iets stuk is, en dat is bij een noodherstel juist het
+punt.
+
+`scripts/with-migration-url.js` bleek hiervoor ongeschikt: dat kopieert
+`MIGRATION_DATABASE_URL` naar `DATABASE_URL` en maakt het doelwit dus níét
+expliciet — het tegenovergestelde van wat §3.5 vroeg.
+
+### De rem moest mee, en dat was het echte werk
+
+`eisToestemmingBuitenLokaal()` kende twee soorten: `localhost` en de rest. Dat
+werkte zolang `.env` naar productie wees. Maar **staging staat óók bij Supabase**,
+dus die rem zou bij élk stagingcommando afgaan. Dan typ je `--extern` erbij
+omdat er anders niets werkt, na twee weken is het een gewoonte, en dan typ je
+hem ook op de dag dat je per ongeluk naar productie wijst.
+
+Een waarschuwing die altijd afgaat, is geen waarschuwing meer — dezelfde les als
+bij de backupmelding die niemand las (2026-08-04).
+
+`eisOnbeschermdeDatabase()` vraagt daarom de database zélf wat hij is
+(`clm.omgeving`, migratie 0019). Die markering zit ín de database, niet in een
+hostnaam of poortnummer dat ernaast staat en niet meer klopt zodra iets
+verhuist.
+
+**De naam is bewust veranderd.** De nieuwe functie is `async`, de oude
+synchroon. Zouden ze hetzelfde heten, dan blijft `if (!eis…(url, …))` draaien —
+met een Promise als uitkomst, en die is altijd waarheidsachtig. De rem zou dan
+stilzwijgend nooit meer afgaan: een beveiliging die verdwijnt zonder één
+foutmelding. Met een nieuwe naam faalt een vergeten aanroeper meteen.
+
+**Twee dingen die het beproeven opleverde** — geen van beide was voorzien:
+
+1. **Een verse container blokkeerde.** `clm.omgeving` ontstaat pas bij migratie
+   0019, dus een lege database zou weigeren op precies het commando dat hem moet
+   vullen. Opgelost met een uitzondering die alléén lokaal geldt: niet-lokaal
+   zonder markering blijft geblokkeerd, want dat kan een kopie van productie zijn
+   van vóór 0019.
+2. **De doorloopstack op poort 55500 werd nergens gemarkeerd.** De migratie ging
+   door (lokaal en leeg), maar `seed-vragenlijsten.js` weigerde een stap later —
+   0019 had de database toen op `beschermd` gezet. `verify:volledig` markeert nu
+   ook die stack.
+
+### Beproefd
+
+| Doelwit | Zonder vlag | Met `--extern` |
+|---|---|---|
+| staging (`wegwerp`) | gaat door | n.v.t. |
+| verse lokale container (geen tabel) | gaat door | n.v.t. |
+| lokaal, gemigreerd, nog `beschermd` | geblokkeerd | gaat door |
+| **productie** (`beschermd`) | **geblokkeerd**, exitcode 1 | gaat door, met "LET OP" |
+
+Exitcodes zonder pipe gemeten. `verify:volledig` groen tot en met de 66
+browsertests — en voor het eerst zonder handmatig variabelen mee te geven, want
+`.env` wijst nu vanzelf naar de goede plek.
 
 ---
 
@@ -738,7 +797,7 @@ het als eerste staat.
 | 2b | ✅ **Frontend-image publiceren, frontend in de uitrol** — gedaan 10-08 | Beslist: twee versies, zie hieronder |
 | 3 | ✅ **Uitrol naar staging automatiseren** — gedaan 11-08 | Beslist: applicatie start met de hand, zie §3.3c |
 | 4 | ✅ **Uitrol naar productie automatiseren, met akkoordrem** — gedaan 11-08 | Beslist: backup blijft bij de eigenaar, CI controleert; applicatie start met de hand |
-| 5 | `.env` omleiden naar staging | Nee, maar wel melden wanneer |
+| 5 | ✅ **`.env` omleiden naar staging** — gedaan 11-08 | Beslist: rem kijkt naar `clm.omgeving`; noodtoegang als `NOOD_PRODUCTIE_URL` |
 | 6 | `mcm2-productie` op saxombp opheffen | **Ja — onomkeerbaar** |
 | 7 | `verify:omgevingen` bouwen | Nee |
 | 8 | Productie opnieuw vullen | Nee |

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -15,7 +15,8 @@ faalt als er een runbook bijkomt dat hier niet genoemd wordt.
 
 | Runbook | Waarvoor | Type |
 |---|---|---|
-| [commandos-en-omgeving.md](commandos-en-omgeving.md) | **Lees dit eerst.** Welk commando bestaat er echt, waar praat het naartoe, wat mag nooit. `.env` wijst naar de productiedatabase. | R |
+| [devops-handleiding.md](devops-handleiding.md) | **Begin hier als je iets wilt dóén.** Uitrollen, terugdraaien, status opvragen, wat er misgaat — geschreven vanuit de handeling, niet vanuit de techniek. | D |
+| [commandos-en-omgeving.md](commandos-en-omgeving.md) | Welk commando bestaat er echt, waar praat het naartoe, wat mag nooit. Sinds stap 5 wijst `.env` naar **staging**; productie eist een expliciet adres én `--extern`. | R |
 | [onderhoudskalender.md](onderhoudskalender.md) | Wat er terugkeert en wanneer — automatisch én met de hand. Plus wat nog niet beschreven is. | D |
 
 ---

--- a/docs/runbooks/commandos-en-omgeving.md
+++ b/docs/runbooks/commandos-en-omgeving.md
@@ -72,16 +72,35 @@ niets voor te doen.
 
 ### Waar de controle overal geldt
 
-| Wat | Controle |
-|---|---|
-| e2e-suites (alle 27) | Weigeren te starten tegen `beschermd` |
-| `seed:demo -- --verwijder` | Weigert op `beschermd` |
-| `migrate:deploy` | Alleen de hostcontrole — migreren mág op productie |
-| `seed:vragenlijsten`, `seed:demo` (zonder `--verwijder`) | Alleen de hostcontrole — toevoegen mag |
+*Bijgewerkt bij stap 5 (2026-08-11): de schrijvende scripts kijken niet meer naar
+de hostnaam maar naar `clm.omgeving`.*
 
-**Toevoegen mag op een beschermde database, verwijderen niet.** Dat onderscheid
-is opzet: anders kun je een demo-tenant in productie nooit inrichten. De eis
-geldt waar iets onherstelbaar is.
+| Wat | Controle | Zonder vlag op productie |
+|---|---|---|
+| e2e-suites (alle 34) | markering | weigeren te starten |
+| `seed:demo -- --verwijder` | markering, twee keer | weigert |
+| `migrate:deploy` | markering | **weigert** — was: mocht |
+| `seed:vragenlijsten`, `seed:demo` | markering | **weigert** — was: mocht |
+| `platform:inrichten` | markering | **weigert** — was: mocht |
+| `markeer-wegwerp` | hostnaam | weigert |
+| `migratiestand`, `productie:poort` | geen — lezen alleen | gaan door |
+
+**Wat er veranderde:** vóór stap 5 mocht *toevoegen* op een beschermde database
+zonder vlag, en werd alleen *verwijderen* tegengehouden. Dat onderscheid is
+vervallen: nu `.env` naar staging wijst, is een commando dat toch bij productie
+uitkomt vrijwel altijd een vergissing — en dan hoort het te stoppen, ook als het
+"maar" toevoegt.
+
+Is het géén vergissing, dan is `--extern` genoeg. Dat is één woord extra op een
+handeling die je zelden doet, en het staat in je terminalhistorie.
+
+**`markeer-wegwerp` houdt de hostcontrole**, en dat is geen omissie: dat script
+draait per definitie tegen een database die nog `beschermd` is — dat is wat het
+omzet. Met de nieuwe rem zou het altijd blokkeren.
+
+**Lezen blijft vrij.** `migratiestand.js` en `productie-poort.js` doen
+uitsluitend `SELECT count(*)`. Een leesquery tegen productie is precies wat je
+zonder drempel wilt kunnen doen; een vlag die je daarvoor moet meegeven, went.
 
 `otap-doorloop.js` en `provider-migratietest.js` verwijderen ook, maar hebben de
 controle niet nodig: de eerste praat naar een vast adres binnen zijn eigen
@@ -90,24 +109,80 @@ weggooit.
 
 ---
 
-## ⚠ Het belangrijkste: `.env` wijst naar Supabase
+## `.env` wijst naar STAGING — sinds stap 5 (2026-08-11)
 
 ```
-DATABASE_URL            → clm_api_runtime @ aws-1-eu-west-1.pooler.supabase.com
-MIGRATION_DATABASE_URL  → clm_migrator    @ aws-1-eu-west-1.pooler.supabase.com
+DATABASE_URL            → clm_api_runtime @ clm-staging3   (oefendatabase)
+MIGRATION_DATABASE_URL  → clm_migrator    @ clm-staging3   (oefendatabase)
+BACKUP_DATABASE_URL     → postgres        @ clm-enterprise (PRODUCTIE — bewust)
+NOOD_PRODUCTIE_URL      → clm_migrator    @ clm-enterprise (leest geen enkel script)
 ```
 
-**Dat is de echte database.** Elk commando dat deze variabelen gebruikt en dat je
-draait zónder ze te overschrijven, raakt Supabase.
+**Een commando zonder eigen adres komt nu op staging uit.** Daar kan niets kapot.
 
-Dit is precies waar **Issue #86** op misging: `npm run migrate:deploy` draaide
-tegen productie terwijl een wegwerpcontainer de bedoeling was. Het script meldde
-"Migraties draaien als rol 'clm_migrator'" en daarna "Migraties voltooid" —
-beide waar, geen van beide verklapte het doelwit. Die rol heet lokaal precies zo.
+### Wat hier vóór 11 augustus stond, en waarom het weg moest
 
-**Vóór elk commando dat de database schrijft:** stel vast waar het naartoe gaat.
-Sinds PR #93 noemen de schrijvende scripts hun doelwit zelf en weigeren ze
-buiten lokaal zonder bevestiging. Vertrouw daarop, maar lees de melding.
+Deze paragraaf begon met *"⚠ Het belangrijkste: `.env` wijst naar Supabase"* —
+naar **productie**. Elk databasecommando raakte de echte klantgegevens, niet
+omdat iemand dat koos maar omdat het de standaard was. Dat is de
+gemeenschappelijke oorzaak onder alle drie de incidenten:
+
+- **2026-08-04** — productie liep achter, de dump miste 9 van 18 tabellen (#25)
+- **2026-08-06** — `migrate:deploy` draaide tegen productie (Issue #86). Het
+  script meldde "Migraties draaien als rol 'clm_migrator'" en daarna "Migraties
+  voltooid" — beide waar, geen van beide verklapte het doelwit. Die rol heet
+  lokaal precies zo.
+- **2026-08-07** — vier verzonnen commando's; bijna een migratie op productie
+
+Nu de uitrol via GitHub loopt (stappen 3 en 4), hoeft deze machine het
+productieadres niet meer standaard te kennen.
+
+### Hoe je tóch bij productie komt
+
+Twee keer bewust kiezen:
+
+```powershell
+# 1. het adres meegeven — uit NOOD_PRODUCTIE_URL in .env
+$p = (Get-Content .env | Select-String '^NOOD_PRODUCTIE_URL=').Line -replace '^NOOD_PRODUCTIE_URL=',''
+$env:MIGRATION_DATABASE_URL = $p.Trim('"')
+
+# 2. én de vlag, want productie is 'beschermd'
+node scripts/migrate.js --extern
+```
+
+`NOOD_PRODUCTIE_URL` wordt door **geen enkel script** gelezen. Dat is de hele
+bescherming: `dotenv` laadt hem wel, maar niets vraagt ernaar.
+
+> Sluit je terminal daarna, of maak de variabele leeg. Hij blijft anders gelden
+> voor élk volgend commando in dezelfde sessie.
+
+### De rem: de database zegt zelf wat hij is
+
+Vóór stap 5 keek de rem naar de **hostnaam**: localhost mocht, de rest niet. Dat
+werkte zolang `.env` naar productie wees, maar staging staat óók bij Supabase —
+die rem zou dus bij élk stagingcommando afgaan. Dan typ je `--extern` erbij
+omdat er anders niets werkt, en na twee weken is het een gewoonte.
+
+**Een waarschuwing die altijd afgaat, is geen waarschuwing meer.**
+
+Daarom vraagt de rem nu aan de database zelf wat hij is (`clm.omgeving`,
+migratie 0019):
+
+| Database | Markering | Zonder vlag |
+|---|---|---|
+| staging | `wegwerp` | gaat door |
+| jouw wegwerpcontainers | `wegwerp` | gaat door |
+| verse container, nog niet gemigreerd | *(geen tabel)* | gaat door — **alleen lokaal** |
+| **productie** | **`beschermd`** | **geblokkeerd** |
+| demo (poort 55450) | `beschermd` | geblokkeerd |
+
+Die derde regel is er omdat `clm.omgeving` pas bij migratie 0019 ontstaat: een
+lege container zou anders blokkeren op precies het commando dat hem moet vullen.
+Niet-lokaal en zonder markering blijft geblokkeerd — dat kan een kopie van
+productie zijn van vóór 0019.
+
+**Vóór elk commando dat de database schrijft:** lees de doelwitregel. De
+schrijvende scripts noemen hem zelf, vóór ze iets doen.
 
 ---
 

--- a/docs/runbooks/devops-handleiding.md
+++ b/docs/runbooks/devops-handleiding.md
@@ -1,362 +1,296 @@
-# DevOps-handleiding — MCM2
+# DevOps-handleiding — wat jij doet
 
 **Type:** D — routineoperaties
 **Eigenaar:** de eigenaar (Chris)
 **Laatste update:** 2026-08-11
-**Vereiste toegang:** GitHub (AlingAdvies/MCM2), Tailscale (saxombp), Supabase
-
-Dit document is geschreven vanuit **wat je wilt doen**, niet vanuit hoe het
-werkt. Zoek je de techniek erachter, dan staat onder elk stuk een verwijzing.
-
-De rest van de runbooks is naslag; dit is het startpunt.
+**Vereiste toegang:** GitHub (AlingAdvies/MCM2), Supabase, Telegram op je telefoon
 
 ---
 
-## 1. Waar draait wat
+## Hoe dit werkt
 
-| Omgeving | Waarvoor | Applicatie | Database |
-|---|---|---|---|
-| **lokaal** | ontwikkelen | je laptop | wegwerpcontainer die je zelf opzet |
-| **acceptatie** | uitproberen, inloggen | saxombp `:5011` / `:3010` | container op saxombp |
-| **staging** | repetitie vóór productie | saxombp `:5031` / `:3030` | Supabase `clm-staging3` |
-| **productie** | echte klanten | saxombp `:5021` | Supabase `clm-enterprise` |
+Je typt zelf geen commando's. **Je vraagt ze aan Claude in de chat**, en die voert
+ze uit. Wat jij doet is: opdracht geven, knoppen indrukken die alleen jij mag
+indrukken, en reageren op meldingen.
 
-**Waarom staging bij Supabase staat en niet op saxombp:** productie draait
-Postgres bij AWS in Ierland achter een connection pooler. Een repetitie in een
-lokale container bewijst het verkeerde — de pooler is precies de plek waar het
-anders gaat.
+Deze handleiding is daarom geordend naar **jouw handelingen**. Elk hoofdstuk
+begint met wat er van jou wordt verwacht. De uitleg erachter is achtergrond —
+sla die gerust over.
 
-> **Let op — twee dingen heten "productie".** Op saxombp draait `mcm2-productie`
-> op poort 5021 met een *eigen lokale* database. Dat is procesbewijs, niet de
-> echte productie. De echte klantgegevens staan bij Supabase. Dat verschil wordt
-> opgeheven in stap 6 van het OTAP-plan.
-
----
-
-## 2. Het belangrijkste dat je moet weten
-
-**Je laptop wijst standaard naar STAGING.** Sinds 2026-08-11.
-
-Typ je een databasecommando zonder er zelf een adres bij te geven, dan komt het
-op de oefendatabase uit. Daar kan niets kapot.
-
-**Wil je bij productie, dan moet je twee keer bewust kiezen:**
-
-1. het adres meegeven (`NOOD_PRODUCTIE_URL` uit `.env`)
-2. én `--extern` erbij typen
-
-Doe je maar één van beide, dan stopt het commando met een melding die zegt wat
-er aan de hand is.
-
-**Waarom dit telt:** vóór 11 augustus wees je laptop naar productie. Elk
-commando raakte dus de echte klantgegevens — niet omdat je dat koos, maar omdat
-het de standaard was. Dat is de oorzaak onder de drie incidenten van 4, 7 en 10
-augustus.
-
-> Naslag: `.env.example`, en §3.5 van
-> [`plan-otap-straat-met-staging.md`](../architectuur/plan-otap-straat-met-staging.md)
-
----
-
-## 3. "Ik heb iets veranderd en wil het uitrollen"
-
-### Stap 1 — Zorg dat het klopt
-
-```powershell
-npm run verify:volledig
-```
-
-Dit is **het** bewijs: zeven stappen, van opmaakcontrole tot een browser die
-een leverancier aanmaakt en terugziet. Duurt een paar minuten.
-
-> Losse commando's als `npm test` bewijzen niets over het geheel. Gebruik nooit
-> `npm run lint` of `npm run format` om "groen" vast te stellen — die
-> *wijzigen* bestanden. CI draait `lint:check` en `format:check`.
-
-### Stap 2 — Branch, commit, pull request
-
-Nooit rechtstreeks op `main` werken.
-
-```powershell
-git checkout -b feat/waar-het-over-gaat
-# ... wijzigen ...
-git add -A
-git commit -m "feat(scope): wat er verandert"
-git push -u origin feat/waar-het-over-gaat
-```
-
-Daarna een pull request openen op GitHub, en wachten tot de drie controles
-groen zijn.
-
-### Stap 3 — Mergen
-
-Als de PR groen is: **Merge**, en verwijder de branch.
-
-Wat er dan vanzelf gebeurt:
-
-```
-merge op main
-  → CI: opmaak, tests, build
-  → image naar GHCR (met een SHA-tag)
-  → migraties naar staging
-  → teruglezen of ze er echt staan
-```
-
-### Stap 4 — Staging bijwerken (één commando)
-
-CI zet de migraties klaar, maar start de applicatie niet. Dat doe jij:
-
-```powershell
-npm run deploy:staging -- --versie sha-<twaalf tekens>
-```
-
-De juiste tag staat in de samenvatting van de CI-run.
-
-> **De tag is twaalf tekens.** `sha-ffd27dc9` bestaat niet, `sha-ffd27dc9472f`
-> wel. Dat ging twee keer mis; beide keren hield de rem het tegen met
-> *"Er is niets gewijzigd"*.
-
-### Stap 5 — Naar productie
-
-Zie hoofdstuk 4 hieronder. Dat is een apart verhaal, met remmen.
-
-> Naslag: [`uitrol-acceptatie-en-productie.md`](uitrol-acceptatie-en-productie.md)
-
----
-
-## 4. "Ik wil naar productie"
-
-### Vooraf: is de backup bij?
-
-De uitrol weigert als de backupcontrole ouder is dan 36 uur.
-
-Meestal hoef je niets te doen — de geplande taken draaien elke ochtend om 07:00
-en 07:30. **Maar je moet het bewijs wél committen:**
-
-```powershell
-git add docs/runbooks/backup-bewijs.json
-git commit -m "chore(backup): bewijs van vandaag"
-git push
-```
-
-Controleren of alles klaarstaat:
-
-```powershell
-npm run productie:poort
-```
-
-### De uitrol starten
-
-1. GitHub → tabblad **Actions**
-2. Links: **Uitrol naar productie**
-3. Knop **Run workflow**
-4. Invullen:
-
-| Veld | Wat |
+| Symbool | Betekent |
 |---|---|
-| `versie` | de backend-tag, bijv. `sha-e8e462d6eec8`. Leeg = laatste van main |
-| `frontend_versie` | de frontend-tag. Leeg = `latest` |
-| `reden` | **verplicht** — waarom rol je uit? |
+| 🧑 **JIJ** | jouw vingers, jouw beslissing |
+| 🤖 **CLAUDE** | vraag je in de chat |
+| ⚙️ **VANZELF** | gebeurt zonder dat iemand iets doet |
 
-### Wat er dan gebeurt
+**De enige dingen die Claude niet voor je kan doen:**
 
-```
-→ poort: backup vers? staging op stand? productie niet vóór?
-→ JOUW AKKOORD                              ← de run staat stil
-→ poort opnieuw (er kan tijd overheen zijn)
-→ migraties + teruglezen + rechtencontrole
-────────────────────────────────────────────
-→ npm run deploy:productie -- --versie …    ← jij, met de hand
-```
+1. Een akkoord geven op GitHub voor een uitrol naar productie
+2. Iets aanklikken in de Supabase-console
+3. Docker Desktop starten op je laptop
+4. Beslissen dát er iets naar productie gaat
 
-Bij het akkoord: gele balk bovenaan de runpagina → **Review deployments** →
-`productie` aanvinken → **Approve and deploy**.
-
-Onderaan de runpagina verschijnt de samenvatting, mét het startcommando en de
-weg terug.
-
-### De vier remmen
-
-| Rem | Wat hem tegenhoudt |
-|---|---|
-| Backup vooraf | geen bewijs, ouder dan 36 uur, of de controle meldde problemen |
-| Staging beproefd | staging staat niet op de stand van de repository |
-| Productie niet vóór | productie telt méér migraties dan de repository |
-| Jouw akkoord | jij drukt niet |
-
-**Blokkeert er een? Dan is er niets stuk.** De melding zegt erbij wat eraan
-schort.
+Al het andere — testen, branches, commits, uitrollen, terugdraaien, status
+opvragen — vraag je aan Claude.
 
 ---
 
-## 5. "Er is iets misgegaan, ik wil terug"
+## 1. De drie momenten waarop jij iets MOET doen
 
-Terugdraaien is **geen apart commando**. Het is dezelfde uitrol met de vorige
-tag:
+Dit is het belangrijkste hoofdstuk. De rest is naslag.
 
-```powershell
-npm run deploy:status                                   # wat draait er nu?
-npm run deploy:productie -- --versie sha-<vorige> --frontend-versie sha-<vorige>
-```
+### Moment 1 — Telegram meldt een probleem met de backup
 
-Die regel hoef je niet zelf te bedenken — elke geslaagde uitrol drukt hem af:
+**Je krijgt een bericht op je telefoon.** Zes soorten, en ze vragen niet
+allemaal hetzelfde:
 
-```
-  vorige versie was sha-5428bb954884 met frontend sha-635ff21150bd
-  terugdraaien:  npm run deploy:acceptatie -- --versie sha-5428bb954884 --frontend-versie sha-635ff21150bd
-```
-
-> **Er is géén `npm run rollback:…`.** Dat commando bestaat niet en heeft nooit
-> bestaan.
-
-**Let op bij migraties.** Terugdraaien zet de *applicatie* terug, niet het
-*databaseschema*. Dat gaat goed zolang migraties alleen toevoegen (kolommen
-erbij). Is er iets verwijderd, dan is de backup terugzetten de weg — niet de
-rollback.
-
-> Naslag: [`uitrol-acceptatie-en-productie.md`](uitrol-acceptatie-en-productie.md),
-> hoofdstuk "Terugdraaien"
-
----
-
-## 6. "Ik wil weten hoe het ervoor staat"
-
-```powershell
-npm run deploy:status        # welke versie draait waar, en antwoordt het?
-npm run productie:poort      # zijn de remmen groen?
-npm run backup:controle      # is de backup er, en zit alles erin?
-```
-
-`deploy:status` is de nuttigste: hij toont per omgeving de containers, de
-image-tag, én of de applicatie antwoordt. Dat laatste is het punt — een
-draaiende container is geen werkende app.
-
----
-
-## 7. Terugkerende taken
-
-### Draait vanzelf
-
-| Wanneer | Wat | Jouw rol |
+| Bericht begint met | Wat het betekent | Wat jij doet |
 |---|---|---|
-| dagelijks 07:00 | backup van productie | niets |
-| dagelijks 07:30 | backupcontrole (laag A + B) | de melding lezen |
-| maandag 07:45 | backupcontrole volledig (+ echte restore) | de melding lezen |
-| elke merge op main | tests, image, migraties naar staging | niets |
+| *"Docker draait niet…"* | Docker Desktop staat uit. De backup van vanochtend is waarschijnlijk óók mislukt | **Start Docker Desktop.** Vraag daarna aan Claude: *"haal de gemiste backup in"* |
+| *"De nieuwste dump is … oud"* | De geplande taak heeft stilgelegen | Zelfde als hierboven: Docker starten, Claude vragen in te halen |
+| *"De inhoudsopgave … is niet leesbaar"* | De dump is beschadigd | Vraag Claude: *"de backup is beschadigd, zoek uit wat er mis is"* |
+| *"… mist tabellen"* | De dump is incompleet — **dit is ernstig** | Vraag Claude er meteen naar. Dit is precies wat op 4 augustus misging |
+| *"de verwachtingslijst is verouderd"* | Er is een tabel bijgekomen die de controle nog niet kent | Vraag Claude: *"werk de backup-verwachtingslijst bij"* |
+| *"herstelproef mislukt"* | De dump is er wel, maar er komt niets uit | Vraag Claude er meteen naar |
 
-**Draait Docker Desktop niet, dan falen ze allemaal.** Dat is de meest
-voorkomende storing: elke herstart zonder handmatige start levert een dag zonder
-backup op.
+> **Krijg je een week lang niets?** Dat is óók een signaal. Er hoort elke week
+> een levensteken te komen (een bericht met ✅). Blijft dat uit, dan is de
+> melder zelf stuk, of staat je laptop uit. Vraag Claude om het te controleren.
 
-Een gemiste dag inhalen:
+### Moment 2 — GitHub vraagt je akkoord voor productie
 
-```powershell
-& "C:\DEV\Work\MCM2\scripts\backup-taak.cmd"   # niet: npm run backup:dump
-npm run backup:controle
-```
+**Je krijgt een e-mail van GitHub** met "Deployment review requested", en de
+run staat stil tot jij drukt.
 
-> Gebruik het `.cmd`. `BACKUP_DIR` staat alleen daarin; los gedraaid schrijft
-> het npm-script naar de projectmap en ziet de controle de dump niet.
+**Wat jij doet:**
 
-### Moet je zelf doen
+1. Open de link in de e-mail (of ga naar de repo → tabblad **Actions**)
+2. Bovenaan staat een gele balk → klik **Review deployments**
+3. Vink **productie** aan
+4. Klik **Approve and deploy**
 
-| Ritme | Wat |
+**Waar je op let vóór je drukt:** in de logs van de stap ervóór staat een blok
+dat eindigt met `DOOR — de drie automatische remmen geven groen licht`. Staat
+daar `GEBLOKKEERD`, dan is de knop er niet eens — dan hoef je niets te doen.
+
+### Moment 3 — Je wilt zelf iets uitgerold hebben
+
+Dat begint altijd bij jou, want niemand anders beslist dat. Zie hoofdstuk 2.
+
+---
+
+## 2. "Ik wil dat een wijziging live gaat"
+
+### Naar acceptatie of staging — dat is één opdracht
+
+🤖 **Vraag Claude:** *"rol dit uit naar staging"*
+
+Claude doet dan alles: testen draaien, een branch maken, een pull request
+openen, wachten tot de controles groen zijn, mergen, en de applicatie starten.
+
+🧑 **Jouw enige moment:** Claude vraagt je of de pull request gemerged mag
+worden. Dat is een vraag in de chat, geen knop op GitHub.
+
+### Naar productie — daar komt jouw akkoord bij
+
+🤖 **Vraag Claude:** *"ik wil versie X naar productie"*
+
+Wat er dan gebeurt, in volgorde:
+
+| | Wie | Wat |
+|---|---|---|
+| 1 | 🤖 CLAUDE | controleert of de backup vers genoeg is, en commit het bewijs |
+| 2 | 🤖 CLAUDE | start de workflow op GitHub |
+| 3 | ⚙️ VANZELF | de poort draait: backup, staging, productiestand |
+| 4 | 🧑 **JIJ** | **akkoord geven** — zie moment 2 hierboven |
+| 5 | ⚙️ VANZELF | de poort draait nog eens, dan de migraties |
+| 6 | 🤖 CLAUDE | start de applicatie met het commando uit de samenvatting |
+
+**Stap 4 is het enige moment waarop het op jou wacht.** Alles daarvoor en
+daarna loopt door.
+
+### Wat je nooit hoeft te onthouden
+
+De versienummers. Die staan altijd in de samenvatting van de vorige stap, en
+Claude leest ze daar op. Vraag ernaar in plaats van ze over te typen — ze zijn
+twaalf tekens lang en één cijfer verkeerd betekent "image niet gevonden".
+
+---
+
+## 3. "Er is iets stuk, ik wil terug"
+
+🤖 **Vraag Claude:** *"draai de laatste uitrol terug"*
+
+Claude weet welke versie er daarvóór draaide — dat staat in de logs van de
+vorige uitrol — en zet die terug.
+
+🧑 **Wat jij moet weten:** terugdraaien zet de **applicatie** terug, niet de
+**database**. Zijn er bij die uitrol kolommen verwijderd, dan is terugzetten van
+de backup de weg. Claude zegt het als dat aan de orde is; je hoeft het niet zelf
+te beoordelen.
+
+**Hoe snel:** een rollback duurt ongeveer een minuut. Hij is op 11 augustus
+beproefd op acceptatie, heen en terug.
+
+---
+
+## 4. "Ik wil weten hoe het ervoor staat"
+
+🤖 **Vraag Claude één van deze dingen:**
+
+| Je vraag | Wat je terugkrijgt |
 |---|---|
-| wekelijks | levensteken opgemerkt? Blijft het uit, dan is de melder zelf stuk |
-| wekelijks | staging wakker houden — een gratis Supabase-project pauzeert na 7 dagen |
-| maandelijks | restore-hertest met verificatie van de inhoud |
-| maandelijks | `npm audit` nalopen |
-| per kwartaal | rollback beproeven op acceptatie |
-| vóór productie-uitrol | `backup-bewijs.json` committen |
+| *"wat draait er waar?"* | per omgeving de versie, én of de applicatie antwoordt |
+| *"is de backup in orde?"* | wanneer de laatste was, en of alles erin zit |
+| *"kan er naar productie?"* | of de vier remmen groen staan |
+| *"waar staan we?"* | de stand van het project, uit `docs/STATUS.md` |
 
-> Naslag: [`onderhoudskalender.md`](onderhoudskalender.md)
-
----
-
-## 8. Als het misgaat
-
-### "GESTOPT — deze database is beschermd"
-
-De rem doet zijn werk: je commando kwam bij productie uit. Lees de regel
-erboven — daar staat de host en de database.
-
-Was dat niet de bedoeling? Dan is er een variabele overschreven in je terminal.
-Sluit hem en begin opnieuw.
-
-Was het wél de bedoeling? Zet `--extern` erachter.
-
-### "Kon image … niet ophalen"
-
-De tag bestaat niet. Kijk ze op:
-
-```powershell
-ssh root@saxombp "docker images | grep mcm2/api"
-```
-
-Meestal is het de lengte: twaalf tekens, niet acht.
-
-### "De server is niet bereikbaar"
-
-saxombp staat thuis achter Tailscale. Controleer:
-
-```powershell
-tailscale status | Select-String saxombp
-```
-
-### De workflow blokkeert op de backup
-
-```powershell
-npm run productie:poort
-```
-
-Die zegt precies welke van de drie remmen afgaat, en wat eraan schort.
-
-### Iets anders
-
-```powershell
-npm run deploy:status
-```
-
-Toont of de omgevingen antwoorden. Doet er één dat niet, kijk dan op de server:
-
-```powershell
-ssh root@saxombp "docker ps -a | grep mcm2"
-```
-
-> Naslag: [`uitrol-acceptatie-en-productie.md`](uitrol-acceptatie-en-productie.md),
-> hoofdstuk "Bij afwijking"
+Er is niets dat je zelf moet opzoeken. Als Claude iets niet weet, gaat hij het
+meten in plaats van het te gokken.
 
 ---
 
-## 9. Wat je nooit doet
+## 5. Wat er vanzelf gebeurt — en waar jij op let
+
+### Elke dag
+
+| Tijd | ⚙️ Wat er draait | 🧑 Jouw rol |
+|---|---|---|
+| 07:00 | backup van de productiedatabase | niets |
+| 07:30 | controle: is de dump er, en zit alles erin? | **het Telegram-bericht lezen** |
+| maandag 07:45 | zware controle: dump echt terugzetten in een testdatabase | idem |
+
+### Bij elke wijziging die gemerged wordt
+
+| ⚙️ Wat er draait | 🧑 Jouw rol |
+|---|---|
+| tests, opmaakcontrole, productiebuild | niets |
+| image publiceren naar het register | niets |
+| migraties naar staging + teruglezen | niets |
+
+**De enige storing die je zelf moet oplossen: Docker Desktop staat uit.** Dan
+falen alle drie de dagelijkse taken. Je merkt het aan het Telegram-bericht.
+
+### Wat jij periodiek doet
+
+| Wanneer | Wat | Hoe |
+|---|---|---|
+| elke week | kijken of het levensteken kwam | je telefoon |
+| elke week | staging wakker houden | 🤖 vraag Claude: *"houd staging wakker"* |
+| elke maand | herstelproef met echte controle | 🤖 vraag Claude erom |
+| elk kwartaal | terugdraaien beproeven | 🤖 vraag Claude erom |
+
+> **Waarom staging wakker houden?** Een gratis Supabase-project pauzeert na
+> zeven dagen zonder activiteit. Gebeurt dat, dan faalt de eerstvolgende uitrol
+> met een verbindingsfout die naar de verkeerde oorzaak wijst.
+
+---
+
+## 6. Beslissingen die alleen jij kunt nemen
+
+Claude vraagt het je; dit is waar het over gaat.
+
+| Vraag | Waarom jij |
+|---|---|
+| "Mag deze pull request gemerged worden?" | het is jouw product |
+| "Zal ik dit naar productie brengen?" | er staan klantgegevens op het spel |
+| "Deze branch is klaar — mergen of parkeren?" | een geparkeerde branch is prima, een vergeten branch niet |
+| "Dit is onomkeerbaar. Doorgaan?" | verwijderen, force-pushen, een database leegmaken |
+| "Ik zie een probleem dat je niet vroeg. Oppakken?" | jij bepaalt de volgorde |
+
+**Bij twijfel: vraag om de gevolgen.** *"Wat gebeurt er als dit fout gaat?"* is
+altijd een goede vraag, en het antwoord hoort concreet te zijn.
+
+---
+
+## 7. Als er iets misgaat
+
+Je hoeft geen foutmeldingen te ontleden. **Kopieer wat je ziet en plak het in de
+chat.** Dat is sneller en betrouwbaarder dan zelf zoeken.
+
+Twee dingen die je wel zelf kunt oplossen:
+
+| Situatie | 🧑 Wat jij doet |
+|---|---|
+| Telegram meldt dat Docker uit staat | Docker Desktop starten, daarna Claude vragen de backup in te halen |
+| Er komt al een week geen enkel bericht | Claude vragen te controleren of de melder nog werkt |
+
+**Wat je nooit hoeft te doen:** een commando verzinnen, een versienummer
+overtypen, of zelf bedenken welke database ergens bij hoort. Vraag het.
+
+---
+
+## 8. Wat er nooit mag gebeuren
+
+Dit staat hier niet omdat jij het zou doen, maar zodat je het herkent als Claude
+het voorstelt — dan is er iets mis.
 
 | Nooit | Waarom |
 |---|---|
-| `.env` committen | staat vol wachtwoorden. Staat in `.gitignore`; laat dat zo |
-| Rechtstreeks op `main` werken | elke wijziging via een branch en een PR |
-| `--no-verify` bij een commit | dan slaan de controles over die je juist beschermen |
-| Force-pushen naar `main` | onherstelbaar voor iedereen |
-| De demo-database markeren als wegwerp | poort 55450. De e2e-tests wissen hem dan leeg — gebeurd op 7 augustus |
-| Een commando verzinnen | staat het niet in `package.json`, dan bestaat het niet |
+| Het bestand `.env` in GitHub | daar staan alle wachtwoorden in |
+| Rechtstreeks werken op `main` | elke wijziging hoort via een pull request |
+| Controles overslaan bij een commit | dan werken de beveiligingen niet die je beschermen |
+| Force-pushen naar `main` | onherstelbaar, voor iedereen |
+| De demo-database wissen | poort 55450. Dat gebeurde op 7 augustus |
+| Een uitrol zonder verse backup | daar zit sinds 11 augustus een rem op |
 
-Alle commando's opvragen:
+---
 
-```powershell
-(Get-Content package.json | ConvertFrom-Json).scripts
-```
+## 9. Achtergrond — alleen als je wilt weten waarom
+
+### Er zijn vier omgevingen
+
+| | Waarvoor | Wie komt eraan |
+|---|---|---|
+| **lokaal** | ontwikkelen | Claude, op je laptop |
+| **acceptatie** | uitproberen, zelf inloggen | jij, via `saxombp:3010` |
+| **staging** | repetitie vóór productie | niemand — dit is een generale |
+| **productie** | echte klanten | de klant |
+
+**Waarom staging bestaat:** productie draait bij Amazon in Ierland, achter een
+verbindingslaag die zich anders gedraagt dan een database op je eigen machine.
+Staging draait op precies diezelfde opzet. Een migratie die dáár slaagt, slaagt
+in productie — dat is het hele punt.
+
+### Waarom er remmen op productie zitten
+
+Drie keer ging er iets mis doordat een commando op de verkeerde database
+uitkwam: op 4, 7 en 10 augustus. De oorzaak was steeds hetzelfde — de laptop
+wees standaard naar de echte klantendatabase.
+
+Sinds 11 augustus wijst hij naar staging. En vóór een uitrol naar productie
+staan vier remmen:
+
+1. is er een verse, gecontroleerde backup?
+2. is deze versie op staging beproefd?
+3. loopt productie niet vóór op wat we uitrollen?
+4. **heb jij akkoord gegeven?**
+
+De eerste drie kan een computer vaststellen. De vierde bewust niet.
+
+### Waarom "het is gelukt" niet genoeg is
+
+Dit project heeft drie keer een geruststellende melding gehad over iets dat niet
+gebeurd was. *"Migraties voltooid"* terwijl er niets gebeurde. *"Backup
+compleet"* terwijl de helft ontbrak. *"Mail verstuurd"* terwijl er geen mail was.
+
+Daarom leest alles wat nu draait het resultaat terug uit de database in plaats
+van de melding te geloven. Merk je dat Claude iets meldt zonder het te hebben
+gecontroleerd, dan mag je daarnaar vragen.
 
 ---
 
 ## 10. Waar de rest staat
 
+Deze handleiding gaat over wat jij doet. De techniek erachter staat elders:
+
 | Zoek je | Kijk in |
 |---|---|
-| welk commando bestaat en waar het heen praat | [`commandos-en-omgeving.md`](commandos-en-omgeving.md) |
-| uitrollen, terugdraaien, inloggen op een omgeving | [`uitrol-acceptatie-en-productie.md`](uitrol-acceptatie-en-productie.md) |
-| backups: hoe ze werken, wat te doen bij een melding | [`backupcontrole.md`](backupcontrole.md) |
+| welke commando's er bestaan en wat ze raken | [`commandos-en-omgeving.md`](commandos-en-omgeving.md) |
+| de uitrolprocedure in detail | [`uitrol-acceptatie-en-productie.md`](uitrol-acceptatie-en-productie.md) |
+| hoe de backups werken | [`backupcontrole.md`](backupcontrole.md) |
 | wat er wanneer terugkeert | [`onderhoudskalender.md`](onderhoudskalender.md) |
-| zelf iets testen zonder de hele doorloop | [`zelf-testen.md`](zelf-testen.md) |
-| waar het project nu staat | [`../STATUS.md`](../STATUS.md) |
+| waar het project staat | [`../STATUS.md`](../STATUS.md) |
 | waarom de straat zo is opgezet | [`../architectuur/plan-otap-straat-met-staging.md`](../architectuur/plan-otap-straat-met-staging.md) |
 
 **Alle runbooks:** [`README.md`](README.md)

--- a/docs/runbooks/devops-handleiding.md
+++ b/docs/runbooks/devops-handleiding.md
@@ -1,0 +1,362 @@
+# DevOps-handleiding — MCM2
+
+**Type:** D — routineoperaties
+**Eigenaar:** de eigenaar (Chris)
+**Laatste update:** 2026-08-11
+**Vereiste toegang:** GitHub (AlingAdvies/MCM2), Tailscale (saxombp), Supabase
+
+Dit document is geschreven vanuit **wat je wilt doen**, niet vanuit hoe het
+werkt. Zoek je de techniek erachter, dan staat onder elk stuk een verwijzing.
+
+De rest van de runbooks is naslag; dit is het startpunt.
+
+---
+
+## 1. Waar draait wat
+
+| Omgeving | Waarvoor | Applicatie | Database |
+|---|---|---|---|
+| **lokaal** | ontwikkelen | je laptop | wegwerpcontainer die je zelf opzet |
+| **acceptatie** | uitproberen, inloggen | saxombp `:5011` / `:3010` | container op saxombp |
+| **staging** | repetitie vóór productie | saxombp `:5031` / `:3030` | Supabase `clm-staging3` |
+| **productie** | echte klanten | saxombp `:5021` | Supabase `clm-enterprise` |
+
+**Waarom staging bij Supabase staat en niet op saxombp:** productie draait
+Postgres bij AWS in Ierland achter een connection pooler. Een repetitie in een
+lokale container bewijst het verkeerde — de pooler is precies de plek waar het
+anders gaat.
+
+> **Let op — twee dingen heten "productie".** Op saxombp draait `mcm2-productie`
+> op poort 5021 met een *eigen lokale* database. Dat is procesbewijs, niet de
+> echte productie. De echte klantgegevens staan bij Supabase. Dat verschil wordt
+> opgeheven in stap 6 van het OTAP-plan.
+
+---
+
+## 2. Het belangrijkste dat je moet weten
+
+**Je laptop wijst standaard naar STAGING.** Sinds 2026-08-11.
+
+Typ je een databasecommando zonder er zelf een adres bij te geven, dan komt het
+op de oefendatabase uit. Daar kan niets kapot.
+
+**Wil je bij productie, dan moet je twee keer bewust kiezen:**
+
+1. het adres meegeven (`NOOD_PRODUCTIE_URL` uit `.env`)
+2. én `--extern` erbij typen
+
+Doe je maar één van beide, dan stopt het commando met een melding die zegt wat
+er aan de hand is.
+
+**Waarom dit telt:** vóór 11 augustus wees je laptop naar productie. Elk
+commando raakte dus de echte klantgegevens — niet omdat je dat koos, maar omdat
+het de standaard was. Dat is de oorzaak onder de drie incidenten van 4, 7 en 10
+augustus.
+
+> Naslag: `.env.example`, en §3.5 van
+> [`plan-otap-straat-met-staging.md`](../architectuur/plan-otap-straat-met-staging.md)
+
+---
+
+## 3. "Ik heb iets veranderd en wil het uitrollen"
+
+### Stap 1 — Zorg dat het klopt
+
+```powershell
+npm run verify:volledig
+```
+
+Dit is **het** bewijs: zeven stappen, van opmaakcontrole tot een browser die
+een leverancier aanmaakt en terugziet. Duurt een paar minuten.
+
+> Losse commando's als `npm test` bewijzen niets over het geheel. Gebruik nooit
+> `npm run lint` of `npm run format` om "groen" vast te stellen — die
+> *wijzigen* bestanden. CI draait `lint:check` en `format:check`.
+
+### Stap 2 — Branch, commit, pull request
+
+Nooit rechtstreeks op `main` werken.
+
+```powershell
+git checkout -b feat/waar-het-over-gaat
+# ... wijzigen ...
+git add -A
+git commit -m "feat(scope): wat er verandert"
+git push -u origin feat/waar-het-over-gaat
+```
+
+Daarna een pull request openen op GitHub, en wachten tot de drie controles
+groen zijn.
+
+### Stap 3 — Mergen
+
+Als de PR groen is: **Merge**, en verwijder de branch.
+
+Wat er dan vanzelf gebeurt:
+
+```
+merge op main
+  → CI: opmaak, tests, build
+  → image naar GHCR (met een SHA-tag)
+  → migraties naar staging
+  → teruglezen of ze er echt staan
+```
+
+### Stap 4 — Staging bijwerken (één commando)
+
+CI zet de migraties klaar, maar start de applicatie niet. Dat doe jij:
+
+```powershell
+npm run deploy:staging -- --versie sha-<twaalf tekens>
+```
+
+De juiste tag staat in de samenvatting van de CI-run.
+
+> **De tag is twaalf tekens.** `sha-ffd27dc9` bestaat niet, `sha-ffd27dc9472f`
+> wel. Dat ging twee keer mis; beide keren hield de rem het tegen met
+> *"Er is niets gewijzigd"*.
+
+### Stap 5 — Naar productie
+
+Zie hoofdstuk 4 hieronder. Dat is een apart verhaal, met remmen.
+
+> Naslag: [`uitrol-acceptatie-en-productie.md`](uitrol-acceptatie-en-productie.md)
+
+---
+
+## 4. "Ik wil naar productie"
+
+### Vooraf: is de backup bij?
+
+De uitrol weigert als de backupcontrole ouder is dan 36 uur.
+
+Meestal hoef je niets te doen — de geplande taken draaien elke ochtend om 07:00
+en 07:30. **Maar je moet het bewijs wél committen:**
+
+```powershell
+git add docs/runbooks/backup-bewijs.json
+git commit -m "chore(backup): bewijs van vandaag"
+git push
+```
+
+Controleren of alles klaarstaat:
+
+```powershell
+npm run productie:poort
+```
+
+### De uitrol starten
+
+1. GitHub → tabblad **Actions**
+2. Links: **Uitrol naar productie**
+3. Knop **Run workflow**
+4. Invullen:
+
+| Veld | Wat |
+|---|---|
+| `versie` | de backend-tag, bijv. `sha-e8e462d6eec8`. Leeg = laatste van main |
+| `frontend_versie` | de frontend-tag. Leeg = `latest` |
+| `reden` | **verplicht** — waarom rol je uit? |
+
+### Wat er dan gebeurt
+
+```
+→ poort: backup vers? staging op stand? productie niet vóór?
+→ JOUW AKKOORD                              ← de run staat stil
+→ poort opnieuw (er kan tijd overheen zijn)
+→ migraties + teruglezen + rechtencontrole
+────────────────────────────────────────────
+→ npm run deploy:productie -- --versie …    ← jij, met de hand
+```
+
+Bij het akkoord: gele balk bovenaan de runpagina → **Review deployments** →
+`productie` aanvinken → **Approve and deploy**.
+
+Onderaan de runpagina verschijnt de samenvatting, mét het startcommando en de
+weg terug.
+
+### De vier remmen
+
+| Rem | Wat hem tegenhoudt |
+|---|---|
+| Backup vooraf | geen bewijs, ouder dan 36 uur, of de controle meldde problemen |
+| Staging beproefd | staging staat niet op de stand van de repository |
+| Productie niet vóór | productie telt méér migraties dan de repository |
+| Jouw akkoord | jij drukt niet |
+
+**Blokkeert er een? Dan is er niets stuk.** De melding zegt erbij wat eraan
+schort.
+
+---
+
+## 5. "Er is iets misgegaan, ik wil terug"
+
+Terugdraaien is **geen apart commando**. Het is dezelfde uitrol met de vorige
+tag:
+
+```powershell
+npm run deploy:status                                   # wat draait er nu?
+npm run deploy:productie -- --versie sha-<vorige> --frontend-versie sha-<vorige>
+```
+
+Die regel hoef je niet zelf te bedenken — elke geslaagde uitrol drukt hem af:
+
+```
+  vorige versie was sha-5428bb954884 met frontend sha-635ff21150bd
+  terugdraaien:  npm run deploy:acceptatie -- --versie sha-5428bb954884 --frontend-versie sha-635ff21150bd
+```
+
+> **Er is géén `npm run rollback:…`.** Dat commando bestaat niet en heeft nooit
+> bestaan.
+
+**Let op bij migraties.** Terugdraaien zet de *applicatie* terug, niet het
+*databaseschema*. Dat gaat goed zolang migraties alleen toevoegen (kolommen
+erbij). Is er iets verwijderd, dan is de backup terugzetten de weg — niet de
+rollback.
+
+> Naslag: [`uitrol-acceptatie-en-productie.md`](uitrol-acceptatie-en-productie.md),
+> hoofdstuk "Terugdraaien"
+
+---
+
+## 6. "Ik wil weten hoe het ervoor staat"
+
+```powershell
+npm run deploy:status        # welke versie draait waar, en antwoordt het?
+npm run productie:poort      # zijn de remmen groen?
+npm run backup:controle      # is de backup er, en zit alles erin?
+```
+
+`deploy:status` is de nuttigste: hij toont per omgeving de containers, de
+image-tag, én of de applicatie antwoordt. Dat laatste is het punt — een
+draaiende container is geen werkende app.
+
+---
+
+## 7. Terugkerende taken
+
+### Draait vanzelf
+
+| Wanneer | Wat | Jouw rol |
+|---|---|---|
+| dagelijks 07:00 | backup van productie | niets |
+| dagelijks 07:30 | backupcontrole (laag A + B) | de melding lezen |
+| maandag 07:45 | backupcontrole volledig (+ echte restore) | de melding lezen |
+| elke merge op main | tests, image, migraties naar staging | niets |
+
+**Draait Docker Desktop niet, dan falen ze allemaal.** Dat is de meest
+voorkomende storing: elke herstart zonder handmatige start levert een dag zonder
+backup op.
+
+Een gemiste dag inhalen:
+
+```powershell
+& "C:\DEV\Work\MCM2\scripts\backup-taak.cmd"   # niet: npm run backup:dump
+npm run backup:controle
+```
+
+> Gebruik het `.cmd`. `BACKUP_DIR` staat alleen daarin; los gedraaid schrijft
+> het npm-script naar de projectmap en ziet de controle de dump niet.
+
+### Moet je zelf doen
+
+| Ritme | Wat |
+|---|---|
+| wekelijks | levensteken opgemerkt? Blijft het uit, dan is de melder zelf stuk |
+| wekelijks | staging wakker houden — een gratis Supabase-project pauzeert na 7 dagen |
+| maandelijks | restore-hertest met verificatie van de inhoud |
+| maandelijks | `npm audit` nalopen |
+| per kwartaal | rollback beproeven op acceptatie |
+| vóór productie-uitrol | `backup-bewijs.json` committen |
+
+> Naslag: [`onderhoudskalender.md`](onderhoudskalender.md)
+
+---
+
+## 8. Als het misgaat
+
+### "GESTOPT — deze database is beschermd"
+
+De rem doet zijn werk: je commando kwam bij productie uit. Lees de regel
+erboven — daar staat de host en de database.
+
+Was dat niet de bedoeling? Dan is er een variabele overschreven in je terminal.
+Sluit hem en begin opnieuw.
+
+Was het wél de bedoeling? Zet `--extern` erachter.
+
+### "Kon image … niet ophalen"
+
+De tag bestaat niet. Kijk ze op:
+
+```powershell
+ssh root@saxombp "docker images | grep mcm2/api"
+```
+
+Meestal is het de lengte: twaalf tekens, niet acht.
+
+### "De server is niet bereikbaar"
+
+saxombp staat thuis achter Tailscale. Controleer:
+
+```powershell
+tailscale status | Select-String saxombp
+```
+
+### De workflow blokkeert op de backup
+
+```powershell
+npm run productie:poort
+```
+
+Die zegt precies welke van de drie remmen afgaat, en wat eraan schort.
+
+### Iets anders
+
+```powershell
+npm run deploy:status
+```
+
+Toont of de omgevingen antwoorden. Doet er één dat niet, kijk dan op de server:
+
+```powershell
+ssh root@saxombp "docker ps -a | grep mcm2"
+```
+
+> Naslag: [`uitrol-acceptatie-en-productie.md`](uitrol-acceptatie-en-productie.md),
+> hoofdstuk "Bij afwijking"
+
+---
+
+## 9. Wat je nooit doet
+
+| Nooit | Waarom |
+|---|---|
+| `.env` committen | staat vol wachtwoorden. Staat in `.gitignore`; laat dat zo |
+| Rechtstreeks op `main` werken | elke wijziging via een branch en een PR |
+| `--no-verify` bij een commit | dan slaan de controles over die je juist beschermen |
+| Force-pushen naar `main` | onherstelbaar voor iedereen |
+| De demo-database markeren als wegwerp | poort 55450. De e2e-tests wissen hem dan leeg — gebeurd op 7 augustus |
+| Een commando verzinnen | staat het niet in `package.json`, dan bestaat het niet |
+
+Alle commando's opvragen:
+
+```powershell
+(Get-Content package.json | ConvertFrom-Json).scripts
+```
+
+---
+
+## 10. Waar de rest staat
+
+| Zoek je | Kijk in |
+|---|---|
+| welk commando bestaat en waar het heen praat | [`commandos-en-omgeving.md`](commandos-en-omgeving.md) |
+| uitrollen, terugdraaien, inloggen op een omgeving | [`uitrol-acceptatie-en-productie.md`](uitrol-acceptatie-en-productie.md) |
+| backups: hoe ze werken, wat te doen bij een melding | [`backupcontrole.md`](backupcontrole.md) |
+| wat er wanneer terugkeert | [`onderhoudskalender.md`](onderhoudskalender.md) |
+| zelf iets testen zonder de hele doorloop | [`zelf-testen.md`](zelf-testen.md) |
+| waar het project nu staat | [`../STATUS.md`](../STATUS.md) |
+| waarom de straat zo is opgezet | [`../architectuur/plan-otap-straat-met-staging.md`](../architectuur/plan-otap-straat-met-staging.md) |
+
+**Alle runbooks:** [`README.md`](README.md)

--- a/scripts/db-doelwit.js
+++ b/scripts/db-doelwit.js
@@ -148,6 +148,157 @@ function eisToestemmingBuitenLokaal(url, { wat, vlag = '--extern' }) {
 }
 
 /**
+ * Weigert door te gaan tegen een database die zichzelf `beschermd` noemt.
+ *
+ * ── Waarom dit `eisToestemmingBuitenLokaal` vervangt (stap 5, 2026-08-11) ───
+ *
+ * Die oude rem kende maar twee soorten: 'localhost' en 'de rest'. Dat werkte
+ * zolang `.env` naar productie wees — alles buiten deze machine was dan per
+ * definitie gevaarlijk.
+ *
+ * Sinds stap 5 wijst `.env` naar **staging**, en staging staat óók bij Supabase.
+ * De oude rem zou dus bij élk stagingcommando afgaan. Dan typ je `--extern`
+ * erbij omdat er anders niets werkt, na twee weken is het een gewoonte, en dan
+ * typ je hem ook op de dag dat je per ongeluk naar productie wijst.
+ *
+ * **Een waarschuwing die altijd afgaat, is geen waarschuwing meer.** Dat is
+ * dezelfde les als bij de backupmelding die niemand las (2026-08-04).
+ *
+ * Deze rem vraagt daarom aan de database zelf wat hij is. `clm.omgeving`
+ * (migratie 0019) zegt `wegwerp` of `beschermd`, en die markering zit ín de
+ * database — niet in een hostnaam, poortnummer of variabele die ernaast staat
+ * en niet meer klopt zodra iets verhuist.
+ *
+ * Gevolg: de vlag gaat alleen nog af bij een beschermde database. Precies waar
+ * hij voor bedoeld is, en dus houdt hij zijn betekenis.
+ *
+ * ── Waarom `beschermd` de standaard blijft ─────────────────────────────────
+ *
+ * Een database die zich niet meldt, of waarvan `clm.omgeving` niet te lezen is,
+ * wordt behandeld als productie. Andersom zou juist de database die niemand
+ * heeft ingericht — de nieuwe, de vergetene — vogelvrij zijn.
+ *
+ * ── De naam is bewust veranderd ────────────────────────────────────────────
+ *
+ * Deze functie is `async`, de oude was synchroon. Zou hij hetzelfde heten, dan
+ * blijft `if (!eisToestemmingBuitenLokaal(url, …))` compileren én draaien — met
+ * een Promise als uitkomst, en die is altijd waarheidsachtig. De rem zou dan
+ * stilzwijgend nooit meer afgaan: een beveiliging die verdwijnt zonder één
+ * foutmelding.
+ *
+ * Met een nieuwe naam faalt een vergeten aanroeper meteen en zichtbaar.
+ *
+ * @param {string} url
+ * @param {{ wat: string, vlag?: string }} opties
+ * @returns {Promise<boolean>} false wanneer het script moet stoppen.
+ */
+async function eisOnbeschermdeDatabase(url, { wat, vlag = '--extern' }) {
+  const d = ontleed(url);
+
+  if (!d.leesbaar) {
+    console.error(
+      `\n${wat} kan niet doorgaan: de database-URL is ${d.beschrijving}.\n` +
+        'Controleer de betreffende variabele in .env.\n',
+    );
+    process.exitCode = 1;
+    return false;
+  }
+
+  const { soort, reden } = await leesOmgevingssoort(url);
+
+  if (soort === 'wegwerp') return true;
+
+  // ── Een verse lokale database mag door ────────────────────────────────────
+  //
+  // `clm.omgeving` ontstaat pas bij migratie 0019. Een lege container die je
+  // net hebt opgezet heeft die tabel dus nog niet, en zou zonder deze
+  // uitzondering blokkeren op precies het commando dat hem moet vullen —
+  // `migrate.js`. Dan geef je `--extern` mee bij elke nieuwe wegwerpcontainer,
+  // en juist die gewoonte wil stap 5 voorkomen.
+  //
+  // Het geldt alleen op deze machine. Een NIET-lokale database zonder
+  // markering blijft geblokkeerd: dat kan een kopie van productie zijn van
+  // vóór 0019, en dan hoort de bescherming te zwijgen noch door te laten.
+  //
+  // Gevonden bij het beproeven op 2026-08-11: `verify:volledig` en CI zetten
+  // allebei een verse container op, en die zouden hierop zijn vastgelopen.
+  if (d.lokaal && soort === null) {
+    console.log(
+      `${d.beschrijving} is nog niet gemarkeerd (${reden}), maar staat lokaal. Doorgaan.\n`,
+    );
+    return true;
+  }
+
+  // De uitweg staat ná de controle, zodat er altijd in de uitvoer staat wát er
+  // is overruled — ook als iemand de vlag gewoontegetrouw meegeeft.
+  const toegestaan =
+    process.argv.includes(vlag) || process.env.MCM2_EXTERNE_DB === 'ja';
+
+  const status = soort ? `gemarkeerd als '${soort}'` : `niet leesbaar (${reden})`;
+
+  if (toegestaan) {
+    console.log(
+      `LET OP: ${d.beschrijving} is ${status}, maar ${vlag} is meegegeven. Doorgaan.\n`,
+    );
+    return true;
+  }
+
+  console.error(
+    `\n${wat} GESTOPT — deze database is beschermd.\n\n` +
+      `  Doel:   ${d.beschrijving} (rol '${d.rol}')\n` +
+      `  Status: ${status}\n\n` +
+      'Sinds stap 5 wijst .env naar STAGING. Komt dit commando toch bij een\n' +
+      'beschermde database uit, dan is er een variabele overschreven of staat\n' +
+      'er een ander adres in .env dan je denkt.\n\n' +
+      'Kijk waar het heen gaat — de regel hierboven noemt host en database.\n\n' +
+      `Is het wél de bedoeling, geef dan ${vlag} mee:\n` +
+      `  npm run <script> -- ${vlag}\n`,
+  );
+  process.exitCode = 1;
+  return false;
+}
+
+/**
+ * Leest `clm.omgeving`. Eén plek, zodat beide remmen hetzelfde vaststellen.
+ */
+async function leesOmgevingssoort(url) {
+  // Bewust hier vereist: db-doelwit.js wordt ook geladen door scripts die geen
+  // databaseverbinding maken.
+  const { Client } = require('pg');
+  const client = new Client({
+    connectionString: url,
+    // Supabase en RDS eisen TLS; de pooler biedt een certificaat aan dat niet
+    // in de standaardketen van Node zit. Zonder dit faalt élke controle tegen
+    // staging met een verbindingsfout, en dan lijkt de database beschermd
+    // terwijl hij alleen onbereikbaar is.
+    ssl: /supabase|amazonaws|neon/.test(url)
+      ? { rejectUnauthorized: false }
+      : undefined,
+    connectionTimeoutMillis: 30_000,
+  });
+
+  try {
+    await client.connect();
+    const { rows } = await client.query(
+      'SELECT soort FROM clm.omgeving LIMIT 1',
+    );
+    const soort = rows[0]?.soort ?? null;
+    return { soort, reden: soort ? null : 'clm.omgeving is leeg' };
+  } catch (err) {
+    const melding = err.message ?? String(err);
+
+    return {
+      soort: null,
+      reden: /relation .*omgeving.* does not exist/i.test(melding)
+        ? 'clm.omgeving bestaat niet — migratie 0019 is niet toegepast'
+        : `verbinden mislukte: ${melding}`,
+    };
+  } finally {
+    await client.end().catch(() => {});
+  }
+}
+
+/**
  * Weigert door te gaan tegen een database die niet als wegwerp is gemarkeerd.
  *
  * Voor scripts die gegevens verwijderen of overschrijven. Niet voor scripts die
@@ -174,29 +325,10 @@ function eisToestemmingBuitenLokaal(url, { wat, vlag = '--extern' }) {
 async function eisWegwerpdatabase(url, { wat, vlag = '--ook-beschermd' }) {
   const d = ontleed(url);
 
-  // Bewust hier vereist en niet bovenaan het bestand: db-doelwit.js wordt ook
-  // geladen door scripts die geen databaseverbinding maken, en die hoeven pg
-  // niet te laden.
-  const { Client } = require('pg');
-  const client = new Client({ connectionString: url });
-
-  let soort = null;
-  let reden = null;
-
-  try {
-    await client.connect();
-    const { rows } = await client.query('SELECT soort FROM clm.omgeving LIMIT 1');
-    soort = rows[0]?.soort ?? null;
-    if (!soort) reden = 'clm.omgeving is leeg';
-  } catch (err) {
-    const melding = err.message ?? String(err);
-
-    reden = /relation .*omgeving.* does not exist/i.test(melding)
-      ? 'clm.omgeving bestaat niet — migratie 0019 is niet toegepast'
-      : `verbinden mislukte: ${melding}`;
-  } finally {
-    await client.end().catch(() => {});
-  }
+  // Dezelfde leesfunctie als `eisOnbeschermdeDatabase`. Twee kopieën zouden
+  // kunnen gaan afwijken in wat ze als "onleesbaar" behandelen, en dan
+  // beschermen de twee remmen tegen verschillende dingen.
+  const { soort, reden } = await leesOmgevingssoort(url);
 
   if (soort === 'wegwerp') return true;
 
@@ -234,6 +366,13 @@ async function eisWegwerpdatabase(url, { wat, vlag = '--ook-beschermd' }) {
 module.exports = {
   ontleed,
   meldDoelwit,
+  leesOmgevingssoort,
+  // De rem sinds stap 5: vraagt de database wat hij is.
+  eisOnbeschermdeDatabase,
+  // De oude rem, op hostnaam. Blijft bestaan omdat hij synchroon is en dus
+  // bruikbaar op een plek waar geen databaseverbinding gemaakt kan worden.
+  // Gebruik hem niet voor nieuwe scripts: hij kan staging niet van productie
+  // onderscheiden, want beide staan bij Supabase.
   eisToestemmingBuitenLokaal,
   eisWegwerpdatabase,
 };

--- a/scripts/markeer-wegwerp.js
+++ b/scripts/markeer-wegwerp.js
@@ -35,6 +35,19 @@ if (!url) {
 
 meldDoelwit(url, 'Markeren als wegwerp');
 
+// Bewust de OUDE rem, op hostnaam — dit is het enige script dat hem nog
+// gebruikt (stap 5, 2026-08-11).
+//
+// De nieuwe rem `eisOnbeschermdeDatabase()` vraagt de database wat hij is en
+// weigert bij 'beschermd'. Dat is hier onbruikbaar: dit script dráái je juist
+// tegen een database die nog beschermd is — dat is wat het omzet. Zou hij die
+// rem gebruiken, dan blokkeerde hij altijd, en zou je bij elke verse
+// wegwerpcontainer `--extern` moeten meegeven. Precies de gewenning die stap 5
+// wil voorkomen.
+//
+// De hostcontrole doet hier wél wat hij moet: een database bij Supabase als
+// wegwerp markeren is bijna altijd een vergissing, en anders hoort het
+// zichtbaar te zijn.
 if (!eisToestemmingBuitenLokaal(url, { wat: 'Markeren als wegwerp' })) {
   process.exit(1);
 }

--- a/scripts/migrate.js
+++ b/scripts/migrate.js
@@ -33,7 +33,7 @@ const { drizzle } = require('drizzle-orm/node-postgres');
 const { migrate } = require('drizzle-orm/node-postgres/migrator');
 const { Pool } = require('pg');
 
-const { meldDoelwit, eisToestemmingBuitenLokaal } = require('./db-doelwit.js');
+const { meldDoelwit, eisOnbeschermdeDatabase } = require('./db-doelwit.js');
 
 const url = process.env.MIGRATION_DATABASE_URL;
 
@@ -49,11 +49,14 @@ if (!url) {
 // alleen de rolnaam — die lokaal precies zo heet.
 meldDoelwit(url, 'Migraties');
 
-if (!eisToestemmingBuitenLokaal(url, { wat: 'Migraties' })) {
-  process.exit(1);
-}
-
 async function main() {
+  // De rem staat binnen main() en niet erboven, want hij vraagt de database
+  // zélf wat hij is (stap 5) en dat is een asynchrone leesquery. Vóór de
+  // migratiepool, zodat er nog niets gebeurd is als hij weigert.
+  if (!(await eisOnbeschermdeDatabase(url, { wat: 'Migraties' }))) {
+    process.exit(1);
+  }
+
   const pool = new Pool({ connectionString: url });
 
   try {

--- a/scripts/platformbeheerder-inrichten.js
+++ b/scripts/platformbeheerder-inrichten.js
@@ -42,7 +42,7 @@ const { createServer } = require('node:http');
 const { createHash, randomBytes } = require('node:crypto');
 const { Client } = require('pg');
 
-const { meldDoelwit, eisToestemmingBuitenLokaal } = require('./db-doelwit.js');
+const { meldDoelwit, eisOnbeschermdeDatabase } = require('./db-doelwit.js');
 
 /**
  * De thuistenant van het platformbeheer.
@@ -70,10 +70,6 @@ if (!url) {
 
 meldDoelwit(url, 'Platformbeheerder inrichten');
 
-if (!eisToestemmingBuitenLokaal(url, { wat: 'Platformbeheerder inrichten' })) {
-  process.exit(1);
-}
-
 const VERPLICHT = [
   'OIDC_ISSUER',
   'OIDC_TOKEN_ENDPOINT',
@@ -94,6 +90,15 @@ function melding(regel) {
 }
 
 async function main() {
+  // De rem staat binnen main() sinds stap 5: hij vraagt de database zelf of hij
+  // beschermd is, en dat is een asynchrone leesquery. Vóór de inlogserver
+  // start, zodat je niet eerst inlogt om daarna te horen dat het niet mag.
+  if (
+    !(await eisOnbeschermdeDatabase(url, { wat: 'Platformbeheerder inrichten' }))
+  ) {
+    process.exit(1);
+  }
+
   const redirect = new URL(process.env.OIDC_REDIRECT_URI);
   const verifier = randomBytes(32).toString('base64url');
   const challenge = createHash('sha256')

--- a/scripts/seed-demo-tenant.js
+++ b/scripts/seed-demo-tenant.js
@@ -42,7 +42,7 @@ const { Pool } = require('pg');
 
 const {
   meldDoelwit,
-  eisToestemmingBuitenLokaal,
+  eisOnbeschermdeDatabase,
   eisWegwerpdatabase,
 } = require('./db-doelwit.js');
 
@@ -451,9 +451,9 @@ function vragenlijstenLaden() {
 
   // De doelwitvlaggen doorgeven aan het subproces.
   //
-  // `seed-vragenlijsten.js` heeft zijn eigen `eisToestemmingBuitenLokaal()` en
+  // `seed-vragenlijsten.js` heeft zijn eigen `eisOnbeschermdeDatabase()` en
   // kijkt daarvoor naar zijn éígen argv — niet naar die van de aanroeper.
-  // Zonder deze regel stopt het bij een niet-lokaal doelwit terwijl het
+  // Zonder deze regel stopt het bij een beschermde database terwijl het
   // hoofdscript al toestemming heeft gekregen, en dan staan de leveranciers er
   // wél en de vragenlijsten niet.
   //
@@ -1025,7 +1025,9 @@ async function main() {
   // zonder backup (Issue #86).
   meldDoelwit(url, 'Seed demo-tenant');
 
-  if (!eisToestemmingBuitenLokaal(url, { wat: 'Seed demo-tenant' })) {
+  // Sinds stap 5 vraagt de rem de database zelf of hij beschermd is (zie
+  // db-doelwit.js). Staging is `wegwerp` en mag dus zonder vlag.
+  if (!(await eisOnbeschermdeDatabase(url, { wat: 'Seed demo-tenant' }))) {
     process.exit(1);
   }
 

--- a/scripts/seed-vragenlijsten.js
+++ b/scripts/seed-vragenlijsten.js
@@ -24,7 +24,7 @@ const { sql } = require('drizzle-orm');
 const { drizzle } = require('drizzle-orm/node-postgres');
 const { Pool } = require('pg');
 
-const { meldDoelwit, eisToestemmingBuitenLokaal } = require('./db-doelwit.js');
+const { meldDoelwit, eisOnbeschermdeDatabase } = require('./db-doelwit.js');
 
 const SEEDMAP = path.join(__dirname, '..', 'db', 'seeds');
 
@@ -186,7 +186,10 @@ async function main() {
   // dus productiedata raken (Issue #86).
   meldDoelwit(url, 'Seed vragenlijsten');
 
-  if (!eisToestemmingBuitenLokaal(url, { wat: 'Seed vragenlijsten' })) {
+  // Sinds stap 5 vraagt de rem de database zelf of hij beschermd is, in plaats
+  // van naar de hostnaam te kijken. Staging is `wegwerp` en mag dus zonder
+  // vlag; alleen productie eist `--extern`.
+  if (!(await eisOnbeschermdeDatabase(url, { wat: 'Seed vragenlijsten' }))) {
     process.exit(1);
   }
 

--- a/scripts/verify-volledig.js
+++ b/scripts/verify-volledig.js
@@ -412,6 +412,34 @@ function bouwDatabaseOp() {
 
   console.log('  Migraties toegepast op een lege database.');
 
+  // Markeren als wegwerp, net als bij de verify-container hierboven.
+  //
+  // ── Waarom dit sinds stap 5 (2026-08-11) nodig is ─────────────────────────
+  //
+  // De migratie hierboven ging door omdat een verse database nog geen
+  // `clm.omgeving` heeft en lokaal staat — dat is de uitzondering in
+  // `eisOnbeschermdeDatabase()`. Maar migratie 0019 zet hem daarna op
+  // `beschermd`, en dus weigerde `seed-vragenlijsten.js` een stap later met
+  // "deze database is beschermd".
+  //
+  // Gevonden door de doorloop te draaien, niet door hem te beredeneren: de
+  // stack op 55500 werd nergens gemarkeerd, terwijl die op 55441 dat wél werd.
+  const markering = draai(
+    'node',
+    ['scripts/markeer-wegwerp.js', 'verify:volledig — doorloopstack'],
+    {
+      stil: true,
+      env: {
+        MIGRATION_DATABASE_URL:
+          'postgresql://clm_migrator:otap_pw@localhost:55500/postgres',
+      },
+    },
+  );
+
+  if (!markering.ok) {
+    return { ok: false, reden: markering.uitvoer.trim() };
+  }
+
   // Zie de uitleg hierboven: zonder deze herstart blijft de API onbereikbaar.
   draai('docker', [...COMPOSE, 'restart', 'api'], { stil: true });
 


### PR DESCRIPTION
Stap 5 van [`plan-otap-straat-met-staging.md`](docs/architectuur/plan-otap-straat-met-staging.md) — **de grootste veiligheidswinst van het plan.**

De laptop wees standaard naar de productiedatabase. Elk databasecommando raakte dus de echte klantgegevens — niet omdat iemand dat koos, maar omdat het de standaard was. Dat is de gemeenschappelijke oorzaak onder 04-08, 07-08 en 10-08.

## Wat er in `.env` verandert

| Variabele | Wijst nu naar | Waarom |
|---|---|---|
| `DATABASE_URL` | **staging** | het nieuwe standaarddoelwit |
| `MIGRATION_DATABASE_URL` | **staging** | idem |
| `BACKUP_DATABASE_URL` | productie | **bewust** — een backup van de oefendatabase beschermt niets |
| `NOOD_PRODUCTIE_URL` | productie | nieuw; **geen enkel script leest deze naam** |

De bescherming van die laatste zit niet in "onvindbaar" maar in "geen enkel script pakt het automatisch op". `dotenv` laadt hem wel, niets vraagt ernaar — je moet hem bewust doorgeven, én `--extern` meegeven omdat productie `beschermd` is. Twee keer bewust kiezen.

> `scripts/with-migration-url.js` bleek ongeschikt voor de noodweg die §3.5 voorzag: dat kopieert `MIGRATION_DATABASE_URL` naar `DATABASE_URL` en maakt het doelwit dus juist **niet** expliciet.

## De rem moest mee, en dat was het echte werk

`eisToestemmingBuitenLokaal()` kende twee soorten: `localhost` en de rest. Dat werkte zolang `.env` naar productie wees. Maar **staging staat óók bij Supabase**, dus die rem zou bij élk stagingcommando afgaan. Dan typ je `--extern` erbij omdat er anders niets werkt, na twee weken is het een gewoonte, en dan typ je hem ook op de dag dat je per ongeluk naar productie wijst.

**Een waarschuwing die altijd afgaat, is geen waarschuwing meer** — dezelfde les als bij de backupmelding die niemand las (2026-08-04).

`eisOnbeschermdeDatabase()` vraagt daarom de database zélf wat hij is (`clm.omgeving`, migratie 0019). Die markering zit ín de database, niet in een hostnaam die ernaast staat en niet meer klopt zodra iets verhuist.

**De naam is bewust veranderd.** De nieuwe functie is `async`, de oude synchroon. Zouden ze hetzelfde heten, dan blijft `if (!eis…(url, …))` gewoon draaien — met een Promise als uitkomst, en die is altijd waarheidsachtig. De rem zou dan stilzwijgend nooit meer afgaan: een beveiliging die verdwijnt zonder één foutmelding.

`markeer-wegwerp.js` houdt bewust de oude rem: dat script draait per definitie tegen een database die nog `beschermd` is — dat is wat het omzet.

## Twee dingen die alleen het draaien opleverde

1. **Een verse container blokkeerde.** `clm.omgeving` ontstaat pas bij migratie 0019, dus een lege database weigerde op precies het commando dat hem moet vullen. Opgelost met een uitzondering die **alleen lokaal** geldt — niet-lokaal zonder markering blijft geblokkeerd, want dat kan een kopie van productie zijn van vóór 0019.
2. **De doorloopstack op poort 55500 werd nergens gemarkeerd.** De migratie ging door (lokaal en leeg), maar `seed-vragenlijsten.js` weigerde een stap later. `verify:volledig` markeert nu ook die stack.

## Beproefd

| Doelwit | Zonder vlag | Met `--extern` |
|---|---|---|
| staging (`wegwerp`) | door | n.v.t. |
| verse lokale container (geen tabel) | door | n.v.t. |
| lokaal, gemigreerd, nog `beschermd` | geblokkeerd | door |
| **productie** (`beschermd`) | **geblokkeerd**, exitcode 1 | door, met "LET OP" |

Exitcodes zonder pipe gemeten. `verify:volledig` groen tot en met de 66 browsertests — **voor het eerst zonder handmatig variabelen mee te geven**, want `.env` wijst nu vanzelf naar de goede plek.

De staging-wachtwoorden zijn vernieuwd (de oude waren niet meer te achterhalen) en de twee GitHub-secrets zijn bijgewerkt.

## Nieuw: een DevOps-handleiding

[`docs/runbooks/devops-handleiding.md`](docs/runbooks/devops-handleiding.md) — geschreven vanuit de handeling in plaats van vanuit de techniek: uitrollen, terugdraaien, status opvragen, terugkerende taken, wat er misgaat, en wat je nooit doet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)