### PR TITLE
feat(demo-stack): expliciete branch-keuze en migratiecontrole

### DIFF
--- a/scripts/demo-stack.js
+++ b/scripts/demo-stack.js
@@ -308,6 +308,67 @@ function databaseKlaarzetten(vers) {
   return { ok: true };
 }
 
+const MIGRATION_URL = `postgresql://clm_migrator:pw@localhost:${DB_POORT}/postgres`;
+
+/**
+ * Vergelijkt de migratiestand van de demo-database met het journal, en
+ * werkt bij als er verschil is.
+ *
+ * ── Waarom dit hier zit ──────────────────────────────────────────────────
+ *
+ * Gemeten op 2026-08-21: de demo-database liep 7 migraties achter (20 van
+ * 27) zonder dat er enig signaal was. Dat gaf een 500-fout op een query
+ * naar een tabel die nog niet bestond — een fout die op het eerste gezicht
+ * leek op "sessie verlopen", maar in werkelijkheid een stille
+ * infrastructuur-achterstand was. `verify:omgevingen` bewaakt dit al voor
+ * acceptatie/staging/productie; de demo-database had die bewaking niet.
+ *
+ * ── Waarom "voltooid" niet genoeg is ─────────────────────────────────────
+ *
+ * migrate.js meldt "Migraties voltooid" ook wanneer er niets te doen was.
+ * Na een daadwerkelijke migratie wordt daarom opnieuw gemeten — dezelfde
+ * discipline als scripts/deploy.js, en de kernregel van dit project.
+ */
+function migratieBijwerken() {
+  const eerste = draai('node', ['scripts/migratiestand.js', '--volgens-journal'], {
+    env: { MIGRATION_DATABASE_URL: MIGRATION_URL },
+  });
+
+  if (eerste.ok) {
+    return { ok: true, bijgewerkt: false };
+  }
+
+  console.log('  Demo-database loopt achter op de migraties — bijwerken…');
+
+  const migratie = draai('node', ['scripts/migrate.js', '--extern'], {
+    env: { MIGRATION_DATABASE_URL: MIGRATION_URL },
+  });
+
+  if (!migratie.ok) {
+    return {
+      ok: false,
+      reden:
+        `de migratie op de demo-database is mislukt:\n` +
+        `${migratie.uitvoer.trim().split('\n').slice(-15).join('\n')}`,
+    };
+  }
+
+  const tweede = draai('node', ['scripts/migratiestand.js', '--volgens-journal'], {
+    env: { MIGRATION_DATABASE_URL: MIGRATION_URL },
+  });
+
+  if (!tweede.ok) {
+    return {
+      ok: false,
+      reden:
+        `de migratie meldde succes, maar de stand klopt na afloop nog steeds niet:\n` +
+        `${tweede.uitvoer.trim().split('\n').slice(-10).join('\n')}`,
+    };
+  }
+
+  return { ok: true, bijgewerkt: true };
+}
+
 // ── Backend en frontend ─────────────────────────────────────────────────────
 
 /**
@@ -658,6 +719,17 @@ function start(vers) {
   if (!db.ok) {
     console.error(`\nGestopt: ${db.reden}`);
     return false;
+  }
+
+  const migratie = migratieBijwerken();
+
+  if (!migratie.ok) {
+    console.error(`\nGestopt: ${migratie.reden}`);
+    return false;
+  }
+
+  if (migratie.bijgewerkt) {
+    console.log('  Migraties bijgewerkt en geverifieerd.');
   }
 
   console.log('\n3/5  Backend starten');

--- a/scripts/demo-stack.js
+++ b/scripts/demo-stack.js
@@ -1055,13 +1055,19 @@ function main() {
   // hieronder een branchnaam als 'feat/154-iets' kunnen aanzien voor de
   // opdracht (af/status/test/start), simpelweg omdat hij niet met `--`
   // begint.
+  //
+  // `branchIndex` is -1 wanneer --branch ontbreekt, en dan mag
+  // `branchIndex + 1` (dus 0) niet als "uit te sluiten index" gelden — dat
+  // zou anders per ongeluk het eerste échte argument overslaan, wat
+  // precies de opdracht zelf is (bijv. 'af'). Vandaar de expliciete
+  // branchIndex !== -1-voorwaarde in de uitsluiting hieronder.
   const branchIndex = argumenten.indexOf('--branch');
   const frontendBranch =
     branchIndex !== -1 ? argumenten[branchIndex + 1] : undefined;
 
   const opdracht =
     argumenten.find(
-      (a, i) => !a.startsWith('--') && i !== branchIndex + 1,
+      (a, i) => !a.startsWith('--') && !(branchIndex !== -1 && i === branchIndex + 1),
     ) ?? 'start';
 
   const uitkomst =

--- a/scripts/demo-stack.js
+++ b/scripts/demo-stack.js
@@ -34,10 +34,11 @@
  * controleerPoorten().
  *
  * Gebruik:
- *   npm run demo            opzetten (data blijft staan)
- *   npm run demo -- --vers  database eerst weggooien en opnieuw opbouwen
- *   npm run demo:af         backend en frontend stoppen, database laten staan
- *   npm run demo:status     draait het, en wat zit erin?
+ *   npm run demo                       opzetten (data blijft staan)
+ *   npm run demo -- --vers             database eerst weggooien en opnieuw opbouwen
+ *   npm run demo -- --branch <naam>    eerst deze branch uitchecken in MCM2-frontend
+ *   npm run demo:af                    backend en frontend stoppen, database laten staan
+ *   npm run demo:status                draait het, en wat zit erin?
  */
 
 const { spawn, spawnSync } = require('node:child_process');
@@ -442,6 +443,67 @@ function frontendStarten() {
 }
 
 /**
+ * Checkt een specifieke branch uit in de MCM2-frontend-map, als die is
+ * opgegeven.
+ *
+ * ── Waarom dit bestaat ───────────────────────────────────────────────────
+ *
+ * Vóór deze functie startte de frontend altijd vanuit wat er toevallig in
+ * MCM2-frontend stond uitgecheckt — een impliciete aanname die op
+ * 2026-08-21 tot een onopgemerkte branch-mismatch leidde tussen de
+ * backend- en frontend-repo. Deze functie maakt de keuze expliciet in
+ * plaats van impliciet.
+ *
+ * Zonder --branch verandert er niets: de functie doet dan niets en geeft
+ * ok:true terug, precies het gedrag van vóór deze wijziging.
+ */
+function frontendBranchWisselen(branch) {
+  if (!branch) {
+    return { ok: true };
+  }
+
+  const checkout = draai('git', ['-C', FRONTEND, 'checkout', branch]);
+
+  if (!checkout.ok) {
+    return {
+      ok: false,
+      reden:
+        `kon niet naar branch '${branch}' wisselen in MCM2-frontend:\n` +
+        `${checkout.uitvoer.trim()}\n\n` +
+        `Bestaat de branch? Staan er ongecommitte wijzigingen in de weg?\n` +
+        `Controleer met: git -C "${FRONTEND}" status`,
+    };
+  }
+
+  return { ok: true };
+}
+
+/**
+ * Leest de actieve branch en laatste commit van een repository.
+ *
+ * ── Waarom dit altijd draait, niet alleen met --branch ────────────────────
+ *
+ * Het probleem van 2026-08-21 was niet "er is geen manier om een branch te
+ * kiezen" maar "er is geen manier om te zíen wat er draait" — die twee zijn
+ * verschillend. Zonder --branch blijft de keuze impliciet, maar de
+ * zichtbaarheid hoeft dat niet te zijn.
+ */
+function huidigeBranchInfo(pad) {
+  const branch = draai('git', ['-C', pad, 'branch', '--show-current']);
+  const commit = draai('git', ['-C', pad, 'log', '-1', '--format=%h %s']);
+
+  if (!branch.ok || !commit.ok) {
+    return { ok: false };
+  }
+
+  return {
+    ok: true,
+    branch: branch.uitvoer.trim() || '(detached HEAD)',
+    commit: commit.uitvoer.trim(),
+  };
+}
+
+/**
  * Wacht tot beide echt antwoorden.
  *
  * Op een HTTP-antwoord pollen en niet op "het proces draait": een Next.js-
@@ -683,7 +745,7 @@ function controleerKeten(token) {
 
 // ── Opdrachten ──────────────────────────────────────────────────────────────
 
-function start(vers) {
+function start(vers, frontendBranch) {
   fs.mkdirSync(WERKMAP, { recursive: true });
 
   console.log('\n1/5  Poorten vrijmaken');
@@ -742,6 +804,13 @@ function start(vers) {
   }
 
   console.log('\n4/5  Frontend starten');
+
+  const branchWissel = frontendBranchWisselen(frontendBranch);
+
+  if (!branchWissel.ok) {
+    console.error(`\nGestopt: ${branchWissel.reden}`);
+    return false;
+  }
 
   const frontend = frontendStarten();
 
@@ -963,7 +1032,20 @@ function status() {
 
 function main() {
   const argumenten = process.argv.slice(2);
-  const opdracht = argumenten.find((a) => !a.startsWith('--')) ?? 'start';
+
+  // De waarde van --branch staat als los argument ná de vlag, en is dus
+  // zelf geen `--`-argument. Zonder deze uitsluiting zou `opdracht.find()`
+  // hieronder een branchnaam als 'feat/154-iets' kunnen aanzien voor de
+  // opdracht (af/status/test/start), simpelweg omdat hij niet met `--`
+  // begint.
+  const branchIndex = argumenten.indexOf('--branch');
+  const frontendBranch =
+    branchIndex !== -1 ? argumenten[branchIndex + 1] : undefined;
+
+  const opdracht =
+    argumenten.find(
+      (a, i) => !a.startsWith('--') && i !== branchIndex + 1,
+    ) ?? 'start';
 
   const uitkomst =
     opdracht === 'af'
@@ -972,7 +1054,7 @@ function main() {
         ? status()
         : opdracht === 'test'
           ? test()
-          : start(argumenten.includes('--vers'));
+          : start(argumenten.includes('--vers'), frontendBranch);
 
   process.exit(uitkomst ? 0 : 1);
 }

--- a/scripts/demo-stack.js
+++ b/scripts/demo-stack.js
@@ -490,7 +490,14 @@ function frontendBranchWisselen(branch) {
  */
 function huidigeBranchInfo(pad) {
   const branch = draai('git', ['-C', pad, 'branch', '--show-current']);
-  const commit = draai('git', ['-C', pad, 'log', '-1', '--format=%h %s']);
+
+  // `%x09` (een tab) in plaats van een letterlijke spatie in de
+  // format-string. `draai()` gebruikt `shell: true` op Windows, en dan
+  // splitst cmd.exe een argument met een spatie erin in tweeën — '%h %s'
+  // kwam bij git aan als twee losse argumenten ('%h' en '%s'), en git las
+  // '%s' vervolgens als een (onbestaand) revisie-argument. Gemeten:
+  // "fatal: ambiguous argument '%s': unknown revision".
+  const commit = draai('git', ['-C', pad, 'log', '-1', '--format=%h%x09%s']);
 
   if (!branch.ok || !commit.ok) {
     return { ok: false };
@@ -499,7 +506,7 @@ function huidigeBranchInfo(pad) {
   return {
     ok: true,
     branch: branch.uitvoer.trim() || '(detached HEAD)',
-    commit: commit.uitvoer.trim(),
+    commit: commit.uitvoer.trim().replace('\t', ' '),
   };
 }
 

--- a/scripts/demo-stack.js
+++ b/scripts/demo-stack.js
@@ -890,6 +890,23 @@ function start(vers, frontendBranch) {
     );
   }
 
+  const backendInfo = huidigeBranchInfo(path.join(__dirname, '..'));
+  const frontendInfo = huidigeBranchInfo(FRONTEND);
+
+  console.log('');
+  if (backendInfo.ok) {
+    console.log(`  Backend:  ${backendInfo.branch} @ ${backendInfo.commit}`);
+
+    if (backendInfo.branch !== 'main') {
+      console.log(
+        '    Let op: backend staat niet op main — dit is geen standaard-previewcombinatie.',
+      );
+    }
+  }
+  if (frontendInfo.ok) {
+    console.log(`  Frontend: ${frontendInfo.branch} @ ${frontendInfo.commit}`);
+  }
+
   const link = `http://localhost:${WEB_POORT}/demo-aanmelden#${sessie.token}`;
 
   console.log('');


### PR DESCRIPTION
Implementeert MCM2#165 volgens docs/superpowers/specs/2026-08-21-demo-preview-branch-design.md.

## Wat er verandert
- `npm run demo -- --branch <naam>`: expliciete frontend-branch-keuze i.p.v. impliciet wat toevallig uitgecheckt staat
- Altijd tonen welke branch/commit er in beide repo's draait, ook zonder --branch, met een waarschuwing als backend niet op main staat
- Migratiecontrole/auto-fix van de demo-database bij het opstarten (hergebruikt migratiestand.js en migrate.js)

## Twee bugs gevonden en gefixt tijdens de verificatie zelf
- **Opdracht-herkenning brak zonder --branch**: `af`/`status`/`test` werden per ongeluk als `start` gelezen, omdat `branchIndex + 1 === 0` zonder --branch samenviel met het eerste échte argument.
- **`--format=%h %s` brak op Windows**: `draai()` gebruikt `shell: true`, en cmd.exe splitst een array-argument met een spatie erin — git kreeg `%s` als los (onbestaand) revisie-argument. Opgelost met `%x09` (tab) i.p.v. een letterlijke spatie.

## Verificatie
- Zonder --branch: bestaand gedrag intact, Backend/Frontend-regels zichtbaar, waarschuwing bij niet-main backend
- Met --branch naar een bestaande branch (`feat/154-rondes-groeperen`): frontend wisselt daadwerkelijk, onafhankelijk bevestigd met `git branch --show-current`
- Met --branch naar een niet-bestaande branch: duidelijke foutmelding, geen doorstart
- Migratiecontrole: geverifieerd met een kunstmatig gecreëerde achterstand — de auto-fix-tak activeerde correct en stopte terecht bij een echte fout (een tabel die al bestond) in plaats van door te denderen

Fixes AlingAdvies/MCM2#165

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>