### PR TITLE
docs: roadmap-punten omgezet naar issues, roadmap en statusbord gekoppeld

### DIFF
--- a/docs/STATUSBORD.md
+++ b/docs/STATUSBORD.md
@@ -5,7 +5,7 @@ verloren bij de volgende run. Pas in plaats daarvan het issue of het label
 aan op GitHub, en draai `npm run statusbord` opnieuw (of wacht op de
 geplande workflow).
 
-**Gegenereerd:** 2026-08-21 09:46 UTC · **Bron:** `gh issue list --repo AlingAdvies/MCM2`
+**Gegenereerd:** 2026-08-21 10:09 UTC · **Bron:** `gh issue list --repo AlingAdvies/MCM2`
 
 Dit is geen vervanging van de issues zelf (details, acceptatiecriteria,
 discussie staan daar) en geen vervanging van `docs/STATUS.md` (het
@@ -16,8 +16,8 @@ oogopslag zien wat er per thema openstaat, gesorteerd op prioriteit.
 
 ## Op prioriteit, over alle thema's heen
 
-**P0 — voor elke volgende regel productiecode** — 3 open
-**Vóór de pilot** — 12 open
+**P0 — voor elke volgende regel productiecode** — 2 open
+**Vóór de pilot** — 6 open
 **Vóór bredere productie** — 12 open
 **Later — bewust uitgesteld** — 1 open
 
@@ -25,24 +25,31 @@ oogopslag zien wat er per thema openstaat, gesorteerd op prioriteit.
 
 ## Per thema
 
-### Product — vragenlijst, leveranciers, contracten, meldingen (6)
+### Product — vragenlijst, leveranciers, contracten, meldingen (13)
 
-- [#9](https://github.com/AlingAdvies/MCM2/issues/9) `before-pilot` — Certificaat-upload via het token-mechanisme
-- [#13](https://github.com/AlingAdvies/MCM2/issues/13) `before-pilot` — E-mailverzending via Transdev-eigen SMTP
 - [#23](https://github.com/AlingAdvies/MCM2/issues/23) `before-production` — MVM_V2-frontend-inconsistenties oplossen (tenant demo vs. transdev, vendors-lijstpagina)
 - [#52](https://github.com/AlingAdvies/MCM2/issues/52) — Restrisico virusscan vastleggen als bewuste beslissing, met opschalingsvoorwaarde
 - [#83](https://github.com/AlingAdvies/MCM2/issues/83) — Gearchiveerde testrondes stapelen op in de demo-database
 - [#148](https://github.com/AlingAdvies/MCM2/issues/148) — Notificaties per tenant: signaleren wat blijft liggen
+- [#153](https://github.com/AlingAdvies/MCM2/issues/153) — Vragenlijst toont geen contact-/afzenderinfo voor de leverancier
+- [#154](https://github.com/AlingAdvies/MCM2/issues/154) — "Ronde" is een verwarrende naam die straks bezet is voor de echte herhaalde-meting-feature
+- [#155](https://github.com/AlingAdvies/MCM2/issues/155) — Nieuwe feature: vragenlijst-bouwer voor tenant-beheerders
+- [#156](https://github.com/AlingAdvies/MCM2/issues/156) — Veld voor contractbeheerder/contactpersoon ontbreekt bij leverancier
+- [#157](https://github.com/AlingAdvies/MCM2/issues/157) — Contractveld ontbreekt, gekoppeld aan leverancierstype en/of vragenlijst
+- [#158](https://github.com/AlingAdvies/MCM2/issues/158) — Bulk-upload voor leveranciersstamdata
+- [#159](https://github.com/AlingAdvies/MCM2/issues/159) — Leverancierstype makkelijk aanvinken vanuit de leverancierslijst
+- [#160](https://github.com/AlingAdvies/MCM2/issues/160) — Bulk-upload voor contractdata (leverancier, begin-/einddatum)
+- [#161](https://github.com/AlingAdvies/MCM2/issues/161) — Compliance-status: vrij tekstveld → koppeling met beoordelingsuitkomst?
 
-### Beheermenu (3)
+### Beheermenu (4)
 
 - [#75](https://github.com/AlingAdvies/MCM2/issues/75) `before-production` — Beheermenu: gebruikers en rechten per tenant
 - [#76](https://github.com/AlingAdvies/MCM2/issues/76) `before-production` — Beheermenu: e-mailinstellingen (SMTP) per tenant, wachtwoord versleuteld opgeslagen
 - [#77](https://github.com/AlingAdvies/MCM2/issues/77) `before-production` — Beheermenu: uitnodigingen versturen — handpicked en in bulk op leverancierscriteria
+- [#162](https://github.com/AlingAdvies/MCM2/issues/162) — Bug: tenantnaam ontbreekt in de tenantinstellingen-tekst (hardcoded 'AlingAdvies')
 
-### AWS / productie-infrastructuur (6)
+### AWS / productie-infrastructuur (5)
 
-- [#12](https://github.com/AlingAdvies/MCM2/issues/12) `before-pilot` — Kleine AWS-acceptatieomgeving opzetten
 - [#17](https://github.com/AlingAdvies/MCM2/issues/17) `before-pilot` — Logging/monitoring-basislaag vóór de pilot
 - [#21](https://github.com/AlingAdvies/MCM2/issues/21) `before-production` — Volledige AWS-beveiligingsdiensten groep 1 (WAF, GuardDuty, KMS, CloudTrail, SNS, malware-scan)
 - [#57](https://github.com/AlingAdvies/MCM2/issues/57) `before-production` — Platformbeheer-toegang tot klant-tenants: industry standards onderzoeken vóór definitieve keuze
@@ -58,9 +65,8 @@ oogopslag zien wat er per thema openstaat, gesorteerd op prioriteit.
 - [#46](https://github.com/AlingAdvies/MCM2/issues/46) — Duurzame objectopslag voor uploads + ingeplande dump buiten de brondraaimachine
 - [#48](https://github.com/AlingAdvies/MCM2/issues/48) — Pilot-runbook en alerting: wie kijkt wanneer naar welk signaal
 
-### OTAP en CI/CD (7)
+### OTAP en CI/CD (6)
 
-- [#11](https://github.com/AlingAdvies/MCM2/issues/11) `before-pilot` — CI-workflow uitbreiden met test/build/Docker-build (na ORM-spike)
 - [#18](https://github.com/AlingAdvies/MCM2/issues/18) `before-production` — Volledige OTAP-doorloop minimaal één keer bewezen
 - [#20](https://github.com/AlingAdvies/MCM2/issues/20) `before-production` — Dockerfile hardenen: npm ci, multi-stage build, non-root user
 - [#22](https://github.com/AlingAdvies/MCM2/issues/22) `before-production` — Dependabot-configuratie
@@ -68,15 +74,12 @@ oogopslag zien wat er per thema openstaat, gesorteerd op prioriteit.
 - [#51](https://github.com/AlingAdvies/MCM2/issues/51) — Frontend-image promoveerbaar maken: API-URL runtime i.p.v. ingebakken bij build
 - [#53](https://github.com/AlingAdvies/MCM2/issues/53) — OTAP-doorloop periodiek automatiseren zonder cross-repo koppeling
 
-### Toegangsmechanisme (tokens, guards) (3)
+### Toegangsmechanisme (tokens, guards) (1)
 
-- [#8](https://github.com/AlingAdvies/MCM2/issues/8) `before-pilot` — Tijdgebonden, niet-raadbaar, éénmalig-bruikbaar token-mechanisme
-- [#10](https://github.com/AlingAdvies/MCM2/issues/10) `before-pilot` — Token-isolatietest (incl. bestandsupload) als verplichte CI-poort
 - [#47](https://github.com/AlingAdvies/MCM2/issues/47) — Eén Playwright-browsertest van de volledige UC1-flow (token → upload → indienen)
 
-### Database, migraties, RLS (7)
+### Database, migraties, RLS (6)
 
-- [#3](https://github.com/AlingAdvies/MCM2/issues/3) `p0` — tsconfig.json naar strict-mode, module-systeem-inconsistentie oplossen
 - [#14](https://github.com/AlingAdvies/MCM2/issues/14) `before-pilot` — REVOKE UPDATE, DELETE op audit.audit_event voor de runtime-rol
 - [#16](https://github.com/AlingAdvies/MCM2/issues/16) `before-pilot` — Export- en reminder-acties krijgen expliciet meegegeven tenantId
 - [#49](https://github.com/AlingAdvies/MCM2/issues/49) — max_files structureel afdwingen: quotarij met atomaire reservering (kale trigger volstaat niet)
@@ -93,4 +96,4 @@ oogopslag zien wat er per thema openstaat, gesorteerd op prioriteit.
 
 ---
 
-**Totaal open:** 42
+**Totaal open:** 45

--- a/docs/STATUSBORD.md
+++ b/docs/STATUSBORD.md
@@ -5,7 +5,7 @@ verloren bij de volgende run. Pas in plaats daarvan het issue of het label
 aan op GitHub, en draai `npm run statusbord` opnieuw (of wacht op de
 geplande workflow).
 
-**Gegenereerd:** 2026-08-21 10:08 UTC · **Bron:** `gh issue list --repo AlingAdvies/MCM2`
+**Gegenereerd:** 2026-08-21 10:10 UTC · **Bron:** `gh issue list --repo AlingAdvies/MCM2`
 
 Dit is geen vervanging van de issues zelf (details, acceptatiecriteria,
 discussie staan daar) en geen vervanging van `docs/STATUS.md` (het

--- a/docs/architectuur/roadmap-vendor-it-survey.md
+++ b/docs/architectuur/roadmap-vendor-it-survey.md
@@ -1,6 +1,6 @@
 # Roadmap — Vendor IT survey en contractmanagement
 
-**Type:** roadmap — geordend, nog niet vastgelegd als issues
+**Type:** roadmap — overzicht; elk punt heeft een gekoppeld GitHub issue (§2–§4)
 **Eigenaar:** de eigenaar (Chris)
 **Opgesteld:** 2026-08-21, uit `docs/opmerkingen Vendor IT survey.txt`
 **Geldt voor:** MCM2 in generieke zin — niet Transdev-specifiek, ook al zijn de
@@ -14,6 +14,13 @@ door een echte gebruiker gebruikt gaat worden, niet alleen intern getest.
 > uitgewerkt wordt tot een GitHub issue, hoort dat issue-nummer hier
 > teruggekoppeld te worden — anders raken dit document en de backlog uit de
 > pas.
+
+**Koppeling met GitHub Issues.** Dit document is het overzicht; de issues zijn
+de detailwerklijst. Elk punt hieronder heeft een `→ #nummer`-verwijzing naar
+het issue waar de uitwerking, discussie en voortgang staan. Het statusbord
+(`docs/STATUSBORD.md`) toont deze issues onder `thema:product-kern` en
+`thema:beheermenu` — dit document geeft de samenhang die het statusbord niet
+laat zien.
 
 ---
 
@@ -56,7 +63,7 @@ precies waarom #24 de bredere modules bewust "later" noemt.
 
 ## 2. Vragenlijst en uitnodiging
 
-### 2.1 Geen link naar de uitstuurder in de vragenlijst zelf
+### 2.1 Geen link naar de uitstuurder in de vragenlijst zelf → [#153](https://github.com/AlingAdvies/MCM2/issues/153)
 
 **Bevinding:** een leverancier die de vragenlijst invult, ziet nergens een
 verwijzing naar wie de uitnodiging heeft verstuurd of waar hij met vragen
@@ -73,7 +80,7 @@ vragenlijst? Neem contact op met [naam/adres]"), gevuld met dezelfde waarde
 als het antwoordadres uit de tenantinstellingen — of, als dat leeg is, de
 contactpersoon-tekst die daar al voor bestaat (zie §5).
 
-### 2.2 "Rondes" is een verwarrende naam voor wat er nu gebeurt
+### 2.2 "Rondes" is een verwarrende naam voor wat er nu gebeurt → [#154](https://github.com/AlingAdvies/MCM2/issues/154)
 
 **Bevinding:** in `/beheer/vragenlijsten` heet elke uitnodiging een "ronde".
 Feitelijk is een herhaalde meting (dezelfde vragenlijst, periodiek opnieuw
@@ -90,7 +97,7 @@ verzending van een vragenlijst) wél moet heten — bijvoorbeeld "verzending" of
 feature. Dit is een kleine wijziging (UI-tekst + eventueel een kolomnaam) als
 hij nu gebeurt, en een grotere migratie als hij later moet.
 
-### 2.3 Nieuwe feature: vragenlijst-bouwer
+### 2.3 Nieuwe feature: vragenlijst-bouwer → [#155](https://github.com/AlingAdvies/MCM2/issues/155)
 
 **Bevinding:** tenant-beheerders kunnen nu geen eigen vragenlijsten
 samenstellen — de acht Transdev-vragen zijn een vaste seed.
@@ -124,7 +131,7 @@ is, zodat dit niet als losse vraag blijft rondzweven.
 Dit is het grootste nieuwe blok, en het correspondeert met stap 3
 ("contractmanagement") uit de grove volgorde.
 
-### 3.1 Contractbeheerder / contactpersoon ontbreekt als veld
+### 3.1 Contractbeheerder / contactpersoon ontbreekt als veld → [#156](https://github.com/AlingAdvies/MCM2/issues/156)
 
 **Bevinding:** bij een leverancier is er geen veld voor wie er intern
 verantwoordelijk is voor het contract of het contact met die leverancier.
@@ -133,7 +140,7 @@ verantwoordelijk is voor het contract of het contact met die leverancier.
 tabel als één leverancier meerdere contractbeheerders kan hebben — dat is een
 scope-vraag die nog niet beantwoord is).
 
-### 3.2 Contractveld, gekoppeld aan leverancierstype en/of vragenlijst
+### 3.2 Contractveld, gekoppeld aan leverancierstype en/of vragenlijst → [#157](https://github.com/AlingAdvies/MCM2/issues/157)
 
 **Bevinding:** er moet een contractveld komen dat linkt naar het type
 leverancier en/of naar de vragenlijst die voor dat type geldt.
@@ -145,7 +152,7 @@ rond `vendor` en `survey_run`/`vragenlijst`, en verdient een eigen ontwerpstap
 vóór er code komt — het is precies het soort keuze waar het
 intake-protocol voor bedoeld is wanneer dit wordt opgepakt.
 
-### 3.3 Bulk-upload voor leveranciersstamdata
+### 3.3 Bulk-upload voor leveranciersstamdata → [#158](https://github.com/AlingAdvies/MCM2/issues/158)
 
 **Bevinding:** er moet een manier zijn om leveranciers in bulk te importeren,
 niet één voor één.
@@ -168,7 +175,7 @@ niet één voor één.
   net als tenant-aanmaak dat al doet. Zonder dat is een verkeerde import
   achteraf niet te herleiden.
 
-### 3.4 Leverancierstype makkelijk aanvinken vanuit de lijst
+### 3.4 Leverancierstype makkelijk aanvinken vanuit de lijst → [#159](https://github.com/AlingAdvies/MCM2/issues/159)
 
 **Bevinding:** vanuit de leverancierslijst moet het type leverancier snel
 aan te vinken zijn, zonder elke leverancier apart te openen.
@@ -177,7 +184,7 @@ aan te vinken zijn, zonder elke leverancier apart te openen.
 rijen in de lijstweergave. Relatief kleine UI-uitbreiding op een bestaand
 scherm.
 
-### 3.5 Bulk-upload voor contractdata
+### 3.5 Bulk-upload voor contractdata → [#160](https://github.com/AlingAdvies/MCM2/issues/160)
 
 **Bevinding:** los van de leveranciersstamdata moet er ook bulk-upload zijn
 voor contractdata: leverancier, begindatum, einddatum.
@@ -187,7 +194,7 @@ feature toegepast op een ander gegevenstype, en kan vermoedelijk dezelfde
 import-mechaniek (preview, matching, audit) hergebruiken zodra die eenmaal
 gebouwd is voor leveranciers.
 
-### 3.6 Compliance-status: vrij tekstveld → koppeling met beoordelingsuitkomst?
+### 3.6 Compliance-status: vrij tekstveld → koppeling met beoordelingsuitkomst? → [#161](https://github.com/AlingAdvies/MCM2/issues/161)
 
 **Bevinding:** de compliance-status bij een leverancier is nu een vrij
 invulbaar tekstveld. De vraag is of dat gekoppeld moet worden aan de
@@ -209,7 +216,7 @@ een automatische overschrijving? Dat verschil bepaalt de hele aanpak.
 
 ## 4. Instellingen
 
-### 4.1 Bug: tenantnaam ontbreekt in de instellingentekst
+### 4.1 Bug: tenantnaam ontbreekt in de instellingentekst → [#162](https://github.com/AlingAdvies/MCM2/issues/162)
 
 **Bevinding:** in de tenantinstellingen staat de tekst:
 
@@ -245,21 +252,27 @@ bewust ook voor demo/bewijs gebruikt — dit is daar een voorbeeld van.
 
 ---
 
-## 6. Voorgestelde volgende stap
+## 6. Alle tien punten zijn nu issues — voorgestelde volgorde
 
-Geen van de punten hierboven is nu al een GitHub issue. Voorstel:
+Aangemaakt 21-08, elk met een `thema:*`-label zodat ze meelopen in het
+statusbord:
 
-1. **§4.1 (tenantnaam-bug)** eerst en los oppakken — klein, geen ontwerpvraag.
-2. **§2.2 (naamgeving "ronde")** vroeg beslissen, vóórdat er meer code op de
-   huidige naam gebouwd wordt — voorkomt een latere naamsbotsing.
-3. De rest van §2 en §3 wachten op een keuze: welke van deze punten hoort bij
-   "stap 1: een goede vragenlijst" (dus nu) en welke bij "stap 3:
-   contractmanagement" (dus later)? Dat onderscheid bepaalt de volgorde
-   waarin ze als issue worden aangemaakt.
+| Issue | Sectie | Voorstel volgorde |
+|---|---|---|
+| [#162](https://github.com/AlingAdvies/MCM2/issues/162) | §4.1 — tenantnaam-bug | Eerst — klein, geen ontwerpvraag |
+| [#154](https://github.com/AlingAdvies/MCM2/issues/154) | §2.2 — naamgeving "ronde" | Vroeg — voorkomt een latere naamsbotsing |
+| [#153](https://github.com/AlingAdvies/MCM2/issues/153) | §2.1 — contactinfo in vragenlijst | Bij stap 1 (goede vragenlijst) |
+| [#155](https://github.com/AlingAdvies/MCM2/issues/155) | §2.3 — vragenlijst-bouwer | Bij stap 1 (goede vragenlijst) |
+| [#156](https://github.com/AlingAdvies/MCM2/issues/156) | §3.1 — contractbeheerder-veld | Bij stap 3 (contractmanagement) |
+| [#157](https://github.com/AlingAdvies/MCM2/issues/157) | §3.2 — contractveld/type-koppeling | Bij stap 3, na §3.1 (ontwerpstap eerst) |
+| [#158](https://github.com/AlingAdvies/MCM2/issues/158) | §3.3 — bulk-upload leveranciers | Bij stap 3 |
+| [#160](https://github.com/AlingAdvies/MCM2/issues/160) | §3.5 — bulk-upload contracten | Bij stap 3, na §3.3 (hergebruikt de mechaniek) |
+| [#159](https://github.com/AlingAdvies/MCM2/issues/159) | §3.4 — leverancierstype aanvinken | Bij stap 3, kleine UI-uitbreiding |
+| [#161](https://github.com/AlingAdvies/MCM2/issues/161) | §3.6 — compliance-status koppeling | Open vraag, geen datum — eerst besluiten wat het moet worden |
 
-**Wat dit document bewust niet doet:** de punten al aan een fase toewijzen.
-Dat is een prioriteringskeuze die bij de eigenaar hoort te liggen, niet iets
-om hier aan te nemen.
+**Wat dit document bewust niet doet:** de volgorde hierboven als vaststaand
+behandelen. Het is een voorstel; de eigenaar bepaalt de daadwerkelijke
+volgorde via het statusbord en de issues zelf.
 
 ---
 


### PR DESCRIPTION
Tien punten uit `roadmap-vendor-it-survey.md` (§2–§4) omgezet naar losse GitHub issues (#153-#162), elk met een `thema:*`-label zodat ze in het statusbord verschijnen. De roadmap verwijst nu per sectie terug naar het issue, en §6 is herschreven naar een voorgestelde volgorde.

Alleen documentatie, geen codewijziging.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>