### PR TITLE
feat(aws): geautomatiseerde uitrol naar AWS-productie

### DIFF
--- a/.github/workflows/productie-aws.yml
+++ b/.github/workflows/productie-aws.yml
@@ -1,0 +1,270 @@
+name: Uitrol naar AWS-productie
+
+# ── Verhouding tot productie.yml ─────────────────────────────────────────────
+#
+# `productie.yml` rolt uit naar saxombp en draait bewust ALLEEN de migraties
+# automatisch — de container starten bleef daar handwerk, omdat een
+# GitHub-runner via Tailscale niet bij een apparaat met een gebruikersidentiteit
+# kan (zie de toelichting bovenaan die workflow).
+#
+# Die beperking geldt niet voor AWS: ECS heeft een gewone AWS-API die een
+# workflow met de juiste IAM-rol probleemloos mag aanroepen. Deze workflow rolt
+# daarom VOLLEDIG automatisch uit — migraties én de nieuwe containerversie —
+# achter dezelfde vier remmen als productie.yml (§3.4 van het OTAP-plan):
+#
+#   1. handmatig akkoord      GitHub Environment `productie`, required reviewer
+#   2. backup vooraf          productie-poort.js leest het backup-bewijs
+#   3. migratiestand          vóór, ná, én vergeleken met staging
+#   4. terugdraaien           de vorige image-tag staat in de samenvatting
+#
+# ── Authenticatie: OIDC, geen langlevende sleutel ────────────────────────────
+#
+# GitHub wisselt per run een kortlevend token uit met AWS via de IAM Identity
+# Provider `token.actions.githubusercontent.com` (ingericht 2026-08-20). Er
+# staat geen AWS-sleutel in GitHub Secrets — alleen de rol-ARN, die zelf geen
+# toegang geeft zonder een geldig GitHub-token voor deze repo op de
+# `main`-branch (zie de trust policy op de rol `GitHubActions-MCM2-ECS-Deploy`).
+
+on:
+  workflow_dispatch:
+    inputs:
+      versie:
+        description: "Backend-image, bijv. sha-abc123def456 (leeg = laatste van main)"
+        required: false
+        default: ""
+      frontend_versie:
+        description: "Frontend-image, bijv. sha-987fed654321 (leeg = laatste van main)"
+        required: false
+        default: ""
+      reden:
+        description: "Waarom rol je uit? Komt in de samenvatting en het akkoordverzoek."
+        required: true
+
+permissions:
+  contents: read
+
+env:
+  AWS_REGION: eu-west-1
+  ECS_CLUSTER: default
+
+jobs:
+  # ── Rem 2 en 3 ─────────────────────────────────────────────────────────────
+  #
+  # Zelfde poort als productie.yml, hergebruikt zonder wijziging. Draait vóór
+  # het akkoord: blokkeert deze job, dan is er niemand lastiggevallen met een
+  # vraag die toch nergens toe kon leiden.
+  poort:
+    name: Poort — backup en migratiestanden
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Node.js instellen
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: ".nvmrc"
+          cache: "npm"
+
+      - name: Dependencies installeren
+        run: npm ci
+
+      - name: De drie automatische remmen
+        env:
+          STAGING_MIGRATION_DATABASE_URL: ${{ secrets.STAGING_MIGRATION_DATABASE_URL }}
+          PRODUCTIE_MIGRATION_DATABASE_URL: ${{ secrets.PRODUCTIE_MIGRATION_DATABASE_URL }}
+        run: node scripts/productie-poort.js
+
+      - name: Migratiestand van productie vóór de uitrol
+        id: voor
+        env:
+          MIGRATION_DATABASE_URL: ${{ secrets.PRODUCTIE_MIGRATION_DATABASE_URL }}
+        run: |
+          VOOR=$(node scripts/migratiestand.js | grep -oE '[0-9]+$' | head -1)
+          echo "aantal=$VOOR" >> "$GITHUB_OUTPUT"
+          echo "Productie stond op $VOOR migraties."
+    outputs:
+      voor: ${{ steps.voor.outputs.aantal }}
+
+  # ── Rem 1: het akkoord, gevolgd door de daadwerkelijke uitrol ───────────────
+  #
+  # De `environment`-regel is de hele rem. GitHub pauzeert deze job en stuurt
+  # een verzoek naar de reviewers van de Environment `productie`.
+  uitrollen:
+    name: Migraties en ECS-uitrol
+    runs-on: ubuntu-latest
+    needs: [poort]
+    environment: productie
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Node.js instellen
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: ".nvmrc"
+          cache: "npm"
+
+      - name: Dependencies installeren
+        run: npm ci
+
+      # Tussen de poort en het akkoord kan tijd zitten — een akkoord kan een dag
+      # blijven wachten. Opnieuw toetsen kost seconden en sluit uit dat het
+      # akkoord ergens anders over ging dan wat er nu gebeurt.
+      - name: De remmen opnieuw, ná het akkoord
+        env:
+          STAGING_MIGRATION_DATABASE_URL: ${{ secrets.STAGING_MIGRATION_DATABASE_URL }}
+          PRODUCTIE_MIGRATION_DATABASE_URL: ${{ secrets.PRODUCTIE_MIGRATION_DATABASE_URL }}
+        run: node scripts/productie-poort.js
+
+      - name: Migraties draaien tegen productie
+        env:
+          MIGRATION_DATABASE_URL: ${{ secrets.PRODUCTIE_MIGRATION_DATABASE_URL }}
+        run: node scripts/migrate.js --extern
+
+      # Teruglezen, niet de melding geloven — zelfde discipline als productie.yml.
+      - name: Migratiestand teruglezen en vergelijken met de repository
+        env:
+          MIGRATION_DATABASE_URL: ${{ secrets.PRODUCTIE_MIGRATION_DATABASE_URL }}
+        run: node scripts/migratiestand.js --volgens-journal
+
+      - name: AWS-credentials via OIDC
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: ${{ secrets.AWS_GITHUB_DEPLOY_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      # ── mcm2-api ────────────────────────────────────────────────────────────
+      #
+      # `--query taskDefinition` haalt precies de vorm op die render/deploy
+      # verwachten; de extra ECS-velden die describe-task-definition meegeeft
+      # (status, revisie, registeredAt, ...) horen daar niet bij een nieuwe
+      # registratie en worden door render-task-definition genegeerd noch nodig.
+      - name: Vorige image-tag van mcm2-api onthouden (voor de samenvatting)
+        id: vorige_api
+        run: |
+          VORIGE=$(aws ecs describe-task-definition \
+            --task-definition default-mcm2-api \
+            --query 'taskDefinition.containerDefinitions[0].image' \
+            --output text)
+          echo "image=$VORIGE" >> "$GITHUB_OUTPUT"
+
+      - name: Huidige task-definitie van mcm2-api ophalen
+        run: |
+          aws ecs describe-task-definition \
+            --task-definition default-mcm2-api \
+            --query taskDefinition > api-task-definition.json
+
+      - name: Nieuwe image-tag in de task-definitie zetten
+        id: api-task-def
+        uses: aws-actions/amazon-ecs-render-task-definition@v1
+        with:
+          task-definition: api-task-definition.json
+          container-name: Main
+          image: ghcr.io/alingadvies/mcm2/api:${{ inputs.versie != '' && inputs.versie || format('sha-{0}', github.sha) }}
+
+      - name: mcm2-api uitrollen
+        uses: aws-actions/amazon-ecs-deploy-task-definition@v2
+        with:
+          task-definition: ${{ steps.api-task-def.outputs.task-definition }}
+          service: mcm2-api
+          cluster: ${{ env.ECS_CLUSTER }}
+          wait-for-service-stability: true
+
+      # ── mcm2-frontend (service web-23bd) ───────────────────────────────────
+      - name: Vorige image-tag van mcm2-frontend onthouden (voor de samenvatting)
+        id: vorige_frontend
+        run: |
+          VORIGE=$(aws ecs describe-task-definition \
+            --task-definition default-web-23bd \
+            --query 'taskDefinition.containerDefinitions[0].image' \
+            --output text)
+          echo "image=$VORIGE" >> "$GITHUB_OUTPUT"
+
+      - name: Huidige task-definitie van mcm2-frontend ophalen
+        run: |
+          aws ecs describe-task-definition \
+            --task-definition default-web-23bd \
+            --query taskDefinition > frontend-task-definition.json
+
+      - name: Nieuwe image-tag in de task-definitie zetten
+        id: frontend-task-def
+        uses: aws-actions/amazon-ecs-render-task-definition@v1
+        with:
+          task-definition: frontend-task-definition.json
+          container-name: Main
+          image: ghcr.io/alingadvies/mcm2-frontend/web:${{ inputs.frontend_versie != '' && inputs.frontend_versie || 'latest' }}
+
+      - name: mcm2-frontend uitrollen
+        uses: aws-actions/amazon-ecs-deploy-task-definition@v2
+        with:
+          task-definition: ${{ steps.frontend-task-def.outputs.task-definition }}
+          service: web-23bd
+          cluster: ${{ env.ECS_CLUSTER }}
+          wait-for-service-stability: true
+
+      # Slaagt de uitrol maar faalt dit, dan staan de rechten verkeerd — merk je
+      # anders pas wanneer de applicatie draait en elk scherm een fout geeft.
+      - name: De runtime-rol kan bij zijn eigen gegevens
+        env:
+          DATABASE_URL: ${{ secrets.PRODUCTIE_DATABASE_URL }}
+        run: |
+          node -e "
+            const {Client} = require('pg');
+            const c = new Client({
+              connectionString: process.env.DATABASE_URL,
+              ssl: { rejectUnauthorized: false },
+              connectionTimeoutMillis: 30000,
+            });
+            c.connect()
+              .then(() => c.query('SELECT count(*)::int AS n FROM clm.tenant'))
+              .then((r) => {
+                console.log('clm_api_runtime leest clm.tenant: ' + r.rows[0].n + ' rijen');
+                return c.end();
+              })
+              .catch((e) => { console.error('MISLUKT: ' + e.message); process.exit(1); });
+          "
+
+      # ── Rem 4: terugdraaien ────────────────────────────────────────────────
+      #
+      # `if: always()` omdat juist een MISLUKTE run de weg terug moet tonen.
+      # Terugdraaien op AWS is dezelfde workflow met `versie`/`frontend_versie`
+      # op de vorige tag — er is geen apart script, in tegenstelling tot
+      # `deploy.js` bij saxombp.
+      - name: Samenvatting
+        if: always()
+        env:
+          VERSIE: ${{ inputs.versie }}
+          FRONTEND: ${{ inputs.frontend_versie }}
+          REDEN: ${{ inputs.reden }}
+          VOOR: ${{ needs.poort.outputs.voor }}
+          VORIGE_API: ${{ steps.vorige_api.outputs.image }}
+          VORIGE_FRONTEND: ${{ steps.vorige_frontend.outputs.image }}
+        run: |
+          {
+            echo "### AWS-productie — uitgerold"
+            echo ""
+            echo "| | |"
+            echo "|---|---|"
+            echo "| Reden | $REDEN |"
+            echo "| Commit | \`${GITHUB_SHA::12}\` |"
+            echo "| Migraties vóór | $VOOR |"
+            echo "| Migraties ná | teruggelezen, gelijk aan het journal |"
+            echo "| mcm2-api, vorige image | \`$VORIGE_API\` |"
+            echo "| mcm2-frontend, vorige image | \`$VORIGE_FRONTEND\` |"
+            echo ""
+            echo "#### Als het misgaat"
+            echo ""
+            echo "Terugdraaien is dezelfde workflow, met \`versie\`/\`frontend_versie\`"
+            echo "op de vorige tags hierboven. Geen apart script — de vier remmen"
+            echo "gelden dan opnieuw, wat bewust is: een rollback is ook een uitrol."
+            echo ""
+            echo "> Let op: een teruggedraaide **applicatie** draait tegen een database"
+            echo "> die de nieuwe migraties al heeft. Dat gaat goed zolang migraties"
+            echo "> achterwaarts verdraagzaam zijn — kolommen toevoegen wel, kolommen"
+            echo "> verwijderen niet. Staat er een verwijderende migratie in, dan is"
+            echo "> terugzetten van de backup de weg, niet de rollback."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -2,6 +2,34 @@
 
 ## Laatst bijgewerkt
 
+**2026-08-18, avond — Transdev als eerste echte tenant; AWS-inrichting loopt.**
+
+Twee sporen tegelijk in gang gezet:
+
+**1. AWS-inrichting (nieuw account "AlingAdvies", 727732213368).**
+IAM-gebruiker `MCM2-Deploy` + groep `mcm2-deploy-group` aangemaakt. Onderweg
+twee fouten gevonden en hersteld: verkeerde policy (`AmazonS3ExpressFullAccess`
+i.p.v. `AmazonS3FullAccess`) en de gebruiker bleek niet in de groep te zitten
+(gaf overal "access denied" ondanks zichtbare `IAMFullAccess` — opgelost door
+als root in te loggen). S3-bucket `mcm2-deploy-eu-west-1` (eu-west-1) staat.
+**Volgende AWS-stap: Secrets Manager** (database-URL's, Entra client secret,
+sessie-secret — waarden komen uit `.env`, niet uit deze chat).
+
+**2. Besluit: MCM2 wordt multi-tenant, Transdev is de eerste echte klant**
+(niet mock zoals AlingAdvies — herziening van het 12-08-uitgangspunt "één
+tenant"). Tenant **"Transdev_IT_Survey"** aangemaakt op **acceptatie**
+(`tenant_id 9878b187-99de-4ce3-8ec2-64909d29b9a1`), eerste beheerder
+`cmaling+TransdevIT@gmail.com`, inloggen bevestigd werkend. Bewust nog niet op
+productie: het sub-pad-probleem hieronder (Bug 3) is niet opgelost, en een
+echte klant hoort daar niet tegenaan te lopen — Transdev verhuist naar de
+definitieve productieomgeving zodra AWS/App Runner met eigen hostnamen staat.
+
+**Morgen eerst:** vragenlijst (8 Transdev-vragen) inrichten als ronde binnen
+de Transdev_IT_Survey-tenant, dan een testvendor-flow (indienen → beoordelen)
+eenmaal doorlopen.
+
+---
+
 **2026-08-17, avond — het sub-pad is stukken kapotter dan gedacht.**
 
 Aanleiding: `cmaling@gmail.com` kon niet inloggen op productie/staging.

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -24,9 +24,12 @@ productie: het sub-pad-probleem hieronder (Bug 3) is niet opgelost, en een
 echte klant hoort daar niet tegenaan te lopen — Transdev verhuist naar de
 definitieve productieomgeving zodra AWS/App Runner met eigen hostnamen staat.
 
-**Morgen eerst:** vragenlijst (8 Transdev-vragen) inrichten als ronde binnen
-de Transdev_IT_Survey-tenant, dan een testvendor-flow (indienen → beoordelen)
-eenmaal doorlopen.
+**Bewuste keuze 18-08 avond: eerst AWS afmaken en in de lucht krijgen, vóór de
+Transdev-vragenlijst wordt ingericht.** Die vragenlijst-stap staat klaar
+(tenant + eerste beheerder werken al) maar is geparkeerd tot AWS/App Runner
+met eigen hostnamen draait — reden: geen zin verder te bouwen op een tenant
+die toch naar de nieuwe productieomgeving verhuist. **Morgen eerst: Secrets
+Manager** (zie hierboven), dan de rest van het AWS-stappenplan.
 
 ---
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -2,6 +2,37 @@
 
 ## Laatst bijgewerkt
 
+**2026-08-19, avond — `mcm2-api` draait op ECS Express Mode. App Runner was
+een doodlopende weg (accepteert sinds 30-04-2026 geen nieuwe klanten meer).**
+
+Vandaag grotendeels besteed aan de eerste ECS-service werkend krijgen, met
+vijf losse, elk-voor-zich-opgeloste configuratiefouten onderweg: een
+regio-inconsistentie (een secret per ongeluk in `us-east-1` i.p.v.
+`eu-west-1`), de task execution role miste zowel de basis-AWS-managed-policy
+(`AmazonECSTaskExecutionRolePolicy`, voor logs/ECR-pull) als expliciete
+Secrets Manager/SSM-rechten, `DATABASE_URL` miste de `:json-key::`-syntax
+die nodig is omdat de secret als key/value-paar is opgeslagen (gaf
+`ENOTFOUND base` — de container kreeg de hele secret-JSON als connection-
+string), en de ontdekking dat de gewone "Update service"-knop een nieuw
+aangemaakte task-definitie-revisie NEGEERT — dat moet via het dropdown-
+menu-item "Update with custom task definition" met een expliciet
+revisienummer. Volledige uitleg en het "waarom dit niet vanzelf werkte" per
+fout staat in het projectgeheugen (`mcm2-besluit-18-08-naar-aws`).
+
+**Resultaat, bevestigd in CloudWatch Logs**: `mcm2-api` draait, verbonden met
+de productie-Supabase-database als de juiste, minst bevoorrechte rol
+`clm_api_runtime` (eerst per ongeluk `clm_migrator` — direct gecorrigeerd
+met de al aanwezige `PRODUCTIE_RUNTIME_URL` uit `.env`).
+
+**Morgen eerst**: dezelfde service-opzet herhalen voor `mcm2-frontend` (nu
+met alle vijf lessen direct toegepast, zou sneller moeten gaan). Daarna:
+custom domain `clm.alingadvies.nl` koppelen (het huidige DNS A-record naar
+saxombp moet vervangen worden door een CNAME + ACM-validatie), de vier
+placeholder-URL's in `mcm2-api` bijwerken naar de echte productie-URL,
+CloudWatch Logs-retentie, AWS Budget-alert.
+
+---
+
 **2026-08-18, avond — Transdev als eerste echte tenant; AWS-inrichting loopt.**
 
 Twee sporen tegelijk in gang gezet:

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -2,6 +2,31 @@
 
 ## Laatst bijgewerkt
 
+**2026-08-20, middag — login werkt volledig end-to-end op AWS.**
+
+Bevestigd: ingelogd als `kees@alingadvies.nl` op
+`clm.alingadvies.nl/beheer/leveranciers`, "Live"-badge (echte backend).
+Onderweg een omweg gemaakt (een apart sub-domein `api.clm.alingadvies.nl`
+voor de API) die niet nodig bleek — de frontend heeft al een eigen
+doorgeefluik (`/api/backend/*`, ADR-012/Issue #51) dat alles naar
+`mcm2-api` doorstuurt, inclusief de OAuth-callback. `OIDC_REDIRECT_URI`
+staat nu correct op `https://clm.alingadvies.nl/api/backend/auth/callback`.
+Volledige toedracht in het projectgeheugen (`mcm2-besluit-18-08-naar-aws`,
+sectie 20-08 middag).
+
+**Open todo — opruimen:** het overbodige sub-domein `api.clm.alingadvies.nl`
+verwijderen: DNS-record bij mijndomein.nl, ACM-certificaat, en de
+OR-conditie met `api.clm.alingadvies.nl` op listener-regel 44990 van
+`ecs-express-gateway-alb-c6b07d03`. Functioneel niet nodig, kost niets om
+te laten staan, maar is ruis.
+
+**Open todo — devops-handleiding:** de eigenaar wil een volledig
+referentiedocument: welke URL's, secrets en infrastructuur nodig zijn om
+de app in AWS aan de praat te krijgen én te houden. Hoort thuis in
+`docs/runbooks/`.
+
+---
+
 **2026-08-20, ochtend — `mcm2-frontend` draait ook op ECS Express Mode.
 Login staat klaar om getest te worden zodra het domein gekoppeld is.**
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -2,6 +2,32 @@
 
 ## Laatst bijgewerkt
 
+**2026-08-20, ochtend — `mcm2-frontend` draait ook op ECS Express Mode.
+Login staat klaar om getest te worden zodra het domein gekoppeld is.**
+
+Zelfde ECS-opzet als gisteren herhaald voor de frontend (repo
+`AlingAdvies/MCM2-frontend`, image `ghcr.io/alingadvies/mcm2-frontend/web:latest`,
+service-naam werd automatisch `web-23bd`). Eén nieuwe fout onderweg:
+"Server Reference ID did not match the expected format" in CloudWatch —
+Next.js self-hosted op meerdere instanties genereert zonder een vaste
+`NEXT_SERVER_ACTIONS_ENCRYPTION_KEY` per instantie een eigen sleutel voor
+Server Actions. Bevestigd via de officiële Next.js-documentatie, niet
+gegokt. Fix: plaintext-secret aangemaakt en als env var gekoppeld — daarna
+`✓ Ready in 799ms` in de logs, geen fouten meer.
+
+Frontend-URL: `https://we-0d50abb730584356b38804a7f1ae0868.ecs.eu-west-1.on.aws`
+— pagina laadt, inlogflow start, Microsoft weigert de login (verwacht: het
+ECS-adres staat nog niet als redirect-URI bij Entra, en `mcm2-api`'s
+`OIDC_REDIRECT_URI` staat nog op een placeholder).
+
+**Bewust besluit:** eerst het domein `clm.alingadvies.nl` koppelen aan ECS,
+dán pas Entra en de vier placeholder-URL's bijwerken — voorkomt dat de
+Entra-registratie twee keer aangepast moet worden. Dat is het eerstvolgende
+werk. Volledige stappenlijst in het projectgeheugen
+(`mcm2-besluit-18-08-naar-aws`, sectie 2026-08-20).
+
+---
+
 **2026-08-19, avond — `mcm2-api` draait op ECS Express Mode. App Runner was
 een doodlopende weg (accepteert sinds 30-04-2026 geen nieuwe klanten meer).**
 

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -4,6 +4,12 @@
 **Eigenaar:** de eigenaar (Chris)
 **Laatste update:** 2026-08-10
 
+> ⚠️ **Let op sinds 2026-08-19:** productie draait niet meer op `saxombp` maar
+> op AWS ECS Express Mode. Runbooks die uitrol/deploy naar productie
+> beschrijven (`uitrol-acceptatie-en-productie.md`, `devops-handleiding.md`)
+> zijn op dat punt verouderd — ze dragen zelf een waarschuwingsblok. Staging
+> en acceptatie blijven ongewijzigd op saxombp. Zie `docs/STATUS.md`.
+
 Elk runbook beschrijft één handeling: wat je doet, wat je mag verwachten, en wat
 je doet als het anders uitpakt. Deze index is de enige plek waar ze allemaal
 staan — [verify:onderhoud](onderhoudskalender.md#4-hoe-dit-document-actueel-blijft)

--- a/docs/runbooks/commandos-en-omgeving.md
+++ b/docs/runbooks/commandos-en-omgeving.md
@@ -11,6 +11,13 @@ de verkeerde database zou hebben gedraaid.
 Node/npm-scripts uit `package.json`, `netstat`/`taskkill`/`findstr` in
 `C:\Windows\system32`, image `postgres:17.6` lokaal aanwezig.
 
+> ⚠️ **Deels verouderd sinds 2026-08-19.** De database-doelwit-logica hieronder
+> (`beschermd`/`wegwerp`, `.env` naar staging, `--extern`) blijft geldig —
+> die gaat over Supabase, niet over waar de app draait. Maar verwijzingen naar
+> **productie op `saxombp`** (SSH, `docker compose -p mcm2-productie`, poort
+> 3020/5021) zijn achterhaald: productie draait nu op AWS ECS Express Mode.
+> Zie `docs/STATUS.md`.
+
 > **`psql` staat NIET op deze machine.** Er is geen PostgreSQL-client op de host
 > geïnstalleerd. Elke `psql`-aanroep hieronder loopt daarom via
 > `docker exec <container> psql …`. Een kaal `psql ...` faalt met

--- a/docs/runbooks/devops-handleiding.md
+++ b/docs/runbooks/devops-handleiding.md
@@ -5,6 +5,13 @@
 **Laatste update:** 2026-08-12
 **Vereiste toegang:** GitHub (AlingAdvies/MCM2), Supabase, Telegram op je telefoon
 
+> ⚠️ **VEROUDERD VOOR PRODUCTIE, sinds 2026-08-19.** Productie draait sinds
+> vandaag op AWS ECS Express Mode, niet meer op `saxombp`. Verwijzingen naar
+> "de GitHub Environment `productie`-akkoordknop" en de bestaande
+> uitrol-workflow beschrijven het OUDE mechanisme — dat moet nog gekoppeld
+> worden aan de nieuwe AWS-deploy. Acceptatie/staging op saxombp zijn
+> ongewijzigd. Zie `docs/STATUS.md` voor de actuele stand.
+
 ---
 
 ## Hoe dit werkt

--- a/docs/runbooks/uitrol-acceptatie-en-productie.md
+++ b/docs/runbooks/uitrol-acceptatie-en-productie.md
@@ -6,6 +6,18 @@
 **Vereiste toegang:** Tailscale (voor `saxombp`), GitHub, deze repository
 **Raakt:** Issue #12, #18, #51, ADR-012
 
+> ⚠️ **VEROUDERD VOOR PRODUCTIE, sinds 2026-08-19.** Productie draait niet
+> meer op `saxombp` — het staat nu op AWS ECS Express Mode (zie
+> `docs/STATUS.md` en het projectgeheugen `mcm2-besluit-18-08-naar-aws`).
+> Alles hieronder over `mcm2-productie`, poort 3020/5021,
+> `ssh root@saxombp ... docker compose -p mcm2-productie`, en de
+> `productie.yml`-workflow beschrijft de OUDE route en werkt niet meer voor
+> productie-uitrol. **Acceptatie blijft ongewijzigd op saxombp** — die
+> onderdelen van dit runbook kloppen nog. Dit bestand wordt herschreven
+> zodra de AWS-migratie (frontend-service, custom domain, CI/CD-koppeling)
+> volledig af is; tot dan: voor een productie-uitrol niet dit runbook
+> volgen, eerst navragen hoe de ECS-deploy nu werkt.
+
 ---
 
 ## Waarvoor dit bestaat


### PR DESCRIPTION
## Wat dit toevoegt

Nieuwe workflow `productie-aws.yml`, gebaseerd op het bestaande vier-remmen-patroon
van `productie.yml` (poort, handmatig akkoord, migraties, terugdraai-instructie),
uitgebreid met de daadwerkelijke ECS-uitrol van `mcm2-api` en `mcm2-frontend`.

## Waarom dit anders is dan productie.yml

`productie.yml` (saxombp) rolt alleen migraties automatisch uit — de container
starten bleef handwerk omdat een GitHub-runner via Tailscale niet bij saxombp
kan. Die beperking geldt niet voor AWS: ECS heeft een gewone AWS-API.

## Authenticatie

OIDC via een nieuwe IAM Identity Provider + rol `GitHubActions-MCM2-ECS-Deploy`,
ingericht 2026-08-20. Geen langlevende AWS-sleutel in GitHub Secrets — alleen
de rol-ARN, en die rol vertrouwt uitsluitend `main`.

## Nog te testen

Kan pas getest worden na mergen (de trust policy staat alleen `main` toe).
Wordt direct na mergen handmatig getriggerd.

🤖 Generated with [Claude Code](https://claude.com/claude-code)