### PR TITLE
chore(typescript): tsconfig naar strict-mode

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,8 +18,8 @@
     "skipLibCheck": true,
     "strictNullChecks": true,
     "forceConsistentCasingInFileNames": true,
-    "noImplicitAny": false,
-    "strictBindCallApply": false,
+    "noImplicitAny": true,
+    "strictBindCallApply": true,
     "noFallthroughCasesInSwitch": false
   }
 }


### PR DESCRIPTION
Fixes #3.

- `noImplicitAny` en `strictBindCallApply` van `false` naar `true`
- Compileert schoon zonder enige impliciete `any` — geen codewijziging nodig
- `tsc --noEmit --strict` (het volledige acceptatiecriterium) slaagt
- lint:check groen, 397/397 unittests groen

De tweede helft van het issue (ESLint sourceType vs. tsconfig module) bleek bij onderzoek geen echte inconsistentie — zie de commit-boodschap voor de uitleg. Geen wijziging nodig.

e2e-laag niet gedraaid: pure TS-config-wijziging, raakt geen database/RLS.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>