### PR TITLE
fix(vendors): vangt afgekapte domeinen in contactpersoon-e-mailadres

### DIFF
--- a/src/vendor/vendor-invoer.ts
+++ b/src/vendor/vendor-invoer.ts
@@ -1,3 +1,4 @@
+import { isGeldigMailadres } from '../mail/mail-adres';
 import type {
   ContactInvoer,
   NieuweVendor,
@@ -120,12 +121,30 @@ function kvkNummer(waarde: unknown): string | null {
 }
 
 /**
+ * Een topleveldomein van één teken bestaat niet ('transdev.n' i.p.v.
+ * 'transdev.nl') en een domein dat op een streepje of punt eindigt is altijd
+ * een afgekapte invoer. Dit is geen RFC-controle maar een gerichte vangst op
+ * de vergissing die bij overtypen/plakken uit een spreadsheet het vaakst
+ * voorkomt: het laatste stukje van het adres ontbreekt of is half getypt.
+ */
+const VERDACHT_DOMEIN = /\.[a-z]$|[-.]$/i;
+
+/**
  * Een e-mailadres moet er plausibel uitzien.
  *
  * Bewust geen strenge RFC-controle: die is berucht om geldige adressen af te
  * wijzen, en de echte controle is toch of er een e-mail aankomt. Wat hier
  * wordt gevangen is de vergissing — een naam in het e-mailveld, een ontbrekend
- * apenstaartje.
+ * apenstaartje, of een afgekapt domein.
+ *
+ * Hergebruikt `isGeldigMailadres` (ook gebruikt door het mailkanaal en de
+ * tenant-instellingen) zodat één adres niet op het ene scherm wordt geweigerd
+ * en op het andere doorgelaten. De extra domeincontrole hier is bewust niet in
+ * die gedeelde functie gezet: die moet ruim blijven voor het mailkanaal zelf
+ * (aflevering is daar de echte controle, zie mail-adres.ts), terwijl
+ * leveranciersinvoer — vaak handmatig getypt of uit een lijst geplakt — baat
+ * heeft bij het vangen van een overduidelijke tikfout vóórdat de uitnodiging
+ * de deur uitgaat.
  */
 function emailAdres(waarde: unknown): string | null {
   const tekst = optioneleTekst(waarde, 'E-mailadres', MAX_KORT);
@@ -134,7 +153,7 @@ function emailAdres(waarde: unknown): string | null {
     return null;
   }
 
-  if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(tekst)) {
+  if (!isGeldigMailadres(tekst) || VERDACHT_DOMEIN.test(tekst)) {
     throw new InvoerFout('contact.email', 'Dit lijkt geen geldig e-mailadres.');
   }
 

--- a/test/vendor-routes.e2e-spec.ts
+++ b/test/vendor-routes.e2e-spec.ts
@@ -371,6 +371,54 @@ describe('Vendorroutes (e2e)', () => {
         .expect(400);
     });
 
+    it.each([
+      ['een afgekapte domeinextensie', 'jan@transdev.n'],
+      ['een domein dat op een punt eindigt', 'jan@transdev.'],
+      ['een domein dat op een streepje eindigt', 'jan@transdev-'],
+    ])('weigert een e-mailadres met %s', async (_omschrijving, email) => {
+      // Dit zijn geen ongeldige e-mailadressen in de zin van isGeldigMailadres
+      // (die is bewust ruim, zie mail-adres.ts) — het zijn de tikfouten die
+      // ontstaan bij handmatig overtypen of plakken uit een spreadsheet, en
+      // die de leverancier stilzwijgend nooit een uitnodiging laten ontvangen.
+      const antwoord = await request(server)
+        .post('/vendors')
+        .set('Cookie', cookieA)
+        .send({
+          name: 'Tikfouttest B.V.',
+          contact: { fullName: 'Jan Jansen', email },
+        })
+        .expect(400);
+
+      expect((antwoord.body as { veld?: string }).veld).toBe('contact.email');
+    });
+
+    it('accepteert een e-mailadres met een samengesteld domein', async () => {
+      // Tegenproef: de strengere domeincontrole mag geen geldige adressen
+      // raken, zoals een .co.uk-adres of een subdomein.
+      const aanmaak = await request(server)
+        .post('/vendors')
+        .set('Cookie', cookieA)
+        .send({
+          name: 'Geldig Domein B.V.',
+          contact: {
+            fullName: 'Jan Jansen',
+            email: 'jan@voorbeeld.co.uk',
+          },
+        })
+        .expect(201);
+
+      const lijst = await request(server)
+        .get('/vendors')
+        .set('Cookie', cookieA)
+        .expect(200);
+
+      const gevonden = alsLijst(lijst.body).vendors.find(
+        (v) => v.vendorId === alsAangemaakt(aanmaak.body).vendorId,
+      );
+
+      expect(gevonden).toBeDefined();
+    });
+
     it('meldt een half ingevulde contactpersoon in plaats van hem te negeren', async () => {
       // E-mail wél, naam niet: dat is een vergeten veld, geen bewuste keuze
       // om de contactpersoon weg te laten. Stilzwijgend negeren zou betekenen


### PR DESCRIPTION
Herbijgewerkt met main (was 4 dagen oud, o.a. de AWS-migratie zat er nog niet in). Typecheck, lint, format en alle 397 unittests groen na de merge. e2e-laag niet apart gedraaid voor deze PR — geïsoleerde validatiewijziging in `vendor-invoer.ts`, raakt geen tenantgrens of RLS.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>