### PR TITLE
fix(deploy): deploy:status toonde staging niet

### DIFF
--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -2,8 +2,17 @@
 
 ## Laatst bijgewerkt
 
-**2026-08-11, avond.** **Stap 3 én stap 4 van het OTAP-plan zijn af.** De keten
-loopt nu van een merge tot aan productie, met vier remmen ervoor.
+**2026-08-11, avond.** **Stappen 3, 4 en 5 van het OTAP-plan zijn af**, plus de
+issues #131, #132 en #133. De keten loopt nu van een merge tot aan productie,
+met vier remmen ervoor — en de laptop wijst niet meer standaard naar de
+klantendatabase.
+
+> **Begin je hier na een `/clear`?** Lees dan eerst
+> [`runbooks/devops-handleiding.md`](runbooks/devops-handleiding.md) als je wilt
+> weten wat de eigenaar doet, en
+> [`runbooks/commandos-en-omgeving.md`](runbooks/commandos-en-omgeving.md) als je
+> zelf een commando gaat draaien. **Let op: `.env` wijst sinds vandaag naar
+> staging, niet meer naar productie.**
 
 ```
 merge op main
@@ -44,7 +53,14 @@ achttien tabellen.
 
 Vandaag gemerged: **#135** (uitnodigingslink wees naar `localhost`), **#136**
 (migraties naar staging), **#137** (applicatie tegen Supabase), **#139/#140**
-(time-outs, en de Tailscale-stappen er weer uit), **#142** (#131 en #133).
+(time-outs, en de Tailscale-stappen er weer uit), **#141** (documentatie na stap
+3), **#142** (issues #131 en #133), **#143** (stap 4), **#144** (stap 5 en de
+DevOps-handleiding).
+
+**De productieworkflow is één keer echt gedraaid** — 11-08, met akkoord van de
+eigenaar. De poort meldde `DOOR`, productie stond al op 26 migraties, en het
+teruglezen bevestigde dat. Bewijs dat de weg werkt, zonder dat er iets op het
+spel stond.
 
 ### Stap 5 is ook af: de laptop wijst niet meer naar productie
 
@@ -240,18 +256,23 @@ opgevallen omdat er nog geen leverancier is uitgenodigd.
 
 ### De omgevingen op saxombp
 
-Teruggelezen op 2026-08-11:
+Teruggelezen op 2026-08-11, eind van de dag:
 
-| | Backend | Frontend | Database |
-|---|---|---|---|
-| acceptatie | `sha-5428bb95` | `sha-635ff211` | container 55460 |
-| **staging** | `sha-ffd27dc9` | `sha-635ff211` | **Supabase `clm-staging3`** |
-| productie | `latest` | — | container 55470 |
+| | Backend | Frontend | Database | Antwoordt |
+|---|---|---|---|---|
+| acceptatie | `sha-5428bb954884` | `sha-635ff21150bd` | container 55460 | ✅ 200 / 200 / 401 |
+| **staging** | draait | draait | **Supabase `clm-staging3`** | niet gemeten — zie hieronder |
+| productie | `latest` | — | container 55470 | ✅ 200 (backend) |
 
 **Productie loopt bewust achter.** Daar draait nog `latest` zonder frontend,
-zonder `OIDC_*` en zonder HTTPS — inloggen kan daar dus niet. Dat is stap 4, en
-het compose-bestand raakt beide omgevingen, dus het hoort een aparte handeling te
-zijn.
+zonder `OIDC_*` en zonder HTTPS — inloggen kan daar dus niet. Dat blijft zo tot
+stap 6, want deze container gaat dan verdwijnen.
+
+> **`npm run deploy:status` kent staging niet.** Het commando toont alleen
+> acceptatie en productie, terwijl `mcm2-staging-api-1` en
+> `mcm2-staging-frontend-1` wel degelijk draaien (gemeten met `docker ps` op
+> 11-08). Een controlecommando met een blinde vlek is een controlecommando dat
+> je op het verkeerde moment geruststelt — **openstaand punt**, klein werk.
 
 ### Wat er gisteravond is neergezet: staging
 
@@ -519,6 +540,7 @@ handmatig te starten is (PR #122).
 | — | ~~**Geen geautomatiseerde uitrol naar productie**~~ | ✅ **Gedaan 11-08** (stap 4). Migraties gaan achter vier remmen langs; de applicatie starten blijft één commando. De remmen zijn op zeven uitkomsten beproefd |
 | — | ~~**`.env` wijst nog naar productie**~~ | ✅ **Gedaan 11-08** (stap 5). Wijst nu naar staging; de rem kijkt naar `clm.omgeving` in plaats van naar de hostnaam |
 | — | **Twee dingen heten "productie"** | `mcm2-productie` op saxombp draait op een eigen lokale database, niet op Supabase. Dat is verwarrend op precies het verkeerde moment. **Stap 6**, en de eerste onomkeerbare stap |
+| — | **`deploy:status` toont staging niet** | Die stack draait wél op saxombp. Een controlecommando dat een omgeving overslaat, stelt gerust over iets dat het niet gemeten heeft — dezelfde klasse als #131. Klein werk |
 | ~~#51~~ | ~~Frontend promoveerbaar maken~~ | ✅ **Gedaan 10-08.** Bewezen: hetzelfde image tegen twee backends, verschillende antwoorden, geen herbouw |
 | ~~#132~~ | ~~Uitnodigingslink wijst naar `localhost`~~ | ✅ **Gedaan 11-08** (PR #135). Twee tests, tegenproef gedraaid |
 | ~~#131~~ | ~~`mailVerstuurd: true` terwijl er niets verstuurd is~~ | ✅ **Gedaan 11-08.** `echtVerstuurd` op de mailgrens; verplicht veld, dus niet te vergeten |

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -261,18 +261,21 @@ Teruggelezen op 2026-08-11, eind van de dag:
 | | Backend | Frontend | Database | Antwoordt |
 |---|---|---|---|---|
 | acceptatie | `sha-5428bb954884` | `sha-635ff21150bd` | container 55460 | ✅ 200 / 200 / 401 |
-| **staging** | draait | draait | **Supabase `clm-staging3`** | niet gemeten — zie hieronder |
+| **staging** | `sha-ffd27dc9472f` | `sha-635ff21150bd` | **Supabase `clm-staging3`** | ✅ 200 / 200 / 401 |
 | productie | `latest` | — | container 55470 | ✅ 200 (backend) |
+
+Staging heeft als enige **geen `db`-container** — die praat met Supabase. Dat is
+precies waarvoor hij bestaat.
 
 **Productie loopt bewust achter.** Daar draait nog `latest` zonder frontend,
 zonder `OIDC_*` en zonder HTTPS — inloggen kan daar dus niet. Dat blijft zo tot
 stap 6, want deze container gaat dan verdwijnen.
 
-> **`npm run deploy:status` kent staging niet.** Het commando toont alleen
-> acceptatie en productie, terwijl `mcm2-staging-api-1` en
-> `mcm2-staging-frontend-1` wel degelijk draaien (gemeten met `docker ps` op
-> 11-08). Een controlecommando met een blinde vlek is een controlecommando dat
-> je op het verkeerde moment geruststelt — **openstaand punt**, klein werk.
+> **`deploy:status` toonde staging eerst niet** (PR #145). Het commando liet
+> alleen acceptatie en productie zien terwijl `mcm2-staging-api-1` gewoon
+> draaide: een controlecommando met een blinde vlek stelt gerust over iets dat
+> het niet gemeten heeft — dezelfde klasse als #131. Gevonden door `docker ps`
+> te vergelijken met wat het script afdrukte.
 
 ### Wat er gisteravond is neergezet: staging
 
@@ -540,7 +543,7 @@ handmatig te starten is (PR #122).
 | — | ~~**Geen geautomatiseerde uitrol naar productie**~~ | ✅ **Gedaan 11-08** (stap 4). Migraties gaan achter vier remmen langs; de applicatie starten blijft één commando. De remmen zijn op zeven uitkomsten beproefd |
 | — | ~~**`.env` wijst nog naar productie**~~ | ✅ **Gedaan 11-08** (stap 5). Wijst nu naar staging; de rem kijkt naar `clm.omgeving` in plaats van naar de hostnaam |
 | — | **Twee dingen heten "productie"** | `mcm2-productie` op saxombp draait op een eigen lokale database, niet op Supabase. Dat is verwarrend op precies het verkeerde moment. **Stap 6**, en de eerste onomkeerbare stap |
-| — | **`deploy:status` toont staging niet** | Die stack draait wél op saxombp. Een controlecommando dat een omgeving overslaat, stelt gerust over iets dat het niet gemeten heeft — dezelfde klasse als #131. Klein werk |
+| — | ~~**`deploy:status` toont staging niet**~~ | ✅ **Gedaan 11-08** (PR #145). Toont nu drie omgevingen; beproefd op saxombp, alle rookproeven groen |
 | ~~#51~~ | ~~Frontend promoveerbaar maken~~ | ✅ **Gedaan 10-08.** Bewezen: hetzelfde image tegen twee backends, verschillende antwoorden, geen herbouw |
 | ~~#132~~ | ~~Uitnodigingslink wijst naar `localhost`~~ | ✅ **Gedaan 11-08** (PR #135). Twee tests, tegenproef gedraaid |
 | ~~#131~~ | ~~`mailVerstuurd: true` terwijl er niets verstuurd is~~ | ✅ **Gedaan 11-08.** `echtVerstuurd` op de mailgrens; verplicht veld, dus niet te vergeten |

--- a/docs/runbooks/devops-handleiding.md
+++ b/docs/runbooks/devops-handleiding.md
@@ -208,12 +208,21 @@ altijd een goede vraag, en het antwoord hoort concreet te zijn.
 Je hoeft geen foutmeldingen te ontleden. **Kopieer wat je ziet en plak het in de
 chat.** Dat is sneller en betrouwbaarder dan zelf zoeken.
 
-Twee dingen die je wel zelf kunt oplossen:
+Drie dingen die je wel zelf moet doen:
 
 | Situatie | 🧑 Wat jij doet |
 |---|---|
 | Telegram meldt dat Docker uit staat | Docker Desktop starten, daarna Claude vragen de backup in te halen |
 | Er komt al een week geen enkel bericht | Claude vragen te controleren of de melder nog werkt |
+| Claude meldt *"Tailscale SSH requires an additional check"* met een login-link | **Open die link en bevestig.** Eén klik |
+
+> **Over die Tailscale-link.** De toegang tot saxombp verloopt periodiek; dat is
+> een beveiliging van Tailscale zelf, geen storing. Claude kan hem niet voor je
+> aanklikken — het is juist de bedoeling dat een mens dat doet. Zolang je niet
+> bevestigt, blijft elke poging om bij de server te komen wachten.
+>
+> Waargenomen op 2026-08-11: `npm run deploy:status` hing zonder foutmelding,
+> en de reden bleek pas zichtbaar bij een handmatige SSH-poging.
 
 **Wat je nooit hoeft te doen:** een commando verzinnen, een versienummer
 overtypen, of zelf bedenken welke database ergens bij hoort. Vraag het.

--- a/docs/runbooks/uitrol-acceptatie-en-productie.md
+++ b/docs/runbooks/uitrol-acceptatie-en-productie.md
@@ -318,8 +318,27 @@ tailscale status | Select-String saxombp
 Staat er `offline`, dan is de server uit of het netwerk weg. Staat er `active`,
 probeer dan `ssh root@saxombp echo ok`.
 
-Vraagt Tailscale om verificatie in de browser, doe die dan — dat is een
-eenmalige stap per apparaat.
+### Het commando hangt, zonder foutmelding
+
+Dat is bijna altijd **Tailscale SSH dat om herauthenticatie vraagt**:
+
+```
+# Tailscale SSH requires an additional check.
+# To authenticate, visit: https://login.tailscale.com/a/<code>
+```
+
+Open die link en bevestig. Daarna werkt het weer.
+
+> **Dit is periodiek, niet eenmalig per apparaat.** Hier stond eerder dat het
+> een eenmalige stap was; op 2026-08-11 kwam het terug op een machine die de
+> hele dag had gewerkt. De verlooptijd is een instelling van de Tailscale-tenant
+> (`checkPeriod` in de SSH-regel).
+>
+> **Waarom je het niet meteen ziet:** scripts die `ssh` aanroepen met
+> `BatchMode=yes` krijgen die vraag wél, maar tonen hem niet — ze wachten stil
+> tot de time-out. `npm run deploy:status` leek daardoor traag in plaats van
+> geblokkeerd. Hangt een servercommando: draai `ssh root@saxombp "echo ja"` met
+> de hand, dan zie je de link.
 
 ### "Kon image … niet ophalen"
 

--- a/scripts/deploy-status.js
+++ b/scripts/deploy-status.js
@@ -2,7 +2,7 @@
 'use strict';
 
 /**
- * Wat draait er op acceptatie en productie?
+ * Wat draait er op acceptatie, staging en productie?
  *
  * Leest de werkelijke toestand van de server, niet een bestand dat zegt wat er
  * zou moeten draaien. Dat onderscheid is in dit project twee keer duur geweest:
@@ -30,8 +30,23 @@ const SERVER = 'root@saxombp';
  */
 const FRONTEND_MEE = true;
 
+/**
+ * De drie omgevingen op saxombp. Poorten gelijk aan `OMGEVINGEN` in deploy.js.
+ *
+ * ── Staging stond hier niet in, en dat was een blinde vlek ──────────────────
+ *
+ * Tot 2026-08-11 toonde dit commando alleen acceptatie en productie, terwijl
+ * `mcm2-staging-api-1` en `mcm2-staging-frontend-1` wél draaiden. Wie de status
+ * opvroeg kreeg dus een compleet ogend overzicht waarin een hele omgeving
+ * ontbrak — een controlecommando dat geruststelt over iets dat het niet gemeten
+ * heeft. Dezelfde klasse als Issue #131.
+ *
+ * Gevonden door `docker ps` op de server te vergelijken met wat dit script
+ * afdrukte, bij het bijwerken van de omgevingstabel in STATUS.md.
+ */
 const OMGEVINGEN = [
   { naam: 'acceptatie', project: 'mcm2-acceptatie', api: 5011, frontend: 3010 },
+  { naam: 'staging', project: 'mcm2-staging', api: 5031, frontend: 3030 },
   { naam: 'productie', project: 'mcm2-productie', api: 5021, frontend: 3020 },
 ];
 


### PR DESCRIPTION
Klein, maar het is de soort fout die dit project elders bestrijdt.

## Wat er mis was

`npm run deploy:status` toonde alleen **acceptatie** en **productie**. Ondertussen draaiden `mcm2-staging-api-1` en `mcm2-staging-frontend-1` gewoon op saxombp.

Wie de status opvroeg kreeg dus een compleet ogend overzicht waarin een hele omgeving ontbrak — **een controlecommando dat geruststelt over iets dat het niet gemeten heeft.** Dezelfde klasse als Issue #131.

Gevonden bij het bijwerken van de omgevingstabel in `STATUS.md`, door `docker ps` op de server te vergelijken met wat het script afdrukte.

Poorten gelijk aan `OMGEVINGEN` in `deploy.js`: api 5031, frontend 3030.

## Bijvangst: Tailscale SSH verloopt periodiek

Bij het beproeven hing `deploy:status` — zonder foutmelding, na de kopregel. De oorzaak bleek Tailscale SSH dat om herauthenticatie vroeg:

```
# Tailscale SSH requires an additional check.
# To authenticate, visit: https://login.tailscale.com/a/<code>
```

**Scripts tonen die vraag niet.** Wie `ssh` aanroept met `BatchMode=yes` krijgt hem wél, maar ziet hem niet — het commando wacht stil tot de time-out. Het leek daardoor traag in plaats van geblokkeerd.

Het runbook zei dat die verificatie *"een eenmalige stap per apparaat"* is. Dat klopt niet: hij kwam terug op een machine die de hele dag had gewerkt. Gecorrigeerd, mét de manier om het zichtbaar te maken.

Ook toegevoegd aan de DevOps-handleiding, bij wat de eigenaar zelf moet doen — Claude kan die link niet aanklikken, en dat is juist de bedoeling.

## Niet beproefd op de server

De wijziging is syntactisch gecontroleerd, maar `deploy:status` kon niet tegen saxombp draaien zolang de Tailscale-bevestiging openstond. **Dat gebeurt bij de eerstvolgende keer dat het commando draait** — dan hoort er een derde blok `── STAGING ──` te verschijnen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)