### PR TITLE
feat(otap): stap 6 — nog maar één ding heet "productie"

### DIFF
--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -2,10 +2,34 @@
 
 ## Laatst bijgewerkt
 
-**2026-08-11, avond.** **Stappen 3, 4 en 5 van het OTAP-plan zijn af**, plus de
+**2026-08-12.** **Stappen 3, 4, 5 en 6 van het OTAP-plan zijn af**, plus de
 issues #131, #132 en #133. De keten loopt nu van een merge tot aan productie,
-met vier remmen ervoor — en de laptop wijst niet meer standaard naar de
-klantendatabase.
+met vier remmen ervoor — de laptop wijst niet meer standaard naar de
+klantendatabase, en **nog maar één ding heet "productie"**.
+
+### Stap 6: de dubbele betekenis van "productie" is weg
+
+Er waren er twee. De workflow migreerde naar Supabase `clm-enterprise` — de
+echte klantgegevens — terwijl `npm run deploy:productie` een applicatie startte
+tegen een **lege Postgres-container** op saxombp. Wie het commando draaide dat
+de workflow zelf afdrukt, kreeg een draaiende app op een database waarin niets
+stond, met de volle overtuiging dat productie was uitgerold.
+
+Dat is precies de verwarring die op 2026-08-10 tot het verkeerde antwoord op
+"wat zijn mijn rollen" leidde, en daarmee tot het dataverlies.
+
+**Wat er is gebeurd**, in deze volgorde:
+
+1. `deploy.js` en `deploy-inrichten.js`: productie heeft geen lokale database
+   meer (`lokaleDatabase: false`, `dbPoort: null`) — net als staging
+2. `productie.env` op de server wijst naar Supabase
+3. acceptatie bijgewerkt naar `sha-e8e462d6eec8`, zodat de OTAP-volgorde klopte
+4. productie uitgerold op diezelfde versie — vier rookproeven groen
+5. de container en zijn volume verwijderd
+
+**Vóór het verwijderen gemeten:** 26 migraties, 0 tenants, 0 gebruikers,
+0 leveranciers, 0 antwoorden, 0 actieve verbindingen. Er is niets verloren
+gegaan. Een backup is daarom bewust overgeslagen (besluit eigenaar).
 
 > **Begin je hier na een `/clear`?** Lees dan eerst
 > [`runbooks/devops-handleiding.md`](runbooks/devops-handleiding.md) als je wilt
@@ -260,16 +284,16 @@ Teruggelezen op 2026-08-11, eind van de dag:
 
 | | Backend | Frontend | Database | Antwoordt |
 |---|---|---|---|---|
-| acceptatie | `sha-5428bb954884` | `sha-635ff21150bd` | container 55460 | ✅ 200 / 200 / 401 |
+| acceptatie | `sha-e8e462d6eec8` | `sha-635ff21150bd` | container 55460 | ✅ 200 / 200 / 401 |
 | **staging** | `sha-ffd27dc9472f` | `sha-635ff21150bd` | **Supabase `clm-staging3`** | ✅ 200 / 200 / 401 |
-| productie | `latest` | — | container 55470 | ✅ 200 (backend) |
+| **productie** | `sha-e8e462d6eec8` | `sha-635ff21150bd` | **Supabase `clm-enterprise`** | ✅ 200 / 200 / 401 |
 
-Staging heeft als enige **geen `db`-container** — die praat met Supabase. Dat is
-precies waarvoor hij bestaat.
+**Staging én productie hebben geen `db`-container meer** — beide praten met
+Supabase. Alleen acceptatie heeft er nog een, en dat is opzet: die mag stuk.
 
-**Productie loopt bewust achter.** Daar draait nog `latest` zonder frontend,
-zonder `OIDC_*` en zonder HTTPS — inloggen kan daar dus niet. Dat blijft zo tot
-stap 6, want deze container gaat dan verdwijnen.
+Productie draait sinds stap 6 (11-08) voor het eerst **op dezelfde versie als
+acceptatie**, mét een frontend. Inloggen kan daar nog steeds niet — geen
+`OIDC_*`, geen HTTPS — maar dat is nu het enige verschil.
 
 > **`deploy:status` toonde staging eerst niet** (PR #145). Het commando liet
 > alleen acceptatie en productie zien terwijl `mcm2-staging-api-1` gewoon
@@ -450,6 +474,10 @@ merge naar main → CI (3 poorten) → image naar GHCR
 | Acceptatie | `saxombp` | `:5011` | 55460 (127.0.0.1) |
 | Productie | `saxombp` | `:5021` | 55470 (127.0.0.1) |
 
+> **Achterhaald sinds stap 6 (2026-08-11):** de databasecontainer op 55470 is
+> opgeheven. Productie praat nu met Supabase `clm-enterprise`, net als staging
+> met `clm-staging3`. Zie de omgevingstabel bovenaan dit document.
+
 Bereikbaar via Tailscale, niet vanaf internet. Docker is op die server
 geïnstalleerd; de Saxo-app op 8080/8081 is aantoonbaar ongemoeid gebleven —
 zelfde PID's voor en na.
@@ -542,7 +570,7 @@ handmatig te starten is (PR #122).
 |---|---|---|
 | — | ~~**Geen geautomatiseerde uitrol naar productie**~~ | ✅ **Gedaan 11-08** (stap 4). Migraties gaan achter vier remmen langs; de applicatie starten blijft één commando. De remmen zijn op zeven uitkomsten beproefd |
 | — | ~~**`.env` wijst nog naar productie**~~ | ✅ **Gedaan 11-08** (stap 5). Wijst nu naar staging; de rem kijkt naar `clm.omgeving` in plaats van naar de hostnaam |
-| — | **Twee dingen heten "productie"** | `mcm2-productie` op saxombp draait op een eigen lokale database, niet op Supabase. Dat is verwarrend op precies het verkeerde moment. **Stap 6**, en de eerste onomkeerbare stap |
+| — | ~~**Twee dingen heten "productie"**~~ | ✅ **Gedaan 12-08** (stap 6). De lege databasecontainer op saxombp is opgeheven; productie praat nu met Supabase. Gemeten vóór het verwijderen: 0 tenants, 0 gebruikers, 0 antwoorden |
 | — | ~~**`deploy:status` toont staging niet**~~ | ✅ **Gedaan 11-08** (PR #145). Toont nu drie omgevingen; beproefd op saxombp, alle rookproeven groen |
 | ~~#51~~ | ~~Frontend promoveerbaar maken~~ | ✅ **Gedaan 10-08.** Bewezen: hetzelfde image tegen twee backends, verschillende antwoorden, geen herbouw |
 | ~~#132~~ | ~~Uitnodigingslink wijst naar `localhost`~~ | ✅ **Gedaan 11-08** (PR #135). Twee tests, tegenproef gedraaid |

--- a/docs/architectuur/plan-otap-straat-met-staging.md
+++ b/docs/architectuur/plan-otap-straat-met-staging.md
@@ -1,8 +1,8 @@
 # Plan — een OTAP-straat met staging, van nul opnieuw doordacht
 
-**Status:** in uitvoering — **stap 1, 2, 2b en 3 zijn gedaan**. Volgende: stap 4
-(uitrol naar productie met een akkoordrem)
-**Datum:** 2026-08-10, bijgewerkt dezelfde avond
+**Status:** in uitvoering — **stap 1, 2, 2b, 3, 4, 5 en 6 zijn gedaan**.
+Volgende: stap 7 (`verify:omgevingen` bouwen)
+**Datum:** 2026-08-10, bijgewerkt 2026-08-12
 **Eigenaar:** Kees Aling
 **Aanleiding:** de straat die op 09/10-08 op saxombp gebouwd is, loopt niet uit
 op de database die er werkelijk toe doet. Dit plan trekt hem door tot het einde,
@@ -90,6 +90,9 @@ Bij optie A verandert de rol van saxombp, maar hij verdwijnt niet:
 - **Productie (5021) wordt opgeheven.** Die simuleerde iets dat straks echt
   bestaat. Twee dingen die "productie" heten is precies de verwarring die op
   10-08 tot dataverlies leidde.
+  → ✅ **Gedaan 12-08.** De *databasecontainer* is weg; de applicatie op 5021
+  blijft draaien, maar nu tegen Supabase `clm-enterprise`. Zie §"Eén ding heet
+  productie".
 - **De machine blijft de plek** waar gereedschap wordt uitgeprobeerd zonder
   risico. Dat is echte waarde.
 
@@ -639,13 +642,18 @@ weet dat het klopt.
 
 ### 4.1 Wat er per omgeving hoort te zijn
 
-*Bijgewerkt 2026-08-11 naar wat er werkelijk staat; teruggelezen, niet gepland.*
+*Bijgewerkt 2026-08-12 naar wat er werkelijk staat; teruggelezen, niet gepland.*
+
+> **Deze tabel beschreef productie al als Supabase — en dat klopte niet.** Tot
+> stap 6 draaide de applicatie daar tegen een lege lokale container. Het plan
+> beschreef dus de bedoeling terwijl de werkelijkheid afweek, en niemand merkte
+> het omdat er niets in stond. Sinds 12-08 kloppen ze weer op elkaar.
 
 | | Acceptatie | Staging | Productie |
 |---|---|---|---|
-| Applicatie | saxombp `:5011` / `:3010` | saxombp `:5031` / `:3030` | saxombp `:5021` (procesbewijs) |
-| Database | container 55460 | **Supabase `clm-staging3`** | Supabase `clm-enterprise` |
-| Migraties door | `deploy:acceptatie` | **CI, automatisch** | met de hand — stap 4 |
+| Applicatie | saxombp `:5011` / `:3010` | saxombp `:5031` / `:3030` | saxombp `:5021` / `:3020` |
+| Database | container 55460 | **Supabase `clm-staging3`** | **Supabase `clm-enterprise`** |
+| Migraties door | `deploy:acceptatie` | **CI, automatisch** | **workflow, achter vier remmen** |
 | `clm.omgeving` | `wegwerp` | `wegwerp` | `beschermd` |
 | Rollen | migrator + runtime | migrator + runtime | migrator + runtime |
 | RLS | actief | **actief — geverifieerd** | actief |
@@ -751,11 +759,49 @@ Aan de status is dus niet te zien welke code draait. Vanaf nu: **alleen
 SHA-tags in acceptatie, staging en productie.** `latest` blijft bestaan voor
 handmatig gebruik, maar de straat raakt hem niet aan.
 
-### Eén ding heet "productie"
+### Eén ding heet "productie" — ✅ gedaan 2026-08-12
 
 `mcm2-productie` op saxombp wordt opgeheven. Twee dingen die "productie" heten
 is precies de verwarring die op 10-08 tot het verkeerde antwoord op de vraag
 "wat zijn mijn rollen" leidde — en daarmee tot het dataverlies.
+
+**Wat het bij nader inzien was.** Niet alleen een verwarrende naam: de twee
+praatten langs elkaar heen. De workflow uit stap 4 migreerde naar Supabase
+`clm-enterprise`, terwijl `npm run deploy:productie` een applicatie startte
+tegen een lege container op saxombp. Wie het commando draaide dat de workflow
+zélf afdrukt, kreeg een draaiende app op een database waarin niets stond — met
+de volle overtuiging dat productie was uitgerold.
+
+Dat maakte stap 6 dringender dan "opruimen": stap 4 was pas werkelijk af nadat
+dit recht was gezet.
+
+**Uitgevoerd in deze volgorde**, code vóór server zodat terugdraaien mogelijk
+bleef:
+
+1. `deploy.js` — `lokaleDatabase: false` en `migratiesOverslaan: true`, net als
+   staging. De migratiestap meldt nu *"overgeslagen — teruglezen gebeurt in CI"*.
+2. `deploy-inrichten.js` — `dbPoort: null`, waardoor `productie.env` een leeg
+   `DATABASE_URL` krijgt dat met de hand ingevuld moet worden. Zelfde behandeling
+   als staging: een connectiestring is een geheim en hoort niet uit een script.
+3. `productie.env` op de server naar Supabase.
+4. **Acceptatie eerst bijgewerkt** naar `sha-e8e462d6eec8`. Het script waarschuwde
+   terecht dat de versie daar niet beproefd was — precies de rem die OTAP
+   voorschrijft, en die is gerespecteerd in plaats van weggeklikt.
+5. Productie uitgerold op diezelfde versie. Vier rookproeven groen, inclusief het
+   doorgeefluik (401) — voor het eerst mét een frontend.
+6. Container en volume verwijderd.
+
+**Gemeten vóór het verwijderen:** 26 migraties, 0 tenants, 0 gebruikers,
+0 leveranciers, 0 antwoorden, 0 actieve verbindingen. Leeg. Een backup is
+daarom bewust overgeslagen (besluit eigenaar 12-08).
+
+**Teruggelezen na afloop:** onder `mcm2-productie` draaien alleen nog `api` en
+`frontend`; het volume `mcm2-productie_db-data` bestaat niet meer;
+`deploy:status` geeft 200 / 200 / 401 op alle drie de omgevingen.
+
+**Wat hiermee ook opgelost is:** staging en productie zien er nu identiek uit —
+api plus frontend, database bij Supabase, migraties uit een workflow. Alleen
+acceptatie houdt een eigen container, en dat is opzet: die mag stuk.
 
 ### Teruglezen is verplicht, melden is niet genoeg
 
@@ -798,7 +844,7 @@ het als eerste staat.
 | 3 | ✅ **Uitrol naar staging automatiseren** — gedaan 11-08 | Beslist: applicatie start met de hand, zie §3.3c |
 | 4 | ✅ **Uitrol naar productie automatiseren, met akkoordrem** — gedaan 11-08 | Beslist: backup blijft bij de eigenaar, CI controleert; applicatie start met de hand |
 | 5 | ✅ **`.env` omleiden naar staging** — gedaan 11-08 | Beslist: rem kijkt naar `clm.omgeving`; noodtoegang als `NOOD_PRODUCTIE_URL` |
-| 6 | `mcm2-productie` op saxombp opheffen | **Ja — onomkeerbaar** |
+| 6 | ✅ **`mcm2-productie` op saxombp opheffen** — gedaan 12-08 | Akkoord gegeven; database was aantoonbaar leeg, backup bewust overgeslagen |
 | 7 | `verify:omgevingen` bouwen | Nee |
 | 8 | Productie opnieuw vullen | Nee |
 | 9 | Testdata op staging | Nee |

--- a/docs/runbooks/devops-handleiding.md
+++ b/docs/runbooks/devops-handleiding.md
@@ -2,7 +2,7 @@
 
 **Type:** D — routineoperaties
 **Eigenaar:** de eigenaar (Chris)
-**Laatste update:** 2026-08-11
+**Laatste update:** 2026-08-12
 **Vereiste toegang:** GitHub (AlingAdvies/MCM2), Supabase, Telegram op je telefoon
 
 ---
@@ -255,6 +255,11 @@ het voorstelt — dan is er iets mis.
 | **acceptatie** | uitproberen, zelf inloggen | jij, via `saxombp:3010` |
 | **staging** | repetitie vóór productie | niemand — dit is een generale |
 | **productie** | echte klanten | de klant |
+
+> **Tot 12 augustus heetten er twee dingen "productie".** De echte database bij
+> Supabase, én een lege database op saxombp waar de applicatie tegenaan praatte.
+> Dat is opgeheven: er is er nu één. Als je ergens nog leest over "de
+> productiecontainer op poort 55470" — die bestaat niet meer.
 
 **Waarom staging bestaat:** productie draait bij Amazon in Ierland, achter een
 verbindingslaag die zich anders gedraagt dan een database op je eigen machine.

--- a/docs/runbooks/uitrol-acceptatie-en-productie.md
+++ b/docs/runbooks/uitrol-acceptatie-en-productie.md
@@ -31,22 +31,30 @@ lopen.
 | **T** test | laptop, tijdelijk | — | — | wegwerp 55441 |
 | **A** acceptatie | `saxombp` | 3010 | 5011 | 55460 (127.0.0.1) |
 | **S** staging | `saxombp` | 3030 | 5031 | **Supabase `clm-staging3`** |
-| **P** productie | `saxombp` | 3020 | 5021 | 55470 (127.0.0.1) |
+| **P** productie | `saxombp` | 3020 | 5021 | **Supabase `clm-enterprise`** |
 
 Bereikbaar via Tailscale. Acceptatie ook op
 `https://saxombp.tail4b29b.ts.net`; niet vanaf internet — alleen vanaf je eigen
 apparaten.
 
-> **Staging is de enige omgeving zonder eigen databasecontainer**, en dat is de
-> reden dat hij bestaat. Productie draait Postgres bij AWS in Ierland achter een
-> connection pooler; een repetitie in een lokale container bewijst het verkeerde
-> (§1 van het OTAP-plan). De pooler is precies waar het anders gaat —
-> verbindingen die anders worden vastgehouden, andere timeouts, ander gedrag bij
-> migraties die een tabel vergrendelen.
+> **Staging én productie hebben geen eigen databasecontainer** — beide praten
+> met Supabase. Alleen acceptatie heeft er nog een, en dat is opzet: die mag
+> stuk.
 >
-> **De migraties van staging draaien vanuit CI**, niet vanaf een laptop. Zie de
-> job `staging` in `.github/workflows/ci.yml`; `npm run deploy:staging` slaat
-> die stap over en zegt dat ook.
+> Dat staging bij Supabase staat, is de reden dat hij bestaat. Productie draait
+> Postgres bij AWS in Ierland achter een connection pooler; een repetitie in een
+> lokale container bewijst het verkeerde (§1 van het OTAP-plan). De pooler is
+> precies waar het anders gaat — verbindingen die anders worden vastgehouden,
+> andere timeouts, ander gedrag bij migraties die een tabel vergrendelen.
+>
+> **De migraties draaien vanuit een workflow**, niet vanaf een laptop:
+> staging via de job `staging` in `.github/workflows/ci.yml`, productie via
+> `.github/workflows/productie.yml`. Beide uitrolcommando's slaan die stap over
+> en zeggen dat ook — je ziet `4/6 Migraties — overgeslagen` met de reden erbij.
+>
+> **Tot stap 6 (2026-08-12) had productie wél een eigen container**, op poort
+> 55470. Die was leeg, terwijl de workflow naar Supabase migreerde: twee dingen
+> die "productie" heetten. Zie STATUS.md voor wat daar precies misging.
 
 **Op dezelfde server draait de Saxo-app** onder PM2, op poort 8080 en 8081.
 Die is geen onderdeel van MCM2 en mag nooit geraakt worden. Zowel

--- a/scripts/deploy-inrichten.js
+++ b/scripts/deploy-inrichten.js
@@ -65,10 +65,21 @@ const OMGEVINGEN = [
     project: 'mcm2-staging',
   },
   {
+    // Sinds stap 6 (2026-08-11) heeft productie net zo min een dbPoort als
+    // staging: de database staat bij Supabase (`clm-enterprise`).
+    //
+    // Hier stond `dbPoort: 55470`, en dat gaf productie een eigen
+    // Postgres-container op saxombp. Ondertussen migreerde
+    // .github/workflows/productie.yml naar Supabase. Twee dingen die
+    // "productie" heten, met de echte klantgegevens op de ene plek en een
+    // draaiende applicatie op de andere.
+    //
+    // De opgeheven container is vóór het verwijderen gemeten: 26 migraties,
+    // 0 tenants, 0 gebruikers, 0 leveranciers. Leeg.
     naam: 'productie',
     apiPoort: 5021,
     frontendPoort: 3020,
-    dbPoort: 55470,
+    dbPoort: null,
     project: 'mcm2-productie',
   },
 ];

--- a/scripts/deploy.js
+++ b/scripts/deploy.js
@@ -142,7 +142,29 @@ const OMGEVINGEN = {
     // Productie krijgt nooit een stille uitrol. Ook niet als het "maar een
     // kleine wijziging" is — juist dan.
     bevestiging: true,
-    lokaleDatabase: true,
+    // ── Sinds stap 6 (2026-08-11): GEEN lokale database meer ────────────────
+    //
+    // Hier stond `lokaleDatabase: true`, en dat betekende dat dit commando een
+    // eigen Postgres-container startte op saxombp. Ondertussen migreerde de
+    // productieworkflow naar Supabase `clm-enterprise`, waar de echte
+    // klantgegevens staan.
+    //
+    // Twee dingen heetten dus "productie", en ze praatten langs elkaar heen:
+    // de migraties gingen naar Supabase, de applicatie startte tegen een
+    // container waarin niets stond. Wie het commando draaide dat de workflow
+    // zelf afdrukt, kreeg een draaiende app op een lege database — met de
+    // volle overtuiging dat productie was uitgerold.
+    //
+    // Dat is precies de verwarring die op 2026-08-10 tot het verkeerde antwoord
+    // op "wat zijn mijn rollen" leidde, en daarmee tot het dataverlies.
+    //
+    // Gemeten vóór het opheffen: 26 migraties, 0 tenants, 0 gebruikers,
+    // 0 leveranciers. De container was leeg; er is niets verloren gegaan.
+    lokaleDatabase: false,
+    // Net als staging: de migraties draaien vanuit de workflow
+    // (.github/workflows/productie.yml), niet vanaf deze machine. Deze uitrol
+    // start alleen de applicatie.
+    migratiesOverslaan: true,
   },
 };
 
@@ -618,9 +640,11 @@ async function main() {
       : '4/6  Migraties op de database van deze omgeving',
   );
 
-  // Staging migreert niet vanaf deze machine. Dat gebeurt in CI, tegen
-  // Supabase, met het teruglezen erin — zie de job `staging` in
-  // .github/workflows/ci.yml.
+  // Staging én productie migreren niet vanaf deze machine. Dat gebeurt in een
+  // workflow, tegen Supabase, met het teruglezen erin:
+  //
+  //   staging    → job `staging` in .github/workflows/ci.yml
+  //   productie  → .github/workflows/productie.yml, achter vier remmen
   //
   // Ze hier nóg een keer draaien zou betekenen dat een laptop schrijft naar een
   // database die de pipeline beheert. Dat is precies de gewoonte die dit plan


### PR DESCRIPTION
Stap 6 van [`plan-otap-straat-met-staging.md`](docs/architectuur/plan-otap-straat-met-staging.md) — de eerste onomkeerbare stap, met akkoord van de eigenaar.

## Het was erger dan een verwarrende naam

Er waren twee dingen die "productie" heetten, en **ze praatten langs elkaar heen**:

| | Wat "productie" betekende |
|---|---|
| de workflow uit stap 4 | Supabase `clm-enterprise` — de echte klantgegevens |
| `npm run deploy:productie` | een **lege** Postgres-container op saxombp |

Wie het commando draaide dat de workflow zélf afdrukt, kreeg een draaiende app op een database waarin niets stond — met de volle overtuiging dat productie was uitgerold.

Dat is precies de verwarring die op 2026-08-10 tot het verkeerde antwoord op *"wat zijn mijn rollen"* leidde, en daarmee tot het dataverlies. **Stap 4 was dus pas werkelijk af nadat dit rechtgezet was.**

## Uitgevoerd — code vóór server, zodat terugdraaien mogelijk bleef

1. **`deploy.js`** — `lokaleDatabase: false` en `migratiesOverslaan: true`, net als staging. De migratiestap meldt nu `4/6 Migraties — overgeslagen` met de reden erbij.
2. **`deploy-inrichten.js`** — `dbPoort: null`, waardoor `productie.env` een leeg `DATABASE_URL` krijgt dat met de hand ingevuld moet worden. Zelfde behandeling als staging: een connectiestring is een geheim en hoort niet uit een script.
3. **`productie.env`** op de server naar Supabase (kopie bewaard als `productie.env.voor-stap6`).
4. **Acceptatie eerst bijgewerkt** naar `sha-e8e462d6eec8`. Het script waarschuwde terecht dat die versie daar niet beproefd was — die rem is *gerespecteerd*, niet weggeklikt.
5. **Productie uitgerold** op diezelfde versie. Vier rookproeven groen, inclusief het doorgeefluik (401) — voor het eerst mét een frontend.
6. **Container en volume verwijderd.**

## Gemeten vóór het verwijderen

```
migraties=26 tenants=0 users=0 vendors=0 responses=0
actieve verbindingen: 0
```

Leeg. Een backup is daarom bewust overgeslagen (besluit eigenaar).

## Teruggelezen na afloop

```
── PRODUCTIE ─────────────────────────────────────────
   ● frontend   sha-635ff21150bd
   ● api        sha-e8e462d6eec8

   backend  http://saxombp:5021/health   200
   frontend http://saxombp:3020/         200
   frontend → backend                       401
```

Geen `db`-container meer, en het volume `mcm2-productie_db-data` bestaat niet meer. Alle drie de omgevingen geven 200 / 200 / 401.

## Wat het plan zelf beweerde

§4.1 beschreef productie **al** als Supabase — en dat klopte niet. Het plan beschreef de bedoeling terwijl de werkelijkheid afweek, en niemand merkte het omdat er niets in stond. Die tabel is nu teruggelezen in plaats van gepland, met een aantekening erbij.

Staging en productie zien er nu identiek uit: api plus frontend, database bij Supabase, migraties uit een workflow. Alleen acceptatie houdt een eigen container — dat is opzet, die mag stuk.

## Gemeten

`verify:volledig` groen tot en met de 66 browsertests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)