### PR TITLE
feat(contract): contractmanagement-datamodel + UI-dichtheid spec/plan

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,6 @@ report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json
 
 # Schermafdrukken uit browsersessies — werkmateriaal, geen broncode.
 /*.png
+
+# superpowers brainstorm-companion mockups (tijdelijk, hoort niet in git)
+.superpowers/

--- a/MCM2-CLAUDE.md
+++ b/MCM2-CLAUDE.md
@@ -81,6 +81,83 @@ geheugen te herhalen.
 - Dit voorkomt dat een al opgeloste klasse fout een tweede keer wordt
   gemaakt, alleen op een nieuwe tabel — precies het patroon van vandaag.
 
+### 1c. Frontend-smaak is net zo goed een regel als een backend-regel
+
+*Vastgelegd 2026-08-22, na een vergelijking met MVM_V2. Daar leverde
+frontend-werk consequent bruikbare, dichte schermen op; bij MCM2 wisselde
+de kwaliteit per scherm. Het verschil zat niet in vaardigheid maar in
+vastlegging: MVM_V2's `CLAUDE.md` normeert dichtheid, verplicht een
+intake per datascherm, en houdt een groeiende tabel van UI-beslissingen
+bij. MCM2's instructies normeerden dat nergens — met als gevolg dat elk
+scherm de smaak opnieuw moest raden. Dit hoofdstuk kopieert dat patroon,
+toegesneden op MCM2.*
+
+**Design tokens — al aanwezig, blijft de enige bron van waarheid.**
+`MCM2-frontend/src/shared/design-tokens.ts` is letterlijk overgenomen uit
+MVM_V2 (zie het bestand zelf). Nooit een kleur, font-size of spacing-
+waarde hardcoden in een component — altijd `tokens`, `typography`,
+`spacing` of `statusConfig` uit dat bestand, of de Tailwind-klassen die
+eruit zijn afgeleid. Wijk je hiervan af, benoem dat expliciet en waarom.
+
+**Informatiedichtheid — de standaard, niet de uitzondering.**
+De doelgroep werkt op een pc met een groot scherm. Standaard geldt:
+
+- Gebruik de volle breedte van het scherm; geen onnodig witruimte of
+  smalle centrale kolommen op een breed scherm.
+- Tabelrijen: 6–8px verticale padding (`spacing.tableRowPaddingY`), niet
+  de royalere default-padding van een ongestylede component.
+- Bij een verzameling gerelateerde gegevens (stamgegevens, classificatie,
+  contactpersonen, contractvelden): een compacte, ingedikte weergave is
+  het startpunt. Ruim uitgesponnen kaarten met veel lucht ertussen zijn de
+  uitzondering, niet de standaard — kies daar expliciet voor en benoem
+  waarom.
+- Twijfel je of iets dicht genoeg is: vergelijk met een bestaand dicht
+  scherm in deze repo (bijvoorbeeld de contractentabel), niet met een
+  generieke aanname over "nette" spacing.
+
+**Verplichte mini-intake vóór een nieuw datascherm.**
+Voordat je een nieuw scherm of formulier bouwt dat een entiteit toont,
+aanmaakt of bewerkt (vendor, contract, contactpersoon, vragenlijst,
+gebruiker, etc.), beantwoord — kort, voor jezelf of hardop tegen de
+eigenaar — deze vragen. Dit is geen bureaucratie maar het voorkomt precies
+de gaten die tot nu toe steeds achteraf ontdekt werden (een niet-
+vooringevulde bewerkmodus, een ontbrekend pad naar de volgende stap, een
+actie die alleen bij aanmaken kon en niet bij bewerken):
+
+1. **Velden**: welke zijn verplicht, welke optioneel, en welke worden
+   afgeleid/berekend?
+2. **Bewerken = aanmaken**: als een gebruiker een bestaand record opent
+   om te bewerken, staan dan alle bestaande waarden vooringevuld? Kan
+   alles wat bij aanmaken kan (zoals een gekoppelde contactpersoon
+   toevoegen) ook bij bewerken?
+3. **Vervolgstap**: als dit scherm een record aanmaakt dat later een
+   actie triggert (een uitnodiging versturen, een survey koppelen), is er
+   een zichtbaar, direct pad naar die actie — niet alleen een vlag die
+   ergens anders passief wordt afgelezen?
+4. **Wie mag dit zien/bewerken**: is er een rol- of tenantbeperking?
+5. **Waar in de navigatie**: hoort dit in een bestaand scherm thuis (zoals
+   de contractensectie op de leveranciersdetailpagina) of is het een
+   nieuwe toppagina?
+
+Bij twijfel: vraag het de eigenaar, kort en concreet — net als bij een
+architectuurkeuze (§1a). Sla deze intake alleen bewust over bij een
+zuivere bugfix of een cosmetische wijziging.
+
+**Vaste toetsvraag bij elk scherm.**
+Analoog aan MVM_V2's Contract 360-toets: *"Ziet de gebruiker in één
+oogopslag wat hij moet weten en kan hij van daaruit direct verder?"* Een
+scherm dat wel de juiste data toont maar geen actie mogelijk maakt
+(bijvoorbeeld: een gekoppelde vragenlijst zien, zonder een knop om hem
+te versturen) is niet compleet, ook al zijn alle velden gevuld.
+
+**Groeiende tabel van UI-beslissingen — bijhouden vanaf nu.**
+Zodra een sessie een frontend-patroon vaststelt (een component-indeling,
+een interactiepatroon zoals fold-out-formulieren, een tabel- versus
+lijstweergave), leg die vast in `docs/architectuur/ui-beslissingen.md`
+in plaats van hem opnieuw te laten ontdekken in een volgende sessie.
+Format: één regel per beslissing, met datum en korte reden — zoals de
+"Bekende beslissingen"-tabel in MVM_V2's `CLAUDE.md`.
+
 ---
 
 ## 2. Productdoel

--- a/MCM2-CLAUDE.md
+++ b/MCM2-CLAUDE.md
@@ -32,6 +32,55 @@ Ga nooit uit van een oplossing omdat die eerder genoemd, gepland of deels gebouw
 
 **Drizzle is geen doel. Prisma is geen vaststaand besluit. AWS is een richting, geen reden voor vroegtijdige complexiteit.**
 
+### 1a. Stel basale vragen — de eigenaar is product owner, geen IT'er
+
+*Vastgelegd 2026-08-22, na een sessie waarin een complete backend
+(migratie, service, API) werd gebouwd en voor "klaar" werd aangezien
+zonder dat er een scherm bestond om hem te gebruiken. Dat werd pas
+duidelijk toen de eigenaar vroeg om een preview.*
+
+De eigenaar denkt vanuit het product, niet vanuit lagen als "backend" en
+"frontend" — die scheiding is voor jou vanzelfsprekend, voor hem niet. Een
+plan dat alleen een API oplevert kan voor hem onopgemerkt "compleet"
+lijken. Vandaar:
+
+- Bij elke nieuwe functionaliteit die een gebruiker ooit gaat bedienen:
+  **default is backend + scherm samen**, tenzij expliciet en bewust
+  gekozen voor backend-only (bijvoorbeeld een interne migratie of een API
+  die een al bestaand scherm bedient). Die keuze hoort een vraag te zijn,
+  niet een aanname.
+- Stel bij twijfel een basale vraag, ook als hij vanzelfsprekend lijkt:
+  "moet dit ook een scherm krijgen?", "is dit compleet genoeg om te
+  testen/previewen?", "waar in de bestaande navigatie hoort dit?". Een
+  vraag te veel kost een antwoord; een vraag te weinig kost een hele
+  bouwronde over.
+- Rond een implementatietaak nooit af met "klaar" of "backend staat"
+  zonder expliciet te benoemen wat een gebruiker er wél en niet mee kan
+  in de browser. "Klaar" betekent bruikbaar, niet "de tests zijn groen".
+
+### 1b. Nieuwe code volgt een bestaand precedent, niet een nieuw ontwerp
+
+*Vastgelegd 2026-08-22, na twee fouten in één migratie (0027) die allebei
+al eerder waren opgelost — een RLS-policy met `deleted_at IS NULL` in
+`USING` (exact het probleem dat migratie 0004/Issue #31 al oploste) en een
+GRANT zonder de voorafgaande `REVOKE ALL` (exact het patroon dat migratie
+0022 vastlegt in `src/db/rechten-contract.ts`). Beide fouten waren te
+voorkomen geweest door vóór het schrijven een vergelijkbare, recente
+migratie als sjabloon te lezen in plaats van de architectuurregel uit het
+geheugen te herhalen.
+
+- **Voordat je een migratie, RLS-policy, service of controller schrijft:**
+  zoek eerst het meest recente vergelijkbare voorbeeld in de repo op en
+  gebruik dat als sjabloon — niet als inspiratie, als sjabloon. Voor een
+  nieuwe tenanttabel is dat de laatste migratie die zoiets deed (nu:
+  0022/0027 voor rechten, 0015 voor een nieuwe tabel met RLS), niet de
+  regel in dit bestand die het principe samenvat.
+  Regels als "elke tenanttabel krijgt RLS" (§7) zeggen **wat** moet
+  gebeuren; ze zijn geen vervanging voor het lezen van **hoe** de vorige
+  keer een fout is voorkomen.
+- Dit voorkomt dat een al opgeloste klasse fout een tweede keer wordt
+  gemaakt, alleen op een nieuwe tabel — precies het patroon van vandaag.
+
 ---
 
 ## 2. Productdoel
@@ -211,6 +260,10 @@ Toon nooit secrets in terminaloutput, documenten, commits, chat of logs. Let ero
 ---
 
 ## 7. Database- en migratieregels
+
+**Lees eerst §1b.** De regels hieronder zeggen wat een migratie moet
+bevatten; ze vervangen niet het lezen van een recente, vergelijkbare
+migratie als sjabloon vóórdat je schrijft.
 
 1. Wijzig database-schema’s uitsluitend via versioned migrationbestanden.
 2. Gebruik nooit directe Supabase-dashboardwijzigingen als vervanging van een migratie.

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -2,6 +2,65 @@
 
 ## Laatst bijgewerkt
 
+**2026-08-23 — de vier UI-punten van "21 augustus III" gebouwd:
+leveranciersscherm herzien (badge-strip, twee kolommen, modal, uitklapbare
+contractrij, wachtlijst-label, urgentiekleur). Beide branches gepusht, PR
+#15 (frontend) open.**
+
+Vervolg op de sessie van 22-08. Brainstorm begon met een expliciete
+vergelijking met MVM_V2 (`vendors/[id]/page.tsx`, `VendorContactsPanel.tsx`)
+op verzoek van de eigenaar — dat leverde twee koerswijzigingen op t.o.v. het
+oorspronkelijke idee: **modal in plaats van fold-out** voor
+contactpersoon-toevoegen (MVM_V2's patroon), en een heroverweging van
+Contract 360 als eigen toppagina — bewust **niet** nu gebouwd, vastgelegd als
+issue #173 voor later.
+
+Tijdens het ontwerpgesprek bracht de eigenaar een vijfde eis in die niet in
+de oorspronkelijke vier punten stond: zichtbare urgentie voor aflopende
+contracten, vanwege het reële schaderisico van stilzwijgende verlenging. Het
+volledige mechanisme (opzegtermijn-veld + "verlengt automatisch"-
+waarschuwing) vraagt een nieuw databaseveld en is vastgelegd als **issue
+#174 — front+backend, expliciet als eerstvolgende stap na deze sessie**. Wat
+nu wél gebouwd is: kleurgecodeerde einddatum (grijs/oranje/rood, 90/30-
+dagendrempel) als tussenoplossing.
+
+**Spec en plan geschreven en gecommit** op `docs/contractmanagement-design`
+(backend-repo): `docs/superpowers/specs/2026-08-23-leveranciersscherm-
+dichtheid-design.md`, `docs/superpowers/plans/2026-08-23-leveranciersscherm-
+dichtheid.md`.
+
+**Implementatie** (inline, negen taken) op `feat/contractmanagement-scherm`
+(frontend-repo): het 1913-regelige `page.tsx` opgesplitst in
+`Stamgegevens.tsx`, `ClassificatieBadges.tsx`, `ContactpersoonModal.tsx`,
+`Contactpersonen.tsx`, `Contracten.tsx`, `contractUrgentie.ts` — elk met een
+eigen, enkelvoudige verantwoordelijkheid.
+
+**Vier echte bugs gevonden en gefixt tijdens de e2e-verificatie**
+(systematisch gedebugd, root cause per fout, geen symptoombestrijding):
+veldfout-matching in drie nieuwe componenten matchte kaal op
+`contactNaam`/`contactEmail`/`name`, terwijl de backend `'Naam'`/
+`'contact.email'` gooit — het origineel loste dit op via een gedeelde
+`hoortBij()`-aliasfunctie die niet was overgenomen, nu per bestand hersteld.
+Plus een onbedoelde tekstwijziging in de verwijderbevestiging
+(`'Ja'/'Nee'` i.p.v. het originele `'Ja, verwijderen'/'Annuleren'`) en een
+gemist testpad na het uitklapbaar maken van de contractrij.
+
+**Volledige verificatie gedraaid** op verzoek van de eigenaar ("doe met de
+frontend hetzelfde als met de backend"): `typecheck`, `lint` (0 warnings),
+`format:check` alle drie schoon; volledige e2e-suite tegen de demo-stack: 71
+passed, 4 failed, 5 skipped. De vier faalgevallen zijn bevestigd
+niet-gerelateerd (cross-suite-interferentie op de gegroeide demo-database,
+plus een al bekende pre-existing fout — zie #83, becommentarieerd vandaag).
+
+**Preview door de eigenaar bekeken en akkoord bevonden** vóór de PR werd
+aangemaakt. Beide branches (backend en frontend) vandaag voor het eerst
+gepusht; **PR #15** open op MCM2-frontend. Backend-branch
+(`docs/contractmanagement-design`) is documentatie-only bovenop het al
+eerder gebouwde datamodel van 22-08 — nog geen eigen PR, zie "Eerstvolgende
+goedgekeurde stap".
+
+---
+
 **2026-08-22 — contractmanagement gebouwd (backend + frontend), sessie
 bewust vroeg gestopt op "UI needs work"; §1c toegevoegd aan MCM2-CLAUDE.md
 na vergelijking met MVM_V2.**
@@ -2117,6 +2176,19 @@ Transdev Vendor IT Compliance Survey als eerste verticale MVP-slice.
 
 ## Actieve blokkades
 
+- **NIET BLOKKEREND (2026-08-23) — e2e-cross-suite-interferentie op de
+  demo-database, bevestigd, niet vandaag ontstaan.** Een volledige
+  `npm run demo:test`-run gaf 4 faalgevallen naast de 71 die slaagden:
+  `e2e/uitnodigen.spec.ts:323` (pre-existing, zie #83 — de vorige test
+  start een ronde die het overzicht niet betrouwbaar toont) en 3 gevallen
+  in `e2e/beheer-leveranciers.spec.ts` die bij isolatie alle drie slagen
+  (de leverancierslijst is gegroeid door eerdere testruns in dezelfde
+  sessie, waardoor aantalsverwachtingen niet meer kloppen). Comment
+  toegevoegd op #83 met de details. Blokkeert PR #15
+  (MCM2-frontend) niet: geen van de vier faalgevallen raakt de gewijzigde
+  bestanden, en CI draait tegen een verse wegwerpdatabase waar dit
+  patroon niet optreedt.
+
 - **OPGELOST 2026-08-07, ochtend — het CI-gat is gedicht.** GitHub Actions stond weer op
   `operational`, waarna de vijf wachtende PR's stuk voor stuk met een groene run zijn gemerged.
   De Docker-productiebuild en de RLS tenant-isolatietest hebben `main` daarmee weer gezien,
@@ -2560,6 +2632,43 @@ Praktische valkuilen die daadwerkelijk zijn tegengekomen, niet bedacht. Ze staan
 
 ## Huidige branch en Git-status
 
+**Stand op 2026-08-23** (geverifieerd met `git status` en `git branch -vv` in
+beide repo's, ná de sessie leveranciersscherm-dichtheid):
+
+| Repo | Branch | Werkboom | Gepusht |
+|---|---|---|---|
+| MCM2 | `main` | schoon, op `888d56b` | ja |
+| MCM2 | `docs/contractmanagement-design` | schoon, 18 commits vóór `main` | **ja, vandaag voor het eerst** |
+| MCM2-frontend | `main` | schoon, op `b774463` | ja |
+| MCM2-frontend | `feat/contractmanagement-scherm` | schoon, 12 commits vóór `main` | **ja, vandaag voor het eerst** |
+
+**Twee openstaande branches, allebei vandaag voor het eerst gepusht en van een
+open PR voorzien:**
+
+- **`docs/contractmanagement-design`** (backend, MCM2) — spec
+  (`2026-08-23-leveranciersscherm-dichtheid-design.md`) en plan
+  (`2026-08-23-leveranciersscherm-dichtheid.md`) voor de UI-herziening.
+  Bevat ook het eerder gebouwde contractmanagement-datamodel (migraties
+  0027/0028) uit de sessie van 22-08. Zuiver documentatie op deze branch,
+  geen backend-codewijziging vandaag. **Nog geen PR** — dit is
+  documentatie-only en hoeft niet per se een eigen PR te krijgen vóór de
+  frontend-PR gemerged is; zie "Eerstvolgende goedgekeurde stap".
+- **`feat/contractmanagement-scherm`** (frontend, MCM2-frontend) — de
+  daadwerkelijke implementatie: badge-strip, twee kolommen,
+  `ContactpersoonModal`, uitklapbare contractrij, wachtlijst-label,
+  urgentiekleur. **PR #15** open:
+  <https://github.com/AlingAdvies/MCM2-frontend/pull/15>. Preview door de
+  eigenaar bekeken en akkoord bevonden vóór de PR werd aangemaakt.
+
+**Verificatie vóór de PR** (conform §10 CI-verplichtingen, handmatig
+gedraaid omdat er geen `verify:volledig`-equivalent in MCM2-frontend
+bestaat): `typecheck`, `lint` (0 warnings) en `format:check` alle drie
+schoon; volledige e2e-suite tegen de demo-stack 71 passed / 4 failed / 5
+skipped. De vier faalgevallen zijn bevestigd niet-gerelateerd aan deze
+wijziging — zie "Actieve blokkades" hieronder en de comment op #83.
+
+---
+
 **Stand op 2026-08-04, ochtend** (geverifieerd met `git status` en `git branch -a`):
 
 | Repo | Branch | Werkboom | Gepusht |
@@ -2634,6 +2743,27 @@ Praktische valkuilen die daadwerkelijk zijn tegengekomen, niet bedacht. Ze staan
 
 ## Eerstvolgende goedgekeurde stap
 
+**Stand 2026-08-23.** In deze volgorde, zoals besproken met de eigenaar:
+
+1. **PR #15 (MCM2-frontend) beoordelen en mergen of bewust parkeren.**
+   Preview al bekeken en akkoord bevonden; wacht op de merge/parkeer-keuze
+   van de eigenaar volgens het git-ritueel.
+2. **`docs/contractmanagement-design` (backend) afhandelen** — bevat
+   uitsluitend documentatie (spec + plan) bovenop het al eerder gebouwde
+   contractmanagement-datamodel van 22-08. Zelfde merge/parkeer-vraag als
+   bij de frontend-branch.
+3. **Issue #174 — opzegtermijn-veld + waarschuwing (front+backend), direct
+   hierna.** Expliciet door de eigenaar als eerstvolgende prioriteit
+   aangewezen: reëel schaderisico van stilzwijgende contractverlenging.
+4. **Issue #173 — Contract 360 als eigen toppagina.** Later, apart
+   traject; bewust niet meegenomen in de huidige UI-ronde.
+5. **"21 augustus II" punt 1+2** (issues #171, #172: contracten in de
+   linkerbalk, dashboard-hernoeming + 90-dagen-widget) — ander deel van
+   het scherm/de navigatie, staat los van de bovenstaande volgorde.
+
+<details>
+<summary>Vorige eerstvolgende stap (2026-08-04, inmiddels ver voorbij — laten staan als historie)</summary>
+
 **Stand 2026-08-04.** Twee dingen, in deze volgorde:
 
 1. ~~**De backupcontrole inrichten**~~ — **gedaan op 2026-08-04.** Credentials, beide taken, testbericht aangekomen, beide taken via Taakplanner gedraaid.
@@ -2646,6 +2776,8 @@ Praktische valkuilen die daadwerkelijk zijn tegengekomen, niet bedacht. Ze staan
 - **#78** — het besluit over welke rol de backup maakt. Nu feitelijk de `postgres`-rol met `BYPASSRLS`, zonder dat dat ergens als besluit staat.
 - **#19** — de hersteltest moet over. Die van 30 juli draaide tegen negen tabellen en bewees dus het herstelpad, niet de compleetheid. De backupcontrole doet dit inmiddels wekelijks, wat het issue grotendeels afdekt.
 - **#83** — gearchiveerde testrondes stapelen op in de demo-database. De e2e-suite archiveert ze (verwijderen kan niet en hoort ook niet te kunnen), maar ze blijven in de lijst staan. Logisch moment om aan te pakken is fase C, want dan wordt het rondeoverzicht toch herzien.
+
+</details>
 
 <details>
 <summary>Vorige eerstvolgende stap (2026-07-31, inmiddels uitgevoerd)</summary>

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -2,6 +2,96 @@
 
 ## Laatst bijgewerkt
 
+**2026-08-22 — contractmanagement gebouwd (backend + frontend), sessie
+bewust vroeg gestopt op "UI needs work"; §1c toegevoegd aan MCM2-CLAUDE.md
+na vergelijking met MVM_V2.**
+
+Twee delen. **Deel 1 (overdag): contractmanagement.** Backend en frontend
+zijn allebei volledig gebouwd op basis van `docs/opmerkingen Vendor IT
+survey.txt` (21/20 augustus-secties): datamodel (`clm.contract`,
+`ref.contract_status`, `clm.contract_survey_template` met een
+`wachtlijst`-vlag), API, en een scherm ingebed op de leveranciersdetail-
+pagina (niet als losse toppagina — dat was een bewuste keuze na
+vergelijking met MVM_V2's Contract 360-patroon, dat wél top-level is).
+Backend staat op branch `docs/contractmanagement-design`
+(16 commits, migraties 0027+0028, alle e2e groen), frontend op
+`feat/contractmanagement-scherm` (9 commits, Playwright groen). **Beide
+branches zijn bewust geparkeerd, niet gemerged** — de eigenaar vond de UI
+na meerdere preview-rondes nog niet goed genoeg en wilde niet mergen vóór
+dat opgelost is. Onderweg is een echt gat gedicht: een survey-template
+koppelen aan een contract had eerst geen zichtbaar pad naar een echte
+uitnodiging — dat is opgelost door `survey_run.contract_id` (een kolom die
+sinds migratie 0007 ongebruikt bestond) daadwerkelijk te vullen, plus
+directe "nu uitnodigen"-links per gekoppelde template.
+
+Aan het eind van de dag zette de eigenaar vier losse observaties in de
+opmerkingen-txt, sectie **"21 augustus III"** — dit zijn de openstaande
+punten voor de volgende sessie, in volgorde:
+
+1. **Dichtheid.** Stamgegevens/classificatie/contactpersonen op
+   `/beheer/leveranciers/[id]` zijn te veel uitgesponnen — drie brede
+   kaarten onder elkaar, elk met eigen `p-6` en interne grid, terwijl de
+   doelgroep op een groot pc-scherm werkt. Grootste, meest zichtbare
+   impact — als eerste oppakken.
+2. **Fold-out contactformulier.** Het "Contactpersoon toevoegen"-
+   formulier in `Contactpersonen` (huidige component,
+   `MCM2-frontend/src/app/beheer/leveranciers/[id]/page.tsx`) staat altijd
+   open onderaan de lijst. Moet een inklapbare fold-out worden — kleine,
+   geïsoleerde wijziging, goed te combineren met punt 1 want maakt meteen
+   ruimte vrij.
+3. **Contractrijen direct openklikbaar.** Nu alleen via een aparte
+   edit-knop te bewerken; moet in-place uitklapbaar worden, met daarin
+   zowel bestaande als toekomstige velden zichtbaar. Grotere wijziging,
+   raakt de structuur van `ContractRij`.
+4. **Koppeling vs. wachtlijst — nog geen echte bug, wel verwarrend.**
+   De eigenaar dacht een databug te zien (Microsoft/M365-contract niet
+   zichtbaar op de wachtlijst van zijn survey). Uitgezocht: geen bug — de
+   `wachtlijst`-checkbox stond simpelweg uit terwijl de
+   template-koppeling wél bestond. Dit is dus een UX-onderscheid dat niet
+   duidelijk genoeg overkomt, geen datafout. **Openstaande vraag aan de
+   eigenaar, nog niet beantwoord:** is dit met een visuele verduidelijking
+   op te lossen (bijv. koppeling toont automatisch als "wachtlijst aan"
+   i.p.v. een aparte losse checkbox), of moet het default-gedrag zelf
+   anders (automatisch aan i.p.v. uit bij koppelen)? Dit moet als eerste
+   met de eigenaar besproken worden vóór er gebouwd wordt — niet zelf
+   invullen.
+
+**Deel 2 (avond, na de stop-instructie): §1c toegevoegd aan
+`MCM2-CLAUDE.md`.** De eigenaar merkte op dat frontend-adviezen bij MCM2
+wisselender van kwaliteit zijn dan destijds bij MVM_V2, en vroeg om
+MVM_V2's instructiebestand te lezen op wat MCM2 zou kunnen overnemen.
+Bevinding: het verschil zat niet in vaardigheid maar in vastlegging —
+MVM_V2's `CLAUDE.md` normeert dichtheid expliciet, verplicht een intake
+per nieuw datascherm (velden, bewerken=aanmaken-symmetrie, vervolgstap,
+rol, navigatieplek), en houdt een groeiende "Bekende beslissingen"-tabel
+bij. MCM2 had daar niets van — vandaar dat elk scherm de smaak opnieuw
+moest raden. Tokengebruik zelf bleek al goed (geen hardcoded hex-kleuren
+gevonden in `src/app`), dus dát was niet het probleem.
+
+Toegevoegd:
+- **§1c in `MCM2-CLAUDE.md`** — dichtheidsregel, verplichte mini-intake
+  vóór een nieuw datascherm, vaste toetsvraag per scherm, verwijzing naar
+  het bestaande `design-tokens.ts`.
+- **`docs/architectuur/ui-beslissingen.md`** — nieuw, de groeiende tabel;
+  bevat al drie patronen uit deze sessie plus de vier open punten hierboven
+  als "nog niet vastgelegd".
+- **`docs/architectuur/evaluatie-schermen-2026-08-22.md`** — de bestaande
+  schermen getoetst aan §1c. Bevestigt 3 van de 4 punten uit "21 augustus
+  III" met concrete regelverwijzingen, en geeft de aanbevolen volgorde
+  (dichtheid → fold-out → uitklapbare rij → koppeling/wachtlijst) die
+  hierboven ook staat.
+
+**Voor de volgende sessie, als de eigenaar zegt "we gaan verder waar we
+gebleven zijn":** pak bovenstaande vier punten in de gegeven volgorde op.
+Begin met een korte bevestiging van deze samenvatting (niet blind
+doorbouwen) en stel bij punt 4 eerst de open vraag aan de eigenaar voordat
+er iets gebouwd wordt. Beide branches (`docs/contractmanagement-design`,
+`feat/contractmanagement-scherm`) blijven het werkgebied — geen nieuwe
+branch nodig, wél opnieuw het git-ritueel (merge- of parkeer-vraag) zodra
+er weer gepusht wordt.
+
+---
+
 **2026-08-21, avond — eerste feature end-to-end door de volledige,
 geautomatiseerde OTAP-keten: van issue tot productie, inclusief een nieuw
 gebouwd preview-mechanisme.**

--- a/docs/architectuur/evaluatie-schermen-2026-08-22.md
+++ b/docs/architectuur/evaluatie-schermen-2026-08-22.md
@@ -1,0 +1,97 @@
+# Evaluatie bestaande schermen tegen §1c (MCM2-CLAUDE.md)
+
+> Uitgevoerd 2026-08-22, direct na het opstellen van §1c. Toetst de
+> bestaande frontend-schermen (`MCM2-frontend`) aan de vijf punten uit die
+> richtlijn: tokens, dichtheid, bewerken=aanmaken, direct pad naar
+> vervolgstap, navigatieplek. Geen nieuwe regels — alleen bevindingen en
+> een prioritering, ter voorbereiding op de vier punten uit "21 augustus
+> III".
+
+## Samenvatting
+
+| Scherm | Tokens | Dichtheid | Bewerken=aanmaken | Vervolgstap | Oordeel |
+|---|---|---|---|---|---|
+| `/beheer/leveranciers` (lijst) | ✅ | ✅ | n.v.t. | ✅ (uitnodigen-knop) | Goed — referentiepatroon |
+| `/beheer/vragenlijsten` (overzicht) | ✅ | ✅ | n.v.t. | ⚠️ deels | Goed |
+| `/beheer/leveranciers/[id]` (detail) | ✅ | ❌ | ⚠️ deels | ⚠️ deels | Herzien nodig — zie hieronder |
+| `/beheer/vragenlijsten/uitnodigen` | ✅ | ✅ | n.v.t. | ✅ | Goed |
+| `/beheer/vragenlijsten/[id]/wachtlijst` | ✅ | ✅ | n.v.t. | ✅ | Goed |
+
+**Kernbevinding:** het tokenbestand wordt overal consequent gebruikt —
+geen hardcoded hex-kleuren gevonden in `src/app`. Het probleem zit niet in
+tokendiscipline maar in twee dingen die §1c nieuw invoert: dichtheid
+(schermen zijn nog gebouwd als gestapelde losse kaarten, niet als dicht
+paneel) en de bewerken=aanmaken-symmetrie (deels al gefixed deze sessie,
+deels nog niet).
+
+---
+
+## `/beheer/leveranciers/[id]` — het scherm met de bekende klachten
+
+Dit is precies het scherm waar "21 augustus III" over gaat. De opbouw:
+`Stamgegevens` → `Contactpersonen` → `Contracten`, elk een eigen
+`<section className="rounded-lg border border-line bg-card p-6">`,
+verticaal gestapeld met `mb-8`/`mb-6` ertussen.
+
+### Dichtheid — ❌, bevestigt punt 1 uit de notitie
+Drie brede kaarten onder elkaar, elk met eigen `p-6` en interne
+`grid gap-4 sm:grid-cols-2` of `sm:grid-cols-3`. Op een breed pc-scherm
+(de doelgroep, zie §1c) betekent dat: veel witruimte links/rechts van elk
+grid, en veel verticaal scrollen om van stamgegevens naar contracten te
+komen. Geen van de drie secties maakt gebruik van een layout die de volle
+breedte benut (bijvoorbeeld stamgegevens en contactpersonen naast elkaar
+in twee kolommen op een breed scherm).
+→ Directe match met genoteerd open punt in `ui-beslissingen.md`.
+
+### Bewerken = aanmaken — ⚠️ deels
+- **Contactpersonen**: al symmetrisch. `ContactRij` heeft een eigen
+  bewerkstand (toegevoegd vóór deze sessie), en het toevoegformulier staat
+  onderaan de lijst.
+- **Contracten**: sinds deze sessie ook symmetrisch — `ContractRij` heeft
+  een `nieuweContactpersoon`-toggle net als `NieuwContractFormulier`, met
+  de bugfix dat `onContactpersoonAangemaakt` nu correct doorwerkt naar de
+  bovenliggende `Contactpersonen`-sectie.
+- **Nog niet symmetrisch**: het contactpersoon-toevoegformulier in
+  `Contactpersonen` staat **altijd open** onderaan de lijst (regel 789),
+  in plaats van een fold-out zoals punt 2 van de notitie vraagt. Dat is
+  geen bewerken=aanmaken-probleem maar een apart dichtheidsprobleem: een
+  altijd-open formulier met 4 velden neemt blijvend ruimte in, ook als
+  niemand op dat moment een contact toevoegt.
+
+### Vervolgstap — ⚠️ deels
+`VendorUitvraagPaneel` (onderaan) toont lopende uitvragen — dat pad
+bestaat. Maar binnen `Contracten` is de koppeling tussen een
+survey-template en de eigenlijke verzending nog het onderwerp van het
+onopgeloste punt in `ui-beslissingen.md` (checkbox-wachtlijst vs.
+koppeling, visueel niet onderscheidend genoeg).
+
+### Navigatieplek — geen bevinding
+Contractensectie zit terecht op de leveranciersdetailpagina, niet als
+eigen toppagina — conform de UI-spec van deze sessie.
+
+---
+
+## Directe koppeling met "21 augustus III"
+
+| # | Notitiepunt | Bevestigd door deze evaluatie? |
+|---|---|---|
+| 1 | Stamgegevens/classificatie/contactpersonen indikken, meer breedte gebruiken | Ja — zie Dichtheid hierboven |
+| 2 | Contactpersoon-toevoegen moet fold-out zijn | Ja — huidige formulier staat altijd open |
+| 3 | Contractrijen moeten direct openklikbaar zijn, ook toekomstige velden | Nog niet beoordeeld — vereist ontwerp van een uitklapbare rij, niet alleen een evaluatie van bestaande code |
+| 4 | Wachtlijst-"bug" bij Microsoft/M365 | Al onderzocht vorige sessie: geen databug — `wachtlijst = false` terwijl koppeling bestond. Valt samen met het onopgeloste UX-punt in `ui-beslissingen.md` |
+
+## Aanbevolen volgorde voor de volgende sessie
+
+1. Dichtheid van `/beheer/leveranciers/[id]` herzien — grootste, meest
+   zichtbare impact, raakt punt 1 van de notitie direct.
+2. Contactpersoon-formulier fold-out maken (punt 2) — kleine, geïsoleerde
+   wijziging, goed te combineren met punt 1 omdat het ruimte vrijmaakt.
+3. Contractrij uitklapbaar maken in plaats van alleen via edit-knop
+   (punt 3) — grotere wijziging, raakt `ContractRij`-structuur.
+4. Koppeling/wachtlijst-onderscheid oplossen (punt 4) — was al in
+   behandeling, vereist nog een keuze van de eigenaar (visuele
+   verduidelijking vs. gedragswijziging).
+
+Elke stap hierboven die een blijvend patroon oplevert, hoort na afloop in
+`docs/architectuur/ui-beslissingen.md` vastgelegd te worden — dat is
+precies waarvoor dat bestand nu bestaat.

--- a/docs/architectuur/roadmap-vendor-it-survey.md
+++ b/docs/architectuur/roadmap-vendor-it-survey.md
@@ -305,6 +305,23 @@ al te bestaan als `vendor_contact.role_description` — alleen nog niet
 zichtbaar in de UI. Geen apart issue, wordt meegenomen in de
 contractmanagement-implementatie. Zie de spec §1 voor detail.
 
+### 7.1 Vervolgwensen ná de preview (21-08 II) → [#171](https://github.com/AlingAdvies/MCM2/issues/171), [#172](https://github.com/AlingAdvies/MCM2/issues/172)
+
+Bij het bekijken van de eerste preview van de Contracten-sectie (22-08)
+kwamen vier nieuwe punten naar boven. Twee daarvan (contactpersoon en
+survey-koppeling direct bij het aanmaken van een contract) waren klein
+genoeg om nog in dezelfde bouwronde mee te nemen — zie
+`docs/superpowers/plans/2026-08-22-contractmanagement-ui.md`, uitgebreid
+met een Task 12. De andere twee raken schermen buiten het
+vendor-detailscherm (sidebar, startscherm) en zijn losse issues geworden:
+
+- [#171](https://github.com/AlingAdvies/MCM2/issues/171) — Contracten ook
+  in de linkerbalk/navigatie opnemen, niet alleen bereikbaar via een
+  leverancier.
+- [#172](https://github.com/AlingAdvies/MCM2/issues/172) — "Start"
+  hernoemen naar "Dashboard", met een overzicht van contracten die binnen
+  90 dagen verlopen (ook zonder ingevulde status).
+
 ## 8. Productidee: (intake)leveranciersbeoordeling o.b.v. Z-CERT-vragenlijst
 
 **Bevinding (21-08, uit de opmerkingen):** een productidee, geen uitgewerkte

--- a/docs/architectuur/roadmap-vendor-it-survey.md
+++ b/docs/architectuur/roadmap-vendor-it-survey.md
@@ -1,8 +1,11 @@
 # Roadmap — Vendor IT survey en contractmanagement
 
-**Type:** roadmap — overzicht; elk punt heeft een gekoppeld GitHub issue (§2–§4)
+**Type:** roadmap — overzicht; de meeste punten hebben een gekoppeld GitHub
+issue (§2–§4, §6); §7 verwijst naar een uitgewerkte spec i.p.v. een los
+issue, §8 is bewust nog geen issue (zie daar waarom)
 **Eigenaar:** de eigenaar (Chris)
-**Opgesteld:** 2026-08-21, uit `docs/opmerkingen Vendor IT survey.txt`
+**Opgesteld:** 2026-08-21, uit `docs/opmerkingen Vendor IT survey.txt`;
+bijgewerkt 2026-08-22 met de 21-08-vervolgpunten
 **Geldt voor:** MCM2 in generieke zin — niet Transdev-specifiek, ook al zijn de
 opmerkingen ontstaan tijdens het testen met Transdev als eerste echte tenant.
 **Criticality:** productieapp voor een echte klant. Volgorde binnen deze
@@ -100,6 +103,11 @@ bewust intern.
 **Bevestigd in productie (21-08):** gemerged via
 AlingAdvies/MCM2-frontend#14, doorgelopen via staging, uitgerold naar
 `clm.alingadvies.nl`, met eigen ogen bekeken door de eigenaar.
+
+**Vervolgwens (21-08, nieuwe opmerking) → [#170](https://github.com/AlingAdvies/MCM2/issues/170):**
+de uitgeklapte weergave uit #154 werkt goed; twee kolommen erbij gevraagd —
+vendornaam en e-mailadres van de gebruikte contactpersoon. Vermoedelijk
+weer een puur frontend-wijziging, net als #154 zelf.
 
 ### 2.3 Nieuwe feature: vragenlijst-bouwer → [#155](https://github.com/AlingAdvies/MCM2/issues/155)
 
@@ -273,6 +281,7 @@ statusbord:
 | [#160](https://github.com/AlingAdvies/MCM2/issues/160) | §3.5 — bulk-upload contracten | Bij stap 3, na §3.3 (hergebruikt de mechaniek) |
 | [#159](https://github.com/AlingAdvies/MCM2/issues/159) | §3.4 — leverancierstype aanvinken | Bij stap 3, kleine UI-uitbreiding |
 | [#161](https://github.com/AlingAdvies/MCM2/issues/161) | §3.6 — compliance-status koppeling | Open vraag, geen datum — eerst besluiten wat het moet worden |
+| [#170](https://github.com/AlingAdvies/MCM2/issues/170) | §2.2 (vervolg) — kolommen in uitklaplijst | Bij stap 1, kleine UI-uitbreiding op #154 |
 
 **Wat dit document bewust niet doet:** de volgorde hierboven als vaststaand
 behandelen. Het is een voorstel; de eigenaar bepaalt de daadwerkelijke
@@ -280,9 +289,45 @@ volgorde via het statusbord en de issues zelf.
 
 ---
 
+## 7. Contractmanagement — datamodel uitgewerkt → spec
+
+De opmerking van 21-08 (punt 2) over contactpersoon-per-contract en de
+survey-koppeling (§3.2/#157 hierboven) is op 22-08 via een brainstorm-sessie
+uitgewerkt tot een volledig datamodel-ontwerp:
+`docs/superpowers/specs/2026-08-22-contractmanagement-design.md`. Dat
+document dekt #156 en #157 in samenhang — een nieuwe `clm.contract`-tabel,
+statusmodel, en de koppeling met vragenlijst-templates. Zie dat document voor
+de details; dit punt blijft hier alleen als verwijzing zodat de roadmap niet
+opnieuw "nog een ontwerpstap nodig" meldt voor iets dat al ontworpen is.
+
+**Notitieveld bij contactpersoon (21-08, punt 2b):** bleek bij het uitwerken
+al te bestaan als `vendor_contact.role_description` — alleen nog niet
+zichtbaar in de UI. Geen apart issue, wordt meegenomen in de
+contractmanagement-implementatie. Zie de spec §1 voor detail.
+
+## 8. Productidee: (intake)leveranciersbeoordeling o.b.v. Z-CERT-vragenlijst
+
+**Bevinding (21-08, uit de opmerkingen):** een productidee, geen uitgewerkte
+feature — een leveranciersbeoordeling bij de intake van een nieuwe
+leverancier, gebaseerd op de Z-CERT excel-vragenlijst (een bestaande
+sectorstandaard-vragenlijst voor IT-risicobeoordeling van leveranciers,
+gebruikt in de zorgsector).
+
+**Status:** puur een idee, nog niet besproken op scope, doel of verhouding
+tot de bestaande acht Transdev-vragen. Geen issue — dat zou voorbarig zijn
+zolang niet vastligt of dit een aparte vragenlijst-template wordt (past dan
+onder #155, de vragenlijst-bouwer), een uitbreiding van de intake-flow, of
+iets anders. Terugkomen zodra stap 1 (goede basisvragenlijst) en de
+vragenlijst-bouwer verder gevorderd zijn — dit idee leunt op beide.
+
+---
+
 ## Bronnen
 
 - `docs/opmerkingen Vendor IT survey.txt` — de oorspronkelijke, ruwe notities
+  (20 en 21 augustus)
+- `docs/superpowers/specs/2026-08-22-contractmanagement-design.md` — het
+  datamodel-ontwerp voor #156/#157, zie §7
 - `docs/superpowers/specs/2026-08-04-beheermenu-tenantinstellingen.md` — het beheermenu waar §2.1, §4.1 en de #75/#76/#77-issues in landen
 - Issue #24 — de bewuste later-lijst voor bredere modules
 - Issue #77 — bulk/handpicked uitnodigingen, met de nog openstaande criteriavraag

--- a/docs/architectuur/ui-beslissingen.md
+++ b/docs/architectuur/ui-beslissingen.md
@@ -1,0 +1,44 @@
+# UI-beslissingen — MCM2 frontend
+
+> Bijgehouden vanaf 2026-08-22, ingesteld naar aanleiding van §1c in
+> `MCM2-CLAUDE.md`. Analoog aan de "Bekende beslissingen"-tabel in
+> MVM_V2's `CLAUDE.md`: elke keer dat een sessie een frontend-patroon
+> vaststelt, komt het hier bij — zodat het niet opnieuw uitgevonden of
+> per scherm anders toegepast wordt.
+>
+> Eén regel per beslissing. Nieuwste bovenaan per sectie.
+
+---
+
+## Layout & dichtheid
+
+| Datum | Beslissing |
+|---|---|
+| 2026-08-22 | Tabelrijen voor lijsten van entiteiten (contracten, leveranciers) gebruiken een `<table>`, niet een `<ul>`/`<li>`-lijst — meer informatie per rij op minder hoogte. Kolommen tonen de kernvelden direct (naam, contractnummer, contactpersoon, contractbeheerder, status, begin–einde) in plaats van pas na een klik. |
+
+## Formulierpatronen
+
+| Datum | Beslissing |
+|---|---|
+| 2026-08-22 | Een detailscherm dat een record bewerkt, moet alle bestaande waarden vooringevuld tonen én dezelfde acties toestaan die bij aanmaken beschikbaar zijn (bijvoorbeeld: een nieuwe contactpersoon aanmaken vanuit het bewerkformulier van een contract, niet alleen vanuit het aanmaakformulier). |
+
+## Navigatie & vervolgstappen
+
+| Datum | Beslissing |
+|---|---|
+| 2026-08-22 | Een gekoppelde actie (survey aan contract koppelen) krijgt een zichtbaar, direct pad naar de vervolgstap (een "nu uitnodigen"-link per gekoppelde template) — niet alleen een vlag die passief elders afgelezen moet worden. |
+
+## Open punten — nog niet als vaste regel vastgelegd
+
+Vastgesteld maar nog niet doorvertaald naar een concrete, herbruikbare
+regel; oppakken zodra de bijbehorende schermen herzien worden.
+
+- Contactpersoon-toevoegformulier moet een inklapbare "fold out" zijn,
+  niet standaard open.
+- Contractrijen in de lijst moeten direct openklikbaar zijn (niet alleen
+  via een aparte bewerk-knop) en dan alle bestaande én toekomstige velden
+  tonen.
+- Onderscheid tussen "survey gekoppeld aan contract" en "op de
+  wachtlijst voor de volgende ronde" is functioneel duidelijk maar visueel
+  nog verwarrend — een checkbox die default uit staat wordt als afwezige
+  koppeling gelezen. Oplossing nog niet gekozen.

--- a/docs/runbooks/backup-verwachting.json
+++ b/docs/runbooks/backup-verwachting.json
@@ -14,7 +14,7 @@
     "Zie docs/superpowers/specs/2026-08-04-backupcontrole-en-signalering.md, paragraaf 4."
   ],
   "bijgewerkt": "2026-08-22",
-  "migratiestand": "0027_contract",
+  "migratiestand": "0028_contract_survey_wachtlijst",
   "tabellen": [
     "audit.audit_event",
     "clm.contract",

--- a/docs/runbooks/backup-verwachting.json
+++ b/docs/runbooks/backup-verwachting.json
@@ -13,10 +13,12 @@
     "",
     "Zie docs/superpowers/specs/2026-08-04-backupcontrole-en-signalering.md, paragraaf 4."
   ],
-  "bijgewerkt": "2026-08-13",
-  "migratiestand": "0026_tenantregister",
+  "bijgewerkt": "2026-08-22",
+  "migratiestand": "0027_contract",
   "tabellen": [
     "audit.audit_event",
+    "clm.contract",
+    "clm.contract_survey_template",
     "clm.omgeving",
     "clm.platform_admin",
     "clm.response_note",
@@ -39,6 +41,7 @@
     "clm.vendor_tag",
     "ref.business_criticality",
     "ref.compliance_status",
+    "ref.contract_status",
     "ref.vendor_category"
   ]
 }

--- a/docs/superpowers/plans/2026-08-22-contractmanagement-ui.md
+++ b/docs/superpowers/plans/2026-08-22-contractmanagement-ui.md
@@ -2735,10 +2735,901 @@ SELECT run_id, contract_id FROM clm.survey_run WHERE contract_id IS NOT NULL ORD
 
 ---
 
+## Task 14: Tabelweergave, contactpersoon-bij-bewerken, en de wachtlijst
+
+**Toegevoegd 22-08, tijdens de derde preview-ronde.** Drie punten uit
+spec §7–9 (`docs/superpowers/specs/2026-08-22-contractmanagement-ui-design.md`).
+De grootste van de drie is §9 (de wachtlijst): nieuwe migratie, nieuw
+backend-veld, nieuw scherm. Blijft binnen dezelfde twee branches.
+
+### 14.1 Backend: `wachtlijst`-kolom op de koppeltabel
+
+**Files (backend):**
+- Create: `drizzle/0028_contract_survey_wachtlijst.sql`
+- Modify: `drizzle/meta/_journal.json`
+- Modify: `src/db/schema.ts`
+- Modify: `src/contract/contract.service.ts`
+- Modify: `src/contract/contract-invoer.ts`
+- Modify: `src/contract/contract.controller.ts`
+- Test: uitbreiding van `test/contract-routes.e2e-spec.ts`
+
+- [ ] **Step 1: Controleer het volgende migratienummer**
+
+```bash
+ls drizzle/*.sql | tail -3
+```
+
+Dit plan gaat uit van `0028`; pas aan als er ondertussen een andere
+migratie is bijgekomen (zie de waarschuwing bovenaan het vorige plan,
+Task 1).
+
+- [ ] **Step 2: Schrijf de migratie**
+
+```sql
+-- =============================================================================
+-- clm.contract_survey_template krijgt een wachtlijst-kolom.
+--
+-- Spec: docs/superpowers/specs/2026-08-22-contractmanagement-ui-design.md §9.
+--
+-- Uitvinkbaar door de beheerder, geen automatisch proces dat hem zet of
+-- wist: een leverancier "op de wachtlijst" voor de volgende ronde van een
+-- vragenlijst betekent alleen dat hij voorgeselecteerd wordt zodra iemand
+-- bewust een nieuwe ronde start via het nieuwe wachtlijst-scherm — nooit
+-- dat er vanzelf iets verstuurd wordt.
+--
+-- Geen nieuwe tabel: de wachtlijst-status hoort per definitie bij een
+-- specifieke contract-template-koppeling, en die koppeling bestaat al
+-- sinds migratie 0027.
+-- =============================================================================
+
+ALTER TABLE clm.contract_survey_template
+    ADD COLUMN wachtlijst boolean NOT NULL DEFAULT false;--> statement-breakpoint
+
+COMMENT ON COLUMN clm.contract_survey_template.wachtlijst IS
+    'Staat deze leverancier klaar om voorgesteld te worden bij de volgende ronde van deze vragenlijst? Uitvinkbaar door de beheerder, nooit automatisch gezet. Zie spec §9.';
+```
+
+- [ ] **Step 3: Voeg de migratie toe aan `drizzle/meta/_journal.json`**
+
+Zelfde patroon als eerder — nieuwe entry ná de laatste, `when` één hoger,
+`tag: "0028_contract_survey_wachtlijst"`.
+
+- [ ] **Step 4: Draai de migratie tegen de wegwerpcontainer**
+
+```bash
+MIGRATION_DATABASE_URL="postgresql://clm_migrator:pw@localhost:55440/postgres" npm run migrate:deploy
+```
+
+Lees terug, niet vertrouwen op de melding:
+
+```bash
+docker exec mcm2test psql -U postgres -d postgres -c "SELECT column_name, data_type, column_default FROM information_schema.columns WHERE table_schema='clm' AND table_name='contract_survey_template' AND column_name='wachtlijst';"
+```
+
+- [ ] **Step 5: Werk `src/db/schema.ts` bij**
+
+In de `contractSurveyTemplate`-tabeldefinitie, ná `tenantId`:
+
+```typescript
+    wachtlijst: boolean('wachtlijst').notNull().default(false),
+```
+
+(`boolean` staat al geïmporteerd bovenaan het bestand — hergebruiken.)
+
+- [ ] **Step 6: `ContractService` — wachtlijst lezen en schrijven**
+
+`surveyTemplates()` en `zetSurveyTemplates()` in
+`src/contract/contract.service.ts` uitbreiden. Het antwoord wordt een
+lijst van objecten in plaats van alleen id's:
+
+```typescript
+export interface SurveyTemplateKoppeling {
+  templateIds: string[];
+  /** Welke van de gekoppelde templates ook op de wachtlijst staan. */
+  wachtlijstTemplateIds: string[];
+}
+```
+
+In `surveyTemplates()`, de query uitbreiden:
+
+```typescript
+        const resultaat = await tx.execute<{
+          survey_template_id: string;
+          wachtlijst: boolean;
+        }>(
+          sql`SELECT survey_template_id, wachtlijst
+             FROM clm.contract_survey_template
+             WHERE contract_id = ${contractId}
+             ORDER BY created_at`,
+        );
+
+        return {
+          templateIds: resultaat.rows.map((r) => r.survey_template_id),
+          wachtlijstTemplateIds: resultaat.rows
+            .filter((r) => r.wachtlijst)
+            .map((r) => r.survey_template_id),
+        };
+```
+
+In `zetSurveyTemplates()`, de methode krijgt een derde parameter en de
+INSERT wordt uitgebreid:
+
+```typescript
+  async zetSurveyTemplates(
+    tenantId: string,
+    vendorId: string,
+    contractId: string,
+    templateIds: string[],
+    wachtlijstTemplateIds: string[],
+  ): Promise<SurveyTemplateKoppeling | null> {
+```
+
+```typescript
+        for (const templateId of templateIds) {
+          await tx.execute(
+            sql`INSERT INTO clm.contract_survey_template
+                  (contract_id, survey_template_id, tenant_id, wachtlijst)
+                VALUES (${contractId}, ${templateId}, ${tenantId},
+                        ${wachtlijstTemplateIds.includes(templateId)})`,
+          );
+        }
+```
+
+En de return-waarde:
+
+```typescript
+        return { templateIds, wachtlijstTemplateIds };
+```
+
+**Nieuwe methode: leveranciers op de wachtlijst voor een template.**
+Nodig voor het nieuwe scherm (14.3). Toevoegen aan `ContractService`:
+
+```typescript
+  /**
+   * Leveranciers die op de wachtlijst staan voor de volgende ronde van
+   * deze vragenlijst-template, via een gekoppeld contract. Eén leverancier
+   * met meerdere contracten op de wachtlijst voor dezelfde template komt
+   * hier maar één keer voor (DISTINCT) — de UI toont een leverancier, geen
+   * contract.
+   */
+  async wachtlijstVoorTemplate(
+    tenantId: string,
+    templateId: string,
+  ): Promise<{ vendorId: string; vendorNaam: string }[]> {
+    return this.db.withTenant(
+      tenantId,
+      async (tx) => {
+        const resultaat = await tx.execute<{
+          vendor_id: string;
+          name: string;
+        }>(
+          sql`SELECT DISTINCT v.vendor_id, v.name
+             FROM clm.contract_survey_template cst
+             JOIN clm.contract c ON c.contract_id = cst.contract_id
+             JOIN clm.vendor v ON v.vendor_id = c.vendor_id
+             WHERE cst.survey_template_id = ${templateId}
+               AND cst.wachtlijst = true
+               AND c.deleted_at IS NULL
+               AND v.deleted_at IS NULL
+             ORDER BY v.name`,
+        );
+
+        return resultaat.rows.map((r) => ({
+          vendorId: r.vendor_id,
+          vendorNaam: r.name,
+        }));
+      },
+      'medewerker',
+    );
+  }
+```
+
+- [ ] **Step 7: Invoer-validatie en route**
+
+In `src/contract/contract-invoer.ts`, `leesSurveyTemplateKoppeling`
+hernoemen/uitbreiden zodat hij beide lijsten teruggeeft:
+
+```typescript
+export interface SurveyTemplateKoppelingInvoer {
+  templateIds: string[];
+  wachtlijstTemplateIds: string[];
+}
+
+export function leesSurveyTemplateKoppeling(
+  body: unknown,
+): SurveyTemplateKoppelingInvoer {
+  if (typeof body !== 'object' || body === null) {
+    throw new InvoerFout('body', 'Er is geen koppeling meegestuurd.');
+  }
+
+  const ruw = body as Record<string, unknown>;
+
+  function leesIdLijst(veld: string): string[] {
+    if (!(veld in ruw)) return [];
+    const waarde = ruw[veld];
+    if (!Array.isArray(waarde)) {
+      throw new InvoerFout(veld, `${veld} moet een lijst zijn.`);
+    }
+    for (const w of waarde) {
+      if (typeof w !== 'string' || !UUID_PATROON_KOPPELING.test(w)) {
+        throw new InvoerFout(veld, "Een van de id's is ongeldig.");
+      }
+    }
+    return [...new Set(waarde as string[])];
+  }
+
+  if (!('templateIds' in ruw)) {
+    throw new InvoerFout('templateIds', 'templateIds is verplicht.');
+  }
+
+  return {
+    templateIds: leesIdLijst('templateIds'),
+    wachtlijstTemplateIds: leesIdLijst('wachtlijstTemplateIds'),
+  };
+}
+```
+
+Dit vervangt de bestaande functie-body volledig — pas de aanroepende
+code in `ContractController` aan op het nieuwe returntype (Step 8).
+
+In `src/contract/contract.controller.ts`:
+
+```typescript
+  @Put(':id/survey-templates')
+  @VereistRol('admin')
+  async zetSurveyTemplates(
+    @Req() request: RequestMetSessie,
+    @Param('vendorId') vendorId: string,
+    @Param('id') id: string,
+    @Body() body: unknown,
+  ) {
+    const sessie = request.sessie!;
+
+    let invoer: SurveyTemplateKoppelingInvoer;
+
+    try {
+      invoer = leesSurveyTemplateKoppeling(body);
+    } catch (err) {
+      throw alsHttpFout(err);
+    }
+
+    const koppeling = await this.contracts
+      .zetSurveyTemplates(
+        sessie.tenantId,
+        leesUuid(vendorId),
+        leesUuid(id),
+        invoer.templateIds,
+        invoer.wachtlijstTemplateIds,
+      )
+      .catch(alsRefFout);
+
+    if (!koppeling) {
+      throw new NotFoundException('Contract niet gevonden.');
+    }
+
+    return koppeling;
+  }
+```
+
+Importeer `SurveyTemplateKoppelingInvoer` uit `./contract-invoer`.
+
+- [ ] **Step 8: Nieuwe route: wachtlijst per template**
+
+Nieuwe route in `ContractController`, of — beter passend, want dit gaat
+niet over één specifiek contract — een nieuwe kleine controller-methode
+op `VragenlijstBeheerController` (`src/survey/vragenlijst-beheer.controller.ts`,
+waar `GET /admin/survey/templates` al staat). Voeg toe:
+
+```typescript
+  /** Leveranciers die op de wachtlijst staan voor de volgende ronde. */
+  @Get('templates/:id/wachtlijst')
+  async wachtlijst(
+    @Req() request: RequestMetSessie,
+    @Param('id') id: string,
+  ) {
+    const sessie = request.sessie!;
+    const leveranciers = await this.contracten.wachtlijstVoorTemplate(
+      sessie.tenantId,
+      id,
+    );
+    return { leveranciers };
+  }
+```
+
+**Nodig:** `ContractService` injecteren in `VragenlijstBeheerController`
+— controleer de constructor van die controller (er staat al een
+`ContractmanagerService` in, zie `src/survey/vragenlijst-beheer.controller.ts`
+regel 88-89 — dat is een ándere service, niet verwarren). Voeg
+`ContractService` toe als nieuwe constructor-parameter, en `ContractModule`
+als import in `SurveyModule` (zoek de juiste module met
+`grep -rn "VragenlijstBeheerController" src/survey/*.module.ts`).
+
+- [ ] **Step 9: Compileer, draai de e2e-suite, breid tests uit**
+
+```bash
+npx tsc --noEmit
+```
+
+Breid `test/contract-routes.e2e-spec.ts` uit met een test voor
+`wachtlijstTemplateIds` (koppel met wachtlijst=true, haal op, controleer
+dat het terugkomt) en een nieuwe test-suite-toevoeging of los bestand voor
+`GET /admin/survey/templates/:id/wachtlijst` — volg het patroon van de
+bestaande `contract-routes`-suite voor tenant-opzet/opruimen.
+
+```bash
+DATABASE_URL="postgresql://clm_api_runtime:pw@localhost:55440/postgres" \
+MIGRATION_DATABASE_URL="postgresql://clm_migrator:pw@localhost:55440/postgres" \
+npx jest --config test/jest-e2e.json --forceExit
+```
+
+- [ ] **Step 10: Prettier, lint, commit**
+
+```bash
+git add drizzle/0028_contract_survey_wachtlijst.sql drizzle/meta/_journal.json src/db/schema.ts src/contract/contract.service.ts src/contract/contract-invoer.ts src/contract/contract.controller.ts src/survey/vragenlijst-beheer.controller.ts test/contract-routes.e2e-spec.ts
+git commit -m "feat(contract): wachtlijst-vlag op de survey-templatekoppeling
+
+Uitvinkbaar, geen automatisch proces. Nieuwe route
+GET /admin/survey/templates/:id/wachtlijst geeft de leveranciers terug die
+voor deze template klaarstaan via een gekoppeld contract.
+
+Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>"
+```
+
+### 14.2 Frontend: contractenlijst als tabel
+
+**Files (`MCM2-frontend`):**
+- Modify: `src/app/beheer/leveranciers/[id]/page.tsx`
+
+- [ ] **Step 1: Vervang de `<ul>`/`<li>`-lijst in `Contracten` door een tabel**
+
+In de `Contracten`-component, het blok met `<ul className="mb-6 divide-y ...">`
+vervangen door een `<table>` met kolomkoppen Naam, Contractnummer,
+Contactpersoon, Contractbeheerder, Status, Begin–Einde, en een lege
+actiekolom. Volg het tabelpatroon van `src/app/beheer/vragenlijsten/page.tsx`
+(regels rond 190–244: `<thead>` met `text-xs uppercase tracking-wide
+text-ink-muted`, `<tr>` met `border-b border-line last:border-0`) — zelfde
+klassen, zelfde structuur, alleen andere kolommen.
+
+`ContractRij` blijft de rijcomponent, maar rendert nu `<tr>`/`<td>` in
+niet-bewerkstand in plaats van `<li>`; in bewerkstand (het formulier)
+blijft een volle-breedte rij met `colSpan` over alle kolommen, zodat het
+formulier niet in een smalle kolom geperst wordt:
+
+```typescript
+  if (bewerkt) {
+    return (
+      <tr data-testid="contract-rij">
+        <td colSpan={7} className="px-4 py-4">
+          {/* bestaande formulier-inhoud, ongewijzigd */}
+        </td>
+      </tr>
+    );
+  }
+
+  return (
+    <tr data-testid="contract-rij" className="border-b border-line last:border-0">
+      <td className="px-4 py-2.5 text-sm font-medium text-ink">{contract.name}</td>
+      <td className="px-4 py-2.5 text-xs text-ink-muted">{contract.contractNumber ?? '—'}</td>
+      <td className="px-4 py-2.5 text-xs text-ink-muted">{contract.vendorContactNaam ?? '—'}</td>
+      <td className="px-4 py-2.5 text-xs text-ink-muted">{contract.ownerGebruikerNaam ?? '—'}</td>
+      <td className="px-4 py-2.5">
+        {contract.statusCode && (
+          <span className={`rounded-full px-2.5 py-0.5 text-xs font-medium ${CONTRACT_STATUS_KLEUR[contract.statusCode] ?? 'bg-slate-100 text-slate-700'}`}>
+            {CONTRACT_STATUS_LABEL[contract.statusCode] ?? contract.statusCode}
+          </span>
+        )}
+      </td>
+      <td className="px-4 py-2.5 text-xs">
+        <div className="text-ink-muted">{contract.startDate ?? '—'} – {contract.endDate ?? '—'}</div>
+        <EindeIndicator contract={contract} />
+      </td>
+      <td className="px-4 py-2.5">
+        {/* bewerken/verwijderen-knoppen, ongewijzigd uit de huidige versie */}
+      </td>
+    </tr>
+  );
+```
+
+Pas de omringende `Contracten`-component aan: de `<ul>` wrapper wordt
+`<table className="w-full text-sm">` met `<thead>`/`<tbody>`, zelfde
+`rounded border border-line`-omkadering als nu.
+
+- [ ] **Step 2: Compileer, prettier, lint**
+
+```bash
+npx tsc --noEmit
+npx prettier --write "src/app/beheer/leveranciers/[id]/page.tsx"
+npx eslint "src/app/beheer/leveranciers/[id]/page.tsx" --max-warnings=0
+```
+
+- [ ] **Step 3: Draai de bestaande `e2e/contracten.spec.ts` — geen enkele test hoort te breken**
+
+De `data-testid`-attributen blijven ongewijzigd (`contract-rij`,
+`contract-status`, etc.), dus de bestaande tests moeten zonder aanpassing
+slagen. Dit is de eerste concrete controle dat de tabel-ombouw niets
+breekt.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add "src/app/beheer/leveranciers/[id]/page.tsx"
+git commit -m "feat(contract): contractenlijst als tabel i.p.v. kaarten
+
+Compacter bij meerdere contracten per leverancier — kolommen i.p.v.
+gestapelde velden. data-testid's ongewijzigd, geen bestaande test raakt.
+
+Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>"
+```
+
+### 14.3 Frontend: contactpersoon + notitie bij bewerken, en het wachtlijst-scherm
+
+**Files (`MCM2-frontend`):**
+- Modify: `src/app/beheer/leveranciers/[id]/page.tsx`
+- Modify: `src/core/services/contractService.ts`
+- Modify: `src/core/models/contract.ts`
+- Modify: `src/core/services/vragenlijstService.ts`
+- Modify: `src/core/models/vragenlijst.ts`
+- Create: `src/app/beheer/vragenlijsten/[id]/wachtlijst/page.tsx`
+- Modify: `src/app/beheer/vragenlijsten/page.tsx`
+
+- [ ] **Step 1: Modellen uitbreiden**
+
+`src/core/models/contract.ts`:
+
+```typescript
+export interface ContractInvoer {
+  // ... bestaande velden ongewijzigd ...
+}
+
+/** Wat het koppelingsblok opstuurt. */
+export interface SurveyTemplateKoppelingInvoer {
+  templateIds: string[];
+  wachtlijstTemplateIds: string[];
+}
+
+export interface SurveyTemplateKoppeling {
+  templateIds: string[];
+  wachtlijstTemplateIds: string[];
+}
+```
+
+`src/core/models/vragenlijst.ts`, nieuw:
+
+```typescript
+export interface WachtlijstLeverancier {
+  vendorId: string;
+  vendorNaam: string;
+}
+```
+
+- [ ] **Step 2: Services uitbreiden**
+
+`src/core/services/contractService.ts`: `haalGekoppeldeTemplates` en
+`zetGekoppeldeTemplates` aanpassen aan het nieuwe antwoordformaat
+(`SurveyTemplateKoppeling` i.p.v. `string[]`):
+
+```typescript
+export async function haalGekoppeldeTemplates(
+  vendorId: string,
+  contractId: string,
+): Promise<SurveyTemplateKoppeling> {
+  if (gebruiktMockData) {
+    return {
+      templateIds: mockKoppelingen.get(contractId) ?? [],
+      wachtlijstTemplateIds: [],
+    };
+  }
+  return haalOp<SurveyTemplateKoppeling>(
+    `/vendors/${vendorId}/contracts/${contractId}/survey-templates`,
+  );
+}
+
+export async function zetGekoppeldeTemplates(
+  vendorId: string,
+  contractId: string,
+  invoer: SurveyTemplateKoppelingInvoer,
+): Promise<{ ok: true } | { ok: false; melding: string }> {
+  if (gebruiktMockData) {
+    mockKoppelingen.set(contractId, invoer.templateIds);
+    return { ok: true };
+  }
+  try {
+    await zetData(
+      `/vendors/${vendorId}/contracts/${contractId}/survey-templates`,
+      invoer,
+    );
+    return { ok: true };
+  } catch (err) {
+    if (err instanceof ApiFout) return { ok: false, melding: err.message };
+    return { ok: false, melding: 'Er ging iets mis.' };
+  }
+}
+```
+
+**Let op:** dit wijzigt de signatuur van `zetGekoppeldeTemplates` (was:
+`(vendorId, contractId, templateIds: string[])`). Werk alle aanroepen in
+`page.tsx` bij naar het nieuwe object-argument — zoek ze op met
+`grep -n "zetGekoppeldeTemplates" "src/app/beheer/leveranciers/[id]/page.tsx"`,
+gok niet hoeveel aanroepplekken er zijn.
+
+`src/core/services/vragenlijstService.ts`, nieuw:
+
+```typescript
+export async function haalWachtlijst(
+  templateId: string,
+): Promise<WachtlijstLeverancier[]> {
+  if (gebruiktMockData) return [];
+  const antwoord = await haalOp<{ leveranciers: WachtlijstLeverancier[] }>(
+    `/admin/survey/templates/${templateId}/wachtlijst`,
+  );
+  return antwoord.leveranciers;
+}
+```
+
+- [ ] **Step 3: `SurveyTemplateKoppelingBlok` — wachtlijst-checkbox erbij**
+
+In `SurveyTemplateKoppelingBlok`, naast elke bestaande checkbox een tweede,
+kleinere checkbox "wachtlijst voor volgende ronde" — alleen actief te
+zetten als de hoofdcheckbox aan staat:
+
+```typescript
+  const [gekoppeld, setGekoppeld] = useState<Set<string>>(new Set());
+  const [wachtlijst, setWachtlijst] = useState<Set<string>>(new Set());
+
+  // In de useEffect die haalGekoppeldeTemplates aanroept:
+  const koppeling = await haalGekoppeldeTemplates(vendorId, contractId);
+  setGekoppeld(new Set(koppeling.templateIds));
+  setWachtlijst(new Set(koppeling.wachtlijstTemplateIds));
+```
+
+Bij het uitvinken van de hoofdcheckbox: ook uit `wachtlijst` verwijderen
+(een niet-gekoppelde template kan niet op de wachtlijst staan). In
+`schakel()`:
+
+```typescript
+  function schakel(templateId: string) {
+    setGelukt(false);
+    setGekoppeld((vorig) => {
+      const nieuw = new Set(vorig);
+      if (nieuw.has(templateId)) {
+        nieuw.delete(templateId);
+        setWachtlijst((w) => {
+          const nw = new Set(w);
+          nw.delete(templateId);
+          return nw;
+        });
+      } else {
+        nieuw.add(templateId);
+      }
+      return nieuw;
+    });
+  }
+
+  function schakelWachtlijst(templateId: string) {
+    setGelukt(false);
+    setWachtlijst((vorig) => {
+      const nieuw = new Set(vorig);
+      if (nieuw.has(templateId)) nieuw.delete(templateId);
+      else nieuw.add(templateId);
+      return nieuw;
+    });
+  }
+```
+
+In de checkbox-lijst-JSX, ná elke hoofdcheckbox:
+
+```typescript
+              <input
+                type="checkbox"
+                data-testid="wachtlijst-checkbox"
+                checked={wachtlijst.has(t.templateId)}
+                disabled={!gekoppeld.has(t.templateId)}
+                onChange={() => schakelWachtlijst(t.templateId)}
+              />
+              <span className="text-xs text-ink-muted">wachtlijst</span>
+```
+
+En `koppelen()` stuurt nu het object:
+
+```typescript
+    const uitkomst = await zetGekoppeldeTemplates(vendorId, contractId, {
+      templateIds: [...gekoppeld],
+      wachtlijstTemplateIds: [...wachtlijst],
+    });
+```
+
+- [ ] **Step 4: Contactpersoon + notitie in `ContactRij` (bestaande sectie) en beide contract-formulieren**
+
+**4a — Notitieveld bij de bestaande Contactpersonen-sectie.** In
+`ContactRij`'s bewerkstand en in `Contactpersonen`'s toevoegformulier
+(zoek met `grep -n "jobTitle" "src/app/beheer/leveranciers/[id]/page.tsx"`
+naar beide plekken), een extra `Veld` toevoegen:
+
+```typescript
+            <Veld
+              id={`bewerkNotitie-${contact.contactId}`}
+              label="Notitie"
+              waarde={waarden.roleDescription ?? ''}
+              onWijzig={(w) => setWaarden((v) => ({ ...v, roleDescription: w }))}
+            />
+```
+
+Vraagt dat `ContactInvoer` (in `src/core/models/vendor.ts`) een
+`roleDescription?: string | null` krijgt, en dat de bestaande
+`wijzigContact`/`voegContactToe`-aanroepen dat veld meesturen. Controleer
+of de backend (`ContactInvoer` in `src/vendor/vendor.service.ts`) dat veld
+al accepteert:
+
+```bash
+grep -n "roleDescription\|role_description" c:/DEV/Work/MCM2/src/vendor/vendor.service.ts c:/DEV/Work/MCM2/src/vendor/vendor-invoer.ts
+```
+
+**Als dat veld nog nergens in de backend-invoer/service zit** (waarschijnlijk
+— de datamodel-spec van 22-08 noemde het alleen als bestaande kolom, geen
+route las of schreef hem ooit), is dat een kleine, extra backend-taak: voeg
+`roleDescription` toe aan `ContactInvoer` (backend), de INSERT/UPDATE in
+`VendorService.voegContactToe`/`wijzigContact`, en de SELECT in
+`detailBinnenTransactie`. Zelfde soort kleine uitbreiding als Task 1/3 van
+het eerdere plan — volg dat patroon, niet opnieuw uitvinden.
+
+**4b — Dezelfde toggle als Task 12, nu ook in `ContractRij`'s bewerkstand.**
+Kopieer de "nieuwe contactpersoon aanmaken"-toggle-logica uit
+`NieuwContractFormulier` (Task 12) naar `ContractRij`: eigen
+`nieuweContactpersoon`/`contactVelden`-state, dezelfde
+`voegContactToe`-aanroep vóór `wijzigContact`, inclusief het
+`roleDescription`-veld uit 4a.
+
+- [ ] **Step 5: Nieuw scherm `src/app/beheer/vragenlijsten/[id]/wachtlijst/page.tsx`**
+
+Volgt het patroon van `src/app/beheer/leveranciers/page.tsx` voor de
+selectie-UI (checkbox-lijst met een `Set<string>`), maar met
+`haalWachtlijst(templateId)` als startpunt in plaats van alle
+leveranciers:
+
+```typescript
+'use client';
+
+import Link from 'next/link';
+import { useParams, useRouter } from 'next/navigation';
+import { useEffect, useState } from 'react';
+
+import type { WachtlijstLeverancier } from '@/core/models/vragenlijst';
+import { haalVragenlijsten, haalWachtlijst } from '@/core/services/vragenlijstService';
+import { haalVendors } from '@/core/services/vendorService';
+import type { VendorSamenvatting } from '@/core/models/vendor';
+import { AppLayout } from '@/shared/components/layout/AppLayout';
+
+export default function WachtlijstPagina() {
+  const params = useParams<{ id: string }>();
+  const router = useRouter();
+  const templateId = params.id;
+
+  const [templateNaam, setTemplateNaam] = useState('');
+  const [alleVendors, setAlleVendors] = useState<VendorSamenvatting[]>([]);
+  const [wachtlijst, setWachtlijst] = useState<WachtlijstLeverancier[]>([]);
+  const [geselecteerd, setGeselecteerd] = useState<Set<string>>(new Set());
+  const [laden, setLaden] = useState(true);
+
+  useEffect(() => {
+    void (async () => {
+      const [lijsten, vendors, wl] = await Promise.all([
+        haalVragenlijsten(),
+        haalVendors(),
+        haalWachtlijst(templateId),
+      ]);
+      setTemplateNaam(lijsten.find((l) => l.templateId === templateId)?.name ?? '');
+      setAlleVendors(vendors);
+      setWachtlijst(wl);
+      setGeselecteerd(new Set(wl.map((w) => w.vendorId)));
+      setLaden(false);
+    })();
+  }, [templateId]);
+
+  function schakel(vendorId: string) {
+    setGeselecteerd((vorig) => {
+      const nieuw = new Set(vorig);
+      if (nieuw.has(vendorId)) nieuw.delete(vendorId);
+      else nieuw.add(vendorId);
+      return nieuw;
+    });
+  }
+
+  function verder() {
+    router.push(
+      `/beheer/vragenlijsten/uitnodigen?leveranciers=${[...geselecteerd].join(',')}&templateId=${templateId}`,
+    );
+  }
+
+  return (
+    <AppLayout
+      titel={`Wachtlijst — ${templateNaam}`}
+      ondertitel="Leveranciers die klaarstaan voor de volgende ronde. Vink aan of uit, en ga verder naar uitnodigen."
+    >
+      <Link
+        href="/beheer/vragenlijsten"
+        className="mb-6 inline-flex items-center gap-1.5 text-sm text-brand-primary hover:underline"
+      >
+        Terug naar vragenlijsten
+      </Link>
+
+      {laden ? (
+        <p className="text-sm text-ink-muted">Bezig met laden…</p>
+      ) : (
+        <>
+          <ul className="mb-6 divide-y divide-line rounded border border-line" data-testid="wachtlijst-lijst">
+            {alleVendors
+              .filter((v) => wachtlijst.some((w) => w.vendorId === v.vendorId) || geselecteerd.has(v.vendorId))
+              .map((vendor) => (
+                <li key={vendor.vendorId} className="flex items-center gap-3 px-4 py-2.5">
+                  <input
+                    type="checkbox"
+                    data-testid="wachtlijst-vendor-checkbox"
+                    checked={geselecteerd.has(vendor.vendorId)}
+                    onChange={() => schakel(vendor.vendorId)}
+                  />
+                  <span className="text-sm text-ink">{vendor.name}</span>
+                </li>
+              ))}
+          </ul>
+
+          {wachtlijst.length === 0 && (
+            <p className="mb-6 text-sm text-ink-muted" data-testid="wachtlijst-leeg">
+              Er staat nog niemand op de wachtlijst voor deze vragenlijst.
+            </p>
+          )}
+
+          <button
+            type="button"
+            onClick={verder}
+            disabled={geselecteerd.size === 0}
+            data-testid="wachtlijst-verder"
+            className="rounded bg-brand-primary px-5 py-2 text-sm font-medium text-white disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            Verder naar uitnodigen ({geselecteerd.size})
+          </button>
+        </>
+      )}
+    </AppLayout>
+  );
+}
+```
+
+**Let op:** de filter-regel (`alleVendors.filter(...)`) toont alleen
+leveranciers die al op de wachtlijst stonden óf nu aangevinkt zijn — niet
+de volledige leverancierslijst. Wil je ook kunnen *toevoegen* buiten de
+wachtlijst om, dan is dat een bewuste, latere uitbreiding (zie spec §9.4)
+en niet iets om hier stilzwijgend mee te bouwen.
+
+- [ ] **Step 6: Link vanaf `/beheer/vragenlijsten`**
+
+In `src/app/beheer/vragenlijsten/page.tsx`, de tabel (rond regel 190–244)
+krijgt een extra kolom of een badge in de bestaande "Naam"-kolom die
+alleen verschijnt als er een wachtlijst is. Simpelste optie: een klein
+badge-linkje naast de naam:
+
+```typescript
+                    <td className="px-4 py-3">
+                      <Link
+                        href={`/beheer/vragenlijsten/${lijst.templateId}`}
+                        className="font-medium text-brand-primary hover:underline"
+                        data-testid="vragenlijst-link"
+                      >
+                        {lijst.name}
+                      </Link>
+                      {/* wachtlijst-aantal is geen veld op VragenlijstSamenvatting
+                          — zie de opmerking hieronder vóór je dit implementeert */}
+                    </td>
+```
+
+**Dit vraagt een aantal, en dat aantal bestaat nog niet op
+`VragenlijstSamenvatting`.** Twee opties, kies er één vóór je verdergaat:
+(a) `VragenlijstBeheerService.lijst()` (backend) uitbreiden met een
+`aantalOpWachtlijst`-veld via een subquery, zelfde patroon als
+`aantalContacten` in `VendorService.lijst()`; of (b) de link altijd tonen
+("Wachtlijst bekijken") zonder aantal, en het aantal pas op het
+wachtlijst-scherm zelf laten zien. **Optie (b) is de kleinere wijziging en
+het aanbevolen pad** — geen backend-uitbreiding nodig:
+
+```typescript
+                      <Link
+                        href={`/beheer/vragenlijsten/${lijst.templateId}/wachtlijst`}
+                        className="ml-2 text-xs text-ink-muted hover:underline"
+                        data-testid="wachtlijst-link"
+                      >
+                        wachtlijst
+                      </Link>
+```
+
+- [ ] **Step 7: Compileer, prettier, lint**
+
+```bash
+npx tsc --noEmit
+npx prettier --write "src/core/models/contract.ts" "src/core/models/vragenlijst.ts" "src/core/services/contractService.ts" "src/core/services/vragenlijstService.ts" "src/app/beheer/leveranciers/[id]/page.tsx" "src/app/beheer/vragenlijsten/page.tsx" "src/app/beheer/vragenlijsten/[id]/wachtlijst/page.tsx"
+npx eslint "src/core/models/contract.ts" "src/core/models/vragenlijst.ts" "src/core/services/contractService.ts" "src/core/services/vragenlijstService.ts" "src/app/beheer/leveranciers/[id]/page.tsx" "src/app/beheer/vragenlijsten/page.tsx" "src/app/beheer/vragenlijsten/[id]/wachtlijst/page.tsx" --max-warnings=0
+```
+
+- [ ] **Step 8: Playwright-tests**
+
+Uitbreiding van `e2e/contracten.spec.ts`: een test die de wachtlijst-
+checkbox aanvinkt naast een gekoppelde template, opslaat, en dan navigeert
+naar `/beheer/vragenlijsten/[templateId]/wachtlijst` om te bevestigen dat
+de leverancier daar verschijnt en aangevinkt staat.
+
+```typescript
+  test('een leverancier op de wachtlijst verschijnt op het wachtlijst-scherm', async ({
+    page,
+  }) => {
+    const { vendorId } = await maakEnOpen(page);
+
+    const checkboxen = page.getByTestId('nieuw-contract-survey-checkbox');
+    const aantal = await checkboxen.count();
+    test.skip(aantal === 0, 'Geen vragenlijst-templates aanwezig.');
+
+    await page
+      .locator('#nieuw-contract-name')
+      .fill(`Contract-wachtlijst-${Date.now()}`);
+    await checkboxen.first().check();
+    await page.getByTestId('voeg-contract-toe').click();
+    await expect(page.getByTestId('contract-rij').first()).toBeVisible();
+
+    await page.getByTestId('bewerk-contract').first().click();
+    await page.getByTestId('wachtlijst-checkbox').first().check();
+    await page.getByTestId('koppel-survey-templates').click();
+    await expect(page.getByTestId('survey-koppeling-gelukt')).toBeVisible();
+
+    // templateId uit de link halen om naar het wachtlijst-scherm te gaan.
+    const knop = page.getByTestId('uitnodigen-vanuit-contract-knop').first();
+    const href = await knop.getAttribute('href');
+    const templateId = new URL(href!, 'http://localhost').searchParams.get(
+      'templateId',
+    );
+
+    await page.goto(`/beheer/vragenlijsten/${templateId}/wachtlijst`);
+    await expect(
+      page.getByTestId('wachtlijst-vendor-checkbox').first(),
+    ).toBeChecked();
+  });
+```
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/core/models/contract.ts src/core/models/vragenlijst.ts src/core/services/contractService.ts src/core/services/vragenlijstService.ts "src/app/beheer/leveranciers/[id]/page.tsx" src/app/beheer/vragenlijsten/page.tsx "src/app/beheer/vragenlijsten/[id]/wachtlijst/page.tsx" e2e/contracten.spec.ts
+git commit -m "feat(contract): contactpersoon+notitie bij bewerken, wachtlijst-scherm
+
+Toggle om een nieuwe contactpersoon aan te maken nu ook bij het bewerken
+van een bestaand contract, met notitieveld (role_description). Nieuwe
+wachtlijst-checkbox per gekoppelde vragenlijst, en een nieuw scherm
+/beheer/vragenlijsten/[id]/wachtlijst dat de leveranciers toont die
+klaarstaan — met een link door naar het bestaande uitnodigen-scherm.
+Geen automatisch verzenden, spec §9.
+
+Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>"
+```
+
+### 14.4 Vierde, volledige preview-ronde
+
+- [ ] **Step 1: Volledige backend-e2e, dan `npm run demo -- --branch feat/contractmanagement-scherm`**
+
+Herhaal Task 10 (Steps 2–6). Controleer specifiek:
+1. De contractenlijst toont nu als tabel met alle kolommen.
+2. Bij het bewerken van een bestaand contract: de toggle voor een nieuwe
+   contactpersoon staat er, met een notitieveld.
+3. Het notitieveld bij een bestaande contactpersoon (Contactpersonen-
+   sectie) is zichtbaar en bewerkbaar.
+4. Bij het koppelingsblok: een wachtlijst-checkbox naast elke gekoppelde
+   vragenlijst, uitschakelbaar los van de hoofdcheckbox.
+5. Vanaf `/beheer/vragenlijsten`: de "wachtlijst"-link opent het nieuwe
+   scherm, toont de aangevinkte leverancier(s), en "Verder naar
+   uitnodigen" komt uit op het bestaande scherm met de juiste
+   voorselectie.
+
+---
+
 ## Task 11: Samenvoegen — pas na akkoord op de preview
 
 **Niet uitvoeren zonder expliciet akkoord van de eigenaar op Task 10 (en,**
-**als Task 12/13 zijn uitgevoerd, ook op de latere preview-rondes daar).**
+**als Task 12/13/14 zijn uitgevoerd, ook op de latere preview-rondes daar).**
 
 - [ ] **Step 1: Volg `superpowers:finishing-a-development-branch`**
 

--- a/docs/superpowers/plans/2026-08-22-contractmanagement-ui.md
+++ b/docs/superpowers/plans/2026-08-22-contractmanagement-ui.md
@@ -2430,10 +2430,315 @@ dezelfde branch, dus geen nieuwe `--branch`-naam nodig, alleen opnieuw
 
 ---
 
+## Task 13: Een vragenlijst daadwerkelijk kunnen versturen vanuit een contract
+
+**Toegevoegd 22-08, tijdens de tweede preview-ronde.** De eigenaar
+ontdekte dat de survey-templatekoppeling (Task 2/12) een doodlopend
+register was: er bestond geen weg van "dit contract heeft vragenlijst X
+aangevinkt" naar "stuur die vragenlijst nu naar de contactpersoon van dit
+contract". Bij het uitzoeken bleek het gat groter dan verwacht:
+`survey_run.contract_id` — de kolom die migratie 0007 al op 2026-08-14
+klaarzette precies voor dit doel — wordt nergens ingevuld. Niet in
+`RondeBeheerService.maakRonde()`, niet in de route, niet in het
+uitnodigen-scherm.
+
+Dit is geen nieuw datamodel, alleen het vullen van een kolom die al
+bestaat en het doortrekken van een `contractId` door een keten die al
+bestaat. Blijft binnen dezelfde twee branches.
+
+**Files (backend, `c:\DEV\Work\MCM2`):**
+- Modify: `src/survey/ronde-invoer.ts`
+- Modify: `src/survey/ronde-beheer.service.ts`
+- Test: uitbreiding van de bestaande e2e-suite voor rondes (zoek met
+  `grep -rn "maakRonde\|POST.*runs" test/*.e2e-spec.ts` naar de juiste
+  suite vóór je een nieuwe schrijft — hergebruik het bestaande bestand)
+
+- [ ] **Step 1: `NieuweRonde` krijgt een optioneel `contractId`**
+
+In `src/survey/ronde-invoer.ts`:
+
+```typescript
+export interface NieuweRonde {
+  templateId: string;
+  surveyKind: RondeSoort;
+  /** Wanneer de ronde sluit. Null betekent: geen sluitdatum. */
+  closesAt: Date | null;
+  isTest: boolean;
+  /** Op welk contract deze ronde betrekking heeft. Optioneel — zie migratie 0007. */
+  contractId: string | null;
+}
+```
+
+En in `leesNieuweRonde()`, ná de bestaande velden:
+
+```typescript
+  return {
+    templateId,
+    surveyKind: soort as RondeSoort,
+    closesAt: leesSluitdatum(invoer.closesAt),
+    isTest: invoer.isTest === true,
+    contractId:
+      invoer.contractId === undefined || invoer.contractId === null
+        ? null
+        : leesUuid(invoer.contractId, 'contractId'),
+  };
+```
+
+- [ ] **Step 2: `RondeBeheerService.maakRonde()` schrijft de kolom**
+
+In `src/survey/ronde-beheer.service.ts`, de bestaande INSERT uitbreiden:
+
+```typescript
+        const aangemaakt = await tx.execute<RunRij>(
+          sql`INSERT INTO clm.survey_run
+                  (tenant_id, template_id, survey_kind, status, closes_at,
+                   is_test, contract_id)
+              VALUES (${tenantId}, ${invoer.templateId}, ${invoer.surveyKind},
+                      'draft', ${invoer.closesAt?.toISOString() ?? null},
+                      ${invoer.isTest}, ${invoer.contractId})
+              RETURNING run_id, template_id, status, survey_kind, is_test,
+                        closes_at, contract_id`,
+        );
+```
+
+**Let op:** als het contract bij een andere tenant hoort dan de sessie, of
+niet bestaat, faalt dit met een foreign-key-fout (`contract_id` heeft geen
+FK naar een tenant-gefilterde subset — de FK zelf verwijst simpelweg naar
+`clm.contract.contract_id`). Voeg daarom eerst een controle toe, zelfde
+patroon als de bestaande template-controle iets hoger in dezelfde
+methode:
+
+```typescript
+        if (invoer.contractId) {
+          const contracten = await tx.execute<{ contract_id: string }>(
+            sql`SELECT contract_id FROM clm.contract
+               WHERE contract_id = ${invoer.contractId}
+                 AND deleted_at IS NULL`,
+          );
+
+          if (contracten.rows.length === 0) {
+            throw new NotFoundException('Dit contract bestaat niet.');
+          }
+        }
+```
+
+Plaats dit vóór de `INSERT`, ná de bestaande template/vragen-controles.
+RLS filtert automatisch op tenant (net als de template-check hierboven al
+doet) — een contract van een andere tenant levert dus gewoon nul rijen op,
+niet een lek.
+
+Voeg `contractId: r.contract_id` toe aan het teruggegeven object in
+`RondeGestart` (interface uitbreiden met `contractId: string | null`, en
+de `RunRij`-interface met `contract_id: string | null`).
+
+- [ ] **Step 3: Compileer**
+
+```bash
+npx tsc --noEmit
+```
+
+- [ ] **Step 4: Zoek en breid de bestaande e2e-suite voor rondes uit**
+
+```bash
+grep -rln "maakRonde\|POST.*admin/survey/runs" test/*.e2e-spec.ts
+```
+
+Voeg in dat bestand een test toe die bevestigt dat `contractId` wordt
+opgeslagen en teruggegeven, en één die bevestigt dat een onbekend
+`contractId` een 404 geeft — volg het bestaande testpatroon in dat
+bestand exact (tenant-opzet, cookie, opruimen), niet een nieuw patroon
+verzinnen.
+
+- [ ] **Step 5: Draai die suite geïsoleerd, dan de volledige e2e-run**
+
+```bash
+DATABASE_URL="postgresql://clm_api_runtime:pw@localhost:55440/postgres" \
+MIGRATION_DATABASE_URL="postgresql://clm_migrator:pw@localhost:55440/postgres" \
+npx jest --config test/jest-e2e.json --forceExit
+```
+
+- [ ] **Step 6: Prettier, lint, commit**
+
+```bash
+git add src/survey/ronde-invoer.ts src/survey/ronde-beheer.service.ts test/<gevonden-bestand>.e2e-spec.ts
+git commit -m "feat(survey): survey_run.contract_id daadwerkelijk vullen
+
+Kolom bestond sinds migratie 0007 maar werd nergens geschreven. Nu vult
+maakRonde() hem als er een contractId wordt meegestuurd, met een 404 bij
+een onbekend contract.
+
+Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>"
+```
+
+**Files (frontend, `MCM2-frontend`):**
+- Modify: `src/core/services/vragenlijstService.ts`
+- Modify: `src/app/beheer/vragenlijsten/uitnodigen/page.tsx`
+- Modify: `src/app/beheer/leveranciers/[id]/page.tsx`
+
+- [ ] **Step 7: `maakRonde()` stuurt `contractId` mee**
+
+In `src/core/services/vragenlijstService.ts`:
+
+```typescript
+export async function maakRonde(invoer: {
+  templateId: string;
+  closesAt?: string | null;
+  isTest?: boolean;
+  contractId?: string | null;
+}): Promise<RondeGestart> {
+```
+
+De rest van de functie ongewijzigd — `invoer` gaat al in zijn geheel als
+body mee.
+
+- [ ] **Step 8: Het uitnodigen-scherm leest `?contractId=` en voegt het toe aan `start()`**
+
+In `src/app/beheer/vragenlijsten/uitnodigen/page.tsx`, ná de bestaande
+`gekozenIds`-regel:
+
+```typescript
+  const contractId = parameters.get('contractId');
+```
+
+In `start()`, de aanroep naar `maakRonde` uitbreiden:
+
+```typescript
+      const ronde = await maakRonde({
+        templateId,
+        closesAt: sluitdatum ? new Date(sluitdatum).toISOString() : null,
+        contractId,
+      });
+```
+
+Toon daarnaast, wanneer `contractId` gezet is, een korte regel in de
+`kiezen`-stap die bevestigt vanuit welk contract dit uitnodigen komt —
+zonder dat is voor de gebruiker niet zichtbaar of de koppeling meekomt.
+Plaats dit vlak boven de bestaande template-keuze:
+
+```typescript
+      {contractId && (
+        <p
+          data-testid="uitnodigen-vanuit-contract"
+          className="mb-4 rounded border border-line bg-surface px-3 py-2 text-xs text-ink-muted"
+        >
+          Deze uitnodiging wordt gekoppeld aan het contract waar u vandaan
+          kwam.
+        </p>
+      )}
+```
+
+- [ ] **Step 9: Knop op het contract — per gekoppelde vragenlijst een "Uitnodigen"-link**
+
+In `SurveyTemplateKoppelingBlok` (in
+`src/app/beheer/leveranciers/[id]/page.tsx`), een link toevoegen naast
+elke aangevinkte checkbox die naar het uitnodigen-scherm springt met de
+juiste parameters. De component heeft `vendorId` en `contractId` al als
+props — voeg toe, ná de bestaande checkbox-lijst:
+
+```typescript
+      {!laden &&
+        [...gekoppeld].map((templateId) => {
+          const template = templates.find((t) => t.templateId === templateId);
+          if (!template) return null;
+
+          return (
+            <Link
+              key={templateId}
+              href={`/beheer/vragenlijsten/uitnodigen?leveranciers=${vendorId}&contractId=${contractId}&templateId=${templateId}`}
+              data-testid="uitnodigen-vanuit-contract-knop"
+              className="mb-2 inline-flex items-center gap-1.5 text-xs font-medium text-brand-primary hover:underline"
+            >
+              → {template.naam} nu uitnodigen
+            </Link>
+          );
+        })}
+```
+
+Plaats dit ná de checkbox-lijst en vóór de foutmelding/knop-blok. Voeg
+`import Link from 'next/link';` toe als die nog niet bovenaan het bestand
+staat (die is er al, gebruikt door `LeverancierDetailPagina` zelf —
+hergebruiken).
+
+**Let op:** het uitnodigen-scherm (Step 8) leest ook `templateId` uit de
+querystring niet automatisch voor — controleer of dat scherm die
+parameter al oppikt (`parameters.get('templateId')`) of dat er een regel
+bij moet om `setTemplateId` te initialiseren vanuit de querystring, zoals
+al gebeurt voor `alleLijsten.length === 1`. Gok niet, lees de bestaande
+`useEffect` in dat bestand na voordat je hier verdergaat.
+
+- [ ] **Step 10: Compileer, prettier, lint**
+
+```bash
+npx tsc --noEmit
+npx prettier --write "src/core/services/vragenlijstService.ts" "src/app/beheer/vragenlijsten/uitnodigen/page.tsx" "src/app/beheer/leveranciers/[id]/page.tsx"
+npx eslint "src/core/services/vragenlijstService.ts" "src/app/beheer/vragenlijsten/uitnodigen/page.tsx" "src/app/beheer/leveranciers/[id]/page.tsx" --max-warnings=0
+```
+
+- [ ] **Step 11: Playwright-test: van contract naar verstuurde uitnodiging**
+
+Uitbreiding van `e2e/contracten.spec.ts`:
+
+```typescript
+  test('stuurt een vragenlijst rechtstreeks vanuit een gekoppeld contract', async ({
+    page,
+  }) => {
+    await maakEnOpen(page);
+
+    const checkboxen = page.getByTestId('nieuw-contract-survey-checkbox');
+    const aantal = await checkboxen.count();
+    test.skip(
+      aantal === 0,
+      'Geen vragenlijst-templates aanwezig op deze database.',
+    );
+
+    await page
+      .locator('#nieuw-contract-name')
+      .fill(`Contract-uitnodigen-${Date.now()}`);
+    await checkboxen.first().check();
+    await page.getByTestId('voeg-contract-toe').click();
+    await expect(page.getByTestId('contract-rij').first()).toBeVisible();
+
+    await page.getByTestId('bewerk-contract').first().click();
+    await page.getByTestId('uitnodigen-vanuit-contract-knop').first().click();
+
+    await expect(
+      page.getByTestId('uitnodigen-vanuit-contract'),
+    ).toBeVisible();
+  });
+```
+
+- [ ] **Step 12: Commit**
+
+```bash
+git add src/core/services/vragenlijstService.ts "src/app/beheer/vragenlijsten/uitnodigen/page.tsx" "src/app/beheer/leveranciers/[id]/page.tsx" e2e/contracten.spec.ts
+git commit -m "feat(contract): vanuit een gekoppelde vragenlijst rechtstreeks kunnen uitnodigen
+
+Sluit het gat dat de eigenaar vond tijdens de tweede preview: de
+survey-templatekoppeling was een doodlopend register zonder een weg naar
+het daadwerkelijk versturen. Elke gekoppelde vragenlijst op een contract
+krijgt nu een link naar het bestaande uitnodigen-scherm, met leverancier
+en vragenlijst voorgeselecteerd en contract_id meegegeven.
+
+Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>"
+```
+
+- [ ] **Step 13: Derde, korte preview-ronde**
+
+Herhaal Task 10 (Steps 2–6) opnieuw. Controleer specifiek: vanuit een
+contract op "→ … nu uitnodigen" klikken, de melding "gekoppeld aan het
+contract" zien, de ronde afmaken, en — als er tijd voor is — in de
+database bevestigen dat `survey_run.contract_id` daadwerkelijk gevuld is:
+
+```sql
+SELECT run_id, contract_id FROM clm.survey_run WHERE contract_id IS NOT NULL ORDER BY started_at DESC LIMIT 1;
+```
+
+---
+
 ## Task 11: Samenvoegen — pas na akkoord op de preview
 
 **Niet uitvoeren zonder expliciet akkoord van de eigenaar op Task 10 (en,**
-**als Task 12 is uitgevoerd, ook op de tweede preview-ronde daar).**
+**als Task 12/13 zijn uitgevoerd, ook op de latere preview-rondes daar).**
 
 - [ ] **Step 1: Volg `superpowers:finishing-a-development-branch`**
 

--- a/docs/superpowers/plans/2026-08-22-contractmanagement-ui.md
+++ b/docs/superpowers/plans/2026-08-22-contractmanagement-ui.md
@@ -1,0 +1,2123 @@
+# Contractmanagement UI Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** De contractmanagement-backend (migratie 0027, `ContractModule`)
+bruikbaar maken vanuit het scherm: een `Contracten`-sectie op
+`/beheer/leveranciers/[id]` in `MCM2-frontend`, plus de twee ontbrekende
+backend-routes die dat scherm nodig heeft (tenant-gebruikers,
+survey-templatekoppeling). Afgesloten met een **verplichte preview
+conform het bestaande protocol**, niet met "de tests zijn groen".
+
+**Architecture:** Backend-uitbreidingen volgen exact het patroon van
+`VendorController`/`ContractController` (raw SQL, `withTenant`,
+`RolGuard`). Frontend volgt exact het patroon van
+`Contactpersonen`/`ContactRij` op hetzelfde scherm — inline bewerken, een
+los CRUD-blok voor de survey-koppeling, en de bestaande mock/live-schakelaar
+(`NEXT_PUBLIC_API_URL`) zodat het scherm ook zonder draaiende backend te
+beoordelen is.
+
+**Tech Stack:** NestJS/Drizzle (backend, dit repo), Next.js/React/Playwright
+(frontend, `MCM2-frontend`), Jest voor backend-e2e.
+
+**Specs:**
+- `docs/superpowers/specs/2026-08-22-contractmanagement-design.md` (datamodel)
+- `docs/superpowers/specs/2026-08-22-contractmanagement-ui-design.md` (dit plan)
+
+**Twee repo's.** Taken 1–4 zijn in `c:\DEV\Work\MCM2` (backend), taken 5–9
+in `c:\DEV\Work\MCM2-frontend`. Beide op een eigen feature-branch — niet
+tegelijk op main. Taak 10 is de preview, taak 11 het samenvoegen.
+
+---
+
+## Task 1: `GET /tenant/gebruikers` — lijst voor de contractbeheerder-dropdown
+
+**Files (backend):**
+- Modify: `src/tenant/tenant.service.ts`
+- Modify: `src/tenant/tenant.controller.ts`
+- Test: `test/tenant-gebruikers.e2e-spec.ts`
+- Modify: `test/test-ids.ts`
+
+- [ ] **Step 1: Voeg een testblok toe aan `test/test-ids.ts`**
+
+Na het `'contract-routes'`-blok:
+
+```typescript
+  'tenant-gebruikers': {
+    tenant: id('2a'),
+    adminUser: id('2b'),
+    reviewerUser: id('2c'),
+    andereTenant: id('2d'),
+  },
+```
+
+- [ ] **Step 2: Controleer op botsingen**
+
+```bash
+npx jest test/test-ids.spec.ts
+```
+
+Verwacht: PASS. Bij een botsing: kies het eerstvolgende vrije tweeletter-merk
+(zoek met `grep -oE "id\\('[0-9a-f]{2}'\\)" test/test-ids.ts | sort -u`),
+niet zomaar een waarde die toevallig onbezet líjkt.
+
+- [ ] **Step 3: Schrijf de service-methode**
+
+In `src/tenant/tenant.service.ts`, toevoegen aan de bestaande
+`TenantService`-klasse:
+
+```typescript
+export interface TenantGebruiker {
+  userId: string;
+  naam: string;
+}
+```
+
+```typescript
+  /**
+   * De gebruikers van de eigen tenant, voor een keuzelijst (bv. de
+   * contractbeheerder-dropdown). Alleen id en naam — geen e-mailadres of rol,
+   * dat is meer dan een dropdown nodig heeft.
+   */
+  async gebruikers(tenantId: string): Promise<TenantGebruiker[]> {
+    return this.db.withTenant(
+      tenantId,
+      async (tx) => {
+        const resultaat = await tx.execute<{
+          user_id: string;
+          full_name: string;
+        }>(
+          sql`SELECT user_id, full_name FROM clm."user"
+             WHERE deleted_at IS NULL
+             ORDER BY full_name`,
+        );
+
+        return resultaat.rows.map((r) => ({
+          userId: r.user_id,
+          naam: r.full_name,
+        }));
+      },
+      'medewerker',
+    );
+  }
+```
+
+- [ ] **Step 4: Voeg de route toe aan `TenantController`**
+
+```typescript
+  /** De gebruikers van de eigen tenant, voor een keuzelijst. */
+  @Get('gebruikers')
+  async gebruikersLijst(@Req() request: RequestMetSessie) {
+    const gebruikers = await this.tenants.gebruikers(request.sessie!.tenantId);
+    return { gebruikers };
+  }
+```
+
+Geen `@VereistRol`: lezen mag iedereen met een sessie, zelfde als
+`GET /tenant/instellingen` hierboven — het is een keuzelijst, geen
+gevoelige data.
+
+- [ ] **Step 5: Compileer**
+
+```bash
+npx tsc --noEmit
+```
+
+- [ ] **Step 6: Schrijf de e2e-test**
+
+`test/tenant-gebruikers.e2e-spec.ts`, volgt het patroon van
+`contract-routes.e2e-spec.ts` (zie dat bestand voor de volledige
+`beforeAll`/`afterAll`-opzet met `migratieUrl()`/`verwijderTestdata`).
+Kernassertions:
+
+```typescript
+import { INestApplication } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import cookieParser from 'cookie-parser';
+import { Client } from 'pg';
+import request from 'supertest';
+import type { App } from 'supertest/types';
+
+import { AppModule } from '../src/app.module';
+import { SessieService } from '../src/auth/sessie.service';
+import { cookieInstellingen } from '../src/auth/sessie';
+import { TEST_IDS } from './test-ids';
+
+const { tenant, adminUser, reviewerUser, andereTenant } =
+  TEST_IDS['tenant-gebruikers'];
+
+const STEMPEL = Date.now();
+const SUBJECT_ADMIN = `oid-tg-admin-${STEMPEL}`;
+const SUBJECT_REVIEWER = `oid-tg-reviewer-${STEMPEL}`;
+
+function migratieUrl(): string {
+  const runtime = process.env.DATABASE_URL;
+  if (!runtime) throw new Error('DATABASE_URL ontbreekt.');
+  const doel = new URL(runtime);
+  const expliciet = process.env.MIGRATION_DATABASE_URL;
+  if (expliciet) {
+    const gegeven = new URL(expliciet);
+    if (gegeven.host === doel.host && gegeven.pathname === doel.pathname) {
+      return expliciet;
+    }
+  }
+  doel.username = 'clm_migrator';
+  return doel.toString();
+}
+
+async function opruimen(migratieClient: Client): Promise<void> {
+  for (const t of [tenant, andereTenant]) {
+    await migratieClient.query('BEGIN');
+    await migratieClient.query(`SET LOCAL app.current_tenant_id = '${t}'`);
+    await migratieClient.query(
+      'DELETE FROM clm.tenant_membership WHERE tenant_id = $1',
+      [t],
+    );
+    await migratieClient.query('DELETE FROM clm."user" WHERE tenant_id = $1', [
+      t,
+    ]);
+    await migratieClient.query('DELETE FROM clm.tenant WHERE tenant_id = $1', [
+      t,
+    ]);
+    await migratieClient.query('COMMIT');
+  }
+}
+
+describe('Tenant-gebruikers (e2e)', () => {
+  let app: INestApplication<App>;
+  let server: App;
+  let client: Client;
+  let migratieClient: Client;
+  let adminCookie: string;
+  const cookieNaam = cookieInstellingen().naam;
+
+  beforeAll(async () => {
+    client = new Client({ connectionString: process.env.DATABASE_URL });
+    await client.connect();
+    migratieClient = new Client({ connectionString: migratieUrl() });
+    await migratieClient.connect();
+    await opruimen(migratieClient);
+
+    await client.query('BEGIN');
+    await client.query(`SET LOCAL app.current_tenant_id = '${tenant}'`);
+    await client.query(
+      'INSERT INTO clm.tenant (tenant_id, name) VALUES ($1, $2)',
+      [tenant, 'tenant-gebruikers-test'],
+    );
+    await client.query(
+      `INSERT INTO clm."user" (user_id, tenant_id, full_name, external_subject)
+       VALUES ($1, $2, $3, $4), ($5, $2, $6, $7)`,
+      [
+        adminUser,
+        tenant,
+        'Anna Admin',
+        SUBJECT_ADMIN,
+        reviewerUser,
+        'Rob Reviewer',
+        SUBJECT_REVIEWER,
+      ],
+    );
+    await client.query(
+      `INSERT INTO clm.tenant_membership (user_id, tenant_id, role)
+       VALUES ($1, $2, 'admin'), ($3, $2, 'reviewer')`,
+      [adminUser, tenant, reviewerUser],
+    );
+    await client.query('COMMIT');
+
+    const moduleRef = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+    app = moduleRef.createNestApplication();
+    app.use(cookieParser());
+    await app.init();
+    server = app.getHttpServer();
+
+    const sessies = app.get(SessieService);
+    const adminSessie = await sessies.aanmaken(SUBJECT_ADMIN);
+    adminCookie = `${cookieNaam}=${adminSessie!.token}`;
+  });
+
+  afterAll(async () => {
+    await app.close();
+    await opruimen(migratieClient);
+    await client.end();
+    await migratieClient.end();
+  });
+
+  it('geeft de gebruikers van de eigen tenant, met naam', async () => {
+    const respons = await request(server)
+      .get('/tenant/gebruikers')
+      .set('Cookie', adminCookie);
+
+    expect(respons.status).toBe(200);
+    const namen = (
+      respons.body as { gebruikers: { naam: string }[] }
+    ).gebruikers.map((g) => g.naam);
+    expect(namen).toContain('Anna Admin');
+    expect(namen).toContain('Rob Reviewer');
+  });
+
+  it('reviewer mag ook lezen — het is een keuzelijst, geen gevoelige data', async () => {
+    const sessies = app.get(SessieService);
+    const reviewerSessie = await sessies.aanmaken(SUBJECT_REVIEWER);
+    const reviewerCookie = `${cookieNaam}=${reviewerSessie!.token}`;
+
+    const respons = await request(server)
+      .get('/tenant/gebruikers')
+      .set('Cookie', reviewerCookie);
+
+    expect(respons.status).toBe(200);
+  });
+
+  it('geeft 401 zonder sessie', async () => {
+    await request(server).get('/tenant/gebruikers').expect(401);
+  });
+});
+```
+
+- [ ] **Step 7: Draai deze suite geïsoleerd tegen een wegwerpcontainer**
+
+Volg `docs/runbooks/commandos-en-omgeving.md` voor het opzetten van de
+container (zie het vorige plan, Task 1 Step 3, voor het volledige
+commando-recept). Daarna:
+
+```bash
+npx jest test-ids
+DATABASE_URL="postgresql://clm_api_runtime:pw@localhost:55440/postgres" \
+MIGRATION_DATABASE_URL="postgresql://clm_migrator:pw@localhost:55440/postgres" \
+npx jest --config test/jest-e2e.json --forceExit tenant-gebruikers
+```
+
+Verwacht: alle tests slagen.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/tenant/tenant.service.ts src/tenant/tenant.controller.ts test/tenant-gebruikers.e2e-spec.ts test/test-ids.ts
+git commit -m "feat(tenant): GET /tenant/gebruikers — lijst voor keuzelijsten
+
+Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Survey-templatekoppeling — routes op `clm.contract_survey_template`
+
+**Files (backend):**
+- Modify: `src/contract/contract.service.ts`
+- Modify: `src/contract/contract-invoer.ts`
+- Modify: `src/contract/contract.controller.ts`
+- Test: uitbreiding van `test/contract-routes.e2e-spec.ts`
+
+- [ ] **Step 1: Voeg service-methodes toe aan `ContractService`**
+
+In `src/contract/contract.service.ts`:
+
+```typescript
+export interface SurveyTemplateKoppeling {
+  templateIds: string[];
+}
+```
+
+```typescript
+  /** Welke vragenlijst-templates aan dit contract gekoppeld zijn. */
+  async surveyTemplates(
+    tenantId: string,
+    vendorId: string,
+    contractId: string,
+  ): Promise<SurveyTemplateKoppeling | null> {
+    return this.db.withTenant(
+      tenantId,
+      async (tx) => {
+        const bestaat = await tx.execute<{ contract_id: string }>(
+          sql`SELECT contract_id FROM clm.contract
+             WHERE contract_id = ${contractId}
+               AND vendor_id = ${vendorId}
+               AND deleted_at IS NULL`,
+        );
+
+        if (bestaat.rows.length === 0) {
+          return null;
+        }
+
+        const resultaat = await tx.execute<{ survey_template_id: string }>(
+          sql`SELECT survey_template_id FROM clm.contract_survey_template
+             WHERE contract_id = ${contractId}
+             ORDER BY created_at`,
+        );
+
+        return {
+          templateIds: resultaat.rows.map((r) => r.survey_template_id),
+        };
+      },
+      'medewerker',
+    );
+  }
+
+  /**
+   * Vervangt de volledige set gekoppelde templates in één transactie.
+   *
+   * Geen diff (verwijderen wat wegvalt, toevoegen wat nieuw is): bij een klein
+   * aantal templates per contract is "alles weg, alles opnieuw" even correct
+   * en eenvoudiger. Zie spec §3.2.
+   */
+  async zetSurveyTemplates(
+    tenantId: string,
+    vendorId: string,
+    contractId: string,
+    templateIds: string[],
+  ): Promise<SurveyTemplateKoppeling | null> {
+    return this.db.withTenant(
+      tenantId,
+      async (tx) => {
+        const bestaat = await tx.execute<{ contract_id: string }>(
+          sql`SELECT contract_id FROM clm.contract
+             WHERE contract_id = ${contractId}
+               AND vendor_id = ${vendorId}
+               AND deleted_at IS NULL`,
+        );
+
+        if (bestaat.rows.length === 0) {
+          return null;
+        }
+
+        await tx.execute(
+          sql`DELETE FROM clm.contract_survey_template
+             WHERE contract_id = ${contractId}`,
+        );
+
+        for (const templateId of templateIds) {
+          await tx.execute(
+            sql`INSERT INTO clm.contract_survey_template
+                  (contract_id, survey_template_id, tenant_id)
+                VALUES (${contractId}, ${templateId}, ${tenantId})`,
+          );
+        }
+
+        this.logger.log(
+          `Survey-templates gekoppeld aan contract ${contractId}: ${templateIds.length}.`,
+        );
+
+        return { templateIds };
+      },
+      'medewerker',
+    );
+  }
+```
+
+- [ ] **Step 2: Voeg invoer-validatie toe aan `contract-invoer.ts`**
+
+```typescript
+/** Leest de body van PUT .../contracts/:id/survey-templates. */
+export function leesSurveyTemplateKoppeling(body: unknown): string[] {
+  if (typeof body !== 'object' || body === null) {
+    throw new InvoerFout('body', 'Er is geen koppeling meegestuurd.');
+  }
+
+  const ruw = body as Record<string, unknown>;
+
+  if (!('templateIds' in ruw)) {
+    throw new InvoerFout('templateIds', 'templateIds is verplicht.');
+  }
+
+  if (!Array.isArray(ruw.templateIds)) {
+    throw new InvoerFout('templateIds', 'templateIds moet een lijst zijn.');
+  }
+
+  const UUID_PATROON =
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+  for (const waarde of ruw.templateIds) {
+    if (typeof waarde !== 'string' || !UUID_PATROON.test(waarde)) {
+      throw new InvoerFout('templateIds', 'Een van de id\'s is ongeldig.');
+    }
+  }
+
+  // Dubbele ids negeren, niet weigeren: een dubbelklik in de checkbox-lijst
+  // is een UI-detail, geen fout van de gebruiker.
+  return [...new Set(ruw.templateIds as string[])];
+}
+```
+
+- [ ] **Step 3: Voeg routes toe aan `ContractController`**
+
+```typescript
+  @Get(':id/survey-templates')
+  async surveyTemplates(
+    @Req() request: RequestMetSessie,
+    @Param('vendorId') vendorId: string,
+    @Param('id') id: string,
+  ) {
+    const sessie = request.sessie!;
+
+    const koppeling = await this.contracts.surveyTemplates(
+      sessie.tenantId,
+      leesUuid(vendorId),
+      leesUuid(id),
+    );
+
+    if (!koppeling) {
+      throw new NotFoundException('Contract niet gevonden.');
+    }
+
+    return koppeling;
+  }
+
+  @Put(':id/survey-templates')
+  @VereistRol('admin')
+  async zetSurveyTemplates(
+    @Req() request: RequestMetSessie,
+    @Param('vendorId') vendorId: string,
+    @Param('id') id: string,
+    @Body() body: unknown,
+  ) {
+    const sessie = request.sessie!;
+
+    let templateIds: string[];
+
+    try {
+      templateIds = leesSurveyTemplateKoppeling(body);
+    } catch (err) {
+      throw alsHttpFout(err);
+    }
+
+    const koppeling = await this.contracts
+      .zetSurveyTemplates(sessie.tenantId, leesUuid(vendorId), leesUuid(id), templateIds)
+      .catch(alsRefFout);
+
+    if (!koppeling) {
+      throw new NotFoundException('Contract niet gevonden.');
+    }
+
+    return koppeling;
+  }
+```
+
+Voeg `Put` toe aan de `@nestjs/common`-import bovenaan het bestand, en
+`leesSurveyTemplateKoppeling` aan de import uit `./contract-invoer`.
+
+- [ ] **Step 4: Compileer**
+
+```bash
+npx tsc --noEmit
+```
+
+- [ ] **Step 5: Breid `test/contract-routes.e2e-spec.ts` uit**
+
+Voeg toe aan de bestaande suite (na de laatste `it(...)`):
+
+```typescript
+  it('koppelt en ontkoppelt vragenlijst-templates aan een contract', async () => {
+    // Eerst een template aanmaken om aan te koppelen — direct via de
+    // database, want dit is geen backendtaak van deze suite.
+    const templateResultaat = await client.query<{ template_id: string }>(
+      `INSERT INTO clm.survey_template (tenant_id, name, version)
+       VALUES ($1, $2, 1) RETURNING template_id`,
+      [tenant, `Testvragenlijst-${STEMPEL}`],
+    );
+    const templateId = templateResultaat.rows[0].template_id;
+
+    const aangemaakt = await request(server)
+      .post(`/vendors/${vendorId}/contracts`)
+      .set('Cookie', adminCookie)
+      .send({ name: 'Contract met vragenlijst' });
+    const contractId = alsContract(aangemaakt.body).contractId;
+
+    const gekoppeld = await request(server)
+      .put(`/vendors/${vendorId}/contracts/${contractId}/survey-templates`)
+      .set('Cookie', adminCookie)
+      .send({ templateIds: [templateId] });
+
+    expect(gekoppeld.status).toBe(200);
+    expect(
+      (gekoppeld.body as { templateIds: string[] }).templateIds,
+    ).toEqual([templateId]);
+
+    const opgehaald = await request(server)
+      .get(`/vendors/${vendorId}/contracts/${contractId}/survey-templates`)
+      .set('Cookie', adminCookie);
+
+    expect(
+      (opgehaald.body as { templateIds: string[] }).templateIds,
+    ).toEqual([templateId]);
+
+    // Ontkoppelen: lege lijst is geldig.
+    const ontkoppeld = await request(server)
+      .put(`/vendors/${vendorId}/contracts/${contractId}/survey-templates`)
+      .set('Cookie', adminCookie)
+      .send({ templateIds: [] });
+
+    expect(ontkoppeld.status).toBe(200);
+    expect(
+      (ontkoppeld.body as { templateIds: string[] }).templateIds,
+    ).toEqual([]);
+  });
+
+  it('reviewer kan geen templates koppelen (403)', async () => {
+    const aangemaakt = await request(server)
+      .post(`/vendors/${vendorId}/contracts`)
+      .set('Cookie', adminCookie)
+      .send({ name: 'Contract zonder reviewer-koppeling' });
+    const contractId = alsContract(aangemaakt.body).contractId;
+
+    const respons = await request(server)
+      .put(`/vendors/${vendorId}/contracts/${contractId}/survey-templates`)
+      .set('Cookie', reviewerCookie)
+      .send({ templateIds: [] });
+
+    expect(respons.status).toBe(403);
+  });
+```
+
+Ook: voeg `DELETE FROM clm.contract_survey_template WHERE tenant_id = $1`
+en `DELETE FROM clm.survey_template WHERE tenant_id = $1` toe aan
+`verwijderTestdata` in datzelfde bestand, vóór de `DELETE FROM clm.contract`
+-regel (foreign key: `contract_survey_template` verwijst naar `contract`,
+dus moet eerst weg).
+
+- [ ] **Step 6: Draai de volledige suite geïsoleerd**
+
+```bash
+DATABASE_URL="postgresql://clm_api_runtime:pw@localhost:55440/postgres" \
+MIGRATION_DATABASE_URL="postgresql://clm_migrator:pw@localhost:55440/postgres" \
+npx jest --config test/jest-e2e.json --forceExit contract-routes
+```
+
+Verwacht: alle tests slagen (de 8 bestaande plus de 2 nieuwe).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/contract/contract.service.ts src/contract/contract-invoer.ts src/contract/contract.controller.ts test/contract-routes.e2e-spec.ts
+git commit -m "feat(contract): routes voor de survey-templatekoppeling
+
+GET/PUT .../contracts/:id/survey-templates. PUT vervangt de hele set in
+één transactie, conform spec §3.2.
+
+Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Namen in plaats van alleen id's op `ContractDetail`
+
+**Files (backend):**
+- Modify: `src/contract/contract.service.ts`
+
+- [ ] **Step 1: Breid `ContractDetail` en `ContractSamenvatting` uit**
+
+```typescript
+export interface ContractSamenvatting {
+  contractId: string;
+  name: string;
+  contractNumber: string | null;
+  statusCode: string | null;
+  startDate: string | null;
+  endDate: string | null;
+  vendorContactNaam: string | null;
+  ownerGebruikerNaam: string | null;
+  createdAt: string;
+}
+```
+
+En hetzelfde paar velden op `ContractDetail`.
+
+- [ ] **Step 2: Pas de queries aan met een LEFT JOIN**
+
+In `lijst()`:
+
+```typescript
+        const resultaat = await tx.execute<ContractRij>(
+          sql`SELECT c.contract_id, c.name, c.contract_number, c.status_code,
+                     c.start_date, c.end_date, c.created_at,
+                     vc.full_name AS vendor_contact_naam,
+                     u.full_name AS owner_naam
+                FROM clm.contract c
+                LEFT JOIN clm.vendor_contact vc ON vc.contact_id = c.vendor_contact_id
+                LEFT JOIN clm."user" u ON u.user_id = c.owner_user_id
+               WHERE c.vendor_id = ${vendorId} AND c.deleted_at IS NULL
+               ORDER BY c.created_at DESC`,
+        );
+```
+
+Update `ContractRij` met `vendor_contact_naam: string | null` en
+`owner_naam: string | null`, en de mapping in de return met
+`vendorContactNaam: r.vendor_contact_naam` /
+`ownerGebruikerNaam: r.owner_naam`.
+
+Zelfde patroon in `detailBinnenTransactie()`.
+
+- [ ] **Step 3: Compileer, en draai de bestaande contract-routes-suite opnieuw**
+
+```bash
+npx tsc --noEmit
+DATABASE_URL="postgresql://clm_api_runtime:pw@localhost:55440/postgres" \
+MIGRATION_DATABASE_URL="postgresql://clm_migrator:pw@localhost:55440/postgres" \
+npx jest --config test/jest-e2e.json --forceExit contract-routes
+```
+
+Verwacht: nog steeds alle tests groen (de bestaande assertions checken geen
+volledige objectgelijkheid, dus de extra velden breken niets).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/contract/contract.service.ts
+git commit -m "feat(contract): naam van contactpersoon en beheerder in lijst en detail
+
+Voorkomt een n+1-lookup per rij in de UI, zelfde reden als
+VendorService.lijst() zijn subquery.
+
+Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Backend volledig verifiëren vóór de frontend begint
+
+**Files:** geen wijzigingen — alleen controleren.
+
+- [ ] **Step 1: Volledige e2e-run tegen de wegwerpcontainer**
+
+```bash
+DATABASE_URL="postgresql://clm_api_runtime:pw@localhost:55440/postgres" \
+MIGRATION_DATABASE_URL="postgresql://clm_migrator:pw@localhost:55440/postgres" \
+npx jest --config test/jest-e2e.json --forceExit
+```
+
+Verwacht: alle suites groen, inclusief `schema-conformiteit` en
+`rechten-contract` (die laatste vangt een vergeten REVOKE/GRANT — zie
+§1b van `MCM2-CLAUDE.md`, geschreven na precies deze fout op migratie 0027).
+
+- [ ] **Step 2: `npm run verify:volledig`**
+
+Zelfde procedure als in het vorige plan (Task 7): controleer eerst of
+poort 5001/3000 vrij zijn (`netstat -ano | findstr ":5001 "` /
+`":3000 "`), sluit een eigen achtergebleven dev-server af indien nodig, en
+draai:
+
+```bash
+npm run verify:volledig
+```
+
+Dit bouwt ook een frontend-image uit de **huidige** `MCM2-frontend`-checkout
+— zorg dat die op `main` staat en actueel is
+(`cd ../MCM2-frontend && git checkout main && git pull`), anders test deze
+stap een oude frontend-stand.
+
+Verwacht: groen. Als `backup-verwachting.json` rood geeft (nieuwe tabellen
+niet genoemd): dat gebeurt hier niet meer, want dat is al gedaan in het
+vorige plan — maar controleer het toch, voor het geval er ondertussen een
+andere migratie is bijgekomen.
+
+---
+
+## Task 5: Frontend — modellen en service voor contracten
+
+**Files (`MCM2-frontend`):**
+- Create: `src/core/models/contract.ts`
+- Create: `src/core/services/contractService.ts`
+- Create: `src/data/contract.mock.ts`
+
+Volgt exact het patroon van `vendor.ts`/`vendorService.ts`/`vendor.mock.ts`.
+
+- [ ] **Step 1: Schrijf `src/core/models/contract.ts`**
+
+```typescript
+/**
+ * Contracten bij een leverancier, zoals de beheerkant ze kent.
+ *
+ * Bewust een eigen model, geen kopie van het databaseschema — zelfde
+ * redenering als vendor.ts.
+ */
+
+export interface Contract {
+  contractId: string;
+  vendorId: string;
+  name: string;
+  contractNumber: string | null;
+  vendorContactId: string | null;
+  vendorContactNaam: string | null;
+  ownerUserId: string | null;
+  ownerGebruikerNaam: string | null;
+  statusCode: string | null;
+  valueEur: string | null;
+  startDate: string | null;
+  endDate: string | null;
+  note: string | null;
+  createdAt: string;
+  updatedAt: string | null;
+}
+
+/** Wat het aanmaak-/bewerkformulier opstuurt. */
+export interface ContractInvoer {
+  name?: string;
+  contractNumber?: string | null;
+  vendorContactId?: string | null;
+  ownerUserId?: string | null;
+  statusCode?: string | null;
+  valueEur?: string | null;
+  startDate?: string | null;
+  endDate?: string | null;
+  note?: string | null;
+}
+
+export type ContractSchrijfResultaat =
+  | { ok: true; waarde: Contract }
+  | { ok: false; soort: 'veld'; veld: string; melding: string }
+  | { ok: false; soort: 'geenRechten'; melding: string }
+  | { ok: false; soort: 'algemeen'; melding: string };
+
+/** Een gebruiker van de tenant, voor de contractbeheerder-dropdown. */
+export interface TenantGebruiker {
+  userId: string;
+  naam: string;
+}
+
+/** Eén vragenlijst-template, voor de checkbox-lijst. */
+export interface SurveyTemplateOptie {
+  templateId: string;
+  naam: string;
+}
+```
+
+- [ ] **Step 2: Schrijf `src/data/contract.mock.ts`**
+
+```typescript
+import type { Contract } from '@/core/models/contract';
+
+export const MOCK_CONTRACTEN: Contract[] = [
+  {
+    contractId: 'mock-contract-1',
+    vendorId: 'mock-vendor-1',
+    name: 'Hosting 2024-2027',
+    contractNumber: 'ERP-4711',
+    vendorContactId: null,
+    vendorContactNaam: null,
+    ownerUserId: null,
+    ownerGebruikerNaam: 'Anna Admin',
+    statusCode: 'actief',
+    valueEur: '12000.00',
+    startDate: '2024-01-01',
+    endDate: '2027-12-31',
+    note: null,
+    createdAt: new Date().toISOString(),
+    updatedAt: null,
+  },
+];
+
+export const MOCK_TENANT_GEBRUIKERS = [
+  { userId: 'mock-user-1', naam: 'Anna Admin' },
+  { userId: 'mock-user-2', naam: 'Rob Reviewer' },
+];
+
+export const MOCK_SURVEY_TEMPLATES = [
+  { templateId: 'mock-template-1', naam: 'Transdev Annual Vendor IT Risk' },
+];
+```
+
+- [ ] **Step 3: Schrijf `src/core/services/contractService.ts`**
+
+```typescript
+import {
+  ApiFout,
+  gebruiktMockData,
+  haalOp,
+  verstuur,
+  verwijder,
+  wijzig,
+} from '@/core/api/client';
+import type {
+  Contract,
+  ContractInvoer,
+  ContractSchrijfResultaat,
+  SurveyTemplateOptie,
+  TenantGebruiker,
+} from '@/core/models/contract';
+import {
+  MOCK_CONTRACTEN,
+  MOCK_SURVEY_TEMPLATES,
+  MOCK_TENANT_GEBRUIKERS,
+} from '@/data/contract.mock';
+
+/** Mock-opslag binnen de sessie — zelfde patroon als vendorService.ts. */
+const mockToegevoegd: Contract[] = [];
+const mockKoppelingen = new Map<string, string[]>();
+
+function leesVeld(body: unknown): string | null {
+  if (body && typeof body === 'object' && 'veld' in body) {
+    const veld = (body as { veld: unknown }).veld;
+    return typeof veld === 'string' ? veld : null;
+  }
+  return null;
+}
+
+function alsSchrijfResultaat(err: unknown): ContractSchrijfResultaat {
+  if (err instanceof ApiFout) {
+    if (err.status === 403) {
+      return {
+        ok: false,
+        soort: 'geenRechten',
+        melding: 'U heeft geen rechten om dit te wijzigen.',
+      };
+    }
+    const veld = leesVeld(err.body);
+    if (veld) {
+      return { ok: false, soort: 'veld', veld, melding: err.message };
+    }
+  }
+  return {
+    ok: false,
+    soort: 'algemeen',
+    melding: 'Er ging iets mis. Probeer het opnieuw.',
+  };
+}
+
+export async function haalContracten(vendorId: string): Promise<Contract[]> {
+  if (gebruiktMockData) {
+    return [
+      ...mockToegevoegd.filter((c) => c.vendorId === vendorId),
+      ...MOCK_CONTRACTEN.filter((c) => c.vendorId === vendorId),
+    ];
+  }
+
+  const antwoord = await haalOp<{ contracten: Contract[] }>(
+    `/vendors/${vendorId}/contracts`,
+  );
+  return antwoord.contracten;
+}
+
+export async function maakContractAan(
+  vendorId: string,
+  invoer: ContractInvoer,
+): Promise<ContractSchrijfResultaat> {
+  if (gebruiktMockData) {
+    const nieuw: Contract = {
+      contractId: `mock-nieuw-${Date.now()}`,
+      vendorId,
+      name: invoer.name ?? '',
+      contractNumber: invoer.contractNumber ?? null,
+      vendorContactId: invoer.vendorContactId ?? null,
+      vendorContactNaam: null,
+      ownerUserId: invoer.ownerUserId ?? null,
+      ownerGebruikerNaam: null,
+      statusCode: invoer.statusCode ?? null,
+      valueEur: invoer.valueEur ?? null,
+      startDate: invoer.startDate ?? null,
+      endDate: invoer.endDate ?? null,
+      note: invoer.note ?? null,
+      createdAt: new Date().toISOString(),
+      updatedAt: null,
+    };
+    mockToegevoegd.unshift(nieuw);
+    return { ok: true, waarde: nieuw };
+  }
+
+  try {
+    const waarde = await verstuur<Contract>(
+      `/vendors/${vendorId}/contracts`,
+      invoer,
+    );
+    return { ok: true, waarde };
+  } catch (err) {
+    return alsSchrijfResultaat(err);
+  }
+}
+
+export async function wijzigContract(
+  vendorId: string,
+  contractId: string,
+  invoer: ContractInvoer,
+): Promise<ContractSchrijfResultaat> {
+  if (gebruiktMockData) {
+    const bestaand = mockToegevoegd.find((c) => c.contractId === contractId);
+    if (bestaand) {
+      Object.assign(bestaand, invoer);
+      return { ok: true, waarde: bestaand };
+    }
+    return {
+      ok: false,
+      soort: 'algemeen',
+      melding: 'Mock-contract niet gevonden.',
+    };
+  }
+
+  try {
+    const waarde = await wijzig<Contract>(
+      `/vendors/${vendorId}/contracts/${contractId}`,
+      invoer,
+    );
+    return { ok: true, waarde };
+  } catch (err) {
+    return alsSchrijfResultaat(err);
+  }
+}
+
+export async function verwijderContract(
+  vendorId: string,
+  contractId: string,
+): Promise<{ ok: true } | { ok: false; melding: string }> {
+  if (gebruiktMockData) {
+    const idx = mockToegevoegd.findIndex((c) => c.contractId === contractId);
+    if (idx >= 0) mockToegevoegd.splice(idx, 1);
+    return { ok: true };
+  }
+
+  try {
+    await verwijder(`/vendors/${vendorId}/contracts/${contractId}`);
+    return { ok: true };
+  } catch (err) {
+    if (err instanceof ApiFout) {
+      return { ok: false, melding: err.message };
+    }
+    return { ok: false, melding: 'Er ging iets mis.' };
+  }
+}
+
+export async function haalTenantGebruikers(): Promise<TenantGebruiker[]> {
+  if (gebruiktMockData) {
+    return MOCK_TENANT_GEBRUIKERS;
+  }
+  const antwoord = await haalOp<{ gebruikers: TenantGebruiker[] }>(
+    '/tenant/gebruikers',
+  );
+  return antwoord.gebruikers;
+}
+
+export async function haalSurveyTemplates(): Promise<SurveyTemplateOptie[]> {
+  if (gebruiktMockData) {
+    return MOCK_SURVEY_TEMPLATES;
+  }
+  const antwoord = await haalOp<{
+    vragenlijsten: { templateId: string; naam: string }[];
+  }>('/admin/survey/templates');
+  return antwoord.vragenlijsten.map((v) => ({
+    templateId: v.templateId,
+    naam: v.naam,
+  }));
+}
+
+export async function haalGekoppeldeTemplates(
+  vendorId: string,
+  contractId: string,
+): Promise<string[]> {
+  if (gebruiktMockData) {
+    return mockKoppelingen.get(contractId) ?? [];
+  }
+  const antwoord = await haalOp<{ templateIds: string[] }>(
+    `/vendors/${vendorId}/contracts/${contractId}/survey-templates`,
+  );
+  return antwoord.templateIds;
+}
+
+export async function zetGekoppeldeTemplates(
+  vendorId: string,
+  contractId: string,
+  templateIds: string[],
+): Promise<{ ok: true } | { ok: false; melding: string }> {
+  if (gebruiktMockData) {
+    mockKoppelingen.set(contractId, templateIds);
+    return { ok: true };
+  }
+
+  try {
+    await wijzig(
+      `/vendors/${vendorId}/contracts/${contractId}/survey-templates`,
+      { templateIds },
+    );
+    return { ok: true };
+  } catch (err) {
+    if (err instanceof ApiFout) {
+      return { ok: false, melding: err.message };
+    }
+    return { ok: false, melding: 'Er ging iets mis.' };
+  }
+}
+```
+
+**Let op bij Step 3:** controleer of `wijzig()` in `client.ts` een PUT of
+PATCH stuurt — als het HTTP-werkwoord van `wijzig()` niet overeenkomt met
+wat `PUT .../survey-templates` verwacht, gebruik dan `verstuur()` met een
+expliciete methode-optie, of voeg een kleine `zetData()`-variant toe aan
+`client.ts` die PUT gebruikt. Controleer dit vóór je verdergaat — gok niet.
+
+```bash
+grep -n "method:" src/core/api/client.ts
+```
+
+- [ ] **Step 4: Compileer**
+
+```bash
+npx tsc --noEmit
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/core/models/contract.ts src/core/services/contractService.ts src/data/contract.mock.ts
+git commit -m "feat(contract): modellen, service en mockdata voor contracten
+
+Zelfde patroon als vendorService.ts: mock/live-schakelaar via
+gebruiktMockData, ContractSchrijfResultaat met vier uitkomsten.
+
+Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: Frontend — `Contracten`-sectie op het vendor-detailscherm
+
+**Files (`MCM2-frontend`):**
+- Modify: `src/app/beheer/leveranciers/[id]/page.tsx`
+
+- [ ] **Step 1: Voeg de import toe**
+
+```typescript
+import type { Contract, ContractInvoer } from '@/core/models/contract';
+import {
+  haalContracten,
+  haalGekoppeldeTemplates,
+  haalSurveyTemplates,
+  haalTenantGebruikers,
+  maakContractAan,
+  verwijderContract,
+  wijzigContract,
+  zetGekoppeldeTemplates,
+} from '@/core/services/contractService';
+```
+
+- [ ] **Step 2: Plaats de sectie in de hoofdcomponent**
+
+In `LeverancierDetailPagina`, ná `<Contactpersonen ... />` en vóór
+`<VendorUitvraagPaneel ... />`:
+
+```typescript
+          <Contracten vendorId={vendor.vendorId} contactenVanVendor={vendor.contacten} />
+```
+
+- [ ] **Step 3: Bouw het `Contracten`-component**
+
+Volgt het patroon van `Contactpersonen`/`ContactRij` (zie het bestaande
+bestand voor het volledige `verwerk()`/`veldFoutVoor()`-hulpapparaat, dat
+ongewijzigd hergebruikt wordt):
+
+```typescript
+// ── Contracten ───────────────────────────────────────────────────────────
+
+const CONTRACT_STATUS_LABEL: Record<string, string> = {
+  actief: 'Actief',
+  verlopen: 'Verlopen',
+  opgezegd: 'Opgezegd',
+};
+
+const CONTRACT_STATUS_KLEUR: Record<string, string> = {
+  actief: 'bg-green-100 text-green-800',
+  verlopen: 'bg-red-100 text-red-800',
+  opgezegd: 'bg-slate-100 text-slate-700',
+};
+
+/** Dagen tot (positief) of sinds (negatief) de einddatum. Null zonder datum. */
+function dagenTotEinde(endDate: string | null): number | null {
+  if (!endDate) return null;
+  const verschil =
+    new Date(endDate).getTime() - new Date().setHours(0, 0, 0, 0);
+  return Math.round(verschil / (1000 * 60 * 60 * 24));
+}
+
+function EindeIndicator({ contract }: { contract: Contract }) {
+  const dagen = dagenTotEinde(contract.endDate);
+  if (dagen === null) return null;
+
+  if (dagen < 0) {
+    return (
+      <span className="text-xs text-red-700">{Math.abs(dagen)}d verlopen</span>
+    );
+  }
+  if (contract.statusCode === 'actief' && dagen <= 90) {
+    return <span className="text-xs text-amber-700">{dagen}d resterend</span>;
+  }
+  return null;
+}
+
+function Contracten({
+  vendorId,
+  contactenVanVendor,
+}: {
+  vendorId: string;
+  contactenVanVendor: Contactpersoon[];
+}) {
+  const [contracten, setContracten] = useState<Contract[]>([]);
+  const [laden, setLaden] = useState(true);
+  const [gebruikers, setGebruikers] = useState<
+    { userId: string; naam: string }[]
+  >([]);
+
+  const laad = useCallback(async () => {
+    setLaden(true);
+    try {
+      const [c, g] = await Promise.all([
+        haalContracten(vendorId),
+        haalTenantGebruikers(),
+      ]);
+      setContracten(c);
+      setGebruikers(g);
+    } finally {
+      setLaden(false);
+    }
+  }, [vendorId]);
+
+  useEffect(() => {
+    void laad();
+  }, [laad]);
+
+  return (
+    <section
+      aria-labelledby="contracten-kop"
+      className="mb-8 rounded-lg border border-line bg-card p-6"
+    >
+      <h2 id="contracten-kop" className="mb-4 text-lg font-semibold text-brand-dark">
+        Contracten{' '}
+        <span
+          data-testid="aantal-contracten"
+          className="text-sm font-normal text-ink-muted"
+        >
+          ({contracten.length})
+        </span>
+      </h2>
+
+      {laden && <p className="text-sm text-ink-muted">Bezig met laden…</p>}
+
+      {!laden && contracten.length === 0 && (
+        <p className="mb-6 text-sm text-ink-muted">
+          Er is nog geen contract bij deze leverancier.
+        </p>
+      )}
+
+      {!laden && contracten.length > 0 && (
+        <ul className="mb-6 divide-y divide-line rounded border border-line">
+          {contracten.map((contract) => (
+            <ContractRij
+              key={contract.contractId}
+              contract={contract}
+              vendorId={vendorId}
+              contactenVanVendor={contactenVanVendor}
+              gebruikers={gebruikers}
+              onGewijzigd={laad}
+            />
+          ))}
+        </ul>
+      )}
+
+      <NieuwContractFormulier
+        vendorId={vendorId}
+        contactenVanVendor={contactenVanVendor}
+        gebruikers={gebruikers}
+        onAangemaakt={laad}
+      />
+    </section>
+  );
+}
+```
+
+- [ ] **Step 4: Bouw `ContractRij` — weergave, inline bewerken, verwijderen**
+
+```typescript
+function ContractRij({
+  contract,
+  vendorId,
+  contactenVanVendor,
+  gebruikers,
+  onGewijzigd,
+}: {
+  contract: Contract;
+  vendorId: string;
+  contactenVanVendor: Contactpersoon[];
+  gebruikers: { userId: string; naam: string }[];
+  onGewijzigd: () => void | Promise<void>;
+}) {
+  const [bewerkt, setBewerkt] = useState(false);
+  const [bezig, setBezig] = useState(false);
+  const [fout, setFout] = useState<string | null>(null);
+  const [veldFout, setVeldFout] = useState<{
+    veld: string;
+    melding: string;
+  } | null>(null);
+  const [bevestigVerwijderen, setBevestigVerwijderen] = useState(false);
+  const [waarden, setWaarden] = useState<ContractInvoer>(() => uitContract(contract));
+
+  function beginBewerken() {
+    setWaarden(uitContract(contract));
+    setFout(null);
+    setVeldFout(null);
+    setBewerkt(true);
+  }
+
+  async function bewaar(gebeurtenis: React.FormEvent) {
+    gebeurtenis.preventDefault();
+    setBezig(true);
+    setFout(null);
+    setVeldFout(null);
+
+    const uitkomst = await wijzigContract(vendorId, contract.contractId, waarden);
+    setBezig(false);
+
+    verwerk(uitkomst, {
+      opGelukt: async () => {
+        setBewerkt(false);
+        await onGewijzigd();
+      },
+      opVeldFout: setVeldFout,
+      opAlgemeneFout: setFout,
+    });
+  }
+
+  async function verwijderDeze() {
+    setBezig(true);
+    const uitkomst = await verwijderContract(vendorId, contract.contractId);
+    setBezig(false);
+
+    if (uitkomst.ok) {
+      await onGewijzigd();
+      return;
+    }
+    setBevestigVerwijderen(false);
+    setFout(uitkomst.melding);
+  }
+
+  if (bewerkt) {
+    return (
+      <li data-testid="contract-rij" className="px-4 py-4">
+        <ContractFormuliervelden
+          waarden={waarden}
+          onWijzig={setWaarden}
+          contactenVanVendor={contactenVanVendor}
+          gebruikers={gebruikers}
+          veldFout={veldFout}
+          idPrefix={`bewerk-${contract.contractId}`}
+        />
+
+        <SurveyTemplateKoppelingBlok
+          vendorId={vendorId}
+          contractId={contract.contractId}
+        />
+
+        {fout && (
+          <p
+            role="alert"
+            data-testid="bewerk-contract-fout"
+            className="mt-4 rounded border border-red-300 bg-red-50 px-3 py-2 text-sm text-red-800"
+          >
+            {fout}
+          </p>
+        )}
+
+        <div className="mt-4 flex items-center gap-2">
+          <button
+            type="button"
+            onClick={bewaar}
+            disabled={bezig}
+            data-testid="bewaar-contract"
+            className="rounded bg-brand-primary px-4 py-2 text-sm font-medium text-white transition hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {bezig ? 'Bezig…' : 'Opslaan'}
+          </button>
+          <button
+            type="button"
+            onClick={() => setBewerkt(false)}
+            data-testid="annuleer-contract"
+            className="rounded border border-line px-4 py-2 text-sm text-ink transition hover:bg-surface"
+          >
+            Annuleren
+          </button>
+        </div>
+      </li>
+    );
+  }
+
+  return (
+    <li
+      data-testid="contract-rij"
+      className="flex flex-wrap items-center justify-between gap-3 px-4 py-3"
+    >
+      <div className="min-w-0">
+        <p className="text-sm font-medium text-ink">{contract.name}</p>
+        <p className="text-xs text-ink-muted">
+          {contract.contractNumber ?? 'geen contractnummer'}
+        </p>
+        <p className="mt-1 text-xs text-ink-muted">
+          {[contract.vendorContactNaam, contract.ownerGebruikerNaam]
+            .filter(Boolean)
+            .join(' · ') || 'geen contactpersoon of beheerder'}
+        </p>
+      </div>
+
+      <div className="flex items-center gap-3">
+        {contract.statusCode && (
+          <span
+            data-testid="contract-status"
+            className={`rounded-full px-2.5 py-0.5 text-xs font-medium ${CONTRACT_STATUS_KLEUR[contract.statusCode] ?? 'bg-slate-100 text-slate-700'}`}
+          >
+            {CONTRACT_STATUS_LABEL[contract.statusCode] ?? contract.statusCode}
+          </span>
+        )}
+        <div className="text-right text-xs">
+          <div className="text-ink-muted">
+            {contract.startDate ?? '—'} – {contract.endDate ?? '—'}
+          </div>
+          <EindeIndicator contract={contract} />
+        </div>
+
+        <button
+          type="button"
+          onClick={beginBewerken}
+          aria-label={`${contract.name} bewerken`}
+          data-testid="bewerk-contract"
+          className="rounded border border-line p-1.5 text-ink transition hover:bg-surface"
+        >
+          <Pencil size={13} />
+        </button>
+
+        {bevestigVerwijderen ? (
+          <div className="flex items-center gap-2">
+            <span className="text-xs text-ink-muted">Zeker?</span>
+            <button
+              type="button"
+              onClick={() => void verwijderDeze()}
+              disabled={bezig}
+              data-testid="verwijder-contract-bevestig"
+              className="rounded bg-red-600 px-2 py-1 text-xs font-medium text-white hover:brightness-95"
+            >
+              Ja
+            </button>
+            <button
+              type="button"
+              onClick={() => setBevestigVerwijderen(false)}
+              className="rounded border border-line px-2 py-1 text-xs text-ink hover:bg-surface"
+            >
+              Nee
+            </button>
+          </div>
+        ) : (
+          <button
+            type="button"
+            onClick={() => setBevestigVerwijderen(true)}
+            aria-label={`${contract.name} verwijderen`}
+            data-testid="verwijder-contract"
+            className="rounded border border-line p-1.5 text-red-700 transition hover:bg-red-50"
+          >
+            <Trash2 size={13} />
+          </button>
+        )}
+      </div>
+    </li>
+  );
+}
+
+function uitContract(contract: Contract): ContractInvoer {
+  return {
+    name: contract.name,
+    contractNumber: contract.contractNumber ?? '',
+    vendorContactId: contract.vendorContactId ?? '',
+    ownerUserId: contract.ownerUserId ?? '',
+    statusCode: contract.statusCode ?? '',
+    valueEur: contract.valueEur ?? '',
+    startDate: contract.startDate ?? '',
+    endDate: contract.endDate ?? '',
+    note: contract.note ?? '',
+  };
+}
+```
+
+- [ ] **Step 5: Bouw `ContractFormuliervelden` (gedeeld door bewerken en aanmaken)**
+
+```typescript
+function ContractFormuliervelden({
+  waarden,
+  onWijzig,
+  contactenVanVendor,
+  gebruikers,
+  veldFout,
+  idPrefix,
+}: {
+  waarden: ContractInvoer;
+  onWijzig: (w: ContractInvoer) => void;
+  contactenVanVendor: Contactpersoon[];
+  gebruikers: { userId: string; naam: string }[];
+  veldFout: { veld: string; melding: string } | null;
+  idPrefix: string;
+}) {
+  function veld<K extends keyof ContractInvoer>(sleutel: K, waarde: string) {
+    onWijzig({ ...waarden, [sleutel]: waarde });
+  }
+
+  return (
+    <div className="grid gap-4 sm:grid-cols-3">
+      <Veld
+        id={`${idPrefix}-name`}
+        label="Naam"
+        verplicht
+        waarde={waarden.name ?? ''}
+        onWijzig={(w) => veld('name', w)}
+        fout={veldFoutVoor(veldFout, 'Naam')}
+      />
+      <Veld
+        id={`${idPrefix}-contractNumber`}
+        label="Contractnummer"
+        waarde={waarden.contractNumber ?? ''}
+        onWijzig={(w) => veld('contractNumber', w)}
+        fout={veldFoutVoor(veldFout, 'Contractnummer')}
+      />
+      <Keuzeveld
+        id={`${idPrefix}-statusCode`}
+        label="Status"
+        waarde={waarden.statusCode ?? ''}
+        keuzes={[
+          { code: 'actief', label: 'Actief' },
+          { code: 'verlopen', label: 'Verlopen' },
+          { code: 'opgezegd', label: 'Opgezegd' },
+        ]}
+        onWijzig={(w) => veld('statusCode', w)}
+      />
+      <Veld
+        id={`${idPrefix}-startDate`}
+        label="Begindatum"
+        type="date"
+        waarde={waarden.startDate ?? ''}
+        onWijzig={(w) => veld('startDate', w)}
+        fout={veldFoutVoor(veldFout, 'Begindatum')}
+      />
+      <Veld
+        id={`${idPrefix}-endDate`}
+        label="Einddatum"
+        type="date"
+        waarde={waarden.endDate ?? ''}
+        onWijzig={(w) => veld('endDate', w)}
+        fout={veldFoutVoor(veldFout, 'Einddatum')}
+      />
+      <Veld
+        id={`${idPrefix}-valueEur`}
+        label="Waarde (EUR)"
+        waarde={waarden.valueEur ?? ''}
+        onWijzig={(w) => veld('valueEur', w)}
+        fout={veldFoutVoor(veldFout, 'Waarde')}
+      />
+      <Keuzeveld
+        id={`${idPrefix}-vendorContactId`}
+        label="Contactpersoon"
+        waarde={waarden.vendorContactId ?? ''}
+        keuzes={contactenVanVendor.map((c) => ({
+          code: c.contactId,
+          label: c.fullName,
+        }))}
+        onWijzig={(w) => veld('vendorContactId', w)}
+      />
+      <Keuzeveld
+        id={`${idPrefix}-ownerUserId`}
+        label="Contractbeheerder"
+        waarde={waarden.ownerUserId ?? ''}
+        keuzes={gebruikers.map((g) => ({ code: g.userId, label: g.naam }))}
+        onWijzig={(w) => veld('ownerUserId', w)}
+      />
+      <div className="sm:col-span-3">
+        <label
+          htmlFor={`${idPrefix}-note`}
+          className="mb-1 block text-sm font-medium text-ink"
+        >
+          Notitie
+        </label>
+        <textarea
+          id={`${idPrefix}-note`}
+          value={waarden.note ?? ''}
+          onChange={(e) => veld('note', e.target.value)}
+          rows={2}
+          className="w-full rounded border border-line px-3 py-2 text-sm outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-brand-primary"
+        />
+      </div>
+    </div>
+  );
+}
+```
+
+**Controleer vóór dit compileert of `Keuzeveld` een `keuzes`-prop van de
+vorm `{ code, label }[]` verwacht** (zie het gebruik bij
+`CATEGORIEEN`/`keuzesMetHuidige` bovenin het bestaande bestand) — pas de
+vorm aan als die afwijkt, gok niet.
+
+- [ ] **Step 6: Bouw `NieuwContractFormulier`**
+
+```typescript
+function NieuwContractFormulier({
+  vendorId,
+  contactenVanVendor,
+  gebruikers,
+  onAangemaakt,
+}: {
+  vendorId: string;
+  contactenVanVendor: Contactpersoon[];
+  gebruikers: { userId: string; naam: string }[];
+  onAangemaakt: () => void | Promise<void>;
+}) {
+  const [waarden, setWaarden] = useState<ContractInvoer>({});
+  const [bezig, setBezig] = useState(false);
+  const [fout, setFout] = useState<string | null>(null);
+  const [veldFout, setVeldFout] = useState<{
+    veld: string;
+    melding: string;
+  } | null>(null);
+
+  async function voegToe(gebeurtenis: React.FormEvent) {
+    gebeurtenis.preventDefault();
+    setBezig(true);
+    setFout(null);
+    setVeldFout(null);
+
+    const uitkomst = await maakContractAan(vendorId, waarden);
+    setBezig(false);
+
+    verwerk(uitkomst, {
+      opGelukt: async () => {
+        setWaarden({});
+        await onAangemaakt();
+      },
+      opVeldFout: setVeldFout,
+      opAlgemeneFout: setFout,
+    });
+  }
+
+  return (
+    <form onSubmit={voegToe} noValidate className="border-t border-line pt-5">
+      <p className="mb-3 text-sm font-medium text-ink">Contract toevoegen</p>
+
+      <ContractFormuliervelden
+        waarden={waarden}
+        onWijzig={setWaarden}
+        contactenVanVendor={contactenVanVendor}
+        gebruikers={gebruikers}
+        veldFout={veldFout}
+        idPrefix="nieuw-contract"
+      />
+
+      {fout && (
+        <p
+          role="alert"
+          data-testid="nieuw-contract-fout"
+          className="mt-4 rounded border border-red-300 bg-red-50 px-3 py-2 text-sm text-red-800"
+        >
+          {fout}
+        </p>
+      )}
+
+      <button
+        type="submit"
+        disabled={bezig}
+        data-testid="voeg-contract-toe"
+        className="mt-5 rounded border border-brand-primary px-4 py-2 text-sm font-medium text-brand-primary transition hover:bg-brand-primary hover:text-white disabled:cursor-not-allowed disabled:opacity-60"
+      >
+        {bezig ? 'Bezig…' : 'Toevoegen'}
+      </button>
+    </form>
+  );
+}
+```
+
+- [ ] **Step 7: Compileer**
+
+```bash
+npx tsc --noEmit
+```
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/app/beheer/leveranciers/\[id\]/page.tsx
+git commit -m "feat(contract): Contracten-sectie op het vendor-detailscherm
+
+Lijst met inline bewerken/verwijderen, statusbadge, dagen-resterend/
+verlopen-indicator. Patroon van Contactpersonen/ContactRij.
+
+Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 7: Frontend — het losse survey-templatekoppeling-blok
+
+**Files (`MCM2-frontend`):**
+- Modify: `src/app/beheer/leveranciers/[id]/page.tsx`
+
+- [ ] **Step 1: Bouw `SurveyTemplateKoppelingBlok`**
+
+Eigen state, eigen knop, eigen foutmelding — los van de rest van het
+contractformulier, conform spec §4.3.
+
+```typescript
+function SurveyTemplateKoppelingBlok({
+  vendorId,
+  contractId,
+}: {
+  vendorId: string;
+  contractId: string;
+}) {
+  const [templates, setTemplates] = useState<
+    { templateId: string; naam: string }[]
+  >([]);
+  const [gekoppeld, setGekoppeld] = useState<Set<string>>(new Set());
+  const [laden, setLaden] = useState(true);
+  const [bezig, setBezig] = useState(false);
+  const [fout, setFout] = useState<string | null>(null);
+  const [gelukt, setGelukt] = useState(false);
+
+  useEffect(() => {
+    let actief = true;
+
+    void (async () => {
+      setLaden(true);
+      const [alle, huidig] = await Promise.all([
+        haalSurveyTemplates(),
+        haalGekoppeldeTemplates(vendorId, contractId),
+      ]);
+      if (!actief) return;
+      setTemplates(alle);
+      setGekoppeld(new Set(huidig));
+      setLaden(false);
+    })();
+
+    return () => {
+      actief = false;
+    };
+  }, [vendorId, contractId]);
+
+  function schakel(templateId: string) {
+    setGelukt(false);
+    setGekoppeld((vorig) => {
+      const nieuw = new Set(vorig);
+      if (nieuw.has(templateId)) {
+        nieuw.delete(templateId);
+      } else {
+        nieuw.add(templateId);
+      }
+      return nieuw;
+    });
+  }
+
+  async function koppelen() {
+    setBezig(true);
+    setFout(null);
+    setGelukt(false);
+
+    const uitkomst = await zetGekoppeldeTemplates(
+      vendorId,
+      contractId,
+      [...gekoppeld],
+    );
+
+    setBezig(false);
+
+    if (uitkomst.ok) {
+      setGelukt(true);
+      return;
+    }
+    setFout(uitkomst.melding);
+  }
+
+  return (
+    <div className="mt-5 border-t border-line pt-4">
+      <p className="mb-2 text-sm font-medium text-ink">
+        Van toepassing zijnde vragenlijst(en)
+      </p>
+
+      {laden && <p className="text-xs text-ink-muted">Bezig met laden…</p>}
+
+      {!laden && templates.length === 0 && (
+        <p className="text-xs text-ink-muted">
+          Er zijn nog geen vragenlijsten aangemaakt.
+        </p>
+      )}
+
+      {!laden && templates.length > 0 && (
+        <div className="mb-3 flex flex-col gap-1.5">
+          {templates.map((t) => (
+            <label
+              key={t.templateId}
+              className="flex items-center gap-2 text-sm text-ink"
+            >
+              <input
+                type="checkbox"
+                data-testid="survey-template-checkbox"
+                checked={gekoppeld.has(t.templateId)}
+                onChange={() => schakel(t.templateId)}
+              />
+              {t.naam}
+            </label>
+          ))}
+        </div>
+      )}
+
+      {fout && (
+        <p
+          role="alert"
+          data-testid="survey-koppeling-fout"
+          className="mb-3 rounded border border-red-300 bg-red-50 px-3 py-2 text-xs text-red-800"
+        >
+          {fout}
+        </p>
+      )}
+
+      {gelukt && (
+        <p
+          role="status"
+          data-testid="survey-koppeling-gelukt"
+          className="mb-3 rounded border border-green-300 bg-green-50 px-3 py-2 text-xs text-green-800"
+        >
+          Opgeslagen.
+        </p>
+      )}
+
+      <button
+        type="button"
+        onClick={() => void koppelen()}
+        disabled={bezig || laden}
+        data-testid="koppel-survey-templates"
+        className="rounded border border-line px-3 py-1.5 text-xs font-medium text-ink transition hover:bg-surface disabled:cursor-not-allowed disabled:opacity-60"
+      >
+        {bezig ? 'Bezig…' : 'Vragenlijsten koppelen'}
+      </button>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Compileer**
+
+```bash
+npx tsc --noEmit
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/app/beheer/leveranciers/\[id\]/page.tsx
+git commit -m "feat(contract): los blok voor de survey-templatekoppeling
+
+Eigen 'Vragenlijsten koppelen'-knop, eigen foutmelding — los van het
+contractformulier zelf, conform spec §4.3.
+
+Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 8: Frontend e2e-tests (Playwright)
+
+**Files (`MCM2-frontend`):**
+- Create: `e2e/contracten.spec.ts`
+
+Volgt het patroon van `e2e/vendor-detail.spec.ts` (zie dat bestand voor de
+volledige `beforeEach`/`afterEach`-opzet met `BEHEER_COOKIE` en opruimen via
+de API).
+
+- [ ] **Step 1: Schrijf de suite**
+
+```typescript
+import { expect, test } from '@playwright/test';
+
+/**
+ * De Contracten-sectie op het leveranciersdetailscherm.
+ *
+ * Zelfde opzet als vendor-detail.spec.ts: een draaiende stack en een geldig
+ * BEHEER_COOKIE, opruimen via de API en niet via de UI.
+ */
+
+const COOKIE = process.env.BEHEER_COOKIE;
+
+let teller = 0;
+function uniekeNaam() {
+  teller += 1;
+  return `Contracttest ${Date.now()}${teller}`;
+}
+
+test.describe('Contracten', () => {
+  let vendorId: string;
+
+  test.beforeEach(async ({ context, page, request }) => {
+    test.skip(
+      !COOKIE,
+      'BEHEER_COOKIE ontbreekt. Draai `npm run verify:volledig` in de backend-repo.',
+    );
+
+    const [naam, ...rest] = COOKIE!.split('=');
+    await context.addCookies([
+      {
+        name: naam,
+        value: rest.join('='),
+        url:
+          page.url() !== 'about:blank' ? page.url() : 'http://localhost:3000',
+      },
+    ]);
+
+    const aangemaakt = await request.post('/api/backend/vendors', {
+      headers: { Cookie: COOKIE! },
+      data: { name: `Contracttest-vendor-${Date.now()}` },
+    });
+    const body = (await aangemaakt.json()) as { vendorId: string };
+    vendorId = body.vendorId;
+  });
+
+  test.afterEach(async ({ request }) => {
+    if (!COOKIE || !vendorId) return;
+    await request
+      .delete(`/api/backend/vendors/${vendorId}`, {
+        headers: { Cookie: COOKIE },
+      })
+      .catch(() => undefined);
+  });
+
+  test('maakt een contract aan en toont het in de lijst', async ({ page }) => {
+    await page.goto(`/beheer/leveranciers/${vendorId}`);
+
+    const naam = uniekeNaam();
+    await page.getByLabel('Naam', { exact: true }).nth(1).fill(naam);
+    // nth(1): het eerste "Naam"-veld hoort bij Stamgegevens, het tweede bij
+    // Contracten. Zie ARIA-labels in ContractFormuliervelden.
+    await page.getByTestId('voeg-contract-toe').click();
+
+    await expect(page.getByTestId('contract-rij').first()).toContainText(naam);
+  });
+
+  test('toont status en einddatum-indicator', async ({ page, request }) => {
+    await request.post(`/api/backend/vendors/${vendorId}/contracts`, {
+      headers: { Cookie: COOKIE! },
+      data: {
+        name: uniekeNaam(),
+        statusCode: 'actief',
+        endDate: new Date(Date.now() + 30 * 86400000)
+          .toISOString()
+          .slice(0, 10),
+      },
+    });
+
+    await page.goto(`/beheer/leveranciers/${vendorId}`);
+
+    await expect(page.getByTestId('contract-status').first()).toHaveText(
+      'Actief',
+    );
+    await expect(page.getByTestId('contract-rij').first()).toContainText(
+      'd resterend',
+    );
+  });
+
+  test('koppelt een vragenlijst-template en bewaart de keuze', async ({
+    page,
+    request,
+  }) => {
+    const templateResultaat = await request.post(
+      '/api/backend/admin/survey/templates',
+      {
+        headers: { Cookie: COOKIE! },
+        data: { name: uniekeNaam(), version: 1 },
+      },
+    );
+    // Als er geen route bestaat om een template via de API aan te maken,
+    // gebruik dan een bestaande seed-template (zie db/seeds) in plaats van
+    // dit verzoek — controleer dit vóór de test draait, gok niet.
+    test.skip(
+      templateResultaat.status() >= 400,
+      'Geen route om een testtemplate aan te maken — gebruik een seed-template.',
+    );
+
+    await page.goto(`/beheer/leveranciers/${vendorId}`);
+    await page.getByTestId('voeg-contract-toe').click();
+    await page.getByTestId('bewerk-contract').first().click();
+
+    await page.getByTestId('survey-template-checkbox').first().check();
+    await page.getByTestId('koppel-survey-templates').click();
+
+    await expect(page.getByTestId('survey-koppeling-gelukt')).toBeVisible();
+
+    await page.reload();
+    await page.getByTestId('bewerk-contract').first().click();
+    await expect(
+      page.getByTestId('survey-template-checkbox').first(),
+    ).toBeChecked();
+  });
+
+  test('verwijdert een contract na bevestiging', async ({ page, request }) => {
+    const naam = uniekeNaam();
+    await request.post(`/api/backend/vendors/${vendorId}/contracts`, {
+      headers: { Cookie: COOKIE! },
+      data: { name: naam },
+    });
+
+    await page.goto(`/beheer/leveranciers/${vendorId}`);
+    await page.getByTestId('verwijder-contract').first().click();
+    await page.getByTestId('verwijder-contract-bevestig').click();
+
+    await expect(page.getByTestId('contract-rij')).toHaveCount(0);
+  });
+});
+```
+
+- [ ] **Step 2: Draai deze suite specifiek**
+
+Vereist een draaiende stack met `BEHEER_COOKIE` gezet — zie de opmerking
+bovenin het testbestand. In de praktijk gebeurt dit via
+`npm run verify:volledig` in de backend-repo (Task 9), niet los.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add e2e/contracten.spec.ts
+git commit -m "test(contract): Playwright-suite voor de Contracten-sectie
+
+Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 9: Volledige verificatie — beide repo's samen
+
+**Files:** geen wijzigingen — alleen controleren.
+
+- [ ] **Step 1: Backend-e2e nogmaals, met de frontend-wijzigingen erbij**
+
+```bash
+cd c:\DEV\Work\MCM2
+DATABASE_URL="postgresql://clm_api_runtime:pw@localhost:55440/postgres" \
+MIGRATION_DATABASE_URL="postgresql://clm_migrator:pw@localhost:55440/postgres" \
+npx jest --config test/jest-e2e.json --forceExit
+```
+
+- [ ] **Step 2: `npm run verify:volledig`, nu met de nieuwe frontend-branch**
+
+Volgens `docs/superpowers/plans/2026-08-22-contractmanagement.md` Task 7,
+Step 1 wordt dit script normaliter tegen `MCM2-frontend`'s huidige checkout
+gedraaid. Voor dit plan is dat de nieuwe contract-UI-branch — commit eerst
+alles in `MCM2-frontend` (Taken 5–8 hierboven), dan pas draaien:
+
+```bash
+cd c:\DEV\Work\MCM2
+npm run verify:volledig
+```
+
+Controleer eerst of poort 5001/3000 vrij zijn, zoals in het vorige plan.
+
+Verwacht: groen, inclusief de nieuwe `e2e/contracten.spec.ts`-suite in de
+Playwright-browsertests.
+
+- [ ] **Step 3: Als iets rood is, fix het waar het hoort**
+
+Bij twijfel: `superpowers:systematic-debugging`. Niet een test aanpassen om
+hem groen te krijgen tenzij de test zelf aantoonbaar fout is.
+
+---
+
+## Task 10: Preview — verplicht, conform het bestaande protocol
+
+**Dit is geen optionele stap.** Volgens de memory
+`mcm2-demo-link-incognito-hard-reload` (21-08, expliciet en dwingend
+vastgesteld door de eigenaar): bij elke frontend-wijziging altijd
+proactief een preview aanbieden vóórdat er gemerged wordt, en exact de
+onderstaande procedure volgen — geen kortere weg.
+
+- [ ] **Step 1: Bevestig dat dit een frontend-zichtbare wijziging is**
+
+Ja — dat is precies waarom dit plan bestaat (in tegenstelling tot het
+vorige, backend-only plan). Geen uitzondering van toepassing.
+
+- [ ] **Step 2: Start de demo-stack met de juiste branches**
+
+```bash
+cd c:\DEV\Work\MCM2
+npm run demo -- --branch <naam-van-de-contract-ui-branch>
+```
+
+**Backend blijft op de branch met de contractmanagement-backend**
+(taken 1–4 van dit plan, of `main` als die inmiddels gemerged is) — niet
+op `main` als de backend-wijzigingen daar nog niet in zitten. Dit is de
+"expliciete reden om ook de backend te wisselen" die de memory noemt: de
+frontend-sectie roept routes aan die pas met deze backend-branch bestaan.
+
+- [ ] **Step 3: Bij een bezette poort**
+
+Zoek en ruim eerst op (`netstat -ano | findstr ":5001 "` / `":3000 "`, dan
+`Stop-Process -Id <pid> -Force`) — nooit doordrukken of een tweede instantie
+ernaast starten.
+
+- [ ] **Step 4: Wacht op de volledige "5/5 Sessie en zelfcontrole"-melding**
+
+Controleer expliciet de regels `Backend: ...` en `Frontend: ...` — dat
+bevestigt dat precies de juiste branches draaien. Geen link geven vóór die
+regels gezien zijn.
+
+- [ ] **Step 5: Geef de link samen met deze twee instructies, nooit los**
+
+- Open in een **incognito/privévenster**.
+- **Ctrl+Shift+R** (harde herlaad) vóór het inloggen.
+
+- [ ] **Step 6: Vraag de eigenaar expliciet te controleren**
+
+Minimaal: een contract aanmaken, de statusbadge en dagen-indicator zien,
+een vragenlijst koppelen en de koppeling na een herlaadactie terugzien,
+een contract verwijderen. Dit is het moment waarop "compleet genoeg om te
+testen" (§1a van `MCM2-CLAUDE.md`) daadwerkelijk getoetst wordt door een
+mens, niet alleen door tests.
+
+- [ ] **Step 7: Na afloop**
+
+```bash
+npm run demo:af
+```
+
+---
+
+## Task 11: Samenvoegen — pas na akkoord op de preview
+
+**Niet uitvoeren zonder expliciet akkoord van de eigenaar op Task 10.**
+
+- [ ] **Step 1: Volg `superpowers:finishing-a-development-branch`**
+
+Voor beide repo's apart: backend-branch (taken 1–4) en frontend-branch
+(taken 5–8). Presenteer de opties (PR, direct mergen, branch parkeren)
+zoals die skill voorschrijft — niet zelf beslissen.
+
+---
+
+## Self-review
+
+**Spec-dekking (tegen `docs/superpowers/specs/2026-08-22-contractmanagement-ui-design.md`):**
+
+- §3.1 `GET /tenant/gebruikers` — Task 1. ✅
+- §3.2 survey-templatekoppeling-routes — Task 2. ✅ PUT vervangt de hele
+  set, geen diff, zoals de spec voorschrijft.
+- §3.3 namen i.p.v. alleen id's — Task 3. ✅
+- §4.1 lijst met statusbadge en dagen-indicator — Task 6, `ContractRij`
+  en `EindeIndicator`. ✅
+- §4.2 bewerk-/aanmaakformulier met alle genoemde velden, één
+  opslaan-actie — Task 6, `ContractFormuliervelden`. ✅ Contactpersoon en
+  contractbeheerder zijn inbegrepen (expliciet bevestigd tijdens de
+  brainstorm, in afwijking van het aanvankelijke voorstel in de spec-tekst
+  zelf — de spec-tekst noemt dit ook, zie §3.3 daar).
+- §4.3 los blok, eigen knop voor de survey-koppeling — Task 7,
+  `SurveyTemplateKoppelingBlok`. ✅ Eigen "bezig"/foutmelding, aparte
+  `PUT`-aanroep.
+- §4.4 "wat dit scherm niet doet" — geen ronde-start-knop, geen
+  tijdlijn/CATS-fasen, geen bulk-acties: dit plan bouwt niets daarvan. ✅
+
+**Placeholder-scan:** geen TBD/TODO. Twee plekken vragen wel een expliciete
+controle tijdens uitvoering in plaats van blind te kopiëren (Task 5 Step 3:
+HTTP-werkwoord van `wijzig()`; Task 5 Step 5: vorm van `Keuzeveld`-props) —
+dat zijn bewuste "controleer dit, gok niet"-instructies, geen onvolledige
+stappen: de stap zelf zegt precies wat te doen als de aanname niet klopt.
+
+**Type-consistentie:** `ContractInvoer`/`Contract` in
+`src/core/models/contract.ts` (Task 5) komen overeen met wat
+`contractService.ts` (Task 5) en de UI-componenten (Task 6–7) gebruiken.
+Backend-veldnamen (`vendorContactId`, `ownerUserId`, `statusCode`, etc.)
+zijn identiek aan wat `ContractService`/`ContractDetail` in het
+backend-plan (`2026-08-22-contractmanagement.md`) al vastlegde.
+
+**Scope-check:** twee repo's, elf taken, gegroepeerd in vier fasen
+(backend §1–4, frontend-bouw §5–8, verificatie §9, preview §10, afronden
+§11) — elke fase levert zelfstandig verifieerbare voortgang op. Groot
+genoeg om subagent-driven uitvoering te overwegen per taak, maar niet
+zodanig dat het decompositie in aparte plannen nodig had.

--- a/docs/superpowers/plans/2026-08-22-contractmanagement-ui.md
+++ b/docs/superpowers/plans/2026-08-22-contractmanagement-ui.md
@@ -2070,15 +2070,376 @@ npm run demo:af
 
 ---
 
+## Task 12: Contactpersoon en survey-koppeling direct bij het aanmaken
+
+**Toegevoegd 22-08, ná de eerste preview van Task 10.** Twee punten uit de
+vervolgopmerkingen ("21-08 II" in `docs/opmerkingen Vendor IT survey.txt`)
+zijn klein genoeg om nog in dezelfde bouwronde mee te nemen, vóór er
+gemerged wordt — zelfde branches, geen nieuw datamodel, dus geen nieuwe
+OTAP-doorloop nodig. De twee grotere punten (navigatie, dashboard) zijn
+losse issues geworden: #171, #172.
+
+**Files (`MCM2-frontend`):**
+- Modify: `src/app/beheer/leveranciers/[id]/page.tsx`
+
+- [ ] **Step 1: Contactpersoon direct aanmaken — toggle naast de dropdown**
+
+In `NieuwContractFormulier`, een schakelaar naast de bestaande
+contactpersoon-dropdown. Aangevinkt: de dropdown verdwijnt, drie extra
+velden (naam, e-mail, functie) verschijnen. Bij opslaan: eerst
+`voegContactToe` (bestaande route/service uit `vendorService.ts`, al
+gebruikt door de Contactpersonen-sectie hierboven), dan het contract met
+het net teruggekregen `contactId`.
+
+```typescript
+function NieuwContractFormulier({
+  vendorId,
+  contactenVanVendor,
+  gebruikers,
+  onAangemaakt,
+}: {
+  vendorId: string;
+  contactenVanVendor: Contactpersoon[];
+  gebruikers: { userId: string; naam: string }[];
+  onAangemaakt: () => void | Promise<void>;
+}) {
+  const [waarden, setWaarden] = useState<ContractInvoer>({});
+  const [nieuweContactpersoon, setNieuweContactpersoon] = useState(false);
+  const [contactVelden, setContactVelden] = useState({
+    fullName: '',
+    email: '',
+    jobTitle: '',
+  });
+  const [gekoppeldeTemplates, setGekoppeldeTemplates] = useState<Set<string>>(
+    new Set(),
+  );
+  const [templates, setTemplates] = useState<
+    { templateId: string; naam: string }[]
+  >([]);
+  const [bezig, setBezig] = useState(false);
+  const [fout, setFout] = useState<string | null>(null);
+  const [veldFout, setVeldFout] = useState<{
+    veld: string;
+    melding: string;
+  } | null>(null);
+
+  useEffect(() => {
+    void haalSurveyTemplates().then(setTemplates);
+  }, []);
+
+  async function voegToe(gebeurtenis: React.FormEvent) {
+    gebeurtenis.preventDefault();
+    setBezig(true);
+    setFout(null);
+    setVeldFout(null);
+
+    let invoer = waarden;
+
+    // Eerst de nieuwe contactpersoon aanmaken, als die optie aanstaat. Faalt
+    // dat, dan wordt het contract niet aangemaakt — een contract met een
+    // verwijzing naar een contactpersoon die niet bestaat is erger dan geen
+    // contract.
+    if (nieuweContactpersoon) {
+      if (!contactVelden.fullName.trim()) {
+        setVeldFout({
+          veld: 'contactNaam',
+          melding: 'Vul de naam van de nieuwe contactpersoon in.',
+        });
+        setBezig(false);
+        return;
+      }
+
+      const contactUitkomst = await voegContactToe(vendorId, {
+        fullName: contactVelden.fullName,
+        email: contactVelden.email.trim() || null,
+        jobTitle: contactVelden.jobTitle.trim() || null,
+      });
+
+      if (!contactUitkomst.ok) {
+        setBezig(false);
+        if (contactUitkomst.soort === 'veld') {
+          setVeldFout({
+            veld: contactUitkomst.veld,
+            melding: contactUitkomst.melding,
+          });
+        } else {
+          setFout(contactUitkomst.melding);
+        }
+        return;
+      }
+
+      invoer = { ...waarden, vendorContactId: contactUitkomst.waarde.contactId };
+    }
+
+    const uitkomst = await maakContractAan(vendorId, invoer);
+
+    if (!uitkomst.ok) {
+      setBezig(false);
+      verwerk(uitkomst, {
+        opGelukt: () => undefined,
+        opVeldFout: setVeldFout,
+        opAlgemeneFout: setFout,
+      });
+      return;
+    }
+
+    // Contract staat er. Als er templates zijn aangevinkt: meteen koppelen,
+    // vóór de gebruiker het resultaat ziet. Twee aanroepen, één actie voor
+    // de gebruiker.
+    if (gekoppeldeTemplates.size > 0) {
+      await zetGekoppeldeTemplates(vendorId, uitkomst.waarde.contractId, [
+        ...gekoppeldeTemplates,
+      ]);
+    }
+
+    setBezig(false);
+    setWaarden({});
+    setNieuweContactpersoon(false);
+    setContactVelden({ fullName: '', email: '', jobTitle: '' });
+    setGekoppeldeTemplates(new Set());
+    await onAangemaakt();
+  }
+
+  return (
+    <form onSubmit={voegToe} noValidate className="border-t border-line pt-5">
+      <p className="mb-3 text-sm font-medium text-ink">Contract toevoegen</p>
+
+      <ContractFormuliervelden
+        waarden={waarden}
+        onWijzig={setWaarden}
+        contactenVanVendor={contactenVanVendor}
+        gebruikers={gebruikers}
+        veldFout={veldFout}
+        idPrefix="nieuw-contract"
+        // Bij een nieuwe contactpersoon toont het formulier de dropdown niet
+        // — die twee horen niet tegelijk zichtbaar te zijn, anders is
+        // onduidelijk welke wint.
+        verbergContactDropdown={nieuweContactpersoon}
+      />
+
+      <div className="mt-3">
+        <button
+          type="button"
+          onClick={() => setNieuweContactpersoon((v) => !v)}
+          data-testid="toggle-nieuwe-contactpersoon"
+          className="text-xs font-medium text-brand-primary hover:underline"
+        >
+          {nieuweContactpersoon
+            ? '← kies een bestaande contactpersoon'
+            : '+ of maak een nieuwe contactpersoon aan'}
+        </button>
+
+        {nieuweContactpersoon && (
+          <div className="mt-3 grid gap-3 sm:grid-cols-3">
+            <Veld
+              id="nieuw-contract-contactNaam"
+              label="Naam"
+              verplicht
+              waarde={contactVelden.fullName}
+              onWijzig={(w) =>
+                setContactVelden((v) => ({ ...v, fullName: w }))
+              }
+              fout={veldFoutVoor(veldFout, 'contactNaam')}
+            />
+            <Veld
+              id="nieuw-contract-contactEmail"
+              label="E-mailadres"
+              type="email"
+              waarde={contactVelden.email}
+              onWijzig={(w) => setContactVelden((v) => ({ ...v, email: w }))}
+            />
+            <Veld
+              id="nieuw-contract-contactFunctie"
+              label="Functie"
+              waarde={contactVelden.jobTitle}
+              onWijzig={(w) =>
+                setContactVelden((v) => ({ ...v, jobTitle: w }))
+              }
+            />
+          </div>
+        )}
+      </div>
+
+      {templates.length > 0 && (
+        <div className="mt-4 border-t border-line pt-3">
+          <p className="mb-2 text-sm font-medium text-ink">
+            Van toepassing zijnde vragenlijst(en)
+          </p>
+          <div className="flex flex-col gap-1.5">
+            {templates.map((t) => (
+              <label
+                key={t.templateId}
+                className="flex items-center gap-2 text-sm text-ink"
+              >
+                <input
+                  type="checkbox"
+                  data-testid="nieuw-contract-survey-checkbox"
+                  checked={gekoppeldeTemplates.has(t.templateId)}
+                  onChange={() =>
+                    setGekoppeldeTemplates((vorig) => {
+                      const nieuw = new Set(vorig);
+                      if (nieuw.has(t.templateId)) {
+                        nieuw.delete(t.templateId);
+                      } else {
+                        nieuw.add(t.templateId);
+                      }
+                      return nieuw;
+                    })
+                  }
+                />
+                {t.naam}
+              </label>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {fout && (
+        <p
+          role="alert"
+          data-testid="nieuw-contract-fout"
+          className="mt-4 rounded border border-red-300 bg-red-50 px-3 py-2 text-sm text-red-800"
+        >
+          {fout}
+        </p>
+      )}
+
+      <button
+        type="submit"
+        disabled={bezig}
+        data-testid="voeg-contract-toe"
+        className="mt-5 rounded border border-brand-primary px-4 py-2 text-sm font-medium text-brand-primary transition hover:bg-brand-primary hover:text-white disabled:cursor-not-allowed disabled:opacity-60"
+      >
+        {bezig ? 'Bezig…' : 'Toevoegen'}
+      </button>
+    </form>
+  );
+}
+```
+
+**Nodig: `voegContactToe` importeren** uit `@/core/services/vendorService`
+(al elders in dit bestand geïmporteerd voor de Contactpersonen-sectie —
+hergebruiken, niet opnieuw definiëren).
+
+- [ ] **Step 2: Voeg `verbergContactDropdown` toe aan `ContractFormuliervelden`**
+
+Kleine uitbreiding van de props uit Task 6 Step 5:
+
+```typescript
+function ContractFormuliervelden({
+  waarden,
+  onWijzig,
+  contactenVanVendor,
+  gebruikers,
+  veldFout,
+  idPrefix,
+  verbergContactDropdown = false,
+}: {
+  waarden: ContractInvoer;
+  onWijzig: (w: ContractInvoer) => void;
+  contactenVanVendor: Contactpersoon[];
+  gebruikers: { userId: string; naam: string }[];
+  veldFout: { veld: string; melding: string } | null;
+  idPrefix: string;
+  verbergContactDropdown?: boolean;
+}) {
+```
+
+En de bestaande `Keuzeveld`-blok voor `vendorContactId` wrap in
+`{!verbergContactDropdown && ( ... )}`.
+
+- [ ] **Step 3: Compileer**
+
+```bash
+npx tsc --noEmit
+```
+
+- [ ] **Step 4: Breid `e2e/contracten.spec.ts` uit met twee tests**
+
+```typescript
+  test('maakt direct een nieuwe contactpersoon aan bij het contract', async ({
+    page,
+  }) => {
+    await maakEnOpen(page);
+
+    await page.getByTestId('toggle-nieuwe-contactpersoon').click();
+    await page.locator('#nieuw-contract-name').fill(`Contract-nc-${Date.now()}`);
+    await page
+      .locator('#nieuw-contract-contactNaam')
+      .fill(`Nieuw Contact ${Date.now()}`);
+    await page.getByTestId('voeg-contract-toe').click();
+
+    await expect(page.getByTestId('contract-rij').first()).toBeVisible();
+
+    // De nieuwe contactpersoon moet ook in de Contactpersonen-sectie
+    // verschijnen — bewijst dat dezelfde route is gebruikt, niet een kopie.
+    await expect(page.getByTestId('contact-rij')).not.toHaveCount(0);
+  });
+
+  test('koppelt meteen een vragenlijst bij het aanmaken', async ({
+    page,
+  }) => {
+    await maakEnOpen(page);
+
+    const checkboxen = page.getByTestId('nieuw-contract-survey-checkbox');
+    const aantal = await checkboxen.count();
+    test.skip(
+      aantal === 0,
+      'Geen vragenlijst-templates aanwezig op deze database.',
+    );
+
+    await page.locator('#nieuw-contract-name').fill(`Contract-vl-${Date.now()}`);
+    await checkboxen.first().check();
+    await page.getByTestId('voeg-contract-toe').click();
+
+    await expect(page.getByTestId('contract-rij').first()).toBeVisible();
+
+    await page.getByTestId('bewerk-contract').first().click();
+    await expect(
+      page.getByTestId('survey-template-checkbox').first(),
+    ).toBeChecked();
+  });
+```
+
+- [ ] **Step 5: Prettier, lint, compileer**
+
+```bash
+npx prettier --write "src/app/beheer/leveranciers/[id]/page.tsx" "e2e/contracten.spec.ts"
+npx eslint "src/app/beheer/leveranciers/[id]/page.tsx" "e2e/contracten.spec.ts" --max-warnings=0
+npx tsc --noEmit
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add "src/app/beheer/leveranciers/[id]/page.tsx" e2e/contracten.spec.ts
+git commit -m "feat(contract): contactpersoon en vragenlijst direct bij aanmaken
+
+21-08 II punt 3+4: een toggle om een nieuwe contactpersoon aan te maken
+i.p.v. te kiezen uit bestaande, en de survey-templatekoppeling al zichtbaar
+in het aanmaakformulier zelf i.p.v. pas na opslaan.
+
+Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>"
+```
+
+- [ ] **Step 7: Tweede, korte preview-ronde**
+
+Herhaal Task 10 (Steps 2–6) met de bijgewerkte frontend-branch — het is
+dezelfde branch, dus geen nieuwe `--branch`-naam nodig, alleen opnieuw
+`npm run demo -- --branch feat/contractmanagement-scherm` na deze commit.
+
+---
+
 ## Task 11: Samenvoegen — pas na akkoord op de preview
 
-**Niet uitvoeren zonder expliciet akkoord van de eigenaar op Task 10.**
+**Niet uitvoeren zonder expliciet akkoord van de eigenaar op Task 10 (en,**
+**als Task 12 is uitgevoerd, ook op de tweede preview-ronde daar).**
 
 - [ ] **Step 1: Volg `superpowers:finishing-a-development-branch`**
 
 Voor beide repo's apart: backend-branch (taken 1–4) en frontend-branch
-(taken 5–8). Presenteer de opties (PR, direct mergen, branch parkeren)
-zoals die skill voorschrijft — niet zelf beslissen.
+(taken 5–8, eventueel 12). Presenteer de opties (PR, direct mergen, branch
+parkeren) zoals die skill voorschrijft — niet zelf beslissen.
 
 ---
 

--- a/docs/superpowers/plans/2026-08-22-contractmanagement.md
+++ b/docs/superpowers/plans/2026-08-22-contractmanagement.md
@@ -1,0 +1,1759 @@
+# Contractmanagement (basismodule) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Een nieuwe `clm.contract`-tabel bouwen (met status-ref-tabel en
+survey-templatekoppeling), volledig RLS-beschermd, plus een CRUD-API
+(`/vendors/:vendorId/contracts`) zodat een tenant-admin contracten kan
+aanmaken, inzien, wijzigen en verwijderen bij een leverancier.
+
+**Architecture:** Eén handgeschreven Drizzle-migratie voegt drie
+databaseobjecten toe (`ref.contract_status`, `clm.contract`,
+`clm.contract_survey_template`) en legt de FK op het al bestaande
+`survey_run.contract_id`. Het Drizzle-schema (`src/db/schema.ts`) wordt
+gelijktijdig bijgewerkt zodat `schema-conformiteit.e2e-spec.ts` slaagt. Een
+nieuwe `ContractModule` (service + controller + invoer-validatie) volgt
+exact het bestaande `VendorModule`-patroon: raw SQL via `DatabaseService.
+withTenant()`, handmatige validatie met `InvoerFout`, soft delete.
+
+**Tech Stack:** NestJS, Drizzle (raw SQL via `tx.execute`), PostgreSQL met
+RLS, Jest (unit + e2e), TypeScript.
+
+**Spec:** `docs/superpowers/specs/2026-08-22-contractmanagement-design.md`
+
+---
+
+## Voorwaarde vóór Task 1
+
+Deze migratie is handgeschreven, geen `drizzle-kit generate`-output (dat is
+kapot, zie Issue #96 / `MCM2-CLAUDE.md`). Elke handgeschreven migratie moet
+in `drizzle/meta/_journal.json` staan, anders slaat `migrate:deploy` hem
+stilzwijgend over.
+
+De volgende migratie-tag is `0027_contract`. Controleer dit vlak vóór Task 1
+begint — als er tussen het schrijven van dit plan en de uitvoering een
+andere migratie is bijgekomen, schuift het nummer op:
+
+```bash
+ls drizzle/*.sql | tail -3
+```
+
+---
+
+## Task 1: Migratie 0027 — `ref.contract_status`, `clm.contract`, `clm.contract_survey_template`
+
+**Files:**
+- Create: `drizzle/0027_contract.sql`
+- Modify: `drizzle/meta/_journal.json`
+
+- [ ] **Step 1: Schrijf de migratie**
+
+```sql
+-- =============================================================================
+-- clm.contract — de contractmanagement-basismodule.
+--
+-- Ontwerp: docs/superpowers/specs/2026-08-22-contractmanagement-design.md
+-- Aanleiding: opmerkingen 21-08 punt 2/2a/2c, roadmap-issues #156/#157.
+--
+-- Lost de belofte van migratie 0007 in: survey_run.contract_id kreeg toen
+-- bewust nog geen foreign key, met het commentaar "zodra clm.contract
+-- bestaat, is dit één ALTER TABLE erbij". Dat gebeurt hieronder in stap 4.
+-- =============================================================================
+
+-- ── 1. ref.contract_status — vaste waardenlijst, zelfde patroon als
+-- ref.compliance_status / ref.business_criticality / ref.vendor_category.
+--
+-- "verlopend" staat hier bewust niet in: dat is een berekende weergavestatus
+-- (status = 'actief' AND end_date <= vandaag + 90 dagen), nooit een
+-- opgeslagen waarde. Zie spec §2.3 voor de volledige redenering — een
+-- opgeslagen "verlopend" zou een achtergrondtaak vereisen die hem bijhoudt,
+-- met het risico dat die taak stil achterloopt.
+
+CREATE TABLE ref.contract_status (
+    code  text PRIMARY KEY,
+    label text NOT NULL
+);--> statement-breakpoint
+
+INSERT INTO ref.contract_status (code, label) VALUES
+    ('actief', 'Actief'),
+    ('verlopen', 'Verlopen'),
+    ('opgezegd', 'Opgezegd')
+ON CONFLICT (code) DO NOTHING;--> statement-breakpoint
+
+-- ref-schema: bewust geen RLS (tenant-agnostische lookup-data), zelfde als
+-- de andere ref-tabellen.
+
+-- ── 2. clm.contract ───────────────────────────────────────────────────────
+--
+-- Patroon: clm.vendor / clm.vendor_contact (0000_baseline_bestaand_schema).
+--
+-- vendor_contact_id is NULLABLE met applicatie-fallback (niet een
+-- database-default): NULL betekent "gebruik de is_primary-contactpersoon
+-- van de vendor". Een database-default zou bevriezen op het moment van
+-- invoegen; de fallback hoort in de leeslaag. Zie spec §2.1.
+--
+-- contract_number heeft bewust geen uniekheidseis: het komt uit een extern
+-- ERP-systeem dat MCM2 niet controleert.
+
+CREATE TABLE clm.contract (
+    contract_id       uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenant_id         uuid NOT NULL,
+    vendor_id         uuid NOT NULL,
+    name              text NOT NULL,
+    contract_number   text,
+    vendor_contact_id uuid,
+    owner_user_id     uuid,
+    status_code       text,
+    value_eur         numeric(15, 2),
+    start_date        date,
+    end_date          date,
+    note              text,
+    created_at        timestamptz NOT NULL DEFAULT now(),
+    updated_at        timestamptz,
+    deleted_at        timestamptz
+);--> statement-breakpoint
+
+ALTER TABLE clm.contract
+    ADD CONSTRAINT contract_tenant_id_tenant_tenant_id_fk
+    FOREIGN KEY (tenant_id) REFERENCES clm.tenant(tenant_id)
+    ON DELETE restrict;--> statement-breakpoint
+
+ALTER TABLE clm.contract
+    ADD CONSTRAINT contract_vendor_id_vendor_vendor_id_fk
+    FOREIGN KEY (vendor_id) REFERENCES clm.vendor(vendor_id)
+    ON DELETE cascade;--> statement-breakpoint
+
+ALTER TABLE clm.contract
+    ADD CONSTRAINT contract_vendor_contact_id_vendor_contact_contact_id_fk
+    FOREIGN KEY (vendor_contact_id) REFERENCES clm.vendor_contact(contact_id)
+    ON DELETE set null;--> statement-breakpoint
+
+ALTER TABLE clm.contract
+    ADD CONSTRAINT contract_owner_user_id_user_user_id_fk
+    FOREIGN KEY (owner_user_id) REFERENCES clm."user"(user_id)
+    ON DELETE set null;--> statement-breakpoint
+
+ALTER TABLE clm.contract
+    ADD CONSTRAINT contract_status_code_contract_status_code_fk
+    FOREIGN KEY (status_code) REFERENCES ref.contract_status(code)
+    ON DELETE set null;--> statement-breakpoint
+
+CREATE INDEX contract_tenant_id_idx ON clm.contract USING btree (tenant_id);--> statement-breakpoint
+CREATE INDEX contract_vendor_id_idx ON clm.contract USING btree (vendor_id);--> statement-breakpoint
+
+CREATE TRIGGER trg_contract_updated_at
+    BEFORE UPDATE ON clm.contract
+    FOR EACH ROW EXECUTE FUNCTION clm.set_updated_at();--> statement-breakpoint
+
+ALTER TABLE clm.contract ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+ALTER TABLE clm.contract FORCE ROW LEVEL SECURITY;--> statement-breakpoint
+
+CREATE POLICY contract_isolation ON clm.contract
+    USING (tenant_id = clm.current_tenant_id() AND deleted_at IS NULL)
+    WITH CHECK (tenant_id = clm.current_tenant_id());--> statement-breakpoint
+
+COMMENT ON TABLE clm.contract IS
+    'Contracten bij een leverancier. vendor_contact_id is nullable: NULL betekent "gebruik de is_primary-contactpersoon van de vendor" (applicatielogica, geen database-default). status_code kent geen "verlopend" — die status is berekend uit end_date, nooit opgeslagen. Zie docs/superpowers/specs/2026-08-22-contractmanagement-design.md.';--> statement-breakpoint
+
+GRANT SELECT, INSERT, UPDATE ON clm.contract TO clm_api_runtime;--> statement-breakpoint
+
+-- ── 3. clm.contract_survey_template — many-to-many, geen extra kolommen ────
+--
+-- Welke vragenlijst-templates relevant zijn voor een contract. Geen
+-- frequentie- of verplicht/optioneel-veld: dat raakt de nog niet gebouwde
+-- rondes/herhaling-feature en is bewust uitgesteld. Zie spec §2.4.
+
+CREATE TABLE clm.contract_survey_template (
+    contract_id       uuid NOT NULL,
+    survey_template_id uuid NOT NULL,
+    tenant_id         uuid NOT NULL,
+    created_at        timestamptz NOT NULL DEFAULT now(),
+    CONSTRAINT contract_survey_template_pkey
+        PRIMARY KEY (contract_id, survey_template_id)
+);--> statement-breakpoint
+
+ALTER TABLE clm.contract_survey_template
+    ADD CONSTRAINT contract_survey_template_contract_id_contract_contract_id_fk
+    FOREIGN KEY (contract_id) REFERENCES clm.contract(contract_id)
+    ON DELETE cascade;--> statement-breakpoint
+
+ALTER TABLE clm.contract_survey_template
+    ADD CONSTRAINT contract_survey_template_survey_template_id_fk
+    FOREIGN KEY (survey_template_id) REFERENCES clm.survey_template(template_id)
+    ON DELETE cascade;--> statement-breakpoint
+
+CREATE INDEX contract_survey_template_tenant_id_idx
+    ON clm.contract_survey_template USING btree (tenant_id);--> statement-breakpoint
+
+ALTER TABLE clm.contract_survey_template ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+ALTER TABLE clm.contract_survey_template FORCE ROW LEVEL SECURITY;--> statement-breakpoint
+
+CREATE POLICY contract_survey_template_isolation ON clm.contract_survey_template
+    USING (tenant_id = clm.current_tenant_id())
+    WITH CHECK (tenant_id = clm.current_tenant_id());--> statement-breakpoint
+
+COMMENT ON TABLE clm.contract_survey_template IS
+    'Welke vragenlijst-templates relevant zijn voor een contract. Many-to-many, geen extra velden. Zie docs/superpowers/specs/2026-08-22-contractmanagement-design.md §2.4.';--> statement-breakpoint
+
+GRANT SELECT, INSERT, DELETE ON clm.contract_survey_template TO clm_api_runtime;--> statement-breakpoint
+
+-- ── 4. survey_run.contract_id krijgt zijn foreign key ──────────────────────
+--
+-- Migratie 0007 introduceerde de kolom bewust zonder FK. Dit is het
+-- aangekondigde vervolg. ON DELETE SET NULL, niet CASCADE of RESTRICT: een
+-- survey-ronde is bewijsmateriaal en mag niet verdwijnen als het contract
+-- wordt verwijderd — hij verliest alleen de koppeling. Zie spec §2.5.
+
+ALTER TABLE clm.survey_run
+    ADD CONSTRAINT survey_run_contract_id_contract_contract_id_fk
+    FOREIGN KEY (contract_id) REFERENCES clm.contract(contract_id)
+    ON DELETE set null;--> statement-breakpoint
+
+COMMENT ON COLUMN clm.survey_run.contract_id IS
+    'Op welk contract deze ronde betrekking heeft. Nullable: een ronde hoeft niet aan een contract te hangen. FK toegevoegd in migratie 0027 zodra clm.contract bestond, zoals migratie 0007 al aankondigde.';
+```
+
+- [ ] **Step 2: Voeg de migratie toe aan `drizzle/meta/_journal.json`**
+
+Open `drizzle/meta/_journal.json`, voeg een entry toe ná de laatste
+(`0026_tenantregister`). Gebruik een `when`-timestamp die na de vorige komt
+(volgende geheel getal is voldoende, het veld is alleen ordening):
+
+```json
+    {
+      "idx": 27,
+      "version": "7",
+      "when": 1787068800001,
+      "tag": "0027_contract",
+      "breakpoints": true
+    }
+```
+
+- [ ] **Step 3: Draai de migratie tegen een wegwerpcontainer**
+
+Volg `docs/runbooks/commandos-en-omgeving.md` voor het opzetten van een
+eigen wegwerpcontainer (nooit tegen staging/productie/demo). Na het opzetten:
+
+```bash
+node scripts/markeer-wegwerp.js "contractmanagement-migratie-testen"
+npm run migrate:deploy
+```
+
+Verwacht: de migratie draait, geen fouten. Lees terug — niet vertrouwen op
+de meldingstekst (§4 van `MCM2-CLAUDE.md`):
+
+```sql
+SELECT string_agg(column_name, ', ' ORDER BY ordinal_position)
+  FROM information_schema.columns WHERE table_schema='clm' AND table_name='contract';
+```
+
+Verwacht: `contract_id, tenant_id, vendor_id, name, contract_number,
+vendor_contact_id, owner_user_id, status_code, value_eur, start_date,
+end_date, note, created_at, updated_at, deleted_at`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add drizzle/0027_contract.sql drizzle/meta/_journal.json
+git commit -m "feat(contract): migratie voor clm.contract, ref.contract_status en contract_survey_template
+
+Nieuwe tabellen volgens docs/superpowers/specs/2026-08-22-contractmanagement-design.md.
+Legt ook de FK op survey_run.contract_id die migratie 0007 aankondigde.
+
+Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Drizzle-schema bijwerken (`src/db/schema.ts`)
+
+**Files:**
+- Modify: `src/db/schema.ts`
+
+`schema-conformiteit.e2e-spec.ts` leidt de verwachte tabellenlijst af uit dit
+bestand via `inventariseerSchema()`. Zonder deze stap meldt die test dat de
+database tabellen bevat die niet in het schema staan.
+
+- [ ] **Step 1: Voeg `contractStatus` toe aan het ref-schema-blok**
+
+Zoek de bestaande ref-tabellen (rond regel 27) en voeg toe, direct na
+`complianceStatus`:
+
+```typescript
+export const contractStatus = ref.table('contract_status', {
+  code: text('code').primaryKey(),
+  label: text('label').notNull(),
+});
+```
+
+- [ ] **Step 2: Voeg `contract` toe, direct na `vendorTag` (rond regel 304)**
+
+```typescript
+export const contract = clm.table(
+  'contract',
+  {
+    contractId: uuid('contract_id').primaryKey().defaultRandom(),
+    tenantId: uuid('tenant_id')
+      .notNull()
+      .references(() => tenant.tenantId, { onDelete: 'restrict' }),
+    vendorId: uuid('vendor_id')
+      .notNull()
+      .references(() => vendor.vendorId, { onDelete: 'cascade' }),
+    name: text('name').notNull(),
+    contractNumber: text('contract_number'),
+    // NULL betekent "gebruik de is_primary-contactpersoon van de vendor" —
+    // applicatielogica, geen database-default. Zie spec §2.1.
+    vendorContactId: uuid('vendor_contact_id').references(
+      () => vendorContact.contactId,
+      { onDelete: 'set null' },
+    ),
+    ownerUserId: uuid('owner_user_id').references(() => user.userId, {
+      onDelete: 'set null',
+    }),
+    // Kent geen 'verlopend' — dat is berekend uit end_date, nooit
+    // opgeslagen. Zie spec §2.3.
+    statusCode: text('status_code').references(() => contractStatus.code, {
+      onDelete: 'set null',
+    }),
+    valueEur: numeric('value_eur', { precision: 15, scale: 2 }),
+    startDate: date('start_date'),
+    endDate: date('end_date'),
+    note: text('note'),
+    createdAt: timestamp('created_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }),
+    deletedAt: timestamp('deleted_at', { withTimezone: true }),
+  },
+  (t) => [
+    index('contract_tenant_id_idx').on(t.tenantId),
+    index('contract_vendor_id_idx').on(t.vendorId),
+  ],
+);
+
+export const contractSurveyTemplate = clm.table(
+  'contract_survey_template',
+  {
+    contractId: uuid('contract_id')
+      .notNull()
+      .references(() => contract.contractId, { onDelete: 'cascade' }),
+    surveyTemplateId: uuid('survey_template_id')
+      .notNull()
+      .references(() => surveyTemplate.templateId, { onDelete: 'cascade' }),
+    tenantId: uuid('tenant_id').notNull(),
+    createdAt: timestamp('created_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (t) => [
+    uniqueIndex('contract_survey_template_pkey').on(
+      t.contractId,
+      t.surveyTemplateId,
+    ),
+    index('contract_survey_template_tenant_id_idx').on(t.tenantId),
+  ],
+);
+```
+
+`vendorContact` en `surveyTemplate` worden pas later in het bestand
+gedefinieerd (`vendorContact` op regel 265, `surveyTemplate` op regel 311) —
+dat is geen probleem, Drizzle's `references()` gebruikt een closure die pas
+uitgevoerd wordt na module-load, zelfde patroon als `vendor.ownerUserId` dat
+al doet met `user` (gedefinieerd vóór `vendor`, dus daar speelt de volgorde
+sowieso niet — controleer bij het invoegen dat `contract` ná `vendorContact`
+en `surveyTemplate` in het bestand staat, dan is er geen closure-truc nodig).
+
+**Concreet:** plaats het `contract`/`contractSurveyTemplate`-blok dus ná de
+definitie van `surveyTemplate` (na regel 335 in het huidige bestand, vóór
+`surveyRun` op regel 337), niet bij `vendorTag`. Dat voorkomt elke discussie
+over declaratievolgorde.
+
+- [ ] **Step 3: Compileer**
+
+```bash
+npx tsc --noEmit
+```
+
+Verwacht: geen fouten.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/db/schema.ts
+git commit -m "feat(contract): Drizzle-schema voor clm.contract en contract_survey_template
+
+Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: `ContractService` — lijst, aanmaken, detail, wijzigen, verwijderen
+
+**Files:**
+- Create: `src/contract/contract.service.ts`
+
+Volgt het patroon van `src/vendor/vendor.service.ts` exact: raw SQL via
+`tx.execute`, `withTenant(tenantId, fn, 'medewerker')`, soft delete via
+`deleted_at`, `leegIsNull()` voor optionele tekst.
+
+- [ ] **Step 1: Schrijf `contract.service.ts`**
+
+```typescript
+import { ConflictException, Injectable, Logger } from '@nestjs/common';
+import { sql, type SQL } from 'drizzle-orm';
+
+import { DatabaseService } from '../db/database.service';
+
+/**
+ * Contracten lezen, aanmaken en wijzigen bij een leverancier.
+ *
+ * Zelfde opzet als VendorService: raw SQL binnen withTenant(), 'medewerker'
+ * als actor, soft delete via deleted_at. Zie
+ * docs/superpowers/specs/2026-08-22-contractmanagement-design.md.
+ */
+
+export interface ContractSamenvatting {
+  contractId: string;
+  name: string;
+  contractNumber: string | null;
+  statusCode: string | null;
+  startDate: string | null;
+  endDate: string | null;
+  createdAt: string;
+}
+
+export interface NieuwContract {
+  name: string;
+  contractNumber?: string | null;
+  vendorContactId?: string | null;
+  ownerUserId?: string | null;
+  statusCode?: string | null;
+  valueEur?: string | null;
+  startDate?: string | null;
+  endDate?: string | null;
+  note?: string | null;
+}
+
+export interface ContractDetail {
+  contractId: string;
+  vendorId: string;
+  name: string;
+  contractNumber: string | null;
+  vendorContactId: string | null;
+  ownerUserId: string | null;
+  statusCode: string | null;
+  valueEur: string | null;
+  startDate: string | null;
+  endDate: string | null;
+  note: string | null;
+  createdAt: string;
+  updatedAt: string | null;
+}
+
+/**
+ * Wat er gewijzigd mag worden aan een contract. Elk veld optioneel; `null`
+ * maakt leeg, `undefined` betekent "niet aangeraakt" — zelfde onderscheid als
+ * VendorWijziging.
+ */
+export interface ContractWijziging {
+  name?: string;
+  contractNumber?: string | null;
+  vendorContactId?: string | null;
+  ownerUserId?: string | null;
+  statusCode?: string | null;
+  valueEur?: string | null;
+  startDate?: string | null;
+  endDate?: string | null;
+  note?: string | null;
+}
+
+interface ContractRij extends Record<string, unknown> {
+  contract_id: string;
+  name: string;
+  contract_number: string | null;
+  status_code: string | null;
+  start_date: string | null;
+  end_date: string | null;
+  created_at: Date | string;
+}
+
+interface ContractDetailRij extends Record<string, unknown> {
+  contract_id: string;
+  vendor_id: string;
+  name: string;
+  contract_number: string | null;
+  vendor_contact_id: string | null;
+  owner_user_id: string | null;
+  status_code: string | null;
+  value_eur: string | null;
+  start_date: string | null;
+  end_date: string | null;
+  note: string | null;
+  created_at: Date | string;
+  updated_at: Date | string | null;
+}
+
+function alsTekst(waarde: Date | string): string {
+  return waarde instanceof Date ? waarde.toISOString() : waarde;
+}
+
+function alsTekstOfNull(waarde: Date | string | null): string | null {
+  return waarde === null ? null : alsTekst(waarde);
+}
+
+function leegIsNull(waarde: string | null | undefined): string | null {
+  const geknipt = waarde?.trim();
+  return geknipt ? geknipt : null;
+}
+
+@Injectable()
+export class ContractService {
+  private readonly logger = new Logger(ContractService.name);
+
+  constructor(private readonly db: DatabaseService) {}
+
+  /** Alle actieve contracten van een leverancier, nieuwste eerst. */
+  async lijst(
+    tenantId: string,
+    vendorId: string,
+  ): Promise<ContractSamenvatting[]> {
+    return this.db.withTenant(
+      tenantId,
+      async (tx) => {
+        const resultaat = await tx.execute<ContractRij>(
+          sql`SELECT contract_id, name, contract_number, status_code,
+                     start_date, end_date, created_at
+                FROM clm.contract
+               WHERE vendor_id = ${vendorId} AND deleted_at IS NULL
+               ORDER BY created_at DESC`,
+        );
+
+        return resultaat.rows.map((r) => ({
+          contractId: r.contract_id,
+          name: r.name,
+          contractNumber: r.contract_number,
+          statusCode: r.status_code,
+          startDate: r.start_date,
+          endDate: r.end_date,
+          createdAt: alsTekst(r.created_at),
+        }));
+      },
+      'medewerker',
+    );
+  }
+
+  /**
+   * Maakt een contract aan bij een leverancier.
+   *
+   * Geeft `null` als de leverancier niet bestaat of niet van deze tenant is
+   * — zelfde redenering als VendorService.detail().
+   */
+  async maakAan(
+    tenantId: string,
+    vendorId: string,
+    invoer: NieuwContract,
+  ): Promise<ContractDetail | null> {
+    return this.db.withTenant(
+      tenantId,
+      async (tx) => {
+        const vendorBestaat = await tx.execute<{ vendor_id: string }>(
+          sql`SELECT vendor_id FROM clm.vendor
+             WHERE vendor_id = ${vendorId} AND deleted_at IS NULL`,
+        );
+
+        if (vendorBestaat.rows.length === 0) {
+          return null;
+        }
+
+        const resultaat = await tx.execute<{ contract_id: string }>(
+          sql`INSERT INTO clm.contract
+                (tenant_id, vendor_id, name, contract_number,
+                 vendor_contact_id, owner_user_id, status_code, value_eur,
+                 start_date, end_date, note)
+              VALUES (${tenantId}, ${vendorId}, ${invoer.name.trim()},
+                      ${leegIsNull(invoer.contractNumber)},
+                      ${invoer.vendorContactId ?? null},
+                      ${invoer.ownerUserId ?? null},
+                      ${leegIsNull(invoer.statusCode)},
+                      ${invoer.valueEur ?? null},
+                      ${invoer.startDate ?? null},
+                      ${invoer.endDate ?? null},
+                      ${leegIsNull(invoer.note)})
+              RETURNING contract_id`,
+        );
+
+        const contractId = resultaat.rows[0].contract_id;
+
+        this.logger.log(`Contract aangemaakt (${contractId}).`);
+
+        return this.detailBinnenTransactie(tx, vendorId, contractId);
+      },
+      'medewerker',
+    );
+  }
+
+  /** Eén contract, mits het bij deze vendor en tenant hoort. */
+  async detail(
+    tenantId: string,
+    vendorId: string,
+    contractId: string,
+  ): Promise<ContractDetail | null> {
+    return this.db.withTenant(
+      tenantId,
+      (tx) => this.detailBinnenTransactie(tx, vendorId, contractId),
+      'medewerker',
+    );
+  }
+
+  /** Wijzigt een contract. Alleen de meegestuurde velden. */
+  async wijzig(
+    tenantId: string,
+    vendorId: string,
+    contractId: string,
+    wijziging: ContractWijziging,
+  ): Promise<ContractDetail | null> {
+    return this.db.withTenant(
+      tenantId,
+      async (tx) => {
+        const bestaat = await tx.execute<{ contract_id: string }>(
+          sql`SELECT contract_id FROM clm.contract
+             WHERE contract_id = ${contractId}
+               AND vendor_id = ${vendorId}
+               AND deleted_at IS NULL`,
+        );
+
+        if (bestaat.rows.length === 0) {
+          return null;
+        }
+
+        const zetten: SQL[] = [];
+
+        if (wijziging.name !== undefined) {
+          zetten.push(sql`name = ${wijziging.name.trim()}`);
+        }
+        if (wijziging.contractNumber !== undefined) {
+          zetten.push(
+            sql`contract_number = ${leegIsNull(wijziging.contractNumber)}`,
+          );
+        }
+        if (wijziging.vendorContactId !== undefined) {
+          zetten.push(
+            sql`vendor_contact_id = ${wijziging.vendorContactId}`,
+          );
+        }
+        if (wijziging.ownerUserId !== undefined) {
+          zetten.push(sql`owner_user_id = ${wijziging.ownerUserId}`);
+        }
+        if (wijziging.statusCode !== undefined) {
+          zetten.push(
+            sql`status_code = ${leegIsNull(wijziging.statusCode)}`,
+          );
+        }
+        if (wijziging.valueEur !== undefined) {
+          zetten.push(sql`value_eur = ${wijziging.valueEur}`);
+        }
+        if (wijziging.startDate !== undefined) {
+          zetten.push(sql`start_date = ${wijziging.startDate}`);
+        }
+        if (wijziging.endDate !== undefined) {
+          zetten.push(sql`end_date = ${wijziging.endDate}`);
+        }
+        if (wijziging.note !== undefined) {
+          zetten.push(sql`note = ${leegIsNull(wijziging.note)}`);
+        }
+
+        if (zetten.length > 0) {
+          zetten.push(sql`updated_at = now()`);
+
+          await tx.execute(
+            sql`UPDATE clm.contract
+                 SET ${sql.join(zetten, sql`, `)}
+               WHERE contract_id = ${contractId}`,
+          );
+
+          this.logger.log(`Contract gewijzigd (${contractId}).`);
+        }
+
+        return this.detailBinnenTransactie(tx, vendorId, contractId);
+      },
+      'medewerker',
+    );
+  }
+
+  /** Verwijdert een contract — soft delete. */
+  async verwijder(
+    tenantId: string,
+    vendorId: string,
+    contractId: string,
+  ): Promise<boolean> {
+    return this.db.withTenant(
+      tenantId,
+      async (tx) => {
+        const resultaat = await tx.execute<{ contract_id: string }>(
+          sql`UPDATE clm.contract
+               SET deleted_at = now()
+             WHERE contract_id = ${contractId}
+               AND vendor_id = ${vendorId}
+               AND deleted_at IS NULL
+             RETURNING contract_id`,
+        );
+
+        if (resultaat.rows.length === 0) {
+          return false;
+        }
+
+        this.logger.log(`Contract verwijderd (${contractId}).`);
+        return true;
+      },
+      'medewerker',
+    );
+  }
+
+  private async detailBinnenTransactie(
+    tx: Parameters<Parameters<DatabaseService['withTenant']>[1]>[0],
+    vendorId: string,
+    contractId: string,
+  ): Promise<ContractDetail | null> {
+    const resultaat = await tx.execute<ContractDetailRij>(
+      sql`SELECT contract_id, vendor_id, name, contract_number,
+                 vendor_contact_id, owner_user_id, status_code, value_eur,
+                 start_date, end_date, note, created_at, updated_at
+            FROM clm.contract
+           WHERE contract_id = ${contractId}
+             AND vendor_id = ${vendorId}
+             AND deleted_at IS NULL`,
+    );
+
+    const rij = resultaat.rows[0];
+
+    if (!rij) {
+      return null;
+    }
+
+    return {
+      contractId: rij.contract_id,
+      vendorId: rij.vendor_id,
+      name: rij.name,
+      contractNumber: rij.contract_number,
+      vendorContactId: rij.vendor_contact_id,
+      ownerUserId: rij.owner_user_id,
+      statusCode: rij.status_code,
+      valueEur: rij.value_eur,
+      startDate: rij.start_date,
+      endDate: rij.end_date,
+      note: rij.note,
+      createdAt: alsTekst(rij.created_at),
+      updatedAt: alsTekstOfNull(rij.updated_at),
+    };
+  }
+}
+```
+
+- [ ] **Step 2: Compileer**
+
+```bash
+npx tsc --noEmit
+```
+
+Verwacht: geen fouten.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/contract/contract.service.ts
+git commit -m "feat(contract): ContractService — lijst, aanmaken, detail, wijzigen, verwijderen
+
+Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Invoer-validatie (`contract-invoer.ts`)
+
+**Files:**
+- Create: `src/contract/contract-invoer.ts`
+- Test: `src/contract/contract-invoer.spec.ts`
+
+Volgt `src/vendor/vendor-invoer.ts`: handmatige validatie op `unknown`,
+`InvoerFout` met veldnaam, ruime regels (alleen evidente vergissingen
+tegenhouden).
+
+- [ ] **Step 1: Schrijf de eerste falende test**
+
+```typescript
+import { leesNieuwContract, InvoerFout } from './contract-invoer';
+
+describe('leesNieuwContract', () => {
+  it('accepteert een minimale geldige invoer (alleen naam)', () => {
+    const invoer = leesNieuwContract({ name: 'Hosting 2024-2027' });
+
+    expect(invoer.name).toBe('Hosting 2024-2027');
+    expect(invoer.contractNumber).toBeNull();
+  });
+
+  it('weigert een lege naam', () => {
+    expect(() => leesNieuwContract({ name: '' })).toThrow(InvoerFout);
+  });
+
+  it('weigert een ontbrekende naam', () => {
+    expect(() => leesNieuwContract({})).toThrow(InvoerFout);
+  });
+
+  it('knipt witruimte van de naam', () => {
+    const invoer = leesNieuwContract({ name: '  Hosting  ' });
+    expect(invoer.name).toBe('Hosting');
+  });
+
+  it('accepteert een geldige startDate en endDate (ISO-datum)', () => {
+    const invoer = leesNieuwContract({
+      name: 'Hosting',
+      startDate: '2024-01-01',
+      endDate: '2027-12-31',
+    });
+
+    expect(invoer.startDate).toBe('2024-01-01');
+    expect(invoer.endDate).toBe('2027-12-31');
+  });
+
+  it('weigert een endDate vóór de startDate', () => {
+    expect(() =>
+      leesNieuwContract({
+        name: 'Hosting',
+        startDate: '2027-01-01',
+        endDate: '2024-01-01',
+      }),
+    ).toThrow(InvoerFout);
+  });
+
+  it('weigert een niet-ISO datum', () => {
+    expect(() =>
+      leesNieuwContract({ name: 'Hosting', startDate: '01-01-2024' }),
+    ).toThrow(InvoerFout);
+  });
+
+  it('accepteert een geldig geldbedrag', () => {
+    const invoer = leesNieuwContract({ name: 'Hosting', valueEur: '1500.50' });
+    expect(invoer.valueEur).toBe('1500.50');
+  });
+
+  it('weigert een negatief geldbedrag', () => {
+    expect(() =>
+      leesNieuwContract({ name: 'Hosting', valueEur: '-100' }),
+    ).toThrow(InvoerFout);
+  });
+
+  it('weigert een niet-numeriek geldbedrag', () => {
+    expect(() =>
+      leesNieuwContract({ name: 'Hosting', valueEur: 'abc' }),
+    ).toThrow(InvoerFout);
+  });
+});
+```
+
+- [ ] **Step 2: Run de test om te zien dat hij faalt**
+
+```bash
+npx jest src/contract/contract-invoer.spec.ts
+```
+
+Verwacht: FAIL — `Cannot find module './contract-invoer'`.
+
+- [ ] **Step 3: Schrijf de implementatie**
+
+```typescript
+import type { NieuwContract, ContractWijziging } from './contract.service';
+
+/**
+ * Validatie van wat een browser opstuurt bij het aanmaken/wijzigen van een
+ * contract. Zelfde opzet als vendor-invoer.ts: handmatig op `unknown`, ruime
+ * regels — wat hier wordt tegengehouden is het soort invoer dat op een
+ * vergissing wijst, niet elke denkbare afwijking.
+ */
+
+const MAX_NAAM = 200;
+const MAX_KORT = 100;
+const MAX_NOTITIE = 2000;
+
+export class InvoerFout extends Error {
+  constructor(
+    readonly veld: string,
+    melding: string,
+  ) {
+    super(melding);
+    this.name = 'InvoerFout';
+  }
+}
+
+function verplichteTekst(
+  waarde: unknown,
+  veld: string,
+  maxLengte: number,
+): string {
+  if (typeof waarde !== 'string' || waarde.trim() === '') {
+    throw new InvoerFout(veld, `${veld} is verplicht.`);
+  }
+
+  const geknipt = waarde.trim();
+
+  if (geknipt.length > maxLengte) {
+    throw new InvoerFout(
+      veld,
+      `${veld} mag maximaal ${maxLengte} tekens bevatten.`,
+    );
+  }
+
+  return geknipt;
+}
+
+function optioneleTekst(
+  waarde: unknown,
+  veld: string,
+  maxLengte: number,
+): string | null {
+  if (waarde === undefined || waarde === null || waarde === '') {
+    return null;
+  }
+
+  if (typeof waarde !== 'string') {
+    throw new InvoerFout(veld, `${veld} moet tekst zijn.`);
+  }
+
+  const geknipt = waarde.trim();
+
+  if (geknipt === '') {
+    return null;
+  }
+
+  if (geknipt.length > maxLengte) {
+    throw new InvoerFout(
+      veld,
+      `${veld} mag maximaal ${maxLengte} tekens bevatten.`,
+    );
+  }
+
+  return geknipt;
+}
+
+function optioneleUuid(waarde: unknown, veld: string): string | null {
+  if (waarde === undefined || waarde === null || waarde === '') {
+    return null;
+  }
+
+  const UUID_PATROON =
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+  if (typeof waarde !== 'string' || !UUID_PATROON.test(waarde)) {
+    throw new InvoerFout(veld, `${veld} is geen geldige id.`);
+  }
+
+  return waarde;
+}
+
+const ISO_DATUM = /^\d{4}-\d{2}-\d{2}$/;
+
+function optioneleDatum(waarde: unknown, veld: string): string | null {
+  if (waarde === undefined || waarde === null || waarde === '') {
+    return null;
+  }
+
+  if (typeof waarde !== 'string' || !ISO_DATUM.test(waarde)) {
+    throw new InvoerFout(veld, `${veld} moet een datum zijn (JJJJ-MM-DD).`);
+  }
+
+  return waarde;
+}
+
+/**
+ * Een geldbedrag als tekst, zodat precisie niet verloren gaat via number.
+ * Numeriek(15,2) in de database — twee decimalen, geen extra validatie op
+ * decimalenaantal hier: de database wijst een te lange waarde zelf af.
+ */
+function optioneelBedrag(waarde: unknown, veld: string): string | null {
+  if (waarde === undefined || waarde === null || waarde === '') {
+    return null;
+  }
+
+  if (typeof waarde !== 'string' || !/^\d+(\.\d{1,2})?$/.test(waarde)) {
+    throw new InvoerFout(veld, `${veld} moet een geldig bedrag zijn.`);
+  }
+
+  return waarde;
+}
+
+function controleerDatumVolgorde(
+  startDate: string | null,
+  endDate: string | null,
+): void {
+  if (startDate && endDate && startDate > endDate) {
+    throw new InvoerFout(
+      'endDate',
+      'De einddatum kan niet vóór de begindatum liggen.',
+    );
+  }
+}
+
+/** Leest en valideert de body van POST /vendors/:vendorId/contracts. */
+export function leesNieuwContract(body: unknown): NieuwContract {
+  if (typeof body !== 'object' || body === null) {
+    throw new InvoerFout('body', 'Er is geen contract meegestuurd.');
+  }
+
+  const ruw = body as Record<string, unknown>;
+
+  const startDate = optioneleDatum(ruw.startDate, 'Begindatum');
+  const endDate = optioneleDatum(ruw.endDate, 'Einddatum');
+  controleerDatumVolgorde(startDate, endDate);
+
+  return {
+    name: verplichteTekst(ruw.name, 'Naam', MAX_NAAM),
+    contractNumber: optioneleTekst(
+      ruw.contractNumber,
+      'Contractnummer',
+      MAX_KORT,
+    ),
+    vendorContactId: optioneleUuid(ruw.vendorContactId, 'Contactpersoon'),
+    ownerUserId: optioneleUuid(ruw.ownerUserId, 'Contractbeheerder'),
+    statusCode: optioneleTekst(ruw.statusCode, 'Status', MAX_KORT),
+    valueEur: optioneelBedrag(ruw.valueEur, 'Waarde'),
+    startDate,
+    endDate,
+    note: optioneleTekst(ruw.note, 'Notitie', MAX_NOTITIE),
+  };
+}
+
+/** Leest de body van PATCH /vendors/:vendorId/contracts/:id. */
+export function leesContractWijziging(body: unknown): ContractWijziging {
+  if (typeof body !== 'object' || body === null) {
+    throw new InvoerFout('body', 'Er is geen wijziging meegestuurd.');
+  }
+
+  const ruw = body as Record<string, unknown>;
+  const wijziging: ContractWijziging = {};
+
+  if ('name' in ruw) {
+    wijziging.name = verplichteTekst(ruw.name, 'Naam', MAX_NAAM);
+  }
+  if ('contractNumber' in ruw) {
+    wijziging.contractNumber = optioneleTekst(
+      ruw.contractNumber,
+      'Contractnummer',
+      MAX_KORT,
+    );
+  }
+  if ('vendorContactId' in ruw) {
+    wijziging.vendorContactId = optioneleUuid(
+      ruw.vendorContactId,
+      'Contactpersoon',
+    );
+  }
+  if ('ownerUserId' in ruw) {
+    wijziging.ownerUserId = optioneleUuid(
+      ruw.ownerUserId,
+      'Contractbeheerder',
+    );
+  }
+  if ('statusCode' in ruw) {
+    wijziging.statusCode = optioneleTekst(ruw.statusCode, 'Status', MAX_KORT);
+  }
+  if ('valueEur' in ruw) {
+    wijziging.valueEur = optioneelBedrag(ruw.valueEur, 'Waarde');
+  }
+  if ('startDate' in ruw) {
+    wijziging.startDate = optioneleDatum(ruw.startDate, 'Begindatum');
+  }
+  if ('endDate' in ruw) {
+    wijziging.endDate = optioneleDatum(ruw.endDate, 'Einddatum');
+  }
+  if ('note' in ruw) {
+    wijziging.note = optioneleTekst(ruw.note, 'Notitie', MAX_NOTITIE);
+  }
+
+  controleerDatumVolgorde(
+    wijziging.startDate ?? null,
+    wijziging.endDate ?? null,
+  );
+
+  return wijziging;
+}
+```
+
+- [ ] **Step 4: Run de test opnieuw**
+
+```bash
+npx jest src/contract/contract-invoer.spec.ts
+```
+
+Verwacht: PASS, alle 10 tests groen.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/contract/contract-invoer.ts src/contract/contract-invoer.spec.ts
+git commit -m "feat(contract): invoer-validatie voor contract aanmaken en wijzigen
+
+Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: `ContractController` + `ContractModule` + registratie in `AppModule`
+
+**Files:**
+- Create: `src/contract/contract.controller.ts`
+- Create: `src/contract/contract.module.ts`
+- Modify: `src/app.module.ts`
+
+Routes onder `/vendors/:vendorId/contracts` — een contract bestaat altijd in
+de context van zijn leverancier, zelfde opzet als
+`/vendors/:id/contacts`.
+
+- [ ] **Step 1: Schrijf `contract.controller.ts`**
+
+```typescript
+import {
+  BadRequestException,
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  NotFoundException,
+  Param,
+  Patch,
+  Post,
+  Req,
+  UseGuards,
+} from '@nestjs/common';
+
+import { RolGuard, VereistRol } from '../auth/rol.guard';
+import {
+  TenantContextGuard,
+  type RequestMetSessie,
+} from '../auth/tenant-context.guard';
+import {
+  InvoerFout,
+  leesContractWijziging,
+  leesNieuwContract,
+} from './contract-invoer';
+import {
+  ContractService,
+  type ContractWijziging,
+  type NieuwContract,
+} from './contract.service';
+
+/**
+ * Contractroutes, altijd in de context van een leverancier.
+ *
+ * Zelfde beveiligingspatroon als VendorController: guards op klasseniveau,
+ * schrijven vereist de rol admin.
+ */
+@Controller('vendors/:vendorId/contracts')
+@UseGuards(TenantContextGuard, RolGuard)
+export class ContractController {
+  constructor(private readonly contracts: ContractService) {}
+
+  @Get()
+  async lijst(
+    @Req() request: RequestMetSessie,
+    @Param('vendorId') vendorId: string,
+  ) {
+    const sessie = request.sessie!;
+
+    const contracten = await this.contracts.lijst(
+      sessie.tenantId,
+      leesUuid(vendorId),
+    );
+
+    return { contracten };
+  }
+
+  @Post()
+  @VereistRol('admin')
+  @HttpCode(201)
+  async maakAan(
+    @Req() request: RequestMetSessie,
+    @Param('vendorId') vendorId: string,
+    @Body() body: unknown,
+  ) {
+    const sessie = request.sessie!;
+
+    let invoer: NieuwContract;
+
+    try {
+      invoer = leesNieuwContract(body);
+    } catch (err) {
+      throw alsHttpFout(err);
+    }
+
+    const contract = await this.contracts
+      .maakAan(sessie.tenantId, leesUuid(vendorId), invoer)
+      .catch(alsRefFout);
+
+    if (!contract) {
+      throw new NotFoundException('Leverancier niet gevonden.');
+    }
+
+    return contract;
+  }
+
+  @Get(':id')
+  async detail(
+    @Req() request: RequestMetSessie,
+    @Param('vendorId') vendorId: string,
+    @Param('id') id: string,
+  ) {
+    const sessie = request.sessie!;
+
+    const contract = await this.contracts.detail(
+      sessie.tenantId,
+      leesUuid(vendorId),
+      leesUuid(id),
+    );
+
+    if (!contract) {
+      throw new NotFoundException('Contract niet gevonden.');
+    }
+
+    return contract;
+  }
+
+  @Patch(':id')
+  @VereistRol('admin')
+  async wijzig(
+    @Req() request: RequestMetSessie,
+    @Param('vendorId') vendorId: string,
+    @Param('id') id: string,
+    @Body() body: unknown,
+  ) {
+    const sessie = request.sessie!;
+
+    let wijziging: ContractWijziging;
+
+    try {
+      wijziging = leesContractWijziging(body);
+    } catch (err) {
+      throw alsHttpFout(err);
+    }
+
+    const contract = await this.contracts
+      .wijzig(sessie.tenantId, leesUuid(vendorId), leesUuid(id), wijziging)
+      .catch(alsRefFout);
+
+    if (!contract) {
+      throw new NotFoundException('Contract niet gevonden.');
+    }
+
+    return contract;
+  }
+
+  @Delete(':id')
+  @VereistRol('admin')
+  @HttpCode(204)
+  async verwijder(
+    @Req() request: RequestMetSessie,
+    @Param('vendorId') vendorId: string,
+    @Param('id') id: string,
+  ) {
+    const sessie = request.sessie!;
+
+    const gelukt = await this.contracts.verwijder(
+      sessie.tenantId,
+      leesUuid(vendorId),
+      leesUuid(id),
+    );
+
+    if (!gelukt) {
+      throw new NotFoundException('Contract niet gevonden.');
+    }
+  }
+}
+
+const UUID_PATROON =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+function leesUuid(waarde: string): string {
+  if (!UUID_PATROON.test(waarde)) {
+    throw new NotFoundException('Niet gevonden.');
+  }
+
+  return waarde;
+}
+
+function alsHttpFout(err: unknown): unknown {
+  if (err instanceof InvoerFout) {
+    return new BadRequestException({ message: err.message, veld: err.veld });
+  }
+
+  return err;
+}
+
+/**
+ * Een onbekende status_code, vendor_contact_id of owner_user_id is een
+ * gebruikersfout, geen storing. Zelfde vertaling als bij VendorController.
+ */
+function alsRefFout(err: unknown): never {
+  const code = (err as { cause?: { code?: string }; code?: string })?.cause
+    ?.code;
+
+  if (code === '23503') {
+    throw new BadRequestException({
+      message:
+        'Onbekende status, contactpersoon of contractbeheerder.',
+      veld: 'statusCode',
+    });
+  }
+
+  throw err;
+}
+```
+
+- [ ] **Step 2: Schrijf `contract.module.ts`**
+
+```typescript
+import { Module } from '@nestjs/common';
+
+import { AuthModule } from '../auth/auth.module';
+import { ContractController } from './contract.controller';
+import { ContractService } from './contract.service';
+
+/**
+ * Contractbeheer bij een leverancier.
+ *
+ * AuthModule voor TenantContextGuard, zelfde reden als VendorModule.
+ */
+@Module({
+  imports: [AuthModule],
+  controllers: [ContractController],
+  providers: [ContractService],
+  exports: [ContractService],
+})
+export class ContractModule {}
+```
+
+- [ ] **Step 3: Registreer in `AppModule`**
+
+Open `src/app.module.ts`. Voeg de import toe naast `VendorModule`:
+
+```typescript
+import { ContractModule } from './contract/contract.module';
+```
+
+En voeg `ContractModule` toe aan de `imports`-array, direct na
+`VendorModule`.
+
+- [ ] **Step 4: Compileer en start op**
+
+```bash
+npx tsc --noEmit
+```
+
+Verwacht: geen fouten.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/contract/contract.controller.ts src/contract/contract.module.ts src/app.module.ts
+git commit -m "feat(contract): ContractController en ContractModule, geregistreerd in AppModule
+
+Routes onder /vendors/:vendorId/contracts, zelfde beveiligingspatroon als
+VendorController.
+
+Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: e2e-testsuite (tenantgrens + rolcontrole)
+
+**Files:**
+- Create: `test/contract-routes.e2e-spec.ts`
+- Modify: `test/test-ids.ts`
+
+Volgt `test/vendor-detail.e2e-spec.ts`: eigen blok in `TEST_IDS`, admin vs.
+reviewer, cross-tenant zichtbaarheid, opruimen vóór en na.
+
+- [ ] **Step 1: Voeg een testblok toe aan `test/test-ids.ts`**
+
+Voeg toe na het `'vendor-detail'`-blok (rond regel 97), vóór
+`'tenant-context-guard'`:
+
+```typescript
+  'contract-routes': {
+    tenant: id('e6'),
+    adminUser: id('e7'),
+    reviewerUser: id('e8'),
+    andereTenant: id('e9'),
+    andereUser: id('f7'),
+  },
+```
+
+- [ ] **Step 2: Controleer dat er geen dubbele ids ontstaan**
+
+```bash
+npx jest test/test-ids.spec.ts
+```
+
+Verwacht: PASS.
+
+- [ ] **Step 3: Schrijf `test/contract-routes.e2e-spec.ts`**
+
+```typescript
+import { INestApplication } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import cookieParser from 'cookie-parser';
+import { Client } from 'pg';
+import request from 'supertest';
+import type { App } from 'supertest/types';
+
+import { AppModule } from '../src/app.module';
+import { SessieService } from '../src/auth/sessie.service';
+import { cookieInstellingen } from '../src/auth/sessie';
+import { TEST_IDS } from './test-ids';
+
+/**
+ * Contractroutes: tenantgrens en rolcontrole.
+ *
+ * Zelfde twee vragen als vendor-detail.e2e-spec.ts: kan een reviewer
+ * schrijven (moet niet), en kan tenant A bij de contracten van tenant B zien
+ * (moet niet).
+ */
+
+const { tenant, adminUser, reviewerUser, andereTenant, andereUser } =
+  TEST_IDS['contract-routes'];
+
+const STEMPEL = Date.now();
+const SUBJECT_ADMIN = `oid-contract-admin-${STEMPEL}`;
+const SUBJECT_REVIEWER = `oid-contract-reviewer-${STEMPEL}`;
+const SUBJECT_ANDER = `oid-contract-ander-${STEMPEL}`;
+
+interface ContractAntwoord {
+  contractId: string;
+  vendorId: string;
+  name: string;
+  contractNumber: string | null;
+  statusCode: string | null;
+}
+
+function alsContract(body: unknown): ContractAntwoord {
+  return body as ContractAntwoord;
+}
+
+async function verwijderTestdata(client: Client): Promise<void> {
+  for (const t of [tenant, andereTenant]) {
+    await client.query('BEGIN');
+    await client.query(`SET LOCAL app.current_tenant_id = '${t}'`);
+    await client.query('DELETE FROM clm.contract WHERE tenant_id = $1', [t]);
+    await client.query('DELETE FROM clm.vendor_contact WHERE tenant_id = $1', [
+      t,
+    ]);
+    await client.query('DELETE FROM clm.vendor WHERE tenant_id = $1', [t]);
+    await client.query(
+      'DELETE FROM clm.tenant_membership WHERE tenant_id = $1',
+      [t],
+    );
+    await client.query('DELETE FROM clm."user" WHERE tenant_id = $1', [t]);
+    await client.query('DELETE FROM clm.tenant WHERE tenant_id = $1', [t]);
+    await client.query('COMMIT');
+  }
+}
+
+describe('Contractroutes (e2e)', () => {
+  let app: INestApplication<App>;
+  let server: App;
+  let client: Client;
+  let sessies: SessieService;
+
+  let adminCookie: string;
+  let reviewerCookie: string;
+  let vendorId: string;
+
+  const cookieNaam = cookieInstellingen().naam;
+
+  beforeAll(async () => {
+    client = new Client({ connectionString: process.env.DATABASE_URL });
+    await client.connect();
+    await verwijderTestdata(client);
+
+    await client.query('BEGIN');
+    await client.query(`SET LOCAL app.current_tenant_id = '${tenant}'`);
+    await client.query(
+      'INSERT INTO clm.tenant (tenant_id, name) VALUES ($1, $2)',
+      [tenant, 'contract-test'],
+    );
+    await client.query(
+      `INSERT INTO clm."user" (user_id, tenant_id, full_name, external_subject)
+       VALUES ($1, $2, $3, $4), ($5, $2, $6, $7)`,
+      [
+        adminUser,
+        tenant,
+        'Anna Admin',
+        SUBJECT_ADMIN,
+        reviewerUser,
+        'Rob Reviewer',
+        SUBJECT_REVIEWER,
+      ],
+    );
+    await client.query(
+      `INSERT INTO clm.tenant_membership (user_id, tenant_id, role)
+       VALUES ($1, $2, 'admin'), ($3, $2, 'reviewer')`,
+      [adminUser, tenant, reviewerUser],
+    );
+
+    const vendorResultaat = await client.query<{ vendor_id: string }>(
+      `INSERT INTO clm.vendor (tenant_id, name) VALUES ($1, $2)
+       RETURNING vendor_id`,
+      [tenant, `Testleverancier-${STEMPEL}`],
+    );
+    vendorId = vendorResultaat.rows[0].vendor_id;
+
+    await client.query('COMMIT');
+
+    const moduleRef = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleRef.createNestApplication();
+    app.use(cookieParser());
+    await app.init();
+    server = app.getHttpServer();
+
+    sessies = app.get(SessieService);
+
+    const adminSessie = await sessies.aanmaken(SUBJECT_ADMIN);
+    const reviewerSessie = await sessies.aanmaken(SUBJECT_REVIEWER);
+
+    adminCookie = `${cookieNaam}=${adminSessie!.token}`;
+    reviewerCookie = `${cookieNaam}=${reviewerSessie!.token}`;
+  });
+
+  afterAll(async () => {
+    await app.close();
+    await verwijderTestdata(client);
+    await client.end();
+  });
+
+  it('admin kan een contract aanmaken', async () => {
+    const respons = await request(server)
+      .post(`/vendors/${vendorId}/contracts`)
+      .set('Cookie', adminCookie)
+      .send({ name: 'Hosting 2024-2027', contractNumber: 'ERP-4711' });
+
+    expect(respons.status).toBe(201);
+    const contract = alsContract(respons.body);
+    expect(contract.name).toBe('Hosting 2024-2027');
+    expect(contract.contractNumber).toBe('ERP-4711');
+    expect(contract.vendorId).toBe(vendorId);
+  });
+
+  it('reviewer kan geen contract aanmaken (403)', async () => {
+    const respons = await request(server)
+      .post(`/vendors/${vendorId}/contracts`)
+      .set('Cookie', reviewerCookie)
+      .send({ name: 'Verboden contract' });
+
+    expect(respons.status).toBe(403);
+  });
+
+  it('admin kan de lijst met contracten van de leverancier ophalen', async () => {
+    const respons = await request(server)
+      .get(`/vendors/${vendorId}/contracts`)
+      .set('Cookie', adminCookie);
+
+    expect(respons.status).toBe(200);
+    expect(Array.isArray(respons.body.contracten)).toBe(true);
+    expect(respons.body.contracten.length).toBeGreaterThan(0);
+  });
+
+  it('reviewer kan de lijst wél lezen (alleen schrijven is geblokkeerd)', async () => {
+    const respons = await request(server)
+      .get(`/vendors/${vendorId}/contracts`)
+      .set('Cookie', reviewerCookie);
+
+    expect(respons.status).toBe(200);
+  });
+
+  it('een tweede tenant ziet de contracten van tenant A niet', async () => {
+    await client.query('BEGIN');
+    await client.query(`SET LOCAL app.current_tenant_id = '${andereTenant}'`);
+    await client.query(
+      'INSERT INTO clm.tenant (tenant_id, name) VALUES ($1, $2)',
+      [andereTenant, 'contract-test-ander'],
+    );
+    await client.query(
+      `INSERT INTO clm."user" (user_id, tenant_id, full_name, external_subject)
+       VALUES ($1, $2, $3, $4)`,
+      [andereUser, andereTenant, 'Bob Buiten', SUBJECT_ANDER],
+    );
+    await client.query(
+      `INSERT INTO clm.tenant_membership (user_id, tenant_id, role)
+       VALUES ($1, $2, 'admin')`,
+      [andereUser, andereTenant],
+    );
+    await client.query('COMMIT');
+
+    const andereSessie = await sessies.aanmaken(SUBJECT_ANDER);
+    const andereCookie = `${cookieNaam}=${andereSessie!.token}`;
+
+    // Directe vendor-id van tenant A opvragen vanuit tenant B: RLS filtert
+    // 'm weg, dus het scherm ziet niets — geen aparte foutmelding die zou
+    // verklappen dat de vendor elders wél bestaat.
+    const respons = await request(server)
+      .get(`/vendors/${vendorId}/contracts`)
+      .set('Cookie', andereCookie);
+
+    expect(respons.status).toBe(200);
+    expect(respons.body.contracten).toEqual([]);
+  });
+
+  it('wijzigen van een niet-bestaand contract geeft 404', async () => {
+    const respons = await request(server)
+      .patch(`/vendors/${vendorId}/contracts/00000000-0000-0000-0000-000000000000`)
+      .set('Cookie', adminCookie)
+      .send({ name: 'Bestaat niet' });
+
+    expect(respons.status).toBe(404);
+  });
+
+  it('een contract aanmaken zonder naam geeft 400 met veldnaam', async () => {
+    const respons = await request(server)
+      .post(`/vendors/${vendorId}/contracts`)
+      .set('Cookie', adminCookie)
+      .send({});
+
+    expect(respons.status).toBe(400);
+    expect(respons.body.veld).toBe('Naam');
+  });
+
+  it('admin kan een contract verwijderen (soft delete)', async () => {
+    const aangemaakt = await request(server)
+      .post(`/vendors/${vendorId}/contracts`)
+      .set('Cookie', adminCookie)
+      .send({ name: 'Te verwijderen contract' });
+
+    const contractId = alsContract(aangemaakt.body).contractId;
+
+    const verwijderd = await request(server)
+      .delete(`/vendors/${vendorId}/contracts/${contractId}`)
+      .set('Cookie', adminCookie);
+
+    expect(verwijderd.status).toBe(204);
+
+    const opgehaald = await request(server)
+      .get(`/vendors/${vendorId}/contracts/${contractId}`)
+      .set('Cookie', adminCookie);
+
+    expect(opgehaald.status).toBe(404);
+  });
+});
+```
+
+- [ ] **Step 4: Draai de nieuwe suite geïsoleerd tegen een wegwerpcontainer**
+
+Volgens `MCM2-CLAUDE.md` §"Een nieuwe e2e-suite schrijven": eerst
+`test-ids`, dan deze suite los, dan de volledige e2e-run.
+
+```bash
+npx jest test-ids
+npx jest --config ./test/jest-e2e.json contract-routes
+```
+
+Verwacht: alle tests in `contract-routes.e2e-spec.ts` slagen (PASS).
+
+- [ ] **Step 5: Draai de volledige e2e-run**
+
+```bash
+npm run test:e2e
+```
+
+Verwacht: alle suites slagen, inclusief `schema-conformiteit.e2e-spec.ts`
+(bewijst dat `clm.contract`, `ref.contract_status` en
+`clm.contract_survey_template` zowel in de database als in
+`src/db/schema.ts` staan) en `rechten-contract.e2e-spec.ts` (bewijst dat de
+nieuwe GRANTs in migratie 0027 kloppen).
+
+Als een andere suite hierdoor rood wordt: dat is een teken dat de gedeelde
+testdatabase geraakt is op een onverwachte manier (zie
+`MCM2-CLAUDE.md` — "welke suite dan omvalt hangt af van de volgorde"). Zoek
+uit welke tabel/rij overlapt vóórdat je verdergaat.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add test/contract-routes.e2e-spec.ts test/test-ids.ts
+git commit -m "test(contract): e2e-suite voor contractroutes — tenantgrens en rolcontrole
+
+Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 7: Volledige verificatie
+
+**Files:** geen wijzigingen — alleen controleren.
+
+- [ ] **Step 1: Draai de volledige verificatieketen**
+
+```bash
+npm run verify:volledig
+```
+
+Verwacht: groen. Dit dekt build, lint:check, format:check, typecheck,
+unit-tests en e2e-tests in één keer — losse commando's bewijzen niets
+(`MCM2-CLAUDE.md` §15a).
+
+- [ ] **Step 2: Als er iets rood is, fix het daar waar het hoort**
+
+Niet de test aanpassen om hem groen te krijgen tenzij de test zelf
+aantoonbaar fout is. Bij twijfel: `superpowers:systematic-debugging`.
+
+- [ ] **Step 3: Ruim de wegwerpcontainer op**
+
+Volgens de regel dat elke database `beschermd` is tot hij zich als
+`wegwerp` meldt: dit was een eigen, gemarkeerde container (Task 1, Step 3) —
+gewoon stoppen/verwijderen, niets om op te schonen in staging/productie/demo.
+
+---
+
+## Self-review
+
+**Spec-dekking (tegen `docs/superpowers/specs/2026-08-22-contractmanagement-design.md`):**
+
+- §2.1 `clm.contract` — Task 1 (migratie) + Task 2 (schema.ts). ✅ alle
+  kolommen aanwezig, inclusief de nullable `vendor_contact_id`-fallback als
+  toelichting.
+- §2.2 `ref.contract_status` — Task 1. ✅ drie codes, geen "verlopend".
+- §2.3 "verlopend" berekend, niet opgeslagen — expliciet in de
+  migratie-commentaar en de service-laag bevat geen kolom of logica die het
+  wél opslaat. ✅ Geen aparte taak nodig: de afwezigheid ván een kolom is de
+  implementatie.
+- §2.4 `clm.contract_survey_template` — Task 1 + Task 2. ✅ Geen route
+  hiervoor gebouwd in dit plan — de spec dekt alleen het datamodel (§5:
+  "geen UI/schermen"), dus dat is bewust buiten scope, net als bij het
+  contract zelf staat vermeld dat schermen een aparte implementatiestap
+  zijn. **Correctie:** de contract-CRUD-routes in Task 5 gaan wél verder dan
+  "alleen datamodel" — dat is een bewuste, kleine uitbreiding van de
+  planscope t.o.v. de spec, nodig om de feature daadwerkelijk bruikbaar te
+  maken en te kunnen e2e-testen (RLS bewijzen vraagt een route). De
+  contract_survey_template-koppelroutes zijn wél weggelaten: die hebben geen
+  UI-consument in dit plan en worden apart opgepakt zodra de
+  rondes-aanmaakflow (roadmap §2.2-vervolg) ze nodig heeft.
+- §2.5 FK op `survey_run.contract_id` — Task 1, Step 1, blok 4. ✅
+- §4 RLS — Task 1: beide nieuwe tabellen krijgen ENABLE + FORCE + policy met
+  USING/WITH CHECK. ✅ Bewezen in Task 7 via `schema-conformiteit.e2e-spec.ts`
+  en de bestaande RLS-inventarisatie.
+- §5 "wat dit niet doet" — geen bulk-upload, geen automatische
+  statuswijziging, geen migratie van bestaande data: dit plan bouwt niets
+  van dat. ✅
+
+**Placeholder-scan:** geen TBD/TODO, elke stap heeft volledige code.
+
+**Type-consistentie:** `NieuwContract`/`ContractWijziging`/`ContractDetail`
+in `contract.service.ts` (Task 3) komen overeen met wat
+`contract-invoer.ts` (Task 4) en `contract.controller.ts` (Task 5)
+importeren en gebruiken — veldnamen zijn doorgangen gecheckt
+(`vendorContactId`, `ownerUserId`, `statusCode`, `valueEur`, `startDate`,
+`endDate`, `note`, `contractNumber`).
+
+**Scope-check:** één samenhangende feature, zeven taken, elke taak levert
+zelfstandig testbare voortgang op (migratie → schema → service → validatie
+→ API → e2e → verificatie). Geen decompositie in aparte plannen nodig.

--- a/docs/superpowers/plans/2026-08-23-leveranciersscherm-dichtheid.md
+++ b/docs/superpowers/plans/2026-08-23-leveranciersscherm-dichtheid.md
@@ -1,0 +1,2227 @@
+# Leveranciersscherm — dichtheid, modal, uitklapbare contracten Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Herzie `/beheer/leveranciers/[id]` (badge-strip + twee kolommen,
+modal voor contactpersoon, uitklapbare contractrij, expliciet
+wachtlijst-label, urgentiekleur op de einddatum) conform
+`docs/superpowers/specs/2026-08-23-leveranciersscherm-dichtheid-design.md`.
+
+**Architecture:** Puur frontend, `MCM2-frontend`-repo, geen backend- of
+databasewijziging. Het bestaande 1913-regelige
+`src/app/beheer/leveranciers/[id]/page.tsx` wordt opgesplitst: de
+Contactpersonen- en Contracten-secties verhuizen naar eigen bestanden onder
+`src/app/beheer/leveranciers/[id]/`, met een nieuwe gedeelde
+`ContactpersoonModal`-component. De hoofdpagina wordt dun: hij haalt de
+vendor op en rendert de badge-strip + twee kolommen met de uitgesplitste
+secties erin.
+
+**Tech Stack:** Next.js 15 App Router, React (client components,
+`'use client'`), Tailwind, bestaande services (`vendorService`,
+`contractService`) — ongewijzigd aangeroepen.
+
+---
+
+## Bestandsoverzicht
+
+| Bestand | Actie | Verantwoordelijkheid |
+|---|---|---|
+| `src/app/beheer/leveranciers/[id]/page.tsx` | Herschrijven (ingekort) | Data ophalen, badge-strip, twee-koloms layout, scroll-naar-contract |
+| `src/app/beheer/leveranciers/[id]/Stamgegevens.tsx` | Nieuw | Compacte stamgegevens-kaart (zonder classificatie-fieldset, die gaat naar de badge-strip) |
+| `src/app/beheer/leveranciers/[id]/ClassificatieBadges.tsx` | Nieuw | Badge-strip: naam, compliance/kritiek/categorie, klikbaar naar bewerken |
+| `src/app/beheer/leveranciers/[id]/ContactpersoonModal.tsx` | Nieuw | Gedeelde modal voor toevoegen én bewerken van een contactpersoon |
+| `src/app/beheer/leveranciers/[id]/Contactpersonen.tsx` | Nieuw (verplaatst) | Compacte contactenlijst + "+ toevoegen"-knop die de modal opent |
+| `src/app/beheer/leveranciers/[id]/Contracten.tsx` | Nieuw (verplaatst) | Contractentabel met uitklapbare rijen, urgentiekleur, wachtlijst-label |
+| `e2e/vendor-detail.spec.ts` | Wijzigen | Testid's/selectors aanpassen aan modal en badge-strip |
+| `e2e/contracten.spec.ts` | Wijzigen | Testid's/selectors aanpassen aan uitklap i.p.v. edit-knop |
+
+---
+
+### Task 1: Stamgegevens loskoppelen van classificatie, eigen bestand
+
+**Files:**
+- Create: `src/app/beheer/leveranciers/[id]/Stamgegevens.tsx`
+- Modify: `src/app/beheer/leveranciers/[id]/page.tsx:164-451` (huidige `Stamgegevens`-functie verwijderen na verplaatsing)
+
+Het bestaande `Stamgegevens`-component (regel 164-451 in de huidige
+`page.tsx`) doet nu twee dingen: het formulier voor naam/KvK/plaats/etc. én
+het classificatie-`<fieldset>` (categorie/kritiek/compliance). Die twee
+worden gesplitst: classificatie gaat naar `ClassificatieBadges.tsx` (Task 2),
+de rest blijft hier maar compacter en zonder de `<fieldset>`.
+
+- [ ] **Step 1: Maak `Stamgegevens.tsx` met de compacte kaart**
+
+```tsx
+'use client';
+
+import { Trash2 } from 'lucide-react';
+import { useState } from 'react';
+
+import type { SchrijfResultaat, VendorDetail } from '@/core/models/vendor';
+import { verwijderVendor, wijzigVendor } from '@/core/services/vendorService';
+import { Veld } from '@/shared/components/Formuliervelden';
+
+interface FormulierStaat {
+  name: string;
+  kvkNumber: string;
+  vestigingsnummer: string;
+  statutoryName: string;
+  city: string;
+  country: string;
+  website: string;
+}
+
+function uitVendor(vendor: VendorDetail): FormulierStaat {
+  return {
+    name: vendor.name,
+    kvkNumber: vendor.kvkNumber ?? '',
+    vestigingsnummer: vendor.vestigingsnummer ?? '',
+    statutoryName: vendor.statutoryName ?? '',
+    city: vendor.city ?? '',
+    country: vendor.country,
+    website: vendor.website ?? '',
+  };
+}
+
+/**
+ * Compacte stamgegevens-kaart voor de linkerkolom.
+ *
+ * Classificatie (categorie/kritiek/compliance) staat hier bewust niet meer
+ * bij — die verhuisde naar de badge-strip bovenaan de pagina
+ * (`ClassificatieBadges`), zichtbaarder dan weggestopt in een fieldset.
+ * Bewerken van die velden blijft mogelijk, alleen niet vanuit dit component.
+ */
+export function Stamgegevens({
+  vendor,
+  onOpgeslagen,
+  onVerwijderd,
+}: {
+  vendor: VendorDetail;
+  onOpgeslagen: (vendor: VendorDetail) => void;
+  onVerwijderd: () => void;
+}) {
+  const [formulier, setFormulier] = useState<FormulierStaat>(() =>
+    uitVendor(vendor),
+  );
+  const [bezig, setBezig] = useState(false);
+  const [veldFout, setVeldFout] = useState<{
+    veld: string;
+    melding: string;
+  } | null>(null);
+  const [algemeneFout, setAlgemeneFout] = useState<string | null>(null);
+  const [gelukt, setGelukt] = useState<string | null>(null);
+  const [bevestigVerwijderen, setBevestigVerwijderen] = useState(false);
+
+  function wijzigVeld(veld: keyof FormulierStaat, waarde: string) {
+    setFormulier((vorig) => ({ ...vorig, [veld]: waarde }));
+    setGelukt(null);
+    if (veldFout && veldFout.veld === veld) {
+      setVeldFout(null);
+    }
+  }
+
+  async function opslaan(gebeurtenis: React.FormEvent) {
+    gebeurtenis.preventDefault();
+
+    setBezig(true);
+    setVeldFout(null);
+    setAlgemeneFout(null);
+    setGelukt(null);
+
+    const uitkomst = await wijzigVendor(vendor.vendorId, {
+      name: formulier.name,
+      kvkNumber: formulier.kvkNumber || null,
+      vestigingsnummer: formulier.vestigingsnummer || null,
+      statutoryName: formulier.statutoryName || null,
+      city: formulier.city || null,
+      country: formulier.country || null,
+      website: formulier.website || null,
+    });
+
+    setBezig(false);
+
+    if (uitkomst.ok) {
+      onOpgeslagen(uitkomst.waarde);
+      setGelukt('De wijzigingen zijn opgeslagen.');
+      return;
+    }
+
+    if (uitkomst.soort === 'veld') {
+      setVeldFout({ veld: uitkomst.veld, melding: uitkomst.melding });
+    } else {
+      setAlgemeneFout(uitkomst.melding);
+    }
+  }
+
+  async function verwijderDeze() {
+    setBezig(true);
+    setAlgemeneFout(null);
+
+    const uitkomst = await verwijderVendor(vendor.vendorId);
+
+    setBezig(false);
+
+    if (uitkomst.ok) {
+      onVerwijderd();
+      return;
+    }
+
+    setBevestigVerwijderen(false);
+    setAlgemeneFout(uitkomst.melding);
+  }
+
+  return (
+    <section
+      aria-labelledby="stamgegevens-kop"
+      className="rounded-lg border border-line bg-card p-4"
+    >
+      <h2
+        id="stamgegevens-kop"
+        className="mb-3 text-sm font-semibold text-brand-dark"
+      >
+        Stamgegevens
+      </h2>
+
+      <form onSubmit={opslaan} noValidate>
+        <div className="space-y-2.5 text-[13px]">
+          <Veld
+            id="name"
+            label="Naam"
+            verplicht
+            waarde={formulier.name}
+            onWijzig={(w) => wijzigVeld('name', w)}
+            fout={veldFout?.veld === 'name' ? veldFout.melding : undefined}
+          />
+          <Veld
+            id="statutoryName"
+            label="Statutaire naam"
+            waarde={formulier.statutoryName}
+            onWijzig={(w) => wijzigVeld('statutoryName', w)}
+          />
+          <Veld
+            id="kvkNumber"
+            label="KvK-nummer"
+            hint="Acht cijfers"
+            waarde={formulier.kvkNumber}
+            onWijzig={(w) => wijzigVeld('kvkNumber', w)}
+            fout={
+              veldFout?.veld === 'kvkNumber' ? veldFout.melding : undefined
+            }
+          />
+          <Veld
+            id="vestigingsnummer"
+            label="Vestigingsnummer"
+            waarde={formulier.vestigingsnummer}
+            onWijzig={(w) => wijzigVeld('vestigingsnummer', w)}
+          />
+          <Veld
+            id="city"
+            label="Plaats"
+            waarde={formulier.city}
+            onWijzig={(w) => wijzigVeld('city', w)}
+          />
+          <Veld
+            id="country"
+            label="Land"
+            waarde={formulier.country}
+            onWijzig={(w) => wijzigVeld('country', w)}
+          />
+          <Veld
+            id="website"
+            label="Website"
+            waarde={formulier.website}
+            onWijzig={(w) => wijzigVeld('website', w)}
+          />
+        </div>
+
+        {algemeneFout && (
+          <p
+            role="alert"
+            data-testid="algemene-fout"
+            className="mt-4 rounded border border-red-300 bg-red-50 px-3 py-2 text-xs text-red-800"
+          >
+            {algemeneFout}
+          </p>
+        )}
+
+        {gelukt && (
+          <p
+            role="status"
+            data-testid="gelukt-melding"
+            className="mt-4 rounded border border-green-300 bg-green-50 px-3 py-2 text-xs text-green-800"
+          >
+            {gelukt}
+          </p>
+        )}
+
+        <div className="mt-4 flex items-center justify-between">
+          <button
+            type="submit"
+            disabled={bezig}
+            data-testid="opslaan"
+            className="rounded bg-brand-primary px-4 py-1.5 text-xs font-medium text-white transition hover:brightness-95 disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {bezig ? 'Bezig…' : 'Opslaan'}
+          </button>
+
+          {bevestigVerwijderen ? (
+            <div className="flex items-center gap-2">
+              <span className="text-xs text-ink-muted">Zeker weten?</span>
+              <button
+                type="button"
+                onClick={() => void verwijderDeze()}
+                disabled={bezig}
+                data-testid="verwijder-bevestig"
+                className="rounded bg-red-600 px-2.5 py-1 text-xs font-medium text-white hover:brightness-95 disabled:opacity-60"
+              >
+                Ja
+              </button>
+              <button
+                type="button"
+                onClick={() => setBevestigVerwijderen(false)}
+                className="rounded border border-line px-2.5 py-1 text-xs text-ink hover:bg-surface"
+              >
+                Nee
+              </button>
+            </div>
+          ) : (
+            <button
+              type="button"
+              onClick={() => setBevestigVerwijderen(true)}
+              data-testid="verwijder-vendor"
+              className="inline-flex items-center gap-1 rounded border border-line px-2.5 py-1 text-xs text-red-700 transition hover:bg-red-50"
+            >
+              <Trash2 size={12} /> Verwijderen
+            </button>
+          )}
+        </div>
+      </form>
+    </section>
+  );
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/app/beheer/leveranciers/[id]/Stamgegevens.tsx
+git commit -m "refactor(vendor): Stamgegevens als eigen, compact component zonder classificatie"
+```
+
+---
+
+### Task 2: Badge-strip met classificatie, eigen bestand
+
+**Files:**
+- Create: `src/app/beheer/leveranciers/[id]/ClassificatieBadges.tsx`
+
+Vervangt het `<fieldset>` uit de oude `Stamgegevens` (regel 343-382 van de
+huidige `page.tsx`). Toont naam + drie badges op één regel; klik op een
+badge opent een klein inline-bewerkformulier voor dat ene veld (geen aparte
+modal nodig — het zijn drie eenvoudige keuzevelden).
+
+- [ ] **Step 1: Maak `ClassificatieBadges.tsx`**
+
+```tsx
+'use client';
+
+import { useState } from 'react';
+
+import {
+  CATEGORIEEN,
+  COMPLIANCE_STATUS,
+  CRITICALITY,
+  keuzesMetHuidige,
+} from '@/core/models/classificatie';
+import type { VendorDetail } from '@/core/models/vendor';
+import { wijzigVendor } from '@/core/services/vendorService';
+import { Keuzeveld } from '@/shared/components/Formuliervelden';
+
+const COMPLIANCE_KLEUR: Record<string, string> = {
+  compliant: 'bg-green-100 text-green-800',
+  niet_compliant: 'bg-red-100 text-red-800',
+};
+
+const COMPLIANCE_LABEL: Record<string, string> = {
+  compliant: 'Compliant',
+  niet_compliant: 'Niet-compliant',
+};
+
+/**
+ * Badge-strip bovenaan het leveranciersscherm.
+ *
+ * Vervangt het classificatie-`<fieldset>` dat voorheen onderin Stamgegevens
+ * stond. Compliance-status is hier het meest opvallende badge omdat het de
+ * eerste vraag is die een contractbeheerder stelt — niet weggestopt in een
+ * formulierveld.
+ *
+ * `scrollNaarContracten` (optioneel): wanneer gezet, scrollt een klik op de
+ * compliance-badge naar de Contracten-sectie in plaats van het bewerkveld te
+ * openen. Zie `page.tsx` voor de aanroep — dit is het doorklik-scenario uit
+ * de spec (§6): "waar staat het contract waar dit over gaat?".
+ */
+export function ClassificatieBadges({
+  vendor,
+  onOpgeslagen,
+  onComplianceKlik,
+}: {
+  vendor: VendorDetail;
+  onOpgeslagen: (vendor: VendorDetail) => void;
+  onComplianceKlik?: () => void;
+}) {
+  const [bewerktVeld, setBewerktVeld] = useState<
+    'categoryCode' | 'businessCriticalityCode' | 'complianceStatusCode' | null
+  >(null);
+  const [bezig, setBezig] = useState(false);
+
+  async function wijzig(
+    veld: 'categoryCode' | 'businessCriticalityCode' | 'complianceStatusCode',
+    waarde: string,
+  ) {
+    setBezig(true);
+    const uitkomst = await wijzigVendor(vendor.vendorId, { [veld]: waarde });
+    setBezig(false);
+
+    if (uitkomst.ok) {
+      onOpgeslagen(uitkomst.waarde);
+      setBewerktVeld(null);
+    }
+  }
+
+  if (bewerktVeld) {
+    const configuratie = {
+      categoryCode: {
+        label: 'Categorie',
+        keuzes: keuzesMetHuidige(CATEGORIEEN, vendor.categoryCode),
+        waarde: vendor.categoryCode ?? '',
+      },
+      businessCriticalityCode: {
+        label: 'Bedrijfskritiek',
+        keuzes: keuzesMetHuidige(CRITICALITY, vendor.businessCriticalityCode),
+        waarde: vendor.businessCriticalityCode ?? '',
+      },
+      complianceStatusCode: {
+        label: 'Compliancestatus',
+        keuzes: keuzesMetHuidige(
+          COMPLIANCE_STATUS,
+          vendor.complianceStatusCode,
+        ),
+        waarde: vendor.complianceStatusCode ?? '',
+      },
+    }[bewerktVeld];
+
+    return (
+      <div
+        data-testid="classificatie-bewerk"
+        className="mb-3 flex items-end gap-2 rounded-lg border border-line bg-card px-4 py-2.5"
+      >
+        <div className="w-56">
+          <Keuzeveld
+            id={`badge-${bewerktVeld}`}
+            label={configuratie.label}
+            waarde={configuratie.waarde}
+            keuzes={configuratie.keuzes}
+            onWijzig={(w) => void wijzig(bewerktVeld, w)}
+          />
+        </div>
+        <button
+          type="button"
+          onClick={() => setBewerktVeld(null)}
+          disabled={bezig}
+          data-testid="annuleer-classificatie"
+          className="rounded border border-line px-2.5 py-1.5 text-xs text-ink hover:bg-surface"
+        >
+          Sluiten
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      data-testid="badge-strip"
+      className="mb-3 flex flex-wrap items-center gap-2 rounded-lg border border-line bg-card px-4 py-2.5"
+    >
+      <span className="mr-1 text-[13px] font-semibold text-ink">
+        {vendor.name}
+      </span>
+
+      <button
+        type="button"
+        data-testid="badge-compliance"
+        onClick={() =>
+          onComplianceKlik ? onComplianceKlik() : setBewerktVeld('complianceStatusCode')
+        }
+        className={`rounded-full px-2.5 py-0.5 text-[11px] font-medium ${
+          COMPLIANCE_KLEUR[vendor.complianceStatusCode ?? ''] ??
+          'bg-slate-100 text-slate-700'
+        }`}
+      >
+        {COMPLIANCE_LABEL[vendor.complianceStatusCode ?? ''] ??
+          'Geen compliancestatus'}
+      </button>
+
+      <button
+        type="button"
+        data-testid="badge-kritiek"
+        onClick={() => setBewerktVeld('businessCriticalityCode')}
+        className="rounded-full bg-amber-100 px-2.5 py-0.5 text-[11px] font-medium text-amber-800"
+      >
+        {vendor.businessCriticalityCode
+          ? `Kritiek: ${vendor.businessCriticalityCode}`
+          : 'Kritiek: onbekend'}
+      </button>
+
+      <button
+        type="button"
+        data-testid="badge-categorie"
+        onClick={() => setBewerktVeld('categoryCode')}
+        className="rounded-full bg-indigo-100 px-2.5 py-0.5 text-[11px] font-medium text-indigo-800"
+      >
+        {vendor.categoryCode ?? 'Categorie onbekend'}
+      </button>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/app/beheer/leveranciers/[id]/ClassificatieBadges.tsx
+git commit -m "feat(vendor): badge-strip voor classificatie boven het leveranciersscherm"
+```
+
+---
+
+### Task 3: `ContactpersoonModal` — gedeeld toevoegen/bewerken
+
+**Files:**
+- Create: `src/app/beheer/leveranciers/[id]/ContactpersoonModal.tsx`
+
+Eén modal-component voor zowel aanmaken als bewerken — vervangt het
+altijd-open formulier onderaan `Contactpersonen` (huidige regel 789-843) én
+de inline bewerkvorm in `ContactRij` (huidige regel 549-617). Gestuurd door
+een `contact`-prop: `null` = aanmaken, gevuld = bewerken (vooringevuld,
+bewerken=aanmaken-symmetrie uit §1c).
+
+- [ ] **Step 1: Maak `ContactpersoonModal.tsx`**
+
+```tsx
+'use client';
+
+import { useEffect, useState } from 'react';
+
+import type { Contactpersoon } from '@/core/models/vendor';
+import { voegContactToe, wijzigContact } from '@/core/services/vendorService';
+import { Veld } from '@/shared/components/Formuliervelden';
+
+interface ContactVelden {
+  fullName: string;
+  email: string;
+  jobTitle: string;
+  roleDescription: string;
+}
+
+const LEEG: ContactVelden = {
+  fullName: '',
+  email: '',
+  jobTitle: '',
+  roleDescription: '',
+};
+
+function uitContact(contact: Contactpersoon): ContactVelden {
+  return {
+    fullName: contact.fullName,
+    email: contact.email ?? '',
+    jobTitle: contact.jobTitle ?? '',
+    roleDescription: contact.roleDescription ?? '',
+  };
+}
+
+/**
+ * Modal voor contactpersoon toevoegen of bewerken.
+ *
+ * Overgenomen patroon van MVM_V2 (`VendorContactsPanel.tsx`, `modalOpen` +
+ * `editingId`): één modal in plaats van een altijd-open inline formulier
+ * (het eerder overwogen "fold-out"-idee). `contact === null` is de
+ * aanmaakstand; een gevulde `contact` is de bewerkstand, vooringevuld.
+ */
+export function ContactpersoonModal({
+  open,
+  vendorId,
+  contact,
+  onGesloten,
+  onOpgeslagen,
+}: {
+  open: boolean;
+  vendorId: string;
+  contact: Contactpersoon | null;
+  onGesloten: () => void;
+  onOpgeslagen: () => void | Promise<void>;
+}) {
+  const [waarden, setWaarden] = useState<ContactVelden>(LEEG);
+  const [bezig, setBezig] = useState(false);
+  const [veldFout, setVeldFout] = useState<{
+    veld: string;
+    melding: string;
+  } | null>(null);
+  const [fout, setFout] = useState<string | null>(null);
+
+  // Bij elke keer openen (of wisselen tussen aanmaken/bewerken) opnieuw
+  // vullen — anders toont een tweede bewerkronde de afgebroken invoer van
+  // de vorige.
+  useEffect(() => {
+    if (open) {
+      setWaarden(contact ? uitContact(contact) : LEEG);
+      setVeldFout(null);
+      setFout(null);
+    }
+  }, [open, contact]);
+
+  if (!open) {
+    return null;
+  }
+
+  async function bewaar(gebeurtenis: React.FormEvent) {
+    gebeurtenis.preventDefault();
+    setBezig(true);
+    setVeldFout(null);
+    setFout(null);
+
+    const payload = {
+      fullName: waarden.fullName,
+      email: waarden.email.trim() || null,
+      jobTitle: waarden.jobTitle.trim() || null,
+      roleDescription: waarden.roleDescription.trim() || null,
+    };
+
+    const uitkomst = contact
+      ? await wijzigContact(vendorId, contact.contactId, payload)
+      : await voegContactToe(vendorId, payload);
+
+    setBezig(false);
+
+    if (uitkomst.ok) {
+      await onOpgeslagen();
+      onGesloten();
+      return;
+    }
+
+    if (uitkomst.soort === 'veld') {
+      setVeldFout({ veld: uitkomst.veld, melding: uitkomst.melding });
+    } else {
+      setFout(uitkomst.melding);
+    }
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 px-4"
+      onClick={onGesloten}
+    >
+      <div
+        role="dialog"
+        aria-labelledby="contact-modal-titel"
+        data-testid="contact-modal"
+        className="w-full max-w-md rounded-lg bg-card p-5 shadow-lg"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h2
+          id="contact-modal-titel"
+          className="mb-4 text-sm font-semibold text-brand-dark"
+        >
+          {contact ? 'Contactpersoon bewerken' : 'Contactpersoon toevoegen'}
+        </h2>
+
+        <form onSubmit={bewaar} noValidate>
+          <div className="space-y-3">
+            <Veld
+              id="modal-contactNaam"
+              label="Naam"
+              verplicht
+              waarde={waarden.fullName}
+              onWijzig={(w) => setWaarden((v) => ({ ...v, fullName: w }))}
+              fout={
+                veldFout?.veld === 'contactNaam' ? veldFout.melding : undefined
+              }
+            />
+            <Veld
+              id="modal-contactEmail"
+              label="E-mailadres"
+              type="email"
+              waarde={waarden.email}
+              onWijzig={(w) => setWaarden((v) => ({ ...v, email: w }))}
+              fout={
+                veldFout?.veld === 'contactEmail'
+                  ? veldFout.melding
+                  : undefined
+              }
+            />
+            <Veld
+              id="modal-contactFunctie"
+              label="Functie"
+              waarde={waarden.jobTitle}
+              onWijzig={(w) => setWaarden((v) => ({ ...v, jobTitle: w }))}
+            />
+            <Veld
+              id="modal-contactNotitie"
+              label="Notitie"
+              waarde={waarden.roleDescription}
+              onWijzig={(w) =>
+                setWaarden((v) => ({ ...v, roleDescription: w }))
+              }
+            />
+          </div>
+
+          {fout && (
+            <p
+              role="alert"
+              data-testid="contact-modal-fout"
+              className="mt-3 rounded border border-red-300 bg-red-50 px-3 py-2 text-xs text-red-800"
+            >
+              {fout}
+            </p>
+          )}
+
+          <div className="mt-4 flex items-center gap-2">
+            <button
+              type="submit"
+              disabled={bezig}
+              data-testid="contact-modal-opslaan"
+              className="rounded bg-brand-primary px-4 py-1.5 text-xs font-medium text-white transition hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              {bezig ? 'Bezig…' : contact ? 'Opslaan' : 'Toevoegen'}
+            </button>
+            <button
+              type="button"
+              onClick={onGesloten}
+              data-testid="contact-modal-annuleer"
+              className="rounded border border-line px-4 py-1.5 text-xs text-ink transition hover:bg-surface"
+            >
+              Annuleren
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/app/beheer/leveranciers/[id]/ContactpersoonModal.tsx
+git commit -m "feat(vendor): ContactpersoonModal — gedeelde modal voor toevoegen en bewerken"
+```
+
+---
+
+### Task 4: `Contactpersonen.tsx` — compacte lijst + modal-trigger
+
+**Files:**
+- Create: `src/app/beheer/leveranciers/[id]/Contactpersonen.tsx`
+
+Vervangt het huidige `Contactpersonen`-component (regel 675-846) en
+`ContactRij` (regel 474-673). Geen inline bewerkstand meer in de rij — een
+klik op "bewerken" opent nu de modal uit Task 3.
+
+- [ ] **Step 1: Maak `Contactpersonen.tsx`**
+
+```tsx
+'use client';
+
+import { Pencil, Star, Trash2 } from 'lucide-react';
+import { useState } from 'react';
+
+import type { Contactpersoon, VendorDetail } from '@/core/models/vendor';
+import { verwijderContact, wijzigContact } from '@/core/services/vendorService';
+
+import { ContactpersoonModal } from './ContactpersoonModal';
+
+/**
+ * Compacte contactenlijst voor de linkerkolom.
+ *
+ * Toevoegen en bewerken gaan allebei via `ContactpersoonModal` — geen
+ * inline formulier meer, zie de spec §4 (modal i.p.v. fold-out, patroon
+ * overgenomen van MVM_V2).
+ */
+export function Contactpersonen({
+  vendor,
+  onGewijzigd,
+}: {
+  vendor: VendorDetail;
+  onGewijzigd: () => void | Promise<void>;
+}) {
+  const [modalOpen, setModalOpen] = useState(false);
+  const [bewerktContact, setBewerktContact] = useState<Contactpersoon | null>(
+    null,
+  );
+  const [fout, setFout] = useState<string | null>(null);
+
+  function openToevoegen() {
+    setBewerktContact(null);
+    setModalOpen(true);
+  }
+
+  function openBewerken(contact: Contactpersoon) {
+    setBewerktContact(contact);
+    setModalOpen(true);
+  }
+
+  async function maakPrimair(contact: Contactpersoon) {
+    setFout(null);
+    const uitkomst = await wijzigContact(vendor.vendorId, contact.contactId, {
+      isPrimary: true,
+    });
+
+    if (uitkomst.ok) {
+      await onGewijzigd();
+    } else {
+      setFout(uitkomst.melding);
+    }
+  }
+
+  async function verwijderDeze(contact: Contactpersoon) {
+    setFout(null);
+    const uitkomst = await verwijderContact(vendor.vendorId, contact.contactId);
+
+    if (uitkomst.ok) {
+      await onGewijzigd();
+    } else {
+      setFout(uitkomst.melding);
+    }
+  }
+
+  return (
+    <section
+      aria-labelledby="contacten-kop"
+      className="rounded-lg border border-line bg-card p-4"
+    >
+      <div className="mb-2 flex items-center justify-between">
+        <h2
+          id="contacten-kop"
+          className="text-sm font-semibold text-brand-dark"
+        >
+          Contactpersonen{' '}
+          <span
+            data-testid="aantal-contacten"
+            className="text-xs font-normal text-ink-muted"
+          >
+            ({vendor.contacten.length})
+          </span>
+        </h2>
+        <button
+          type="button"
+          onClick={openToevoegen}
+          data-testid="open-contact-modal"
+          className="text-xs font-medium text-brand-primary hover:underline"
+        >
+          + toevoegen
+        </button>
+      </div>
+
+      {vendor.contacten.length === 0 ? (
+        <p className="rounded border border-amber-300 bg-amber-50 px-3 py-2 text-xs text-amber-800">
+          Er is nog geen contactpersoon. Zonder e-mailadres kan er geen
+          vragenlijst verstuurd worden.
+        </p>
+      ) : (
+        <ul className="divide-y divide-line">
+          {vendor.contacten.map((contact) => (
+            <li
+              key={contact.contactId}
+              data-testid="contact-rij"
+              className="flex items-start justify-between gap-2 py-2 text-[12px]"
+            >
+              <div className="min-w-0">
+                <p className="flex items-center gap-1 font-medium text-ink">
+                  {contact.isPrimary && (
+                    <Star
+                      size={11}
+                      className="flex-shrink-0 fill-brand-primary text-brand-primary"
+                      aria-label="Primaire contactpersoon"
+                    />
+                  )}
+                  {contact.fullName}
+                </p>
+                <p className="text-[11px] text-ink-muted">
+                  {[contact.jobTitle, contact.email]
+                    .filter(Boolean)
+                    .join(' · ') || 'geen e-mailadres'}
+                </p>
+              </div>
+
+              <div className="flex flex-shrink-0 items-center gap-1">
+                {!contact.isPrimary && (
+                  <button
+                    type="button"
+                    onClick={() => void maakPrimair(contact)}
+                    data-testid="maak-primair"
+                    className="rounded border border-line px-1.5 py-0.5 text-[10px] text-ink transition hover:bg-surface"
+                  >
+                    primair
+                  </button>
+                )}
+                <button
+                  type="button"
+                  onClick={() => openBewerken(contact)}
+                  aria-label={`${contact.fullName} bewerken`}
+                  data-testid="bewerk-contact"
+                  className="rounded border border-line p-1 text-ink transition hover:bg-surface"
+                >
+                  <Pencil size={11} />
+                </button>
+                <button
+                  type="button"
+                  onClick={() => void verwijderDeze(contact)}
+                  aria-label={`${contact.fullName} verwijderen`}
+                  data-testid="verwijder-contact"
+                  className="rounded border border-line p-1 text-red-700 transition hover:bg-red-50"
+                >
+                  <Trash2 size={11} />
+                </button>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {fout && (
+        <p
+          role="alert"
+          data-testid="contact-fout"
+          className="mt-2 rounded border border-red-300 bg-red-50 px-3 py-2 text-xs text-red-800"
+        >
+          {fout}
+        </p>
+      )}
+
+      <ContactpersoonModal
+        open={modalOpen}
+        vendorId={vendor.vendorId}
+        contact={bewerktContact}
+        onGesloten={() => setModalOpen(false)}
+        onOpgeslagen={onGewijzigd}
+      />
+    </section>
+  );
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/app/beheer/leveranciers/[id]/Contactpersonen.tsx
+git commit -m "refactor(vendor): Contactpersonen compact, toevoegen/bewerken via modal"
+```
+
+---
+
+### Task 5: Urgentiekleur op de einddatum
+
+**Files:**
+- Create: `src/app/beheer/leveranciers/[id]/contractUrgentie.ts`
+
+Losse, kleine module met de drempellogica — apart testbaar, en herbruikbaar
+zodra issue #174 de opzegtermijn-correctie toevoegt (dan wordt dit bestand
+uitgebreid, niet vervangen).
+
+- [ ] **Step 1: Maak `contractUrgentie.ts`**
+
+```ts
+/**
+ * Urgentiekleur op een contract-einddatum.
+ *
+ * Tussenoplossing zonder opzegtermijn-correctie — zie issue #174. Zodra dat
+ * veld bestaat, wordt hier de "verlengt automatisch"-waarschuwing
+ * toegevoegd; deze functie blijft dan de kale-datum-drempel als fallback
+ * voor contracten zonder ingevulde opzegtermijn.
+ */
+
+export const URGENTIE_DREMPEL_WAARSCHUWING_DAGEN = 90;
+export const URGENTIE_DREMPEL_ALARM_DAGEN = 30;
+
+export type ContractUrgentie = 'neutraal' | 'waarschuwing' | 'alarm';
+
+/** Dagen tot (positief) of sinds (negatief) de einddatum. Null zonder datum. */
+export function dagenTotEinde(endDate: string | null): number | null {
+  if (!endDate) return null;
+  const verschil =
+    new Date(endDate).getTime() - new Date().setHours(0, 0, 0, 0);
+  return Math.round(verschil / (1000 * 60 * 60 * 24));
+}
+
+export function contractUrgentie(endDate: string | null): ContractUrgentie {
+  const dagen = dagenTotEinde(endDate);
+  if (dagen === null) return 'neutraal';
+  if (dagen <= URGENTIE_DREMPEL_ALARM_DAGEN) return 'alarm';
+  if (dagen <= URGENTIE_DREMPEL_WAARSCHUWING_DAGEN) return 'waarschuwing';
+  return 'neutraal';
+}
+
+export const URGENTIE_TEKSTKLEUR: Record<ContractUrgentie, string> = {
+  neutraal: 'text-ink-muted',
+  waarschuwing: 'text-amber-700',
+  alarm: 'text-red-700',
+};
+```
+
+- [ ] **Step 2: Schrijf een test voor de drempellogica**
+
+Create: `src/app/beheer/leveranciers/[id]/contractUrgentie.spec.ts`
+
+```ts
+import { contractUrgentie, dagenTotEinde } from './contractUrgentie';
+
+describe('contractUrgentie', () => {
+  const vandaag = new Date();
+
+  function datumOver(dagen: number): string {
+    const d = new Date(vandaag);
+    d.setDate(d.getDate() + dagen);
+    return d.toISOString().slice(0, 10);
+  }
+
+  it('geeft neutraal zonder einddatum', () => {
+    expect(contractUrgentie(null)).toBe('neutraal');
+  });
+
+  it('geeft neutraal ver in de toekomst', () => {
+    expect(contractUrgentie(datumOver(120))).toBe('neutraal');
+  });
+
+  it('geeft waarschuwing binnen 90 dagen', () => {
+    expect(contractUrgentie(datumOver(45))).toBe('waarschuwing');
+  });
+
+  it('geeft alarm binnen 30 dagen', () => {
+    expect(contractUrgentie(datumOver(10))).toBe('alarm');
+  });
+
+  it('geeft alarm als de datum al verstreken is', () => {
+    expect(contractUrgentie(datumOver(-5))).toBe('alarm');
+  });
+
+  it('dagenTotEinde is negatief voor een verstreken datum', () => {
+    expect(dagenTotEinde(datumOver(-5))).toBeLessThan(0);
+  });
+});
+```
+
+- [ ] **Step 3: Draai de test, verwacht PASS**
+
+Run: `npx jest contractUrgentie --config jest.config.js` (of het bestaande
+testcommando uit `package.json` voor unittests — controleer eerst met
+`(Get-Content package.json | ConvertFrom-Json).scripts` welk commando de
+frontend-repo hiervoor heeft)
+
+Expected: 6 passed
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/app/beheer/leveranciers/[id]/contractUrgentie.ts src/app/beheer/leveranciers/[id]/contractUrgentie.spec.ts
+git commit -m "feat(contract): urgentiedrempels voor de einddatum, met tests"
+```
+
+---
+
+### Task 6: `Contracten.tsx` — uitklapbare rij, wachtlijst-label, urgentiekleur
+
+**Files:**
+- Create: `src/app/beheer/leveranciers/[id]/Contracten.tsx`
+
+Vervangt `Contracten`, `ContractRij`, `ContractFormuliervelden`,
+`NieuwContractFormulier`, `SurveyTemplateKoppelingBlok`,
+`EindeIndicator` (huidige regel 848-1855). De rij zelf is nu de trigger om
+uit te klappen (geen edit-knop meer nodig om details te *zien* — wel blijft
+er een expliciete edit-actie voor het *bewerken*, binnen de uitgeklapte
+rij). Wachtlijst-status krijgt een tekstlabel i.p.v. een stille checkbox.
+
+- [ ] **Step 1: Maak `Contracten.tsx`**
+
+```tsx
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+
+import type { Contract, ContractInvoer } from '@/core/models/contract';
+import type { Contactpersoon } from '@/core/models/vendor';
+import {
+  haalContracten,
+  haalGekoppeldeTemplates,
+  haalSurveyTemplates,
+  haalTenantGebruikers,
+  maakContractAan,
+  verwijderContract,
+  wijzigContract,
+  zetGekoppeldeTemplates,
+} from '@/core/services/contractService';
+import { voegContactToe } from '@/core/services/vendorService';
+import { Keuzeveld, Veld } from '@/shared/components/Formuliervelden';
+import Link from 'next/link';
+
+import {
+  contractUrgentie,
+  dagenTotEinde,
+  URGENTIE_TEKSTKLEUR,
+} from './contractUrgentie';
+
+const CONTRACT_STATUS_LABEL: Record<string, string> = {
+  actief: 'Actief',
+  verlopen: 'Verlopen',
+  opgezegd: 'Opgezegd',
+};
+
+const CONTRACT_STATUS_KLEUR: Record<string, string> = {
+  actief: 'bg-green-100 text-green-800',
+  verlopen: 'bg-red-100 text-red-800',
+  opgezegd: 'bg-slate-100 text-slate-700',
+};
+
+function EindeIndicator({ endDate }: { endDate: string | null }) {
+  const dagen = dagenTotEinde(endDate);
+  if (dagen === null) return null;
+
+  const urgentie = contractUrgentie(endDate);
+  const tekst =
+    dagen < 0 ? `${Math.abs(dagen)}d verlopen` : `nog ${dagen}d`;
+
+  if (urgentie === 'neutraal') return null;
+
+  return (
+    <span className={`block text-[10px] ${URGENTIE_TEKSTKLEUR[urgentie]}`}>
+      {tekst}
+    </span>
+  );
+}
+
+function uitContract(contract: Contract): ContractInvoer {
+  return {
+    name: contract.name,
+    contractNumber: contract.contractNumber ?? '',
+    vendorContactId: contract.vendorContactId ?? '',
+    ownerUserId: contract.ownerUserId ?? '',
+    statusCode: contract.statusCode ?? '',
+    valueEur: contract.valueEur ?? '',
+    startDate: contract.startDate ?? '',
+    endDate: contract.endDate ?? '',
+    note: contract.note ?? '',
+  };
+}
+
+/**
+ * Contracten-sectie voor de rechterkolom.
+ *
+ * De rij is zelf de trigger om uit te klappen (§5 van de spec) — geen
+ * aparte edit-knop meer om details te *bekijken*. Binnen de uitgeklapte rij
+ * staat wel een expliciete "bewerken"-stand voor het wijzigen van velden.
+ */
+export function Contracten({
+  vendorId,
+  contactenVanVendor,
+  onContactpersoonAangemaakt,
+  scrollHaakId = 'contracten-sectie',
+}: {
+  vendorId: string;
+  contactenVanVendor: Contactpersoon[];
+  onContactpersoonAangemaakt: () => void | Promise<void>;
+  scrollHaakId?: string;
+}) {
+  const [contracten, setContracten] = useState<Contract[]>([]);
+  const [laden, setLaden] = useState(true);
+  const [gebruikers, setGebruikers] = useState<
+    { userId: string; naam: string }[]
+  >([]);
+  const [opengeklapt, setOpengeklapt] = useState<string | null>(null);
+
+  const laad = useCallback(async () => {
+    setLaden(true);
+    try {
+      const [c, g] = await Promise.all([
+        haalContracten(vendorId),
+        haalTenantGebruikers(),
+      ]);
+      setContracten(c);
+      setGebruikers(g);
+    } finally {
+      setLaden(false);
+    }
+  }, [vendorId]);
+
+  useEffect(() => {
+    void laad();
+  }, [laad]);
+
+  return (
+    <section
+      id={scrollHaakId}
+      aria-labelledby="contracten-kop"
+      className="overflow-hidden rounded-lg border border-line bg-card"
+    >
+      <div className="flex items-center justify-between border-b border-line px-4 py-3">
+        <h2
+          id="contracten-kop"
+          className="text-sm font-semibold text-brand-dark"
+        >
+          Contracten{' '}
+          <span
+            data-testid="aantal-contracten"
+            className="text-xs font-normal text-ink-muted"
+          >
+            ({contracten.length})
+          </span>
+        </h2>
+      </div>
+
+      {laden && (
+        <p className="px-4 py-4 text-xs text-ink-muted">Bezig met laden…</p>
+      )}
+
+      {!laden && contracten.length === 0 && (
+        <p className="px-4 py-4 text-xs text-ink-muted">
+          Er is nog geen contract bij deze leverancier.
+        </p>
+      )}
+
+      {!laden && contracten.length > 0 && (
+        <table className="w-full text-[12px]">
+          <thead>
+            <tr className="border-b border-line text-left text-[10px] uppercase tracking-wide text-ink-muted">
+              <th className="px-4 py-2 font-medium">Contract</th>
+              <th className="px-4 py-2 font-medium">Status</th>
+              <th className="px-4 py-2 font-medium">Einddatum</th>
+              <th className="px-4 py-2 font-medium">Beheerder</th>
+            </tr>
+          </thead>
+          <tbody>
+            {contracten.map((contract) => (
+              <ContractRijen
+                key={contract.contractId}
+                contract={contract}
+                vendorId={vendorId}
+                contactenVanVendor={contactenVanVendor}
+                gebruikers={gebruikers}
+                opengeklapt={opengeklapt === contract.contractId}
+                onKlik={() =>
+                  setOpengeklapt((v) =>
+                    v === contract.contractId ? null : contract.contractId,
+                  )
+                }
+                onGewijzigd={laad}
+                onContactpersoonAangemaakt={onContactpersoonAangemaakt}
+              />
+            ))}
+          </tbody>
+        </table>
+      )}
+
+      <div className="border-t border-line px-4 py-3">
+        <NieuwContractFormulier
+          vendorId={vendorId}
+          contactenVanVendor={contactenVanVendor}
+          gebruikers={gebruikers}
+          onAangemaakt={laad}
+          onContactpersoonAangemaakt={onContactpersoonAangemaakt}
+        />
+      </div>
+    </section>
+  );
+}
+
+function ContractRijen({
+  contract,
+  vendorId,
+  contactenVanVendor,
+  gebruikers,
+  opengeklapt,
+  onKlik,
+  onGewijzigd,
+  onContactpersoonAangemaakt,
+}: {
+  contract: Contract;
+  vendorId: string;
+  contactenVanVendor: Contactpersoon[];
+  gebruikers: { userId: string; naam: string }[];
+  opengeklapt: boolean;
+  onKlik: () => void;
+  onGewijzigd: () => void | Promise<void>;
+  onContactpersoonAangemaakt: () => void | Promise<void>;
+}) {
+  const [bewerkt, setBewerkt] = useState(false);
+  const [bezig, setBezig] = useState(false);
+  const [fout, setFout] = useState<string | null>(null);
+  const [veldFout, setVeldFout] = useState<{
+    veld: string;
+    melding: string;
+  } | null>(null);
+  const [bevestigVerwijderen, setBevestigVerwijderen] = useState(false);
+  const [waarden, setWaarden] = useState<ContractInvoer>(() =>
+    uitContract(contract),
+  );
+
+  function beginBewerken() {
+    setWaarden(uitContract(contract));
+    setFout(null);
+    setVeldFout(null);
+    setBewerkt(true);
+  }
+
+  async function bewaar(gebeurtenis: React.FormEvent) {
+    gebeurtenis.preventDefault();
+    setBezig(true);
+    setFout(null);
+    setVeldFout(null);
+
+    const uitkomst = await wijzigContract(vendorId, contract.contractId, waarden);
+    setBezig(false);
+
+    if (uitkomst.ok) {
+      setBewerkt(false);
+      await onGewijzigd();
+      return;
+    }
+
+    if (uitkomst.soort === 'veld') {
+      setVeldFout({ veld: uitkomst.veld, melding: uitkomst.melding });
+    } else {
+      setFout(uitkomst.melding);
+    }
+  }
+
+  async function verwijderDeze() {
+    setBezig(true);
+    const uitkomst = await verwijderContract(vendorId, contract.contractId);
+    setBezig(false);
+
+    if (uitkomst.ok) {
+      await onGewijzigd();
+      return;
+    }
+    setBevestigVerwijderen(false);
+    setFout(uitkomst.melding);
+  }
+
+  return (
+    <>
+      <tr
+        data-testid="contract-rij"
+        onClick={onKlik}
+        className="cursor-pointer border-b border-line last:border-0 hover:bg-surface"
+      >
+        <td className="px-4 py-2 font-medium text-ink">
+          {opengeklapt ? '▼' : '▶'} {contract.name}
+        </td>
+        <td className="px-4 py-2">
+          {contract.statusCode && (
+            <span
+              data-testid="contract-status"
+              className={`rounded-full px-2 py-0.5 text-[10px] font-medium ${
+                CONTRACT_STATUS_KLEUR[contract.statusCode] ??
+                'bg-slate-100 text-slate-700'
+              }`}
+            >
+              {CONTRACT_STATUS_LABEL[contract.statusCode] ?? contract.statusCode}
+            </span>
+          )}
+        </td>
+        <td className="px-4 py-2">
+          <span
+            className={URGENTIE_TEKSTKLEUR[contractUrgentie(contract.endDate)]}
+          >
+            {contract.endDate ?? '—'}
+          </span>
+          <EindeIndicator endDate={contract.endDate} />
+        </td>
+        <td className="px-4 py-2 text-ink-muted">
+          {contract.ownerGebruikerNaam ?? '—'}
+        </td>
+      </tr>
+
+      {opengeklapt && (
+        <tr data-testid="contract-detail">
+          <td colSpan={4} className="bg-surface px-4 py-4">
+            {!bewerkt ? (
+              <div className="text-[12px]">
+                <div className="mb-3 grid grid-cols-3 gap-3">
+                  <div>
+                    <span className="text-ink-muted">Contractnummer</span>
+                    <br />
+                    {contract.contractNumber ?? '—'}
+                  </div>
+                  <div>
+                    <span className="text-ink-muted">Begindatum</span>
+                    <br />
+                    {contract.startDate ?? '—'}
+                  </div>
+                  <div>
+                    <span className="text-ink-muted">Contactpersoon</span>
+                    <br />
+                    {contract.vendorContactNaam ?? '—'}
+                  </div>
+                  <div>
+                    <span className="text-ink-muted">Waarde (EUR)</span>
+                    <br />
+                    {contract.valueEur ?? '—'}
+                  </div>
+                  <div className="col-span-2">
+                    <span className="text-ink-muted">Notitie</span>
+                    <br />
+                    {contract.note ?? '—'}
+                  </div>
+                </div>
+
+                <div className="flex items-center gap-2">
+                  <button
+                    type="button"
+                    onClick={beginBewerken}
+                    data-testid="bewerk-contract"
+                    className="rounded border border-line px-2.5 py-1 text-xs text-ink hover:bg-surface"
+                  >
+                    Bewerken
+                  </button>
+                  {bevestigVerwijderen ? (
+                    <>
+                      <span className="text-xs text-ink-muted">Zeker?</span>
+                      <button
+                        type="button"
+                        onClick={() => void verwijderDeze()}
+                        disabled={bezig}
+                        data-testid="verwijder-contract-bevestig"
+                        className="rounded bg-red-600 px-2 py-1 text-xs font-medium text-white hover:brightness-95"
+                      >
+                        Ja
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => setBevestigVerwijderen(false)}
+                        className="rounded border border-line px-2 py-1 text-xs text-ink hover:bg-surface"
+                      >
+                        Nee
+                      </button>
+                    </>
+                  ) : (
+                    <button
+                      type="button"
+                      onClick={() => setBevestigVerwijderen(true)}
+                      data-testid="verwijder-contract"
+                      className="rounded border border-line px-2.5 py-1 text-xs text-red-700 hover:bg-red-50"
+                    >
+                      Verwijderen
+                    </button>
+                  )}
+                </div>
+              </div>
+            ) : (
+              <form onSubmit={bewaar} noValidate>
+                <ContractFormuliervelden
+                  waarden={waarden}
+                  onWijzig={setWaarden}
+                  contactenVanVendor={contactenVanVendor}
+                  gebruikers={gebruikers}
+                  veldFout={veldFout}
+                  idPrefix={`bewerk-${contract.contractId}`}
+                />
+
+                {fout && (
+                  <p
+                    role="alert"
+                    data-testid="bewerk-contract-fout"
+                    className="mt-3 rounded border border-red-300 bg-red-50 px-3 py-2 text-xs text-red-800"
+                  >
+                    {fout}
+                  </p>
+                )}
+
+                <div className="mt-3 flex items-center gap-2">
+                  <button
+                    type="submit"
+                    disabled={bezig}
+                    data-testid="bewaar-contract"
+                    className="rounded bg-brand-primary px-3 py-1.5 text-xs font-medium text-white hover:opacity-90 disabled:opacity-60"
+                  >
+                    {bezig ? 'Bezig…' : 'Opslaan'}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => setBewerkt(false)}
+                    data-testid="annuleer-contract"
+                    className="rounded border border-line px-3 py-1.5 text-xs text-ink hover:bg-surface"
+                  >
+                    Annuleren
+                  </button>
+                </div>
+              </form>
+            )}
+
+            <SurveyTemplateKoppelingBlok
+              vendorId={vendorId}
+              contractId={contract.contractId}
+            />
+          </td>
+        </tr>
+      )}
+    </>
+  );
+}
+
+function ContractFormuliervelden({
+  waarden,
+  onWijzig,
+  contactenVanVendor,
+  gebruikers,
+  veldFout,
+  idPrefix,
+}: {
+  waarden: ContractInvoer;
+  onWijzig: (w: ContractInvoer) => void;
+  contactenVanVendor: Contactpersoon[];
+  gebruikers: { userId: string; naam: string }[];
+  veldFout: { veld: string; melding: string } | null;
+  idPrefix: string;
+}) {
+  function veld<K extends keyof ContractInvoer>(sleutel: K, waarde: string) {
+    onWijzig({ ...waarden, [sleutel]: waarde });
+  }
+
+  function foutVoor(naam: string): string | undefined {
+    return veldFout?.veld === naam ? veldFout.melding : undefined;
+  }
+
+  return (
+    <div className="grid gap-3 sm:grid-cols-3">
+      <Veld
+        id={`${idPrefix}-name`}
+        label="Naam"
+        verplicht
+        waarde={waarden.name ?? ''}
+        onWijzig={(w) => veld('name', w)}
+        fout={foutVoor('Naam')}
+      />
+      <Veld
+        id={`${idPrefix}-contractNumber`}
+        label="Contractnummer"
+        waarde={waarden.contractNumber ?? ''}
+        onWijzig={(w) => veld('contractNumber', w)}
+        fout={foutVoor('Contractnummer')}
+      />
+      <Keuzeveld
+        id={`${idPrefix}-statusCode`}
+        label="Status"
+        waarde={waarden.statusCode ?? ''}
+        keuzes={[
+          { code: 'actief', label: 'Actief' },
+          { code: 'verlopen', label: 'Verlopen' },
+          { code: 'opgezegd', label: 'Opgezegd' },
+        ]}
+        onWijzig={(w) => veld('statusCode', w)}
+      />
+      <Veld
+        id={`${idPrefix}-startDate`}
+        label="Begindatum"
+        type="date"
+        waarde={waarden.startDate ?? ''}
+        onWijzig={(w) => veld('startDate', w)}
+        fout={foutVoor('Begindatum')}
+      />
+      <Veld
+        id={`${idPrefix}-endDate`}
+        label="Einddatum"
+        type="date"
+        waarde={waarden.endDate ?? ''}
+        onWijzig={(w) => veld('endDate', w)}
+        fout={foutVoor('Einddatum')}
+      />
+      <Veld
+        id={`${idPrefix}-valueEur`}
+        label="Waarde (EUR)"
+        waarde={waarden.valueEur ?? ''}
+        onWijzig={(w) => veld('valueEur', w)}
+        fout={foutVoor('Waarde')}
+      />
+      <Keuzeveld
+        id={`${idPrefix}-vendorContactId`}
+        label="Contactpersoon"
+        waarde={waarden.vendorContactId ?? ''}
+        keuzes={contactenVanVendor.map((c) => ({
+          code: c.contactId,
+          label: c.fullName,
+        }))}
+        onWijzig={(w) => veld('vendorContactId', w)}
+      />
+      <Keuzeveld
+        id={`${idPrefix}-ownerUserId`}
+        label="Contractbeheerder"
+        waarde={waarden.ownerUserId ?? ''}
+        keuzes={gebruikers.map((g) => ({ code: g.userId, label: g.naam }))}
+        onWijzig={(w) => veld('ownerUserId', w)}
+      />
+      <div className="sm:col-span-3">
+        <label
+          htmlFor={`${idPrefix}-note`}
+          className="mb-1 block text-xs font-medium text-ink"
+        >
+          Notitie
+        </label>
+        <textarea
+          id={`${idPrefix}-note`}
+          value={waarden.note ?? ''}
+          onChange={(e) => veld('note', e.target.value)}
+          rows={2}
+          className="w-full rounded border border-line px-3 py-2 text-xs outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-brand-primary"
+        />
+      </div>
+    </div>
+  );
+}
+
+function NieuwContractFormulier({
+  vendorId,
+  contactenVanVendor,
+  gebruikers,
+  onAangemaakt,
+  onContactpersoonAangemaakt,
+}: {
+  vendorId: string;
+  contactenVanVendor: Contactpersoon[];
+  gebruikers: { userId: string; naam: string }[];
+  onAangemaakt: () => void | Promise<void>;
+  onContactpersoonAangemaakt: () => void | Promise<void>;
+}) {
+  const [open, setOpen] = useState(false);
+  const [waarden, setWaarden] = useState<ContractInvoer>({});
+  const [bezig, setBezig] = useState(false);
+  const [fout, setFout] = useState<string | null>(null);
+  const [veldFout, setVeldFout] = useState<{
+    veld: string;
+    melding: string;
+  } | null>(null);
+
+  async function maak(gebeurtenis: React.FormEvent) {
+    gebeurtenis.preventDefault();
+    setBezig(true);
+    setFout(null);
+    setVeldFout(null);
+
+    const uitkomst = await maakContractAan(vendorId, waarden);
+    setBezig(false);
+
+    if (uitkomst.ok) {
+      setWaarden({});
+      setOpen(false);
+      await onAangemaakt();
+      return;
+    }
+
+    if (uitkomst.soort === 'veld') {
+      setVeldFout({ veld: uitkomst.veld, melding: uitkomst.melding });
+    } else {
+      setFout(uitkomst.melding);
+    }
+  }
+
+  if (!open) {
+    return (
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        data-testid="open-nieuw-contract"
+        className="text-xs font-medium text-brand-primary hover:underline"
+      >
+        + nieuw contract
+      </button>
+    );
+  }
+
+  return (
+    <form onSubmit={maak} noValidate>
+      <p className="mb-2 text-xs font-medium text-ink">Nieuw contract</p>
+      <ContractFormuliervelden
+        waarden={waarden}
+        onWijzig={setWaarden}
+        contactenVanVendor={contactenVanVendor}
+        gebruikers={gebruikers}
+        veldFout={veldFout}
+        idPrefix="nieuw-contract"
+      />
+
+      {fout && (
+        <p
+          role="alert"
+          data-testid="nieuw-contract-fout"
+          className="mt-3 rounded border border-red-300 bg-red-50 px-3 py-2 text-xs text-red-800"
+        >
+          {fout}
+        </p>
+      )}
+
+      <div className="mt-3 flex items-center gap-2">
+        <button
+          type="submit"
+          disabled={bezig}
+          data-testid="voeg-contract-toe"
+          className="rounded border border-brand-primary px-3 py-1.5 text-xs font-medium text-brand-primary hover:bg-brand-primary hover:text-white disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          {bezig ? 'Bezig…' : 'Toevoegen'}
+        </button>
+        <button
+          type="button"
+          onClick={() => setOpen(false)}
+          data-testid="annuleer-nieuw-contract"
+          className="rounded border border-line px-3 py-1.5 text-xs text-ink hover:bg-surface"
+        >
+          Annuleren
+        </button>
+      </div>
+    </form>
+  );
+}
+
+function SurveyTemplateKoppelingBlok({
+  vendorId,
+  contractId,
+}: {
+  vendorId: string;
+  contractId: string;
+}) {
+  const [templates, setTemplates] = useState<
+    { templateId: string; naam: string }[]
+  >([]);
+  const [gekoppeld, setGekoppeld] = useState<Set<string>>(new Set());
+  const [wachtlijst, setWachtlijst] = useState<Set<string>>(new Set());
+  const [laden, setLaden] = useState(true);
+  const [bezig, setBezig] = useState(false);
+  const [fout, setFout] = useState<string | null>(null);
+  const [gelukt, setGelukt] = useState(false);
+
+  useEffect(() => {
+    let actief = true;
+
+    void (async () => {
+      setLaden(true);
+      const [alle, koppeling] = await Promise.all([
+        haalSurveyTemplates(),
+        haalGekoppeldeTemplates(vendorId, contractId),
+      ]);
+      if (!actief) return;
+      setTemplates(alle);
+      setGekoppeld(new Set(koppeling.templateIds));
+      setWachtlijst(new Set(koppeling.wachtlijstTemplateIds));
+      setLaden(false);
+    })();
+
+    return () => {
+      actief = false;
+    };
+  }, [vendorId, contractId]);
+
+  function schakel(templateId: string) {
+    setGelukt(false);
+    setGekoppeld((vorig) => {
+      const nieuw = new Set(vorig);
+      if (nieuw.has(templateId)) {
+        nieuw.delete(templateId);
+        setWachtlijst((w) => {
+          const nw = new Set(w);
+          nw.delete(templateId);
+          return nw;
+        });
+      } else {
+        nieuw.add(templateId);
+      }
+      return nieuw;
+    });
+  }
+
+  function schakelWachtlijst(templateId: string) {
+    setGelukt(false);
+    setWachtlijst((vorig) => {
+      const nieuw = new Set(vorig);
+      if (nieuw.has(templateId)) {
+        nieuw.delete(templateId);
+      } else {
+        nieuw.add(templateId);
+      }
+      return nieuw;
+    });
+  }
+
+  async function koppelen() {
+    setBezig(true);
+    setFout(null);
+    setGelukt(false);
+
+    const uitkomst = await zetGekoppeldeTemplates(vendorId, contractId, {
+      templateIds: [...gekoppeld],
+      wachtlijstTemplateIds: [...wachtlijst],
+    });
+
+    setBezig(false);
+
+    if (uitkomst.ok) {
+      setGelukt(true);
+      return;
+    }
+    setFout(uitkomst.melding);
+  }
+
+  return (
+    <div className="mt-4 border-t border-line pt-3">
+      <p className="mb-2 text-xs font-medium text-ink">
+        Van toepassing zijnde vragenlijst(en)
+      </p>
+
+      {laden && <p className="text-xs text-ink-muted">Bezig met laden…</p>}
+
+      {!laden && templates.length === 0 && (
+        <p className="text-xs text-ink-muted">
+          Er zijn nog geen vragenlijsten aangemaakt.
+        </p>
+      )}
+
+      {!laden && templates.length > 0 && (
+        <div className="mb-3 flex flex-col gap-1.5">
+          {templates.map((t) => {
+            const isGekoppeld = gekoppeld.has(t.templateId);
+            const opWachtlijst = wachtlijst.has(t.templateId);
+
+            return (
+              <div key={t.templateId} className="flex items-center gap-3">
+                <label className="flex items-center gap-2 text-xs text-ink">
+                  <input
+                    type="checkbox"
+                    data-testid="survey-template-checkbox"
+                    checked={isGekoppeld}
+                    onChange={() => schakel(t.templateId)}
+                  />
+                  {t.naam}
+                </label>
+
+                {isGekoppeld && (
+                  <button
+                    type="button"
+                    onClick={() => schakelWachtlijst(t.templateId)}
+                    data-testid="wachtlijst-label"
+                    className={`rounded-full px-2 py-0.5 text-[10px] font-medium ${
+                      opWachtlijst
+                        ? 'bg-amber-100 text-amber-800'
+                        : 'bg-slate-100 text-slate-600'
+                    }`}
+                  >
+                    wachtlijst {opWachtlijst ? 'AAN' : 'UIT'}
+                  </button>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      {!laden &&
+        [...gekoppeld].map((templateId) => {
+          const template = templates.find((t) => t.templateId === templateId);
+          if (!template) return null;
+
+          return (
+            <Link
+              key={templateId}
+              href={`/beheer/vragenlijsten/uitnodigen?leveranciers=${vendorId}&contractId=${contractId}&templateId=${templateId}`}
+              data-testid="uitnodigen-vanuit-contract-knop"
+              className="mb-2 inline-flex items-center gap-1.5 text-xs font-medium text-brand-primary hover:underline"
+            >
+              → {template.naam} nu uitnodigen
+            </Link>
+          );
+        })}
+
+      {fout && (
+        <p
+          role="alert"
+          data-testid="survey-koppeling-fout"
+          className="mb-3 rounded border border-red-300 bg-red-50 px-3 py-2 text-xs text-red-800"
+        >
+          {fout}
+        </p>
+      )}
+
+      {gelukt && (
+        <p
+          role="status"
+          data-testid="survey-koppeling-gelukt"
+          className="mb-3 rounded border border-green-300 bg-green-50 px-3 py-2 text-xs text-green-800"
+        >
+          Opgeslagen.
+        </p>
+      )}
+
+      <button
+        type="button"
+        onClick={() => void koppelen()}
+        disabled={bezig || laden}
+        data-testid="koppel-survey-templates"
+        className="rounded border border-line px-3 py-1.5 text-xs font-medium text-ink transition hover:bg-surface disabled:cursor-not-allowed disabled:opacity-60"
+      >
+        {bezig ? 'Bezig…' : 'Vragenlijsten koppelen'}
+      </button>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/app/beheer/leveranciers/[id]/Contracten.tsx
+git commit -m "feat(contract): uitklapbare contractrij, wachtlijst-label, urgentiekleur op einddatum"
+```
+
+---
+
+### Task 7: Hoofdpagina herschrijven — badge-strip, twee kolommen, scroll-naar-contract
+
+**Files:**
+- Modify: `src/app/beheer/leveranciers/[id]/page.tsx` (volledige herschrijving, was 1913 regels, wordt kort)
+
+- [ ] **Step 1: Vervang de inhoud van `page.tsx`**
+
+```tsx
+'use client';
+
+import { ArrowLeft } from 'lucide-react';
+import Link from 'next/link';
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+import type { VendorDetail } from '@/core/models/vendor';
+import { haalVendorDetail } from '@/core/services/vendorService';
+import { AppLayout } from '@/shared/components/layout/AppLayout';
+import { VendorUitvraagPaneel } from '@/shared/components/VendorUitvraagPaneel';
+import { useParams, useRouter } from 'next/navigation';
+
+import { ClassificatieBadges } from './ClassificatieBadges';
+import { Contactpersonen } from './Contactpersonen';
+import { Contracten } from './Contracten';
+import { Stamgegevens } from './Stamgegevens';
+
+const CONTRACTEN_SECTIE_ID = 'contracten-sectie';
+
+/**
+ * Eén leverancier: stamgegevens wijzigen en contactpersonen beheren.
+ *
+ * ── Een eigen pagina en geen uitklapper ───────────────────────────────────
+ * `/beheer/leveranciers/[id]` is deelbaar als link, werkt met de terugknop van
+ * de browser, en biedt ruimte voor wat er later bij komt. Zie
+ * `docs/superpowers/specs/2026-08-23-leveranciersscherm-dichtheid-design.md`.
+ *
+ * ── Twee kolommen, badge-strip bovenaan ───────────────────────────────────
+ * Vervangt de drie gestapelde `p-6`-kaarten (dichtheidsprobleem uit
+ * "21 augustus III" punt 1) door een badge-strip met de kerngegevens en een
+ * compacte linkerkolom (stamgegevens, contactpersonen) naast een brede
+ * rechterkolom (contracten, uitvragen) — patroon overgenomen van MVM_V2 na
+ * expliciete vergelijking, zie de spec.
+ *
+ * ── Geen tenant in de URL ─────────────────────────────────────────────────
+ * Alleen het vendor-id. De backend leidt de tenant af uit het sessiecookie en
+ * geeft 404 wanneer dat id bij een andere tenant hoort. Zie MCM2-CLAUDE.md §6.
+ */
+export default function LeverancierDetailPagina() {
+  const params = useParams<{ id: string }>();
+  const router = useRouter();
+  const vendorId = params.id;
+
+  const [vendor, setVendor] = useState<VendorDetail | null>(null);
+  const [laden, setLaden] = useState(true);
+  const [nietGevonden, setNietGevonden] = useState(false);
+  const [ophaalFout, setOphaalFout] = useState<string | null>(null);
+
+  const contractenRef = useRef<HTMLDivElement>(null);
+
+  const laad = useCallback(async () => {
+    setLaden(true);
+    setOphaalFout(null);
+
+    try {
+      const gevonden = await haalVendorDetail(vendorId);
+
+      if (!gevonden) {
+        setNietGevonden(true);
+        return;
+      }
+
+      setVendor(gevonden);
+    } catch {
+      setOphaalFout(
+        'De leverancier kon niet worden opgehaald. Controleer of u nog ingelogd bent.',
+      );
+    } finally {
+      setLaden(false);
+    }
+  }, [vendorId]);
+
+  useEffect(() => {
+    void laad();
+  }, [laad]);
+
+  /**
+   * Doorklik-scenario uit de spec §6: klik op de compliance-badge scrollt
+   * naar de Contracten-sectie. Geen navigatie naar een aparte pagina — dat
+   * is issue #173, bewust niet nu.
+   */
+  function scrollNaarContracten() {
+    document
+      .getElementById(CONTRACTEN_SECTIE_ID)
+      ?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  }
+
+  if (nietGevonden) {
+    return (
+      <AppLayout titel="Leverancier niet gevonden">
+        <p className="text-sm text-ink-muted" data-testid="niet-gevonden">
+          Deze leverancier bestaat niet, of is verwijderd.
+        </p>
+        <Link
+          href="/beheer/leveranciers"
+          className="mt-4 inline-flex items-center gap-1.5 text-sm text-brand-primary hover:underline"
+        >
+          <ArrowLeft size={14} /> Terug naar de lijst
+        </Link>
+      </AppLayout>
+    );
+  }
+
+  return (
+    <AppLayout
+      titel={vendor?.name ?? 'Leverancier'}
+      ondertitel={vendor ? 'Stamgegevens en contactpersonen' : undefined}
+    >
+      <Link
+        href="/beheer/leveranciers"
+        className="mb-4 inline-flex items-center gap-1.5 text-sm text-brand-primary hover:underline"
+      >
+        <ArrowLeft size={14} /> Terug naar de lijst
+      </Link>
+
+      {laden && <p className="text-sm text-ink-muted">Bezig met laden…</p>}
+
+      {ophaalFout && (
+        <p
+          role="alert"
+          data-testid="ophaal-fout"
+          className="rounded border border-red-300 bg-red-50 px-3 py-2 text-sm text-red-800"
+        >
+          {ophaalFout}
+        </p>
+      )}
+
+      {vendor && !laden && (
+        <>
+          <ClassificatieBadges
+            vendor={vendor}
+            onOpgeslagen={setVendor}
+            onComplianceKlik={scrollNaarContracten}
+          />
+
+          <div className="grid grid-cols-1 gap-3 xl:grid-cols-3">
+            <div className="flex flex-col gap-3 xl:col-span-1">
+              <Stamgegevens
+                vendor={vendor}
+                onOpgeslagen={setVendor}
+                onVerwijderd={() => router.push('/beheer/leveranciers')}
+              />
+              <Contactpersonen vendor={vendor} onGewijzigd={laad} />
+            </div>
+
+            <div className="flex flex-col gap-3 xl:col-span-2">
+              <div ref={contractenRef}>
+                <Contracten
+                  vendorId={vendor.vendorId}
+                  contactenVanVendor={vendor.contacten}
+                  onContactpersoonAangemaakt={laad}
+                  scrollHaakId={CONTRACTEN_SECTIE_ID}
+                />
+              </div>
+              <VendorUitvraagPaneel vendorId={vendor.vendorId} />
+            </div>
+          </div>
+        </>
+      )}
+    </AppLayout>
+  );
+}
+```
+
+- [ ] **Step 2: Verwijder de nu ongebruikte hulpfuncties**
+
+De hulpfuncties `verwerk`, `hoortBij`, `veldFoutVoor` (oude regel
+1857-1913) zijn verplaatst/vervangen — `ContactpersoonModal` en
+`Contracten.tsx` gebruiken hun eigen, kleinere foutafhandeling inline (zie
+Task 3 en 6). Controleer met een projectbrede zoekopdracht dat er geen
+resterende import naar deze functies uit de oude `page.tsx` meer bestaat:
+
+```bash
+grep -rn "from '@/app/beheer/leveranciers/\[id\]/page'" src/ e2e/ 2>/dev/null
+```
+
+Expected: geen output (niets importeert rechtstreeks uit dit pagina-bestand
+buiten Next.js' eigen routing).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/app/beheer/leveranciers/[id]/page.tsx
+git commit -m "refactor(vendor): leveranciersdetail — badge-strip, twee kolommen, scroll-naar-contract"
+```
+
+---
+
+### Task 8: Bestaande e2e-tests aanpassen aan modal en uitklap
+
+**Files:**
+- Modify: `e2e/vendor-detail.spec.ts`
+- Modify: `e2e/contracten.spec.ts`
+
+De bestaande suites verwachten een altijd-zichtbaar contactformulier
+(selectors als `#contactNaam`) en een edit-knop die direct een formulier
+toont. Beide interactiepatronen zijn veranderd. Dit is een aanpassing van
+bestaande tests, geen herontwerp van de teststrategie.
+
+- [ ] **Step 1: Zoek alle plekken die het oude contactformulier-pad gebruiken**
+
+```bash
+grep -n "#contactNaam\|#contactEmail\|voeg-contact-toe\|bewerk-contact\b" e2e/vendor-detail.spec.ts
+```
+
+Voor elke match: vervang de directe `#contactNaam`-invulling door eerst een
+klik op `open-contact-modal` (nieuwe testid uit Task 4), dan invullen via
+`#modal-contactNaam` (nieuwe testid uit Task 3), dan
+`contact-modal-opslaan` in plaats van `voeg-contact-toe`. Voorbeeldpatroon:
+
+```ts
+// Was:
+// await page.locator('#contactNaam').fill(naam);
+// await page.getByTestId('voeg-contact-toe').click();
+
+// Wordt:
+await page.getByTestId('open-contact-modal').click();
+await page.locator('#modal-contactNaam').fill(naam);
+await page.getByTestId('contact-modal-opslaan').click();
+```
+
+Pas dit toe op elke bestaande test in `vendor-detail.spec.ts` die een
+contactpersoon aanmaakt of bewerkt (zoek exact met bovenstaand grep-commando
+en werk elke match handmatig na — het aantal matches bepaalt hoeveel tests
+dit raakt, niet aan te nemen zonder het commando gedraaid te hebben).
+
+- [ ] **Step 2: Zoek alle plekken die de oude contract-edit-knop gebruiken**
+
+```bash
+grep -n "bewerk-contract\b" e2e/contracten.spec.ts
+```
+
+Voor elke match: een klik op `bewerk-contract` verwacht nu eerst dat de rij
+al uitgeklapt is (klik op `contract-rij` opent de detailweergave, dan pas
+toont `bewerk-contract` de bewerkstand):
+
+```ts
+// Was:
+// await page.getByTestId('bewerk-contract').click();
+
+// Wordt:
+await page.getByTestId('contract-rij').first().click();
+await page.getByTestId('bewerk-contract').click();
+```
+
+- [ ] **Step 3: Zoek plekken die `wachtlijst-checkbox` gebruiken**
+
+```bash
+grep -n "wachtlijst-checkbox" e2e/contracten.spec.ts
+```
+
+De checkbox-testid is vervangen door een knop-testid `wachtlijst-label`
+(Task 6) die alleen verschijnt als de template al gekoppeld is (checkbox
+aangevinkt). Pas de test aan:
+
+```ts
+// Was:
+// await page.getByTestId('wachtlijst-checkbox').first().check();
+
+// Wordt:
+await page.getByTestId('survey-template-checkbox').first().check();
+await page.getByTestId('wachtlijst-label').first().click();
+await expect(page.getByTestId('wachtlijst-label').first()).toHaveText(
+  /AAN/,
+);
+```
+
+- [ ] **Step 4: Draai de volledige e2e-suite lokaal tegen de demo-stack**
+
+Run (volg `docs/runbooks/commandos-en-omgeving.md` voor de exacte
+demo-opzet in de backend-repo `MCM2`, dan in `MCM2-frontend`):
+
+```powershell
+npx playwright test e2e/vendor-detail.spec.ts e2e/contracten.spec.ts
+```
+
+Expected: alle tests PASS. Blijft een test rood, lees eerst de foutmelding
+van Playwright (welke selector niet gevonden werd) voordat je verder werkt —
+niet aannemen welke test faalt.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add e2e/vendor-detail.spec.ts e2e/contracten.spec.ts
+git commit -m "test(contract): e2e-suites aangepast aan modal en uitklapbare contractrij"
+```
+
+---
+
+### Task 9: Preview en handmatige controle
+
+**Files:** geen bestandswijziging — verificatiestap.
+
+- [ ] **Step 1: Volg de vaste preview-procedure**
+
+Zoals vastgelegd in het projectgeheugen
+(`mcm2-demo-link-incognito-hard-reload`): start de demo-stack met deze
+branch, open de link in **incognito**, met **Ctrl+Shift+R** vooraf.
+
+- [ ] **Step 2: Loop de spec-punten handmatig na**
+
+Op het draaiende scherm, controleer:
+- Badge-strip toont naam + compliance/kritiek/categorie, klik op elke badge
+  opent het juiste bewerkveld.
+- Klik op de compliance-badge scrollt naar Contracten.
+- "+ toevoegen" bij Contactpersonen opent de modal; opslaan sluit hem en
+  toont de nieuwe contactpersoon direct in de lijst.
+- Klik op een contactpersoon-"bewerken"-knop opent dezelfde modal,
+  vooringevuld.
+- Klik op een contractrij klapt de rij uit met alle velden; nogmaals klikken
+  klapt hem weer in.
+- Een contract met een einddatum binnen 90/30 dagen toont de juiste kleur.
+- Een gekoppelde template zonder wachtlijst toont "wachtlijst UIT" plus een
+  "nu uitnodigen"-link.
+
+- [ ] **Step 3: Meld het resultaat**
+
+Geen automatische stap — terugkoppelen aan de eigenaar of de preview klopt
+met de spec, vóór er gemerged wordt (git-ritueel: pushen → mergen of bewust
+parkeren).
+
+---
+
+## Self-review — dekking tegen de spec
+
+- **§3 Layout:** Task 2 (badge-strip), Task 7 (twee kolommen) — gedekt.
+- **§4 Modal i.p.v. fold-out:** Task 3, Task 4 — gedekt.
+- **§5 Uitklapbare rij + wachtlijst-label + urgentiekleur:** Task 5, Task 6
+  — gedekt.
+- **§6 Doorklik badge → contract:** Task 7 (`scrollNaarContracten`,
+  `onComplianceKlik`-prop in Task 2) — gedekt. Vereenvoudigd t.o.v. de spec:
+  scrollt altijd naar de sectie zonder een specifieke rij te forceren
+  open te klappen (spec liet dit als toegestane uitkomst toe wanneer niet
+  eenduidig af te leiden — hier bewust altijd deze eenvoudigere route,
+  geen giswerk over "het" niet-compliante contract).
+- **§7 Ongewijzigd:** `VendorUitvraagPaneel` ongewijzigd meegenomen in
+  Task 7; backend-routes nergens aangeraakt in dit plan — bevestigd.
+- **§8 Test/preview:** Task 8 (e2e), Task 9 (preview) — gedekt.

--- a/docs/superpowers/specs/2026-08-22-contractmanagement-design.md
+++ b/docs/superpowers/specs/2026-08-22-contractmanagement-design.md
@@ -1,0 +1,233 @@
+# Ontwerp — Contractmanagement (basismodule)
+
+**Type:** spec — datamodel + relaties, geen implementatieplan
+**Eigenaar:** de eigenaar (Chris)
+**Opgesteld:** 2026-08-22, uit brainstorming n.a.v. `docs/opmerkingen Vendor IT survey.txt`
+(21-08, punt 2) en `docs/architectuur/roadmap-vendor-it-survey.md` §3.1–3.2
+(issues [#156](https://github.com/AlingAdvies/MCM2/issues/156),
+[#157](https://github.com/AlingAdvies/MCM2/issues/157)).
+**Criticality:** productieapp voor een echte klant (AlingAdvies-tenant, straks
+Transdev). Geen prototype.
+**Platform:** desktop/PC.
+**Security:** volledig tenant-gebonden data, dezelfde RLS-discipline als de
+rest van het schema — geen uitzondering.
+
+---
+
+## 1. Waarom dit nu, en waarom dit de vorm heeft die het heeft
+
+Twee losse bevindingen uit het testen op productie (21-08) bleken bij
+doorvragen dezelfde onderliggende vraag te zijn: *"hoe hangt een contract
+samen met een leverancier, een contactpersoon, en een vragenlijst?"* Dat is
+precies de vraag die de roadmap in §3.2 al signaleerde als iets dat "een
+eigen ontwerpstap vóór er code komt" verdient. Dit document is die stap.
+
+**Twee dingen lagen al klaar voordat dit ontwerp begon**, en die bepalen een
+deel van de vorm:
+
+- `survey_run.contract_id` bestaat al sinds migratie 0007 — nullable, bewust
+  zonder foreign key, met een commentaar dat zegt: *"zodra clm.contract
+  bestaat, is dit één ALTER TABLE erbij."* Dit ontwerp lost die belofte in.
+- `clm.vendor_contact` bestaat al als 1-op-veel bij `vendor`, inclusief een
+  `is_primary`-vlag. Het contract-datamodel hergebruikt dat patroon in plaats
+  van een nieuw contactpersoon-concept te verzinnen.
+
+**Scope van dit document:** het datamodel en de relaties. Niet: de
+schermen/UI (aparte implementatiestap), niet de bulk-upload (issue #160,
+bouwt hier bovenop maar is een apart ontwerp), niet de vragenlijst-bouwer
+(issue #155, ongerelateerd).
+
+---
+
+## 2. Datamodel
+
+### 2.1 `clm.contract` — nieuwe tabel
+
+Naar het bestaande patroon van `clm.vendor` / `clm.vendor_contact`: dezelfde
+kolomstijl, dezelfde RLS-opzet, dezelfde `set_updated_at`-trigger, dezelfde
+soft-delete via `deleted_at`.
+
+| Kolom | Type | Verplicht | Toelichting |
+|---|---|---|---|
+| `contract_id` | uuid PK, `gen_random_uuid()` | ja | |
+| `tenant_id` | uuid | ja | RLS-kolom, zoals overal |
+| `vendor_id` | uuid FK → `clm.vendor(vendor_id)` ON DELETE CASCADE | ja | een leverancier kan meerdere contracten hebben |
+| `name` | text | ja | vrije titel, bv. "Hosting 2024–2027" — nodig zodra een vendor meerdere contracten heeft, anders is een lijst niet te onderscheiden |
+| `contract_number` | text | nee | extern nummer uit het ERP-systeem van de tenant; geen uniekheidseis (MCM2 controleert de nummering van een extern systeem niet) |
+| `vendor_contact_id` | uuid FK → `clm.vendor_contact(contact_id)` ON DELETE SET NULL | nee | contract-specifieke contactpersoon; `NULL` betekent "gebruik de leading (`is_primary = true`) contactpersoon van de vendor" — dit is applicatielogica bij het tonen/gebruiken van het contract, geen database-default |
+| `owner_user_id` | uuid FK → `clm.user(user_id)` ON DELETE SET NULL | nee | contractbeheerder; zelfde patroon als `vendor.owner_user_id` |
+| `status_code` | text FK → `ref.contract_status(code)` ON DELETE SET NULL | nee | zie §2.3 |
+| `value_eur` | numeric(15,2) | nee | contractwaarde |
+| `start_date` | date | nee | |
+| `end_date` | date | nee | |
+| `note` | text | nee | vrij notitieveld, bv. "verwachten geen verlenging na dec-27" |
+| `created_at` | timestamptz, `now()` | ja | |
+| `updated_at` | timestamptz | nee | via trigger |
+| `deleted_at` | timestamptz | nee | soft delete |
+
+**Waarom `vendor_contact_id` nullable met een applicatie-fallback, en niet
+een database-default of een verplicht veld:** het is precies wat in de
+brainstorming is vastgesteld — een contract mag een eigen contactpersoon
+hebben, maar hoeft dat niet. Een database-`DEFAULT` zou het `is_primary`-
+contact van de vendor moeten opzoeken op het moment van invoegen, en zou
+"bevriezen" op dat moment — verandert de leading contactpersoon van de
+vendor later, dan zou een bestaand contract het niet meevolgen zonder dat
+expliciet zo bedoeld is. De fallback hoort dus in de leeslaag (API/frontend),
+niet in de kolom.
+
+**Waarom geen uniekheidseis op `contract_number`:** het nummer komt uit een
+extern systeem dat MCM2 niet beheert. Een uniekheidsconstraint zou fouten
+geven op data die buiten MCM2's controle om al dubbel kan zijn (of gewoon
+leeg blijft omdat een tenant geen ERP-nummering voert). Blokkerend gedrag
+hoort — als het ooit nodig is — bij de bulk-upload-validatie (issue #160),
+niet bij de kolom zelf.
+
+### 2.2 `ref.contract_status` — nieuwe ref-tabel
+
+Zelfde patroon als `ref.compliance_status`, `ref.business_criticality`,
+`ref.vendor_category`: `code` (PK) + `label`.
+
+| code | label |
+|---|---|
+| `actief` | Actief |
+| `verlopen` | Verlopen |
+| `opgezegd` | Opgezegd |
+
+**"Verlopend" staat hier bewust niet in.** Zie §2.3.
+
+### 2.3 "Verlopend" is een afgeleide weergavestatus, geen databasewaarde
+
+Een contract raakt "verlopend" puur door het verstrijken van tijd — niet door
+een handeling van een gebruiker. Dat verschilt fundamenteel van `actief` →
+`opgezegd` (een besluit) of `actief` → `verlopen` (ook een besluit, of in elk
+geval een moment waarop iemand het vaststelt).
+
+**Regel:** een contract toont als "verlopend" in de UI wanneer
+`status_code = 'actief' AND end_date IS NOT NULL AND end_date <= vandaag + 90 dagen`.
+Dit wordt berekend in de leeslaag (API-response of frontend), nooit
+opgeslagen.
+
+**Waarom niet opslaan:** een opgeslagen "verlopend"-status zou ofwel een
+achtergrondtaak vereisen die hem dagelijks bijwerkt (nieuw mechanisme, nieuw
+risico op stil achterlopen — precies het patroon dat dit project al eerder
+trof, zie `MCM2-CLAUDE.md` punt 4b), ofwel zou hij verstoppen achter een
+verouderde waarde totdat iemand toevallig het record opent. Een berekende
+waarde is per definitie nooit verouderd.
+
+### 2.4 `clm.contract_survey_template` — nieuwe koppeltabel
+
+Many-to-many, geen extra kolommen buiten de sleutels:
+
+| Kolom | Type | Toelichting |
+|---|---|---|
+| `contract_id` | uuid FK → `clm.contract(contract_id)` ON DELETE CASCADE | |
+| `survey_template_id` | uuid FK → `clm.survey_template(survey_template_id)` ON DELETE CASCADE | |
+| `tenant_id` | uuid | RLS-kolom |
+| `created_at` | timestamptz, `now()` | |
+
+PK: samengesteld op `(contract_id, survey_template_id)`, zoals
+`clm.vendor_tag` dat al doet met `(vendor_id, tag)`.
+
+**Doel:** vastleggen welke vragenlijst-templates relevant zijn voor een
+contract. Geen frequentie- of verplicht/optioneel-veld — dat raakt de nog
+niet gebouwde "rondes/herhaling"-feature (roadmap §2.2) en is bewust
+uitgesteld tot die feature er is en de vraag concreet wordt.
+
+**Gebruik (buiten scope van dit ontwerp, ter oriëntatie):** bij het
+aanmaken van een nieuwe survey-ronde kan het scherm de templates tonen die
+aan het gekozen contract gekoppeld zijn, als voorstel — niet als
+verplichting. Een ronde zonder contract, of met een template die niet aan
+het contract gekoppeld is, blijft mogelijk (UC1 uit migratie 0007 mag niet
+breken).
+
+### 2.5 `survey_run.contract_id` krijgt zijn foreign key
+
+Migratie 0007 introduceerde de kolom bewust zonder FK, met de aankondiging
+dat dit later "één ALTER TABLE ... ADD CONSTRAINT" zou zijn zodra
+`clm.contract` bestaat. Dat moment is nu:
+
+```sql
+ALTER TABLE "clm"."survey_run"
+  ADD CONSTRAINT "survey_run_contract_id_contract_contract_id_fk"
+  FOREIGN KEY ("contract_id") REFERENCES "clm"."contract"("contract_id")
+  ON DELETE SET NULL;
+```
+
+`ON DELETE SET NULL` (niet CASCADE, niet RESTRICT): een survey-ronde is een
+afgerond of lopend beoordelingsmoment. Een verwijderd contract mag dat
+historische bewijs niet laten verdwijnen — de ronde blijft bestaan, verliest
+alleen de koppeling. Consistent met hoe `vendor.owner_user_id` en
+`vendor.category_code` nu ook `SET NULL` gebruiken in plaats van CASCADE.
+
+Blijft nullable, zoals migratie 0007 al vastlegde: een ronde hoeft niet aan
+een contract te hangen.
+
+---
+
+## 3. Relatieoverzicht
+
+```
+vendor (1) ──< (N) contract ──> (0..1) vendor_contact   [contract.vendor_contact_id, fallback: vendor_contact.is_primary]
+vendor (1) ──< (N) vendor_contact
+contract (0..1) ──> (0..1) clm.user                     [contract.owner_user_id]
+contract (0..1) ──> (0..1) ref.contract_status           [contract.status_code]
+contract (N) ──< contract_survey_template >── (N) survey_template
+survey_run (0..1) ──> (0..1) contract                    [survey_run.contract_id]
+```
+
+---
+
+## 4. Row Level Security
+
+Geen keuze, de architectuurregel (`MCM2-CLAUDE.md` §7): elke nieuwe
+tenant-gebonden tabel krijgt handmatig:
+
+- `ENABLE ROW LEVEL SECURITY`
+- `FORCE ROW LEVEL SECURITY`
+- een policy met zowel `USING` als `WITH CHECK` op `tenant_id = clm.current_tenant_id()`
+
+Dit geldt voor zowel `clm.contract` als `clm.contract_survey_template`.
+`ref.contract_status` is een gedeelde referentietabel zonder `tenant_id` —
+zelfde behandeling als `ref.compliance_status` e.a., geen RLS nodig.
+
+---
+
+## 5. Wat dit ontwerp bewust niet doet
+
+- **Geen UI/schermen.** Dat is een aparte implementatiestap na dit ontwerp.
+- **Geen bulk-upload.** Issue #160 bouwt hier straks bovenop. Dit datamodel
+  is er wel geschikt voor gemaakt: matching kan op `vendor_id` (via
+  vendor-naam/KVK, al bestaand mechanisme) + `contract_number`, zonder dat
+  daarvoor eerst een aparte migratie nodig is. De eigenaar noemde tijdens de
+  brainstorming een verwachte omvang van ~50 contracten nu, oplopend naar
+  150+ — dat is een argument om het datamodel nu bulk-vriendelijk te maken,
+  niet om de bulk-upload-UI nu al te bouwen.
+- **Geen automatische statuswijziging.** Zie §2.3 — "verlopend" is bewust
+  nooit een geschreven waarde.
+- **Geen contract-specifieke velden per leverancierstype.** De koppeling
+  contract → leverancierstype loopt via het bestaande `vendor.category_code`
+  — er komt geen apart `category_code` op `contract` zelf, want dat zou een
+  contract kunnen laten afwijken van het type van zijn eigen vendor, wat geen
+  zinnige toestand is.
+- **Geen migratie van bestaande contractdata.** Er bestaat nergens in MCM2
+  contractdata (geen tabel, geen seed) — er is dus niets over te zetten.
+  `clm.contract` start leeg.
+
+---
+
+## 6. Open vraag voor de implementatiestap
+
+Geen — alle scope-vragen zijn tijdens de brainstorming beantwoord. De
+implementatiestap (via `writing-plans`) kan direct volgen op dit document.
+
+---
+
+## Bronnen
+
+- `docs/opmerkingen Vendor IT survey.txt`, 21 augustus, punt 2/2a/2b/2c
+- `docs/architectuur/roadmap-vendor-it-survey.md` §3.1–3.2 (issues #156, #157)
+- `drizzle/0007_contract_op_survey_run.sql` — de vooraf klaargezette kolom
+  en de reden waarom
+- `drizzle/0000_baseline_bestaand_schema.sql` — het `vendor`/`vendor_contact`-
+  patroon dat dit ontwerp hergebruikt
+- `MCM2-CLAUDE.md` §7 — RLS-verplichting voor elke nieuwe tenant-tabel

--- a/docs/superpowers/specs/2026-08-22-contractmanagement-design.md
+++ b/docs/superpowers/specs/2026-08-22-contractmanagement-design.md
@@ -37,6 +37,14 @@ schermen/UI (aparte implementatiestap), niet de bulk-upload (issue #160,
 bouwt hier bovenop maar is een apart ontwerp), niet de vragenlijst-bouwer
 (issue #155, ongerelateerd).
 
+**Notitieveld bij contactpersoon (opmerking 21-08, punt 2b) — geen nieuwe
+kolom nodig.** `clm.vendor_contact.role_description` bestaat al in het schema
+(`src/db/schema.ts:277`) en dekt precies het gevraagde gebruik (bv. "is
+vervanger van X voor IT-zaken"). Het veld wordt alleen nergens in de UI
+getoond of ingevuld — dat is een implementatiedetail van het contactpersoon-
+scherm, niet een datamodel-wijziging, en hoort dus bij de implementatiestap
+van deze spec, niet bij een nieuwe migratie.
+
 ---
 
 ## 2. Datamodel
@@ -224,7 +232,9 @@ implementatiestap (via `writing-plans`) kan direct volgen op dit document.
 
 ## Bronnen
 
-- `docs/opmerkingen Vendor IT survey.txt`, 21 augustus, punt 2/2a/2b/2c
+- `docs/opmerkingen Vendor IT survey.txt`, 21 augustus, punt 2/2a/2b/2c —
+  2b (notitie bij contactpersoon) bleek al gedekt door het bestaande
+  `vendor_contact.role_description`, zie §1
 - `docs/architectuur/roadmap-vendor-it-survey.md` §3.1–3.2 (issues #156, #157)
 - `drizzle/0007_contract_op_survey_run.sql` — de vooraf klaargezette kolom
   en de reden waarom

--- a/docs/superpowers/specs/2026-08-22-contractmanagement-ui-design.md
+++ b/docs/superpowers/specs/2026-08-22-contractmanagement-ui-design.md
@@ -208,10 +208,121 @@ bulk-upload-UI.
 
 ## 6. Open vraag voor de implementatiestap
 
-Geen — de brainstorming heeft alle scope-vragen beantwoord: welke velden
-(inclusief contactpersoon en contractbeheerder, expliciet bevestigd), de
-plek van de survey-koppeling (eigen blok, eigen knop), en de reikwijdte
-daarvan (koppelen, niet uitsturen).
+Geen voor §1–5 — de brainstorming had alle scope-vragen daar beantwoord.
+§7–9 zijn een latere aanvulling (22-08, na de derde preview) met hun eigen
+scope-vastlegging.
+
+---
+
+## 7. Contractenlijst als tabel, niet als kaarten
+
+**Bevinding (derde preview):** met meerdere contracten per leverancier is
+de kaartweergave uit §4.1 te ruim — elke rij neemt veel verticale hoogte
+in, en contactpersoon/beheerder/status/data zijn niet in één oogopslag te
+vergelijken tussen contracten.
+
+**Wijziging:** de lijst uit §4.1 wordt een compacte HTML-tabel met
+kolommen: Naam, Contractnummer, Contactpersoon, Contractbeheerder, Status,
+Begindatum, Einddatum, acties (bewerken/verwijderen). Zelfde databron
+(`ContractSamenvatting`, met de namen die Task 3 van het backend-plan al
+toevoegde), alleen de weergave verandert — geen backend-wijziging.
+
+Het "Xd resterend"/"Xd verlopen"-label (§4.1, `EindeIndicator`) blijft
+bestaan maar verhuist naar een compacte notatie onder de einddatum in
+dezelfde kolom, niet ernaast.
+
+## 8. Contactpersoon toevoegen bij het BEWERKEN van een bestaand contract
+
+**Bevinding (derde preview):** Task 12 voegde de "nieuwe contactpersoon
+aanmaken"-toggle alleen toe aan het aanmaakformulier (`NieuwContractFormulier`).
+Bij het bewerken van een al bestaand contract (`ContractRij` in
+bewerkstand) ontbreekt diezelfde optie — een contactpersoon toevoegen kan
+dan alleen via de aparte Contactpersonen-sectie, wat het contract-
+bewerkformulier onvolledig maakt.
+
+**Wijziging:** dezelfde toggle-en-drie-velden-aanpak uit Task 12, nu ook in
+`ContractRij`'s bewerkstand. Bij opslaan: eerst de contactpersoon aanmaken
+(`voegContactToe`, bestaande route), dan het contract bijwerken met het
+nieuwe `contactId`.
+
+**Notitieveld bij contactpersoon zichtbaar maken.** De backend-kolom
+`vendor_contact.role_description` bestaat al sinds de basistabel (zie
+`2026-08-22-contractmanagement-design.md` §1) maar staat nergens in de UI
+— nog niet bij de Contactpersonen-sectie, en dus ook niet bij deze nieuwe
+toggle. Beide plekken krijgen een "Notitie"-tekstveld (bv. "is vervanger
+van X voor IT-zaken") dat naar `roleDescription` schrijft. Dit raakt drie
+plekken: `Contactpersonen`/`ContactRij` (het bestaande blok), de toggle in
+`NieuwContractFormulier` (Task 12), en de nieuwe toggle in `ContractRij`
+hier.
+
+## 9. Wachtlijst: een leverancier automatisch voorstellen bij de volgende ronde
+
+**Bevinding (derde preview):** de bestaande survey-templatekoppeling
+(§4.3, Task 2) legt vast *welke* vragenlijst bij een contract hoort, en
+Task 13 voegde een knop toe om *nu direct* uit te nodigen. Wat ontbrak: een
+manier om een leverancier te markeren voor een *toekomstige* ronde, zonder
+dat er nu al iemand op een knop drukt — bijvoorbeeld omdat de huidige ronde
+al loopt en deze leverancier voor de ronde daarna moet meedoen.
+
+**Expliciet niet gevraagd:** volautomatisch verzenden. De eigenaar was
+hier scherp: *"dit hoeft geen volautomatisch proces te worden [...]
+contractbeheerders hebben een hulpmiddel nodig waar ze alle relevante
+informatie in één keer onder de knop hebben, maar beslissen zelf."* Dit
+is dus een **voorstel, geen trigger** — een mens selecteert en verstuurt
+nog steeds bewust, via het bestaande uitnodigen-scherm.
+
+### 9.1 Datamodel: één kolom op de bestaande koppeltabel
+
+`clm.contract_survey_template` krijgt een kolom
+`wachtlijst boolean NOT NULL DEFAULT false` (nieuwe migratie 0028, niet
+een wijziging van migratie 0027 — die is al uitgerold). Geen nieuwe tabel:
+de wachtlijst-status hoort per definitie bij een specifieke
+contract-template-koppeling, en die koppeling bestaat al.
+
+Uitvinkbaar zoals de eigenaar vroeg: de kolom is een gewone boolean die de
+beheerder aan/uit zet, geen automatisch proces dat hem wijzigt.
+
+### 9.2 Zichtbaar en instelbaar: alleen op het contract, geen apart overzicht (nu)
+
+Bewust beperkt tot het bestaande `SurveyTemplateKoppelingBlok`
+(§4.3/Task 2): elke checkbox voor een gekoppelde template krijgt een
+tweede, kleinere checkbox ernaast — "op de wachtlijst voor de volgende
+ronde" — opgeslagen met dezelfde `PUT .../survey-templates`-aanroep
+(kolom `wachtlijst` naast `templateIds` in de body).
+
+Een centraal overzicht "alle leveranciers die klaarstaan voor ronde X" is
+een expliciet latere stap — zie §9.4.
+
+### 9.3 Nieuw, apart startpunt: "Ronde starten vanuit wachtlijst"
+
+Het bestaande uitnodigen-scherm (`/beheer/vragenlijsten/uitnodigen`) werkt
+"leverancier eerst, vragenlijst daarna" — de wachtlijst werkt andersom
+("vragenlijst eerst, dan wie er klaarstaat"). Dat bestaande scherm wordt
+niet omgebouwd (zou alle huidige gebruik en tests raken); in plaats
+daarvan komt er een nieuw, klein scherm:
+
+`/beheer/vragenlijsten/[id]/wachtlijst` (of vergelijkbaar, binnen de
+bestaande `/beheer/vragenlijsten`-sectie): toont per vragenlijst-template
+de leveranciers met `wachtlijst = true` op een gekoppeld contract, elk
+aangevinkt in een leverancierslijst die er verder uitziet als de bestaande
+selectielijst op `/beheer/leveranciers`. De beheerder kan uitvinken of
+aanvullen, en springt dan door naar het bestaande uitnodigen-scherm
+(`?leveranciers=...&templateId=...`) — dezelfde overgang die Task 13 al
+bouwde vanuit een los contract.
+
+**Toegangspunt:** een link/knop bij elke vragenlijst op
+`/beheer/vragenlijsten` ("N leveranciers staan klaar"), zichtbaar zodra
+`wachtlijst`-aantal > 0.
+
+### 9.4 Wat hier bewust niet gebeurt
+
+- Geen automatisch versturen — bevestigd door de eigenaar, zie boven.
+- Geen apart, centraal "alle wachtlijsten"-dashboard — dat is een
+  logische vervolgstap zodra dit scherm in gebruik is, maar een eigen
+  afweging (welke rol mag het zien, hoe filteren bij veel vragenlijsten)
+  die nu niet wordt voorgekookt.
+- Geen wijziging van de bestaande `?leveranciers=`-flow op
+  `/beheer/leveranciers` zelf — die blijft precies zoals hij is.
 
 ---
 

--- a/docs/superpowers/specs/2026-08-22-contractmanagement-ui-design.md
+++ b/docs/superpowers/specs/2026-08-22-contractmanagement-ui-design.md
@@ -1,0 +1,230 @@
+# Ontwerp — Contractmanagement: scherm en ontbrekende backend-routes
+
+**Type:** spec — vervolg op de datamodel-spec, dekt UI en de routes die
+ontbraken om die UI te voeden
+**Eigenaar:** de eigenaar (Chris)
+**Opgesteld:** 2026-08-22, na een harde en terechte constatering tijdens de
+verificatie van de backend-only implementatie: een complete backend zonder
+enig scherm is niet te gebruiken en niet echt te testen. Zie
+`docs/superpowers/plans/2026-08-22-contractmanagement.md` voor wat al
+gebouwd is.
+**Criticality:** productieapp voor een echte klant.
+**Platform:** desktop/PC, zelfde als de rest van MCM2.
+
+---
+
+## 1. Waarom dit een aparte spec is, en niet een uitbreiding van de vorige
+
+De vorige spec (`2026-08-22-contractmanagement-design.md`) beschreef bewust
+alleen het datamodel — §5 zei letterlijk "geen UI/schermen, dat is een
+aparte implementatiestap". Die afbakening was op zichzelf verdedigbaar,
+maar het gevolg bleek een gat: een backend die niemand kan bereiken is niet
+"later nog een schil eromheen", het is een onaf product. Dit document is
+die aparte implementatiestap, nu uitgewerkt.
+
+**Twee dingen ontbreken nog in de backend en horen bij dit werk, niet bij
+een derde spec:**
+
+1. Er bestaat een tabel `clm.contract_survey_template` (migratie 0027) maar
+   geen enkele route ervoor.
+2. Er bestaat geen route om de gebruikers van de eigen tenant op te halen —
+   nodig voor de contractbeheerder-dropdown.
+
+Dat zijn geen nieuwe ontwerpkeuzes over het datamodel, alleen ontbrekende
+lees/schrijf-paden erboven. Vandaar dat ze hier meelopen in plaats van een
+eigen spec te krijgen.
+
+---
+
+## 2. Waar dit scherm hoort, en waarom niet zoals MVM_V2
+
+MVM_V2 heeft contracten als een eigen top-level scherm (`/contracts`) met
+een sorteerbare tabel, tijdlijnweergave en CATS-levenscyclusfasen
+(initiatie/implementatie/uitvoering/monitoring/wijziging/beëindiging).
+
+**MCM2 doet dit anders, bewust:**
+
+- De backend maakt een contract al vendor-gebonden
+  (`/vendors/:vendorId/contracts`), niet los. Een los top-level scherm zou
+  die relatie in de UI moeten herhalen (een vendor-kiezer) terwijl het
+  vendor-detailscherm al precies die context biedt.
+- MCM2 kent geen CATS-levenscyclus, geen issues-koppeling, geen
+  tijdlijnweergave — dat zijn features van een veel verder ontwikkeld
+  contractmanagement-product. Ze meenemen zou een schijn van volledigheid
+  geven die de backend niet waarmaakt.
+
+**Besluit:** een nieuwe sectie `Contracten` op
+`/beheer/leveranciers/[id]`, in de bestaande structuur van dat scherm:
+Stamgegevens → Contactpersonen → **Contracten** (nieuw) →
+VendorUitvraagPaneel. Zelfde patroon als `Contactpersonen`/`ContactRij`:
+een lijst met inline bewerken, een toevoegformulier eronder.
+
+Wat wél uit MVM_V2 wordt overgenomen, als UI-idee (niet als code — MVM_V2
+draait op mock data en een ander framework-patroon):
+
+- Statuskleur per contract (groen=actief, oranje=nadert einde,
+  rood=verlopen)
+- Een "dagen resterend"/"dagen verlopen"-indicator bij de einddatum
+
+---
+
+## 3. Backend — twee ontbrekende stukken
+
+### 3.1 Route voor tenant-gebruikers
+
+**Nieuwe route:** `GET /tenant/gebruikers`, in `TenantModule` (niet
+`ContractModule`: het is generieke tenantdata, geen contract-specifieke
+logica, en een toekomstig scherm dat ook een gebruikerslijst nodig heeft
+hoeft dan niet naar `ContractModule` te kijken).
+
+Antwoord: `{ gebruikers: [{ userId, naam }] }` — alleen wat een dropdown
+nodig heeft. Geen e-mailadres, geen rol: dat is meer dan dit scherm gebruikt
+en zou een nieuwe blootstelling zijn die niet bij deze taak hoort.
+
+Toegankelijk voor elke ingelogde gebruiker van de tenant (`RolGuard` staat
+lezen toe voor zowel admin als reviewer, zelfde patroon als
+`GET /vendors/:id/contracts`) — het is een keuzelijst, geen gevoelige data.
+
+### 3.2 Routes voor de survey-templatekoppeling
+
+**`GET /vendors/:vendorId/contracts/:id/survey-templates`**
+Antwoord: `{ templateIds: string[] }` — de ids van de templates die nu aan
+dit contract gekoppeld zijn.
+
+**`PUT /vendors/:vendorId/contracts/:id/survey-templates`**
+Body: `{ templateIds: string[] }` (mag leeg zijn — "geen enkele vragenlijst
+gekoppeld" is een geldige stand, vastgesteld tijdens de brainstorming).
+
+Implementatie: binnen één transactie de bestaande koppelingen voor dit
+contract verwijderen en de meegestuurde set opnieuw invoegen. Geen
+diff-berekening (verwijderen wat wegvalt, toevoegen wat nieuw is) — bij een
+klein aantal templates per contract (naar verwachting 1–3) is
+"alles weg, alles opnieuw" net zo correct en eenvoudiger te redeneren over
+dan een diff, en de tabel heeft toch geen extra kolommen die verloren
+zouden gaan bij het verwijderen van een rij.
+
+**Waarom een aparte PUT en geen onderdeel van `PATCH .../contracts/:id`:**
+tijdens de brainstorming vastgesteld dat dit een eigen knop en een eigen
+opslaan-actie krijgt in de UI, los van de rest van het contractformulier
+— zelfde structuur als contactpersonen nu al een eigen CRUD-blok zijn naast
+de vendor-stamgegevens. Een aparte route hoort bij een aparte UI-actie.
+
+**Rollen:** `@VereistRol('admin')`, zelfde als de rest van
+`ContractController`.
+
+**RLS:** geen wijziging nodig — `clm.contract_survey_template` heeft al
+zijn policy uit migratie 0027. Een query moet wel expliciet filteren op
+`contract_id` én controleren dat dat contract bij de opgegeven `vendorId`
+en de sessie-tenant hoort (zelfde 404-redenering als de rest van
+`ContractController`: onbekend en "niet van u" zijn niet te onderscheiden).
+
+### 3.3 Contract-detail breidt uit met namen, niet alleen id's
+
+`ContractDetail` (en de lijst) krijgt `vendorContactNaam: string | null` en
+`ownerGebruikerNaam: string | null` naast de bestaande `vendorContactId` /
+`ownerUserId`. Reden: het scherm toont een naam in de lijst en de kaart,
+niet een uuid — zonder deze uitbreiding zou elke rij een aparte lookup naar
+`vendor_contact`/`user` moeten doen, wat exact het n+1-probleem is dat
+`VendorService.lijst()` met zijn subquery-aanpak al vermijdt.
+
+Implementatie: een `LEFT JOIN` in de bestaande `detailBinnenTransactie` en
+`lijst`-query van `ContractService`, geen nieuwe tabel of migratie.
+
+---
+
+## 4. Frontend — de `Contracten`-sectie
+
+### 4.1 Lijst (patroon: `Contactpersonen`/`ContactRij`)
+
+Elke rij toont: naam, contractnummer (klein, onder de naam — zelfde
+plaatsing als de KvK-referentie in MVM_V2's contractlijst), statusbadge,
+begindatum–einddatum met een indicator:
+
+- Status `actief` én einddatum binnen 90 dagen → oranje "Xd resterend"
+- Status `actief` én einddatum verder weg of leeg → geen indicator, alleen
+  de datum
+- Einddatum in het verleden → rood "Xd verlopen" (ongeacht opgeslagen
+  status — een contract dat niemand heeft bijgewerkt naar `verlopen` moet
+  dat toch laten zien, zie spec §2.3 van het datamodel-document)
+- Contactpersoon-naam en beheerder-naam, of "—" als leeg
+
+Acties per rij: bewerken (inline formulier, zelfde interactiepatroon als
+`ContactRij`), verwijderen (met bevestigingsstap, zelfde patroon als
+vendor zelf verwijderen).
+
+### 4.2 Bewerk-/aanmaakformulier
+
+Velden, in deze volgorde: naam (verplicht), contractnummer, status
+(dropdown uit `ref.contract_status`), begindatum, einddatum, waarde,
+contactpersoon (dropdown, gevuld uit `vendor.contacten` — dezelfde data die
+de Contactpersonen-sectie al heeft, geen nieuwe fetch), contractbeheerder
+(dropdown, gevuld uit `GET /tenant/gebruikers`), notitie (tekstveld,
+meerdere regels).
+
+Één "Opslaan"-knop voor al deze velden samen — dezelfde
+`PATCH .../contracts/:id` (of `POST` bij aanmaken) als de backend al biedt.
+
+**Bij aanmaken staat de vragenlijst-koppeling nog niet in dit formulier**:
+een contract heeft eerst een `contractId` nodig voordat er iets aan
+gekoppeld kan worden. Na het aanmaken toont de nieuwe rij meteen het
+koppelingsblok (leeg, klaar om in te vullen) — geen aparte "eerst opslaan,
+dan pas koppelen"-stap die de gebruiker zelf moet herkennen.
+
+### 4.3 Vragenlijst-koppeling — los blok binnen de contractkaart
+
+Onder de rest van de contractvelden, met een eigen kop "Van toepassing
+zijnde vragenlijst(en)": een checkbox-lijst van alle vragenlijst-templates
+van de tenant (uit `GET /admin/survey/templates`, hergebruikt — geen
+zoekveld nodig bij een klein aantal), en een eigen knop "Vragenlijsten
+koppelen" die alleen dit blok opslaat via
+`PUT .../contracts/:id/survey-templates`.
+
+Eigen foutmelding, eigen "bezig"-status, los van de rest van het
+formulier — zelfde onafhankelijkheid als de contactpersonen-sectie nu al
+heeft ten opzichte van de vendor-stamgegevens.
+
+### 4.4 Wat dit scherm bewust niet doet
+
+- Geen knop om vanuit een contract direct een survey-ronde te starten. De
+  koppeling legt alleen vast wélke templates van toepassing zijn; het
+  daadwerkelijk uitsturen blijft bij het bestaande
+  `/beheer/vragenlijsten/uitnodigen`-scherm. Een filter daar op basis van
+  deze koppeling is denkbaar, maar is een aparte, latere uitbreiding met
+  een eigen afweging — niet nu meegenomen.
+- Geen tijdlijnweergave, geen CATS-fasen, geen issues-koppeling (zie §2).
+- Geen bulk-acties op contracten — dat is issue #160 (bulk-upload
+  contractdata), een apart traject.
+
+---
+
+## 5. Wat dit ontwerp bewust niet doet — herhaling van de datamodel-spec
+
+Zoals in `2026-08-22-contractmanagement-design.md` §5: geen automatische
+statuswijziging (de "Xd verlopen"-indicator in §4.1 is weergave, geen
+schrijfactie), geen migratie van bestaande contractdata, geen
+bulk-upload-UI.
+
+---
+
+## 6. Open vraag voor de implementatiestap
+
+Geen — de brainstorming heeft alle scope-vragen beantwoord: welke velden
+(inclusief contactpersoon en contractbeheerder, expliciet bevestigd), de
+plek van de survey-koppeling (eigen blok, eigen knop), en de reikwijdte
+daarvan (koppelen, niet uitsturen).
+
+---
+
+## Bronnen
+
+- `docs/superpowers/specs/2026-08-22-contractmanagement-design.md` — het
+  datamodel dat dit scherm bedient
+- `docs/superpowers/plans/2026-08-22-contractmanagement.md` — de al
+  gebouwde backend (migratie 0027, ContractService/Controller/Module)
+- `MCM2-frontend/src/app/beheer/leveranciers/[id]/page.tsx` — het
+  bestaande patroon (`Contactpersonen`/`ContactRij`) dat dit scherm volgt
+- MVM_V2 `src/app/contracts/page.tsx` — inspiratiebron voor
+  statusweergave en dagen-resterend-indicator, niet gekopieerd (mock data,
+  ander framework-patroon, features die MCM2 niet heeft)
+- `src/survey/vragenlijst-beheer.controller.ts` — bestaande
+  `GET /admin/survey/templates`, hergebruikt voor de checkbox-lijst

--- a/docs/superpowers/specs/2026-08-23-leveranciersscherm-dichtheid-design.md
+++ b/docs/superpowers/specs/2026-08-23-leveranciersscherm-dichtheid-design.md
@@ -1,0 +1,211 @@
+# Leveranciersdetail: dichtheid, uitklapbare contracten, wachtlijst-signaal
+
+**Status:** ontwerp goedgekeurd, klaar voor implementatieplan
+**Datum:** 2026-08-23
+**Scherm:** `MCM2-frontend/src/app/beheer/leveranciers/[id]/page.tsx`
+**Vervolg op:** de vier open punten uit "21 augustus III" in
+`docs/opmerkingen Vendor IT survey.txt`, bevestigd door
+`docs/architectuur/evaluatie-schermen-2026-08-22.md`
+
+---
+
+## 1. Aanleiding
+
+Sessie 22-08 sloot af met vier openstaande UI-punten op het
+leveranciersdetailscherm (zie `docs/STATUS.md`, sectie "21 augustus III"):
+
+1. Stamgegevens/classificatie/contactpersonen te uitgesponnen — meer
+   informatiedichtheid nodig op een breed pc-scherm.
+2. Contactpersoon-toevoegformulier moet een fold-out zijn, niet altijd open.
+3. Contractrijen moeten direct openklikbaar zijn (niet alleen via edit-knop),
+   met alle bestaande én toekomstige velden zichtbaar.
+4. Koppeling vs. wachtlijst is functioneel correct maar visueel verwarrend
+   (Microsoft/M365-voorbeeld).
+
+Deze sessie is gestart met een bewuste vergelijking met MVM_V2
+(`C:\dev\Work\MVM_V2`), expliciet aangewezen door de eigenaar als referentie
+waar hij tevreden over is. Twee bevindingen uit die vergelijking veranderden
+het oorspronkelijke plan:
+
+- **MVM_V2 lost "toevoegen/bewerken" op met een modal** (zie
+  `VendorContactsPanel.tsx`), niet met een inline fold-out. Dat vervangt het
+  fold-out-idee uit punt 2.
+- **MVM_V2 heeft een aparte Contract 360-pagina.** Overwogen en bewust
+  **niet** in deze werkstroom meegenomen — zie issue #173. Dit ontwerp houdt
+  contracten ingebed op de leveranciersdetailpagina, zoals op 22-08 al
+  besloten.
+
+Tijdens het ontwerpgesprek bracht de eigenaar een vijfde, dwingende eis in:
+zichtbare urgentie voor aflopende contracten, vanwege het reële schaderisico
+van stilzwijgende verlenging. Het volledige opzegtermijn-mechanisme (met een
+harde "verlengt automatisch"-waarschuwing) vraagt een nieuw databaseveld en
+is uitgesteld naar issue #174 (front+backend, direct na deze werkstroom). Wat
+**nu wél** gebouwd wordt: een kleurgecodeerde einddatum als tussenoplossing.
+
+---
+
+## 2. Scope
+
+**In scope:**
+- Layout-herziening van de volledige pagina: badge-strip + twee kolommen.
+- Contactpersoon toevoegen/bewerken via modal i.p.v. inline formulier.
+- Contractrij: klikbaar om uit te klappen (bestaande + toekomstige velden),
+  geen aparte edit-knop meer nodig.
+- Wachtlijst-status als expliciet label op de uitgeklapte rij, met een
+  directe "nu uitnodigen"-link waar van toepassing (bestaand mechanisme,
+  hergebruiken).
+- Kleurcodering op de kale einddatum (drie drempels, zie §5).
+- Doorklik-scenario: klik op de compliance-badge in de badge-strip scrollt
+  naar en klapt de relevante contractrij open (geen navigatie).
+
+**Bewust buiten scope (aparte issues):**
+- Contract 360 als eigen toppagina — issue #173.
+- Opzegtermijn-veld + "verlengt automatisch"-waarschuwing — issue #174,
+  front+backend, direct na deze werkstroom.
+- "21 augustus II" punt 1 (contracten in linkerbalk) en punt 2 (dashboard-
+  hernoeming + 90-dagen-widget) — ander deel van het scherm/de navigatie,
+  niet dit ontwerp.
+
+---
+
+## 3. Layout — badge-strip + twee kolommen
+
+Vervangt de huidige opbouw (drie gestapelde `<section className="p-6">`-
+blokken) door:
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│ Naam leverancier   [Compliance-badge]  [Kritiek]  [Categorie]│  ← badge-strip
+├───────────────────────┬───────────────────────────────────────┤
+│ Stamgegevens (compact)│ Contracten — tabel, klikbare rijen     │
+│ Contactpersonen        │ Lopende uitvragen (VendorUitvraagPaneel│
+│  (compact, modal-toevoeg)│  ongewijzigd)                       │
+└───────────────────────┴───────────────────────────────────────┘
+```
+
+- Grid: `grid-cols-1 xl:grid-cols-3`, linkerkolom `xl:col-span-1`,
+  rechterkolom `xl:col-span-2` — zelfde breakpoint-keuze als MVM_V2.
+- Paddings verkleinen: `p-4` in plaats van `p-6` op de kaarten;
+  bodytekst `text-[12px]`/`text-[13px]` in plaats van de huidige `text-sm`
+  overal.
+- Secties in de rechterkolom krijgen een koptekstbalk (`px-4 py-3` met
+  `border-bottom`) i.p.v. een losse `<h2>` boven een groot blok — patroon
+  uit MVM_V2's Certificeringen/Contracten-secties.
+- Classificatie (categorie, bedrijfskritiek, compliancestatus) verhuist van
+  een los `<fieldset>` in Stamgegevens naar de badge-strip bovenaan. De
+  **bewerkbaarheid blijft bestaan** — klik op een badge opent hetzelfde
+  bewerkformulier als nu in Stamgegevens, alleen de weergave-plek verandert.
+- Design-tokens (`@/shared/design-tokens`) blijven de bron voor kleuren;
+  geen hardcoded hex behalve de urgentie-kleurdrempels in §5, die als
+  benoemde constanten in de component komen (geen losse hex her en der).
+
+---
+
+## 4. Contactpersoon: modal i.p.v. inline fold-out
+
+Vervangt het huidige altijd-open formulier (regel ~1035,
+`nieuweContactpersoon`-state) en het eerder overwogen fold-out-idee.
+
+- Kleine "+ toevoegen"-knop naast de sectiekop "Contactpersonen".
+- Klik opent een modal met dezelfde velden als nu (naam, e-mail, functie,
+  notitie/`roleDescription`) — hergebruikt de bestaande formulierlogica,
+  alleen de presentatie verandert van inline-blok naar modal.
+- Bewerken van een bestaande contactpersoon opent dezelfde modal,
+  vooringevuld — bewerken=aanmaken-symmetrie blijft behouden (§1c,
+  `MCM2-CLAUDE.md`), nu via één gedeelde modal-component in plaats van twee
+  aparte inline-vormen.
+- Sluiten: expliciete annuleer-knop of klik buiten de modal. Geen wijziging
+  aan de backend-routes (`voegContactToe`, `wijzigContact` blijven
+  ongewijzigd).
+
+---
+
+## 5. Contractrij: uitklapbaar + urgentiekleur
+
+### Uitklappen
+- De hele rij is klikbaar (niet alleen een edit-icoon). Klik toont/verbergt
+  een detailregel eronder met alle velden: bestaande (contractnummer,
+  startdatum, notitie) én de plek waar toekomstige velden bij komen — geen
+  aparte "bewerken"-modus meer nodig voor het simpelweg *bekijken* van
+  details.
+- Wijzigen van een veld gebeurt in de uitgeklapte rij zelf (bestaand
+  `ContractRij`-bewerkgedrag, verplaatst van "altijd zichtbaar na
+  edit-klik" naar "zichtbaar na uitklappen").
+- De koppeling met survey-templates en de wachtlijst-status (zie hieronder)
+  staat in dezelfde uitgeklapte regel.
+
+### Wachtlijst-signaal (punt 4)
+- Een gekoppelde survey-template toont expliciet **"wachtlijst AAN"** of
+  **"wachtlijst UIT"** als tekstlabel — niet langer alleen een stille
+  checkbox.
+- Staat de wachtlijst uit, dan direct een "nu uitnodigen"-link ernaast
+  (bestaand mechanisme uit `survey_run.contract_id`, sessie 21-08).
+- Geen wijziging aan het default-gedrag van de checkbox zelf in deze stap —
+  dat was de andere optie uit de open vraag van 22-08, en de eigenaar koos
+  voor de visuele verduidelijking, niet voor een gedragswijziging.
+
+### Urgentiekleur op de einddatum (tussenoplossing, issue #174 volgt)
+Drie drempels op de kale `endDate`, zonder opzegtermijn-correctie:
+
+| Resterende dagen tot einddatum | Kleur | Label |
+|---|---|---|
+| > 90 dagen | grijs (standaard tekstkleur) | alleen datum |
+| ≤ 90 dagen | oranje | datum + "nog X dagen" |
+| ≤ 30 dagen of al verstreken | rood | datum + "nog X dagen" / "X dagen geleden" |
+
+Geen claim over automatische verlenging — dat vraagt het opzegtermijn-veld
+uit issue #174. De drempelwaarden (90/30) komen als benoemde constanten in
+de component, niet als losse getallen inline.
+
+---
+
+## 6. Doorklik-scenario: badge → contractrij
+
+Klik op de compliance-badge in de badge-strip (bijv. "Niet-compliant"):
+1. Scrollt naar de Contracten-sectie (`scrollIntoView` op een vaste
+   sectie-id, geen navigatie).
+2. Klapt de rij van het contract open dat de laagste/slechtste
+   compliance-status draagt, als dat eenduidig af te leiden is uit de
+   bestaande data; is dat niet eenduidig, dan scrollt het alleen naar de
+   sectie zonder een specifieke rij te forceren open te klappen — geen
+   giswerk over welk contract "het probleem" is.
+
+Dit blijft binnen dezelfde pagina — geen navigatie naar een aparte
+contractpagina (dat is issue #173).
+
+---
+
+## 7. Wat ongewijzigd blijft
+
+- `VendorUitvraagPaneel` — ongewijzigd, blijft onderaan de rechterkolom.
+- Alle backend-routes (`contractService`, `vendorService`) — deze stap is
+  puur frontend, geen migratie, geen API-wijziging.
+- Verwijderen van een leverancier (bevestigingsflow in Stamgegevens) —
+  ongewijzigd, verhuist mee naar de compacte linkerkolom.
+- `data-testid`-attributen op bestaande knoppen/velden blijven behouden
+  waar de onderliggende functionaliteit hetzelfde blijft, zodat bestaande
+  Playwright-tests niet onnodig breken; nieuwe testid's komen bij nieuwe
+  interactie-elementen (modal, uitklaptrigger, badge-klik).
+
+---
+
+## 8. Test- en previewstrategie
+
+- Bestaande Playwright-suite (`e2e/*.spec.ts` in `MCM2-frontend`) blijft
+  leidend; testid's die van "altijd zichtbaar" naar "zichtbaar na
+  interactie" gaan (modal, uitklap) vragen aangepaste tests, geen nieuwe
+  testinfrastructuur.
+- Preview volgens de vaste procedure (`mcm2-demo-link-incognito-hard-
+  reload`): na implementatie een demo-link met incognito + hard reload,
+  vóór er gemerged wordt.
+- Geen backend-wijziging in deze stap, dus geen migratiecontrole nodig in
+  de preview-stap.
+
+---
+
+## 9. Openstaande issues die uit dit ontwerp voortkomen
+
+- **#173** — Contract 360 als eigen toppagina (`/contracten/[id]`),
+  inclusief nieuwe backend-route. Niet nu.
+- **#174** — Opzegtermijn-veld + "verlengt automatisch"-waarschuwing,
+  front+backend in één werkstroom. Eerstvolgende stap na deze werkstroom.

--- a/drizzle/0027_contract.sql
+++ b/drizzle/0027_contract.sql
@@ -97,14 +97,33 @@ CREATE TRIGGER trg_contract_updated_at
 ALTER TABLE clm.contract ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
 ALTER TABLE clm.contract FORCE ROW LEVEL SECURITY;--> statement-breakpoint
 
+-- Bewust GEEN "AND deleted_at IS NULL" in USING — dat is exact de fout die
+-- migratie 0004 (Issue #31) al eens oploste op vendor/user/vendor_contact.
+-- Met dat filter in USING toetst Postgres bij een UPDATE de zichtbaarheid
+-- van het RESULTAAT: zodra deleted_at gevuld wordt, valt de nieuwe rij
+-- buiten de policy en weigert de soft delete zelf met "new row violates
+-- row-level security policy" — precies de operatie die soft delete moet
+-- toestaan. RLS is de tenant-isolatiegrens; het filteren van zacht
+-- verwijderde rijen is een zaak van de query (zie ContractService, dat
+-- overal expliciet "AND deleted_at IS NULL" toevoegt), niet van de
+-- beveiligingslaag.
 CREATE POLICY contract_isolation ON clm.contract
-    USING (tenant_id = clm.current_tenant_id() AND deleted_at IS NULL)
+    USING (tenant_id = clm.current_tenant_id())
     WITH CHECK (tenant_id = clm.current_tenant_id());--> statement-breakpoint
 
 COMMENT ON TABLE clm.contract IS
     'Contracten bij een leverancier. vendor_contact_id is nullable: NULL betekent "gebruik de is_primary-contactpersoon van de vendor" (applicatielogica, geen database-default). status_code kent geen "verlopend" — die status is berekend uit end_date, nooit opgeslagen. Zie docs/superpowers/specs/2026-08-22-contractmanagement-design.md.';--> statement-breakpoint
 
-GRANT SELECT, INSERT, UPDATE ON clm.contract TO clm_api_runtime;--> statement-breakpoint
+-- REVOKE vóór GRANT, conform migratie 0022 (src/db/rechten-contract.ts): een
+-- kale GRANT beperkt niets, want ALTER DEFAULT PRIVILEGES (migratie 0001)
+-- geeft clm_api via het lidmaatschap van clm_api_runtime al SELECT, INSERT,
+-- UPDATE, DELETE op elke nieuwe tabel in clm. Zonder de REVOKE hieronder zou
+-- clm_api_runtime dus ook DELETE krijgen — ruimer dan bedoeld, en op een
+-- manier die alleen lokaal opvalt (Supabase kent die default niet).
+--
+-- Zacht verwijderd via deleted_at, net als vendor — geen DELETE nodig.
+REVOKE ALL ON clm.contract FROM clm_api, clm_admin, clm_readonly;--> statement-breakpoint
+GRANT SELECT, INSERT, UPDATE ON clm.contract TO clm_api, clm_admin;--> statement-breakpoint
 
 -- ── 3. clm.contract_survey_template — many-to-many, geen extra kolommen ────
 --
@@ -144,7 +163,10 @@ CREATE POLICY contract_survey_template_isolation ON clm.contract_survey_template
 COMMENT ON TABLE clm.contract_survey_template IS
     'Welke vragenlijst-templates relevant zijn voor een contract. Many-to-many, geen extra velden. Zie docs/superpowers/specs/2026-08-22-contractmanagement-design.md §2.4.';--> statement-breakpoint
 
-GRANT SELECT, INSERT, DELETE ON clm.contract_survey_template TO clm_api_runtime;--> statement-breakpoint
+-- Een koppeling bestaat of niet. Wijzigen heeft geen betekenis — ontkoppelen
+-- en opnieuw koppelen wel. Zelfde redenering als template_reviewer (0022).
+REVOKE ALL ON clm.contract_survey_template FROM clm_api, clm_admin, clm_readonly;--> statement-breakpoint
+GRANT SELECT, INSERT, DELETE ON clm.contract_survey_template TO clm_api, clm_admin;--> statement-breakpoint
 
 -- ── 4. survey_run.contract_id krijgt zijn foreign key ──────────────────────
 --

--- a/drizzle/0027_contract.sql
+++ b/drizzle/0027_contract.sql
@@ -1,0 +1,162 @@
+-- =============================================================================
+-- clm.contract — de contractmanagement-basismodule.
+--
+-- Ontwerp: docs/superpowers/specs/2026-08-22-contractmanagement-design.md
+-- Aanleiding: opmerkingen 21-08 punt 2/2a/2c, roadmap-issues #156/#157.
+--
+-- Lost de belofte van migratie 0007 in: survey_run.contract_id kreeg toen
+-- bewust nog geen foreign key, met het commentaar "zodra clm.contract
+-- bestaat, is dit één ALTER TABLE erbij". Dat gebeurt hieronder in stap 4.
+-- =============================================================================
+
+-- ── 1. ref.contract_status — vaste waardenlijst, zelfde patroon als
+-- ref.compliance_status / ref.business_criticality / ref.vendor_category.
+--
+-- "verlopend" staat hier bewust niet in: dat is een berekende weergavestatus
+-- (status = 'actief' AND end_date <= vandaag + 90 dagen), nooit een
+-- opgeslagen waarde. Zie spec §2.3 voor de volledige redenering — een
+-- opgeslagen "verlopend" zou een achtergrondtaak vereisen die hem bijhoudt,
+-- met het risico dat die taak stil achterloopt.
+
+CREATE TABLE ref.contract_status (
+    code  text PRIMARY KEY,
+    label text NOT NULL
+);--> statement-breakpoint
+
+INSERT INTO ref.contract_status (code, label) VALUES
+    ('actief', 'Actief'),
+    ('verlopen', 'Verlopen'),
+    ('opgezegd', 'Opgezegd')
+ON CONFLICT (code) DO NOTHING;--> statement-breakpoint
+
+-- ref-schema: bewust geen RLS (tenant-agnostische lookup-data), zelfde als
+-- de andere ref-tabellen.
+
+-- ── 2. clm.contract ───────────────────────────────────────────────────────
+--
+-- Patroon: clm.vendor / clm.vendor_contact (0000_baseline_bestaand_schema).
+--
+-- vendor_contact_id is NULLABLE met applicatie-fallback (niet een
+-- database-default): NULL betekent "gebruik de is_primary-contactpersoon
+-- van de vendor". Een database-default zou bevriezen op het moment van
+-- invoegen; de fallback hoort in de leeslaag. Zie spec §2.1.
+--
+-- contract_number heeft bewust geen uniekheidseis: het komt uit een extern
+-- ERP-systeem dat MCM2 niet controleert.
+
+CREATE TABLE clm.contract (
+    contract_id       uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenant_id         uuid NOT NULL,
+    vendor_id         uuid NOT NULL,
+    name              text NOT NULL,
+    contract_number   text,
+    vendor_contact_id uuid,
+    owner_user_id     uuid,
+    status_code       text,
+    value_eur         numeric(15, 2),
+    start_date        date,
+    end_date          date,
+    note              text,
+    created_at        timestamptz NOT NULL DEFAULT now(),
+    updated_at        timestamptz,
+    deleted_at        timestamptz
+);--> statement-breakpoint
+
+ALTER TABLE clm.contract
+    ADD CONSTRAINT contract_tenant_id_tenant_tenant_id_fk
+    FOREIGN KEY (tenant_id) REFERENCES clm.tenant(tenant_id)
+    ON DELETE restrict;--> statement-breakpoint
+
+ALTER TABLE clm.contract
+    ADD CONSTRAINT contract_vendor_id_vendor_vendor_id_fk
+    FOREIGN KEY (vendor_id) REFERENCES clm.vendor(vendor_id)
+    ON DELETE cascade;--> statement-breakpoint
+
+ALTER TABLE clm.contract
+    ADD CONSTRAINT contract_vendor_contact_id_vendor_contact_contact_id_fk
+    FOREIGN KEY (vendor_contact_id) REFERENCES clm.vendor_contact(contact_id)
+    ON DELETE set null;--> statement-breakpoint
+
+ALTER TABLE clm.contract
+    ADD CONSTRAINT contract_owner_user_id_user_user_id_fk
+    FOREIGN KEY (owner_user_id) REFERENCES clm."user"(user_id)
+    ON DELETE set null;--> statement-breakpoint
+
+ALTER TABLE clm.contract
+    ADD CONSTRAINT contract_status_code_contract_status_code_fk
+    FOREIGN KEY (status_code) REFERENCES ref.contract_status(code)
+    ON DELETE set null;--> statement-breakpoint
+
+CREATE INDEX contract_tenant_id_idx ON clm.contract USING btree (tenant_id);--> statement-breakpoint
+CREATE INDEX contract_vendor_id_idx ON clm.contract USING btree (vendor_id);--> statement-breakpoint
+
+CREATE TRIGGER trg_contract_updated_at
+    BEFORE UPDATE ON clm.contract
+    FOR EACH ROW EXECUTE FUNCTION clm.set_updated_at();--> statement-breakpoint
+
+ALTER TABLE clm.contract ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+ALTER TABLE clm.contract FORCE ROW LEVEL SECURITY;--> statement-breakpoint
+
+CREATE POLICY contract_isolation ON clm.contract
+    USING (tenant_id = clm.current_tenant_id() AND deleted_at IS NULL)
+    WITH CHECK (tenant_id = clm.current_tenant_id());--> statement-breakpoint
+
+COMMENT ON TABLE clm.contract IS
+    'Contracten bij een leverancier. vendor_contact_id is nullable: NULL betekent "gebruik de is_primary-contactpersoon van de vendor" (applicatielogica, geen database-default). status_code kent geen "verlopend" — die status is berekend uit end_date, nooit opgeslagen. Zie docs/superpowers/specs/2026-08-22-contractmanagement-design.md.';--> statement-breakpoint
+
+GRANT SELECT, INSERT, UPDATE ON clm.contract TO clm_api_runtime;--> statement-breakpoint
+
+-- ── 3. clm.contract_survey_template — many-to-many, geen extra kolommen ────
+--
+-- Welke vragenlijst-templates relevant zijn voor een contract. Geen
+-- frequentie- of verplicht/optioneel-veld: dat raakt de nog niet gebouwde
+-- rondes/herhaling-feature en is bewust uitgesteld. Zie spec §2.4.
+
+CREATE TABLE clm.contract_survey_template (
+    contract_id       uuid NOT NULL,
+    survey_template_id uuid NOT NULL,
+    tenant_id         uuid NOT NULL,
+    created_at        timestamptz NOT NULL DEFAULT now(),
+    CONSTRAINT contract_survey_template_pkey
+        PRIMARY KEY (contract_id, survey_template_id)
+);--> statement-breakpoint
+
+ALTER TABLE clm.contract_survey_template
+    ADD CONSTRAINT contract_survey_template_contract_id_contract_contract_id_fk
+    FOREIGN KEY (contract_id) REFERENCES clm.contract(contract_id)
+    ON DELETE cascade;--> statement-breakpoint
+
+ALTER TABLE clm.contract_survey_template
+    ADD CONSTRAINT contract_survey_template_survey_template_id_fk
+    FOREIGN KEY (survey_template_id) REFERENCES clm.survey_template(template_id)
+    ON DELETE cascade;--> statement-breakpoint
+
+CREATE INDEX contract_survey_template_tenant_id_idx
+    ON clm.contract_survey_template USING btree (tenant_id);--> statement-breakpoint
+
+ALTER TABLE clm.contract_survey_template ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+ALTER TABLE clm.contract_survey_template FORCE ROW LEVEL SECURITY;--> statement-breakpoint
+
+CREATE POLICY contract_survey_template_isolation ON clm.contract_survey_template
+    USING (tenant_id = clm.current_tenant_id())
+    WITH CHECK (tenant_id = clm.current_tenant_id());--> statement-breakpoint
+
+COMMENT ON TABLE clm.contract_survey_template IS
+    'Welke vragenlijst-templates relevant zijn voor een contract. Many-to-many, geen extra velden. Zie docs/superpowers/specs/2026-08-22-contractmanagement-design.md §2.4.';--> statement-breakpoint
+
+GRANT SELECT, INSERT, DELETE ON clm.contract_survey_template TO clm_api_runtime;--> statement-breakpoint
+
+-- ── 4. survey_run.contract_id krijgt zijn foreign key ──────────────────────
+--
+-- Migratie 0007 introduceerde de kolom bewust zonder FK. Dit is het
+-- aangekondigde vervolg. ON DELETE SET NULL, niet CASCADE of RESTRICT: een
+-- survey-ronde is bewijsmateriaal en mag niet verdwijnen als het contract
+-- wordt verwijderd — hij verliest alleen de koppeling. Zie spec §2.5.
+
+ALTER TABLE clm.survey_run
+    ADD CONSTRAINT survey_run_contract_id_contract_contract_id_fk
+    FOREIGN KEY (contract_id) REFERENCES clm.contract(contract_id)
+    ON DELETE set null;--> statement-breakpoint
+
+COMMENT ON COLUMN clm.survey_run.contract_id IS
+    'Op welk contract deze ronde betrekking heeft. Nullable: een ronde hoeft niet aan een contract te hangen. FK toegevoegd in migratie 0027 zodra clm.contract bestond, zoals migratie 0007 al aankondigde.';

--- a/drizzle/0028_contract_survey_wachtlijst.sql
+++ b/drizzle/0028_contract_survey_wachtlijst.sql
@@ -1,0 +1,21 @@
+-- =============================================================================
+-- clm.contract_survey_template krijgt een wachtlijst-kolom.
+--
+-- Spec: docs/superpowers/specs/2026-08-22-contractmanagement-ui-design.md §9.
+--
+-- Uitvinkbaar door de beheerder, geen automatisch proces dat hem zet of
+-- wist: een leverancier "op de wachtlijst" voor de volgende ronde van een
+-- vragenlijst betekent alleen dat hij voorgeselecteerd wordt zodra iemand
+-- bewust een nieuwe ronde start via het nieuwe wachtlijst-scherm — nooit
+-- dat er vanzelf iets verstuurd wordt.
+--
+-- Geen nieuwe tabel: de wachtlijst-status hoort per definitie bij een
+-- specifieke contract-template-koppeling, en die koppeling bestaat al
+-- sinds migratie 0027.
+-- =============================================================================
+
+ALTER TABLE clm.contract_survey_template
+    ADD COLUMN wachtlijst boolean NOT NULL DEFAULT false;--> statement-breakpoint
+
+COMMENT ON COLUMN clm.contract_survey_template.wachtlijst IS
+    'Staat deze leverancier klaar om voorgesteld te worden bij de volgende ronde van deze vragenlijst? Uitvinkbaar door de beheerder, nooit automatisch gezet. Zie spec §9.';

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -190,6 +190,13 @@
       "when": 1787068800000,
       "tag": "0026_tenantregister",
       "breakpoints": true
+    },
+    {
+      "idx": 27,
+      "version": "7",
+      "when": 1787068800001,
+      "tag": "0027_contract",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -197,6 +197,13 @@
       "when": 1787068800001,
       "tag": "0027_contract",
       "breakpoints": true
+    },
+    {
+      "idx": 28,
+      "version": "7",
+      "when": 1787068800002,
+      "tag": "0028_contract_survey_wachtlijst",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { AuthModule } from './auth/auth.module';
+import { ContractModule } from './contract/contract.module';
 import { DatabaseModule } from './db/database.module';
 import { HealthModule } from './health/health.module';
 import { MailModule } from './mail/mail.module';
@@ -17,6 +18,7 @@ import { VendorModule } from './vendor/vendor.module';
     SurveyModule,
     AuthModule,
     VendorModule,
+    ContractModule,
     MailModule,
     PlatformModule,
     TenantModule,

--- a/src/contract/contract-invoer.spec.ts
+++ b/src/contract/contract-invoer.spec.ts
@@ -1,0 +1,67 @@
+import { leesNieuwContract, InvoerFout } from './contract-invoer';
+
+describe('leesNieuwContract', () => {
+  it('accepteert een minimale geldige invoer (alleen naam)', () => {
+    const invoer = leesNieuwContract({ name: 'Hosting 2024-2027' });
+
+    expect(invoer.name).toBe('Hosting 2024-2027');
+    expect(invoer.contractNumber).toBeNull();
+  });
+
+  it('weigert een lege naam', () => {
+    expect(() => leesNieuwContract({ name: '' })).toThrow(InvoerFout);
+  });
+
+  it('weigert een ontbrekende naam', () => {
+    expect(() => leesNieuwContract({})).toThrow(InvoerFout);
+  });
+
+  it('knipt witruimte van de naam', () => {
+    const invoer = leesNieuwContract({ name: '  Hosting  ' });
+    expect(invoer.name).toBe('Hosting');
+  });
+
+  it('accepteert een geldige startDate en endDate (ISO-datum)', () => {
+    const invoer = leesNieuwContract({
+      name: 'Hosting',
+      startDate: '2024-01-01',
+      endDate: '2027-12-31',
+    });
+
+    expect(invoer.startDate).toBe('2024-01-01');
+    expect(invoer.endDate).toBe('2027-12-31');
+  });
+
+  it('weigert een endDate vóór de startDate', () => {
+    expect(() =>
+      leesNieuwContract({
+        name: 'Hosting',
+        startDate: '2027-01-01',
+        endDate: '2024-01-01',
+      }),
+    ).toThrow(InvoerFout);
+  });
+
+  it('weigert een niet-ISO datum', () => {
+    expect(() =>
+      leesNieuwContract({ name: 'Hosting', startDate: '01-01-2024' }),
+    ).toThrow(InvoerFout);
+  });
+
+  it('accepteert een geldig geldbedrag', () => {
+    const invoer = leesNieuwContract({ name: 'Hosting', valueEur: '1500.50' });
+    expect(invoer.valueEur).toBe('1500.50');
+  });
+
+  it('weigert een negatief geldbedrag', () => {
+    expect(() =>
+      leesNieuwContract({ name: 'Hosting', valueEur: '-100' }),
+    ).toThrow(InvoerFout);
+  });
+
+  it('weigert een niet-numeriek geldbedrag', () => {
+    expect(() =>
+      leesNieuwContract({ name: 'Hosting', valueEur: 'abc' }),
+    ).toThrow(InvoerFout);
+  });
+});

--- a/src/contract/contract-invoer.ts
+++ b/src/contract/contract-invoer.ts
@@ -213,29 +213,47 @@ export function leesContractWijziging(body: unknown): ContractWijziging {
 const UUID_PATROON_KOPPELING =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
+export interface SurveyTemplateKoppelingInvoer {
+  templateIds: string[];
+  wachtlijstTemplateIds: string[];
+}
+
 /** Leest de body van PUT .../contracts/:id/survey-templates. */
-export function leesSurveyTemplateKoppeling(body: unknown): string[] {
+export function leesSurveyTemplateKoppeling(
+  body: unknown,
+): SurveyTemplateKoppelingInvoer {
   if (typeof body !== 'object' || body === null) {
     throw new InvoerFout('body', 'Er is geen koppeling meegestuurd.');
   }
 
   const ruw = body as Record<string, unknown>;
 
+  function leesIdLijst(veld: string): string[] {
+    if (!(veld in ruw)) return [];
+
+    const waarde = ruw[veld];
+
+    if (!Array.isArray(waarde)) {
+      throw new InvoerFout(veld, `${veld} moet een lijst zijn.`);
+    }
+
+    for (const w of waarde) {
+      if (typeof w !== 'string' || !UUID_PATROON_KOPPELING.test(w)) {
+        throw new InvoerFout(veld, "Een van de id's is ongeldig.");
+      }
+    }
+
+    // Dubbele ids negeren, niet weigeren: een dubbelklik in de checkbox-lijst
+    // is een UI-detail, geen fout van de gebruiker.
+    return [...new Set(waarde as string[])];
+  }
+
   if (!('templateIds' in ruw)) {
     throw new InvoerFout('templateIds', 'templateIds is verplicht.');
   }
 
-  if (!Array.isArray(ruw.templateIds)) {
-    throw new InvoerFout('templateIds', 'templateIds moet een lijst zijn.');
-  }
-
-  for (const waarde of ruw.templateIds) {
-    if (typeof waarde !== 'string' || !UUID_PATROON_KOPPELING.test(waarde)) {
-      throw new InvoerFout('templateIds', "Een van de id's is ongeldig.");
-    }
-  }
-
-  // Dubbele ids negeren, niet weigeren: een dubbelklik in de checkbox-lijst
-  // is een UI-detail, geen fout van de gebruiker.
-  return [...new Set(ruw.templateIds as string[])];
+  return {
+    templateIds: leesIdLijst('templateIds'),
+    wachtlijstTemplateIds: leesIdLijst('wachtlijstTemplateIds'),
+  };
 }

--- a/src/contract/contract-invoer.ts
+++ b/src/contract/contract-invoer.ts
@@ -184,10 +184,7 @@ export function leesContractWijziging(body: unknown): ContractWijziging {
     );
   }
   if ('ownerUserId' in ruw) {
-    wijziging.ownerUserId = optioneleUuid(
-      ruw.ownerUserId,
-      'Contractbeheerder',
-    );
+    wijziging.ownerUserId = optioneleUuid(ruw.ownerUserId, 'Contractbeheerder');
   }
   if ('statusCode' in ruw) {
     wijziging.statusCode = optioneleTekst(ruw.statusCode, 'Status', MAX_KORT);

--- a/src/contract/contract-invoer.ts
+++ b/src/contract/contract-invoer.ts
@@ -1,0 +1,214 @@
+import type { NieuwContract, ContractWijziging } from './contract.service';
+
+/**
+ * Validatie van wat een browser opstuurt bij het aanmaken/wijzigen van een
+ * contract. Zelfde opzet als vendor-invoer.ts: handmatig op `unknown`, ruime
+ * regels — wat hier wordt tegengehouden is het soort invoer dat op een
+ * vergissing wijst, niet elke denkbare afwijking.
+ */
+
+const MAX_NAAM = 200;
+const MAX_KORT = 100;
+const MAX_NOTITIE = 2000;
+
+export class InvoerFout extends Error {
+  constructor(
+    readonly veld: string,
+    melding: string,
+  ) {
+    super(melding);
+    this.name = 'InvoerFout';
+  }
+}
+
+function verplichteTekst(
+  waarde: unknown,
+  veld: string,
+  maxLengte: number,
+): string {
+  if (typeof waarde !== 'string' || waarde.trim() === '') {
+    throw new InvoerFout(veld, `${veld} is verplicht.`);
+  }
+
+  const geknipt = waarde.trim();
+
+  if (geknipt.length > maxLengte) {
+    throw new InvoerFout(
+      veld,
+      `${veld} mag maximaal ${maxLengte} tekens bevatten.`,
+    );
+  }
+
+  return geknipt;
+}
+
+function optioneleTekst(
+  waarde: unknown,
+  veld: string,
+  maxLengte: number,
+): string | null {
+  if (waarde === undefined || waarde === null || waarde === '') {
+    return null;
+  }
+
+  if (typeof waarde !== 'string') {
+    throw new InvoerFout(veld, `${veld} moet tekst zijn.`);
+  }
+
+  const geknipt = waarde.trim();
+
+  if (geknipt === '') {
+    return null;
+  }
+
+  if (geknipt.length > maxLengte) {
+    throw new InvoerFout(
+      veld,
+      `${veld} mag maximaal ${maxLengte} tekens bevatten.`,
+    );
+  }
+
+  return geknipt;
+}
+
+function optioneleUuid(waarde: unknown, veld: string): string | null {
+  if (waarde === undefined || waarde === null || waarde === '') {
+    return null;
+  }
+
+  const UUID_PATROON =
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+  if (typeof waarde !== 'string' || !UUID_PATROON.test(waarde)) {
+    throw new InvoerFout(veld, `${veld} is geen geldige id.`);
+  }
+
+  return waarde;
+}
+
+const ISO_DATUM = /^\d{4}-\d{2}-\d{2}$/;
+
+function optioneleDatum(waarde: unknown, veld: string): string | null {
+  if (waarde === undefined || waarde === null || waarde === '') {
+    return null;
+  }
+
+  if (typeof waarde !== 'string' || !ISO_DATUM.test(waarde)) {
+    throw new InvoerFout(veld, `${veld} moet een datum zijn (JJJJ-MM-DD).`);
+  }
+
+  return waarde;
+}
+
+/**
+ * Een geldbedrag als tekst, zodat precisie niet verloren gaat via number.
+ * Numeriek(15,2) in de database — twee decimalen, geen extra validatie op
+ * decimalenaantal hier: de database wijst een te lange waarde zelf af.
+ */
+function optioneelBedrag(waarde: unknown, veld: string): string | null {
+  if (waarde === undefined || waarde === null || waarde === '') {
+    return null;
+  }
+
+  if (typeof waarde !== 'string' || !/^\d+(\.\d{1,2})?$/.test(waarde)) {
+    throw new InvoerFout(veld, `${veld} moet een geldig bedrag zijn.`);
+  }
+
+  return waarde;
+}
+
+function controleerDatumVolgorde(
+  startDate: string | null,
+  endDate: string | null,
+): void {
+  if (startDate && endDate && startDate > endDate) {
+    throw new InvoerFout(
+      'endDate',
+      'De einddatum kan niet vóór de begindatum liggen.',
+    );
+  }
+}
+
+/** Leest en valideert de body van POST /vendors/:vendorId/contracts. */
+export function leesNieuwContract(body: unknown): NieuwContract {
+  if (typeof body !== 'object' || body === null) {
+    throw new InvoerFout('body', 'Er is geen contract meegestuurd.');
+  }
+
+  const ruw = body as Record<string, unknown>;
+
+  const startDate = optioneleDatum(ruw.startDate, 'Begindatum');
+  const endDate = optioneleDatum(ruw.endDate, 'Einddatum');
+  controleerDatumVolgorde(startDate, endDate);
+
+  return {
+    name: verplichteTekst(ruw.name, 'Naam', MAX_NAAM),
+    contractNumber: optioneleTekst(
+      ruw.contractNumber,
+      'Contractnummer',
+      MAX_KORT,
+    ),
+    vendorContactId: optioneleUuid(ruw.vendorContactId, 'Contactpersoon'),
+    ownerUserId: optioneleUuid(ruw.ownerUserId, 'Contractbeheerder'),
+    statusCode: optioneleTekst(ruw.statusCode, 'Status', MAX_KORT),
+    valueEur: optioneelBedrag(ruw.valueEur, 'Waarde'),
+    startDate,
+    endDate,
+    note: optioneleTekst(ruw.note, 'Notitie', MAX_NOTITIE),
+  };
+}
+
+/** Leest de body van PATCH /vendors/:vendorId/contracts/:id. */
+export function leesContractWijziging(body: unknown): ContractWijziging {
+  if (typeof body !== 'object' || body === null) {
+    throw new InvoerFout('body', 'Er is geen wijziging meegestuurd.');
+  }
+
+  const ruw = body as Record<string, unknown>;
+  const wijziging: ContractWijziging = {};
+
+  if ('name' in ruw) {
+    wijziging.name = verplichteTekst(ruw.name, 'Naam', MAX_NAAM);
+  }
+  if ('contractNumber' in ruw) {
+    wijziging.contractNumber = optioneleTekst(
+      ruw.contractNumber,
+      'Contractnummer',
+      MAX_KORT,
+    );
+  }
+  if ('vendorContactId' in ruw) {
+    wijziging.vendorContactId = optioneleUuid(
+      ruw.vendorContactId,
+      'Contactpersoon',
+    );
+  }
+  if ('ownerUserId' in ruw) {
+    wijziging.ownerUserId = optioneleUuid(
+      ruw.ownerUserId,
+      'Contractbeheerder',
+    );
+  }
+  if ('statusCode' in ruw) {
+    wijziging.statusCode = optioneleTekst(ruw.statusCode, 'Status', MAX_KORT);
+  }
+  if ('valueEur' in ruw) {
+    wijziging.valueEur = optioneelBedrag(ruw.valueEur, 'Waarde');
+  }
+  if ('startDate' in ruw) {
+    wijziging.startDate = optioneleDatum(ruw.startDate, 'Begindatum');
+  }
+  if ('endDate' in ruw) {
+    wijziging.endDate = optioneleDatum(ruw.endDate, 'Einddatum');
+  }
+  if ('note' in ruw) {
+    wijziging.note = optioneleTekst(ruw.note, 'Notitie', MAX_NOTITIE);
+  }
+
+  controleerDatumVolgorde(
+    wijziging.startDate ?? null,
+    wijziging.endDate ?? null,
+  );
+
+  return wijziging;
+}

--- a/src/contract/contract-invoer.ts
+++ b/src/contract/contract-invoer.ts
@@ -209,3 +209,33 @@ export function leesContractWijziging(body: unknown): ContractWijziging {
 
   return wijziging;
 }
+
+const UUID_PATROON_KOPPELING =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/** Leest de body van PUT .../contracts/:id/survey-templates. */
+export function leesSurveyTemplateKoppeling(body: unknown): string[] {
+  if (typeof body !== 'object' || body === null) {
+    throw new InvoerFout('body', 'Er is geen koppeling meegestuurd.');
+  }
+
+  const ruw = body as Record<string, unknown>;
+
+  if (!('templateIds' in ruw)) {
+    throw new InvoerFout('templateIds', 'templateIds is verplicht.');
+  }
+
+  if (!Array.isArray(ruw.templateIds)) {
+    throw new InvoerFout('templateIds', 'templateIds moet een lijst zijn.');
+  }
+
+  for (const waarde of ruw.templateIds) {
+    if (typeof waarde !== 'string' || !UUID_PATROON_KOPPELING.test(waarde)) {
+      throw new InvoerFout('templateIds', "Een van de id's is ongeldig.");
+    }
+  }
+
+  // Dubbele ids negeren, niet weigeren: een dubbelklik in de checkbox-lijst
+  // is een UI-detail, geen fout van de gebruiker.
+  return [...new Set(ruw.templateIds as string[])];
+}

--- a/src/contract/contract.controller.ts
+++ b/src/contract/contract.controller.ts
@@ -24,6 +24,7 @@ import {
   leesContractWijziging,
   leesNieuwContract,
   leesSurveyTemplateKoppeling,
+  type SurveyTemplateKoppelingInvoer,
 } from './contract-invoer';
 import {
   ContractService,
@@ -188,10 +189,10 @@ export class ContractController {
   ) {
     const sessie = request.sessie!;
 
-    let templateIds: string[];
+    let invoer: SurveyTemplateKoppelingInvoer;
 
     try {
-      templateIds = leesSurveyTemplateKoppeling(body);
+      invoer = leesSurveyTemplateKoppeling(body);
     } catch (err) {
       throw alsHttpFout(err);
     }
@@ -201,7 +202,8 @@ export class ContractController {
         sessie.tenantId,
         leesUuid(vendorId),
         leesUuid(id),
-        templateIds,
+        invoer.templateIds,
+        invoer.wachtlijstTemplateIds,
       )
       .catch(alsRefFout);
 

--- a/src/contract/contract.controller.ts
+++ b/src/contract/contract.controller.ts
@@ -1,0 +1,194 @@
+import {
+  BadRequestException,
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  NotFoundException,
+  Param,
+  Patch,
+  Post,
+  Req,
+  UseGuards,
+} from '@nestjs/common';
+
+import { RolGuard, VereistRol } from '../auth/rol.guard';
+import {
+  TenantContextGuard,
+  type RequestMetSessie,
+} from '../auth/tenant-context.guard';
+import {
+  InvoerFout,
+  leesContractWijziging,
+  leesNieuwContract,
+} from './contract-invoer';
+import {
+  ContractService,
+  type ContractWijziging,
+  type NieuwContract,
+} from './contract.service';
+
+/**
+ * Contractroutes, altijd in de context van een leverancier.
+ *
+ * Zelfde beveiligingspatroon als VendorController: guards op klasseniveau,
+ * schrijven vereist de rol admin.
+ */
+@Controller('vendors/:vendorId/contracts')
+@UseGuards(TenantContextGuard, RolGuard)
+export class ContractController {
+  constructor(private readonly contracts: ContractService) {}
+
+  @Get()
+  async lijst(
+    @Req() request: RequestMetSessie,
+    @Param('vendorId') vendorId: string,
+  ) {
+    const sessie = request.sessie!;
+
+    const contracten = await this.contracts.lijst(
+      sessie.tenantId,
+      leesUuid(vendorId),
+    );
+
+    return { contracten };
+  }
+
+  @Post()
+  @VereistRol('admin')
+  @HttpCode(201)
+  async maakAan(
+    @Req() request: RequestMetSessie,
+    @Param('vendorId') vendorId: string,
+    @Body() body: unknown,
+  ) {
+    const sessie = request.sessie!;
+
+    let invoer: NieuwContract;
+
+    try {
+      invoer = leesNieuwContract(body);
+    } catch (err) {
+      throw alsHttpFout(err);
+    }
+
+    const contract = await this.contracts
+      .maakAan(sessie.tenantId, leesUuid(vendorId), invoer)
+      .catch(alsRefFout);
+
+    if (!contract) {
+      throw new NotFoundException('Leverancier niet gevonden.');
+    }
+
+    return contract;
+  }
+
+  @Get(':id')
+  async detail(
+    @Req() request: RequestMetSessie,
+    @Param('vendorId') vendorId: string,
+    @Param('id') id: string,
+  ) {
+    const sessie = request.sessie!;
+
+    const contract = await this.contracts.detail(
+      sessie.tenantId,
+      leesUuid(vendorId),
+      leesUuid(id),
+    );
+
+    if (!contract) {
+      throw new NotFoundException('Contract niet gevonden.');
+    }
+
+    return contract;
+  }
+
+  @Patch(':id')
+  @VereistRol('admin')
+  async wijzig(
+    @Req() request: RequestMetSessie,
+    @Param('vendorId') vendorId: string,
+    @Param('id') id: string,
+    @Body() body: unknown,
+  ) {
+    const sessie = request.sessie!;
+
+    let wijziging: ContractWijziging;
+
+    try {
+      wijziging = leesContractWijziging(body);
+    } catch (err) {
+      throw alsHttpFout(err);
+    }
+
+    const contract = await this.contracts
+      .wijzig(sessie.tenantId, leesUuid(vendorId), leesUuid(id), wijziging)
+      .catch(alsRefFout);
+
+    if (!contract) {
+      throw new NotFoundException('Contract niet gevonden.');
+    }
+
+    return contract;
+  }
+
+  @Delete(':id')
+  @VereistRol('admin')
+  @HttpCode(204)
+  async verwijder(
+    @Req() request: RequestMetSessie,
+    @Param('vendorId') vendorId: string,
+    @Param('id') id: string,
+  ) {
+    const sessie = request.sessie!;
+
+    const gelukt = await this.contracts.verwijder(
+      sessie.tenantId,
+      leesUuid(vendorId),
+      leesUuid(id),
+    );
+
+    if (!gelukt) {
+      throw new NotFoundException('Contract niet gevonden.');
+    }
+  }
+}
+
+const UUID_PATROON =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+function leesUuid(waarde: string): string {
+  if (!UUID_PATROON.test(waarde)) {
+    throw new NotFoundException('Niet gevonden.');
+  }
+
+  return waarde;
+}
+
+function alsHttpFout(err: unknown): unknown {
+  if (err instanceof InvoerFout) {
+    return new BadRequestException({ message: err.message, veld: err.veld });
+  }
+
+  return err;
+}
+
+/**
+ * Een onbekende status_code, vendor_contact_id of owner_user_id is een
+ * gebruikersfout, geen storing. Zelfde vertaling als bij VendorController.
+ */
+function alsRefFout(err: unknown): never {
+  const code = (err as { cause?: { code?: string }; code?: string })?.cause
+    ?.code;
+
+  if (code === '23503') {
+    throw new BadRequestException({
+      message: 'Onbekende status, contactpersoon of contractbeheerder.',
+      veld: 'statusCode',
+    });
+  }
+
+  throw err;
+}

--- a/src/contract/contract.controller.ts
+++ b/src/contract/contract.controller.ts
@@ -9,6 +9,7 @@ import {
   Param,
   Patch,
   Post,
+  Put,
   Req,
   UseGuards,
 } from '@nestjs/common';
@@ -22,6 +23,7 @@ import {
   InvoerFout,
   leesContractWijziging,
   leesNieuwContract,
+  leesSurveyTemplateKoppeling,
 } from './contract-invoer';
 import {
   ContractService,
@@ -153,6 +155,61 @@ export class ContractController {
     if (!gelukt) {
       throw new NotFoundException('Contract niet gevonden.');
     }
+  }
+
+  @Get(':id/survey-templates')
+  async surveyTemplates(
+    @Req() request: RequestMetSessie,
+    @Param('vendorId') vendorId: string,
+    @Param('id') id: string,
+  ) {
+    const sessie = request.sessie!;
+
+    const koppeling = await this.contracts.surveyTemplates(
+      sessie.tenantId,
+      leesUuid(vendorId),
+      leesUuid(id),
+    );
+
+    if (!koppeling) {
+      throw new NotFoundException('Contract niet gevonden.');
+    }
+
+    return koppeling;
+  }
+
+  @Put(':id/survey-templates')
+  @VereistRol('admin')
+  async zetSurveyTemplates(
+    @Req() request: RequestMetSessie,
+    @Param('vendorId') vendorId: string,
+    @Param('id') id: string,
+    @Body() body: unknown,
+  ) {
+    const sessie = request.sessie!;
+
+    let templateIds: string[];
+
+    try {
+      templateIds = leesSurveyTemplateKoppeling(body);
+    } catch (err) {
+      throw alsHttpFout(err);
+    }
+
+    const koppeling = await this.contracts
+      .zetSurveyTemplates(
+        sessie.tenantId,
+        leesUuid(vendorId),
+        leesUuid(id),
+        templateIds,
+      )
+      .catch(alsRefFout);
+
+    if (!koppeling) {
+      throw new NotFoundException('Contract niet gevonden.');
+    }
+
+    return koppeling;
   }
 }
 

--- a/src/contract/contract.module.ts
+++ b/src/contract/contract.module.ts
@@ -1,0 +1,18 @@
+import { Module } from '@nestjs/common';
+
+import { AuthModule } from '../auth/auth.module';
+import { ContractController } from './contract.controller';
+import { ContractService } from './contract.service';
+
+/**
+ * Contractbeheer bij een leverancier.
+ *
+ * AuthModule voor TenantContextGuard, zelfde reden als VendorModule.
+ */
+@Module({
+  imports: [AuthModule],
+  controllers: [ContractController],
+  providers: [ContractService],
+  exports: [ContractService],
+})
+export class ContractModule {}

--- a/src/contract/contract.service.ts
+++ b/src/contract/contract.service.ts
@@ -13,6 +13,8 @@ import { DatabaseService } from '../db/database.service';
 
 export interface SurveyTemplateKoppeling {
   templateIds: string[];
+  /** Welke van de gekoppelde templates ook op de wachtlijst staan. */
+  wachtlijstTemplateIds: string[];
 }
 
 export interface ContractSamenvatting {
@@ -342,14 +344,21 @@ export class ContractService {
           return null;
         }
 
-        const resultaat = await tx.execute<{ survey_template_id: string }>(
-          sql`SELECT survey_template_id FROM clm.contract_survey_template
+        const resultaat = await tx.execute<{
+          survey_template_id: string;
+          wachtlijst: boolean;
+        }>(
+          sql`SELECT survey_template_id, wachtlijst
+             FROM clm.contract_survey_template
              WHERE contract_id = ${contractId}
              ORDER BY created_at`,
         );
 
         return {
           templateIds: resultaat.rows.map((r) => r.survey_template_id),
+          wachtlijstTemplateIds: resultaat.rows
+            .filter((r) => r.wachtlijst)
+            .map((r) => r.survey_template_id),
         };
       },
       'medewerker',
@@ -368,6 +377,7 @@ export class ContractService {
     vendorId: string,
     contractId: string,
     templateIds: string[],
+    wachtlijstTemplateIds: string[],
   ): Promise<SurveyTemplateKoppeling | null> {
     return this.db.withTenant(
       tenantId,
@@ -391,8 +401,9 @@ export class ContractService {
         for (const templateId of templateIds) {
           await tx.execute(
             sql`INSERT INTO clm.contract_survey_template
-                  (contract_id, survey_template_id, tenant_id)
-                VALUES (${contractId}, ${templateId}, ${tenantId})`,
+                  (contract_id, survey_template_id, tenant_id, wachtlijst)
+                VALUES (${contractId}, ${templateId}, ${tenantId},
+                        ${wachtlijstTemplateIds.includes(templateId)})`,
           );
         }
 
@@ -400,7 +411,45 @@ export class ContractService {
           `Survey-templates gekoppeld aan contract ${contractId}: ${templateIds.length}.`,
         );
 
-        return { templateIds };
+        return { templateIds, wachtlijstTemplateIds };
+      },
+      'medewerker',
+    );
+  }
+
+  /**
+   * Leveranciers die op de wachtlijst staan voor de volgende ronde van
+   * deze vragenlijst-template, via een gekoppeld contract. Eén leverancier
+   * met meerdere contracten op de wachtlijst voor dezelfde template komt
+   * hier maar één keer voor (DISTINCT) — de UI toont een leverancier, geen
+   * contract.
+   */
+  async wachtlijstVoorTemplate(
+    tenantId: string,
+    templateId: string,
+  ): Promise<{ vendorId: string; vendorNaam: string }[]> {
+    return this.db.withTenant(
+      tenantId,
+      async (tx) => {
+        const resultaat = await tx.execute<{
+          vendor_id: string;
+          name: string;
+        }>(
+          sql`SELECT DISTINCT v.vendor_id, v.name
+             FROM clm.contract_survey_template cst
+             JOIN clm.contract c ON c.contract_id = cst.contract_id
+             JOIN clm.vendor v ON v.vendor_id = c.vendor_id
+             WHERE cst.survey_template_id = ${templateId}
+               AND cst.wachtlijst = true
+               AND c.deleted_at IS NULL
+               AND v.deleted_at IS NULL
+             ORDER BY v.name`,
+        );
+
+        return resultaat.rows.map((r) => ({
+          vendorId: r.vendor_id,
+          vendorNaam: r.name,
+        }));
       },
       'medewerker',
     );

--- a/src/contract/contract.service.ts
+++ b/src/contract/contract.service.ts
@@ -11,6 +11,10 @@ import { DatabaseService } from '../db/database.service';
  * docs/superpowers/specs/2026-08-22-contractmanagement-design.md.
  */
 
+export interface SurveyTemplateKoppeling {
+  templateIds: string[];
+}
+
 export interface ContractSamenvatting {
   contractId: string;
   name: string;
@@ -299,6 +303,90 @@ export class ContractService {
 
         this.logger.log(`Contract verwijderd (${contractId}).`);
         return true;
+      },
+      'medewerker',
+    );
+  }
+
+  /** Welke vragenlijst-templates aan dit contract gekoppeld zijn. */
+  async surveyTemplates(
+    tenantId: string,
+    vendorId: string,
+    contractId: string,
+  ): Promise<SurveyTemplateKoppeling | null> {
+    return this.db.withTenant(
+      tenantId,
+      async (tx) => {
+        const bestaat = await tx.execute<{ contract_id: string }>(
+          sql`SELECT contract_id FROM clm.contract
+             WHERE contract_id = ${contractId}
+               AND vendor_id = ${vendorId}
+               AND deleted_at IS NULL`,
+        );
+
+        if (bestaat.rows.length === 0) {
+          return null;
+        }
+
+        const resultaat = await tx.execute<{ survey_template_id: string }>(
+          sql`SELECT survey_template_id FROM clm.contract_survey_template
+             WHERE contract_id = ${contractId}
+             ORDER BY created_at`,
+        );
+
+        return {
+          templateIds: resultaat.rows.map((r) => r.survey_template_id),
+        };
+      },
+      'medewerker',
+    );
+  }
+
+  /**
+   * Vervangt de volledige set gekoppelde templates in één transactie.
+   *
+   * Geen diff (verwijderen wat wegvalt, toevoegen wat nieuw is): bij een klein
+   * aantal templates per contract is "alles weg, alles opnieuw" even correct
+   * en eenvoudiger. Zie spec §3.2.
+   */
+  async zetSurveyTemplates(
+    tenantId: string,
+    vendorId: string,
+    contractId: string,
+    templateIds: string[],
+  ): Promise<SurveyTemplateKoppeling | null> {
+    return this.db.withTenant(
+      tenantId,
+      async (tx) => {
+        const bestaat = await tx.execute<{ contract_id: string }>(
+          sql`SELECT contract_id FROM clm.contract
+             WHERE contract_id = ${contractId}
+               AND vendor_id = ${vendorId}
+               AND deleted_at IS NULL`,
+        );
+
+        if (bestaat.rows.length === 0) {
+          return null;
+        }
+
+        await tx.execute(
+          sql`DELETE FROM clm.contract_survey_template
+             WHERE contract_id = ${contractId}`,
+        );
+
+        for (const templateId of templateIds) {
+          await tx.execute(
+            sql`INSERT INTO clm.contract_survey_template
+                  (contract_id, survey_template_id, tenant_id)
+                VALUES (${contractId}, ${templateId}, ${tenantId})`,
+          );
+        }
+
+        this.logger.log(
+          `Survey-templates gekoppeld aan contract ${contractId}: ${templateIds.length}.`,
+        );
+
+        return { templateIds };
       },
       'medewerker',
     );

--- a/src/contract/contract.service.ts
+++ b/src/contract/contract.service.ts
@@ -1,0 +1,344 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { sql, type SQL } from 'drizzle-orm';
+
+import { DatabaseService } from '../db/database.service';
+
+/**
+ * Contracten lezen, aanmaken en wijzigen bij een leverancier.
+ *
+ * Zelfde opzet als VendorService: raw SQL binnen withTenant(), 'medewerker'
+ * als actor, soft delete via deleted_at. Zie
+ * docs/superpowers/specs/2026-08-22-contractmanagement-design.md.
+ */
+
+export interface ContractSamenvatting {
+  contractId: string;
+  name: string;
+  contractNumber: string | null;
+  statusCode: string | null;
+  startDate: string | null;
+  endDate: string | null;
+  createdAt: string;
+}
+
+export interface NieuwContract {
+  name: string;
+  contractNumber?: string | null;
+  vendorContactId?: string | null;
+  ownerUserId?: string | null;
+  statusCode?: string | null;
+  valueEur?: string | null;
+  startDate?: string | null;
+  endDate?: string | null;
+  note?: string | null;
+}
+
+export interface ContractDetail {
+  contractId: string;
+  vendorId: string;
+  name: string;
+  contractNumber: string | null;
+  vendorContactId: string | null;
+  ownerUserId: string | null;
+  statusCode: string | null;
+  valueEur: string | null;
+  startDate: string | null;
+  endDate: string | null;
+  note: string | null;
+  createdAt: string;
+  updatedAt: string | null;
+}
+
+/**
+ * Wat er gewijzigd mag worden aan een contract. Elk veld optioneel; `null`
+ * maakt leeg, `undefined` betekent "niet aangeraakt" — zelfde onderscheid als
+ * VendorWijziging.
+ */
+export interface ContractWijziging {
+  name?: string;
+  contractNumber?: string | null;
+  vendorContactId?: string | null;
+  ownerUserId?: string | null;
+  statusCode?: string | null;
+  valueEur?: string | null;
+  startDate?: string | null;
+  endDate?: string | null;
+  note?: string | null;
+}
+
+interface ContractRij extends Record<string, unknown> {
+  contract_id: string;
+  name: string;
+  contract_number: string | null;
+  status_code: string | null;
+  start_date: string | null;
+  end_date: string | null;
+  created_at: Date | string;
+}
+
+interface ContractDetailRij extends Record<string, unknown> {
+  contract_id: string;
+  vendor_id: string;
+  name: string;
+  contract_number: string | null;
+  vendor_contact_id: string | null;
+  owner_user_id: string | null;
+  status_code: string | null;
+  value_eur: string | null;
+  start_date: string | null;
+  end_date: string | null;
+  note: string | null;
+  created_at: Date | string;
+  updated_at: Date | string | null;
+}
+
+function alsTekst(waarde: Date | string): string {
+  return waarde instanceof Date ? waarde.toISOString() : waarde;
+}
+
+function alsTekstOfNull(waarde: Date | string | null): string | null {
+  return waarde === null ? null : alsTekst(waarde);
+}
+
+function leegIsNull(waarde: string | null | undefined): string | null {
+  const geknipt = waarde?.trim();
+  return geknipt ? geknipt : null;
+}
+
+@Injectable()
+export class ContractService {
+  private readonly logger = new Logger(ContractService.name);
+
+  constructor(private readonly db: DatabaseService) {}
+
+  /** Alle actieve contracten van een leverancier, nieuwste eerst. */
+  async lijst(
+    tenantId: string,
+    vendorId: string,
+  ): Promise<ContractSamenvatting[]> {
+    return this.db.withTenant(
+      tenantId,
+      async (tx) => {
+        const resultaat = await tx.execute<ContractRij>(
+          sql`SELECT contract_id, name, contract_number, status_code,
+                     start_date, end_date, created_at
+                FROM clm.contract
+               WHERE vendor_id = ${vendorId} AND deleted_at IS NULL
+               ORDER BY created_at DESC`,
+        );
+
+        return resultaat.rows.map((r) => ({
+          contractId: r.contract_id,
+          name: r.name,
+          contractNumber: r.contract_number,
+          statusCode: r.status_code,
+          startDate: r.start_date,
+          endDate: r.end_date,
+          createdAt: alsTekst(r.created_at),
+        }));
+      },
+      'medewerker',
+    );
+  }
+
+  /**
+   * Maakt een contract aan bij een leverancier.
+   *
+   * Geeft `null` als de leverancier niet bestaat of niet van deze tenant is
+   * — zelfde redenering als VendorService.detail().
+   */
+  async maakAan(
+    tenantId: string,
+    vendorId: string,
+    invoer: NieuwContract,
+  ): Promise<ContractDetail | null> {
+    return this.db.withTenant(
+      tenantId,
+      async (tx) => {
+        const vendorBestaat = await tx.execute<{ vendor_id: string }>(
+          sql`SELECT vendor_id FROM clm.vendor
+             WHERE vendor_id = ${vendorId} AND deleted_at IS NULL`,
+        );
+
+        if (vendorBestaat.rows.length === 0) {
+          return null;
+        }
+
+        const resultaat = await tx.execute<{ contract_id: string }>(
+          sql`INSERT INTO clm.contract
+                (tenant_id, vendor_id, name, contract_number,
+                 vendor_contact_id, owner_user_id, status_code, value_eur,
+                 start_date, end_date, note)
+              VALUES (${tenantId}, ${vendorId}, ${invoer.name.trim()},
+                      ${leegIsNull(invoer.contractNumber)},
+                      ${invoer.vendorContactId ?? null},
+                      ${invoer.ownerUserId ?? null},
+                      ${leegIsNull(invoer.statusCode)},
+                      ${invoer.valueEur ?? null},
+                      ${invoer.startDate ?? null},
+                      ${invoer.endDate ?? null},
+                      ${leegIsNull(invoer.note)})
+              RETURNING contract_id`,
+        );
+
+        const contractId = resultaat.rows[0].contract_id;
+
+        this.logger.log(`Contract aangemaakt (${contractId}).`);
+
+        return this.detailBinnenTransactie(tx, vendorId, contractId);
+      },
+      'medewerker',
+    );
+  }
+
+  /** Eén contract, mits het bij deze vendor en tenant hoort. */
+  async detail(
+    tenantId: string,
+    vendorId: string,
+    contractId: string,
+  ): Promise<ContractDetail | null> {
+    return this.db.withTenant(
+      tenantId,
+      (tx) => this.detailBinnenTransactie(tx, vendorId, contractId),
+      'medewerker',
+    );
+  }
+
+  /** Wijzigt een contract. Alleen de meegestuurde velden. */
+  async wijzig(
+    tenantId: string,
+    vendorId: string,
+    contractId: string,
+    wijziging: ContractWijziging,
+  ): Promise<ContractDetail | null> {
+    return this.db.withTenant(
+      tenantId,
+      async (tx) => {
+        const bestaat = await tx.execute<{ contract_id: string }>(
+          sql`SELECT contract_id FROM clm.contract
+             WHERE contract_id = ${contractId}
+               AND vendor_id = ${vendorId}
+               AND deleted_at IS NULL`,
+        );
+
+        if (bestaat.rows.length === 0) {
+          return null;
+        }
+
+        const zetten: SQL[] = [];
+
+        if (wijziging.name !== undefined) {
+          zetten.push(sql`name = ${wijziging.name.trim()}`);
+        }
+        if (wijziging.contractNumber !== undefined) {
+          zetten.push(
+            sql`contract_number = ${leegIsNull(wijziging.contractNumber)}`,
+          );
+        }
+        if (wijziging.vendorContactId !== undefined) {
+          zetten.push(sql`vendor_contact_id = ${wijziging.vendorContactId}`);
+        }
+        if (wijziging.ownerUserId !== undefined) {
+          zetten.push(sql`owner_user_id = ${wijziging.ownerUserId}`);
+        }
+        if (wijziging.statusCode !== undefined) {
+          zetten.push(sql`status_code = ${leegIsNull(wijziging.statusCode)}`);
+        }
+        if (wijziging.valueEur !== undefined) {
+          zetten.push(sql`value_eur = ${wijziging.valueEur}`);
+        }
+        if (wijziging.startDate !== undefined) {
+          zetten.push(sql`start_date = ${wijziging.startDate}`);
+        }
+        if (wijziging.endDate !== undefined) {
+          zetten.push(sql`end_date = ${wijziging.endDate}`);
+        }
+        if (wijziging.note !== undefined) {
+          zetten.push(sql`note = ${leegIsNull(wijziging.note)}`);
+        }
+
+        if (zetten.length > 0) {
+          zetten.push(sql`updated_at = now()`);
+
+          await tx.execute(
+            sql`UPDATE clm.contract
+                 SET ${sql.join(zetten, sql`, `)}
+               WHERE contract_id = ${contractId}`,
+          );
+
+          this.logger.log(`Contract gewijzigd (${contractId}).`);
+        }
+
+        return this.detailBinnenTransactie(tx, vendorId, contractId);
+      },
+      'medewerker',
+    );
+  }
+
+  /** Verwijdert een contract — soft delete. */
+  async verwijder(
+    tenantId: string,
+    vendorId: string,
+    contractId: string,
+  ): Promise<boolean> {
+    return this.db.withTenant(
+      tenantId,
+      async (tx) => {
+        const resultaat = await tx.execute<{ contract_id: string }>(
+          sql`UPDATE clm.contract
+               SET deleted_at = now()
+             WHERE contract_id = ${contractId}
+               AND vendor_id = ${vendorId}
+               AND deleted_at IS NULL
+             RETURNING contract_id`,
+        );
+
+        if (resultaat.rows.length === 0) {
+          return false;
+        }
+
+        this.logger.log(`Contract verwijderd (${contractId}).`);
+        return true;
+      },
+      'medewerker',
+    );
+  }
+
+  private async detailBinnenTransactie(
+    tx: Parameters<Parameters<DatabaseService['withTenant']>[1]>[0],
+    vendorId: string,
+    contractId: string,
+  ): Promise<ContractDetail | null> {
+    const resultaat = await tx.execute<ContractDetailRij>(
+      sql`SELECT contract_id, vendor_id, name, contract_number,
+                 vendor_contact_id, owner_user_id, status_code, value_eur,
+                 start_date, end_date, note, created_at, updated_at
+            FROM clm.contract
+           WHERE contract_id = ${contractId}
+             AND vendor_id = ${vendorId}
+             AND deleted_at IS NULL`,
+    );
+
+    const rij = resultaat.rows[0];
+
+    if (!rij) {
+      return null;
+    }
+
+    return {
+      contractId: rij.contract_id,
+      vendorId: rij.vendor_id,
+      name: rij.name,
+      contractNumber: rij.contract_number,
+      vendorContactId: rij.vendor_contact_id,
+      ownerUserId: rij.owner_user_id,
+      statusCode: rij.status_code,
+      valueEur: rij.value_eur,
+      startDate: rij.start_date,
+      endDate: rij.end_date,
+      note: rij.note,
+      createdAt: alsTekst(rij.created_at),
+      updatedAt: alsTekstOfNull(rij.updated_at),
+    };
+  }
+}

--- a/src/contract/contract.service.ts
+++ b/src/contract/contract.service.ts
@@ -22,6 +22,8 @@ export interface ContractSamenvatting {
   statusCode: string | null;
   startDate: string | null;
   endDate: string | null;
+  vendorContactNaam: string | null;
+  ownerGebruikerNaam: string | null;
   createdAt: string;
 }
 
@@ -43,7 +45,9 @@ export interface ContractDetail {
   name: string;
   contractNumber: string | null;
   vendorContactId: string | null;
+  vendorContactNaam: string | null;
   ownerUserId: string | null;
+  ownerGebruikerNaam: string | null;
   statusCode: string | null;
   valueEur: string | null;
   startDate: string | null;
@@ -77,6 +81,8 @@ interface ContractRij extends Record<string, unknown> {
   status_code: string | null;
   start_date: string | null;
   end_date: string | null;
+  vendor_contact_naam: string | null;
+  owner_naam: string | null;
   created_at: Date | string;
 }
 
@@ -86,7 +92,9 @@ interface ContractDetailRij extends Record<string, unknown> {
   name: string;
   contract_number: string | null;
   vendor_contact_id: string | null;
+  vendor_contact_naam: string | null;
   owner_user_id: string | null;
+  owner_naam: string | null;
   status_code: string | null;
   value_eur: string | null;
   start_date: string | null;
@@ -124,11 +132,15 @@ export class ContractService {
       tenantId,
       async (tx) => {
         const resultaat = await tx.execute<ContractRij>(
-          sql`SELECT contract_id, name, contract_number, status_code,
-                     start_date, end_date, created_at
-                FROM clm.contract
-               WHERE vendor_id = ${vendorId} AND deleted_at IS NULL
-               ORDER BY created_at DESC`,
+          sql`SELECT c.contract_id, c.name, c.contract_number, c.status_code,
+                     c.start_date, c.end_date, c.created_at,
+                     vc.full_name AS vendor_contact_naam,
+                     u.full_name AS owner_naam
+                FROM clm.contract c
+                LEFT JOIN clm.vendor_contact vc ON vc.contact_id = c.vendor_contact_id
+                LEFT JOIN clm."user" u ON u.user_id = c.owner_user_id
+               WHERE c.vendor_id = ${vendorId} AND c.deleted_at IS NULL
+               ORDER BY c.created_at DESC`,
         );
 
         return resultaat.rows.map((r) => ({
@@ -138,6 +150,8 @@ export class ContractService {
           statusCode: r.status_code,
           startDate: r.start_date,
           endDate: r.end_date,
+          vendorContactNaam: r.vendor_contact_naam,
+          ownerGebruikerNaam: r.owner_naam,
           createdAt: alsTekst(r.created_at),
         }));
       },
@@ -398,13 +412,18 @@ export class ContractService {
     contractId: string,
   ): Promise<ContractDetail | null> {
     const resultaat = await tx.execute<ContractDetailRij>(
-      sql`SELECT contract_id, vendor_id, name, contract_number,
-                 vendor_contact_id, owner_user_id, status_code, value_eur,
-                 start_date, end_date, note, created_at, updated_at
-            FROM clm.contract
-           WHERE contract_id = ${contractId}
-             AND vendor_id = ${vendorId}
-             AND deleted_at IS NULL`,
+      sql`SELECT c.contract_id, c.vendor_id, c.name, c.contract_number,
+                 c.vendor_contact_id, c.owner_user_id, c.status_code,
+                 c.value_eur, c.start_date, c.end_date, c.note,
+                 c.created_at, c.updated_at,
+                 vc.full_name AS vendor_contact_naam,
+                 u.full_name AS owner_naam
+            FROM clm.contract c
+            LEFT JOIN clm.vendor_contact vc ON vc.contact_id = c.vendor_contact_id
+            LEFT JOIN clm."user" u ON u.user_id = c.owner_user_id
+           WHERE c.contract_id = ${contractId}
+             AND c.vendor_id = ${vendorId}
+             AND c.deleted_at IS NULL`,
     );
 
     const rij = resultaat.rows[0];
@@ -419,7 +438,9 @@ export class ContractService {
       name: rij.name,
       contractNumber: rij.contract_number,
       vendorContactId: rij.vendor_contact_id,
+      vendorContactNaam: rij.vendor_contact_naam,
       ownerUserId: rij.owner_user_id,
+      ownerGebruikerNaam: rij.owner_naam,
       statusCode: rij.status_code,
       valueEur: rij.value_eur,
       startDate: rij.start_date,

--- a/src/db/rechten-contract.ts
+++ b/src/db/rechten-contract.ts
@@ -95,6 +95,16 @@ export const TABELRECHTEN: Readonly<Record<string, Tabelrechten>> = {
   // maakt hier rijen aan, en support-toegang wordt hier toegekend.
   'clm.tenant_membership': LEZEN_EN_SCHRIJVEN,
 
+  // clm.contract (0027): contractmanagement-basismodule. Zacht verwijderd via
+  // deleted_at, net als vendor — geen DELETE nodig.
+  'clm.contract': NIET_VERWIJDEREN,
+
+  // clm.contract_survey_template (0027): many-to-many-koppeling zonder eigen
+  // levenscyclus. Een koppeling die niet meer geldt, wordt verwijderd, niet
+  // zacht gemarkeerd — anders zou "welke templates horen bij dit contract"
+  // stilzwijgend verouderde rijen blijven meetellen.
+  'clm.contract_survey_template': ['SELECT', 'INSERT', 'DELETE'],
+
   // ── Van nature append-only ─────────────────────────────────────────────────
   //
   // Een oordeel, een notitie of een koppeling verdwijnt niet: hij wordt zacht
@@ -162,6 +172,7 @@ export const TABELRECHTEN: Readonly<Record<string, Tabelrechten>> = {
   'ref.business_criticality': LEZEN_EN_SCHRIJVEN,
   'ref.compliance_status': LEZEN_EN_SCHRIJVEN,
   'ref.vendor_category': LEZEN_EN_SCHRIJVEN,
+  'ref.contract_status': LEZEN_EN_SCHRIJVEN,
 };
 
 /**

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -394,6 +394,10 @@ export const contractSurveyTemplate = clm.table(
       .notNull()
       .references(() => surveyTemplate.templateId, { onDelete: 'cascade' }),
     tenantId: uuid('tenant_id').notNull(),
+    // Staat deze leverancier klaar om voorgesteld te worden bij de volgende
+    // ronde van deze vragenlijst? Uitvinkbaar, nooit automatisch gezet.
+    // Migratie 0028, spec 2026-08-22-contractmanagement-ui-design.md §9.
+    wachtlijst: boolean('wachtlijst').notNull().default(false),
     createdAt: timestamp('created_at', { withTimezone: true })
       .notNull()
       .defaultNow(),

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -38,6 +38,11 @@ export const complianceStatus = ref.table('compliance_status', {
   label: text('label').notNull(),
 });
 
+export const contractStatus = ref.table('contract_status', {
+  code: text('code').primaryKey(),
+  label: text('label').notNull(),
+});
+
 // ─── clm schema: fundament ────────────────────────────────────────────────
 
 export const tenant = clm.table(
@@ -331,6 +336,74 @@ export const surveyTemplate = clm.table(
       t.version,
     ),
     index('survey_template_tenant_id_idx').on(t.tenantId),
+  ],
+);
+
+// ─── clm schema: contractmanagement ────────────────────────────────────────
+// Zie docs/superpowers/specs/2026-08-22-contractmanagement-design.md.
+
+export const contract = clm.table(
+  'contract',
+  {
+    contractId: uuid('contract_id').primaryKey().defaultRandom(),
+    tenantId: uuid('tenant_id')
+      .notNull()
+      .references(() => tenant.tenantId, { onDelete: 'restrict' }),
+    vendorId: uuid('vendor_id')
+      .notNull()
+      .references(() => vendor.vendorId, { onDelete: 'cascade' }),
+    name: text('name').notNull(),
+    contractNumber: text('contract_number'),
+    // NULL betekent "gebruik de is_primary-contactpersoon van de vendor" —
+    // applicatielogica, geen database-default. Zie spec §2.1.
+    vendorContactId: uuid('vendor_contact_id').references(
+      () => vendorContact.contactId,
+      { onDelete: 'set null' },
+    ),
+    ownerUserId: uuid('owner_user_id').references(() => user.userId, {
+      onDelete: 'set null',
+    }),
+    // Kent geen 'verlopend' — dat is berekend uit end_date, nooit
+    // opgeslagen. Zie spec §2.3.
+    statusCode: text('status_code').references(() => contractStatus.code, {
+      onDelete: 'set null',
+    }),
+    valueEur: numeric('value_eur', { precision: 15, scale: 2 }),
+    startDate: date('start_date'),
+    endDate: date('end_date'),
+    note: text('note'),
+    createdAt: timestamp('created_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }),
+    deletedAt: timestamp('deleted_at', { withTimezone: true }),
+  },
+  (t) => [
+    index('contract_tenant_id_idx').on(t.tenantId),
+    index('contract_vendor_id_idx').on(t.vendorId),
+  ],
+);
+
+export const contractSurveyTemplate = clm.table(
+  'contract_survey_template',
+  {
+    contractId: uuid('contract_id')
+      .notNull()
+      .references(() => contract.contractId, { onDelete: 'cascade' }),
+    surveyTemplateId: uuid('survey_template_id')
+      .notNull()
+      .references(() => surveyTemplate.templateId, { onDelete: 'cascade' }),
+    tenantId: uuid('tenant_id').notNull(),
+    createdAt: timestamp('created_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (t) => [
+    uniqueIndex('contract_survey_template_pkey').on(
+      t.contractId,
+      t.surveyTemplateId,
+    ),
+    index('contract_survey_template_tenant_id_idx').on(t.tenantId),
   ],
 );
 

--- a/src/survey/ronde-beheer.service.ts
+++ b/src/survey/ronde-beheer.service.ts
@@ -105,6 +105,7 @@ export interface RondeGestart {
   surveyKind: string;
   isTest: boolean;
   closesAt: string | null;
+  contractId: string | null;
 }
 
 interface RunRij extends Record<string, unknown> {
@@ -115,6 +116,7 @@ interface RunRij extends Record<string, unknown> {
   survey_kind: string;
   is_test: boolean;
   closes_at: Date | string | null;
+  contract_id: string | null;
 }
 
 interface VendorRij extends Record<string, unknown> {
@@ -182,15 +184,30 @@ export class RondeBeheerService {
           });
         }
 
+        // Bestaat het contract, als er een is meegestuurd? RLS filtert
+        // automatisch op tenant — een contract van een andere tenant levert
+        // hier gewoon nul rijen op, niet een lek.
+        if (invoer.contractId) {
+          const contracten = await tx.execute<{ contract_id: string }>(
+            sql`SELECT contract_id FROM clm.contract
+               WHERE contract_id = ${invoer.contractId}
+                 AND deleted_at IS NULL`,
+          );
+
+          if (contracten.rows.length === 0) {
+            throw new NotFoundException('Dit contract bestaat niet.');
+          }
+        }
+
         const aangemaakt = await tx.execute<RunRij>(
           sql`INSERT INTO clm.survey_run
                   (tenant_id, template_id, survey_kind, status, closes_at,
-                   is_test)
+                   is_test, contract_id)
               VALUES (${tenantId}, ${invoer.templateId}, ${invoer.surveyKind},
                       'draft', ${invoer.closesAt?.toISOString() ?? null},
-                      ${invoer.isTest})
+                      ${invoer.isTest}, ${invoer.contractId})
               RETURNING run_id, template_id, status, survey_kind, is_test,
-                        closes_at`,
+                        closes_at, contract_id`,
         );
 
         const r = aangemaakt.rows[0];
@@ -203,6 +220,7 @@ export class RondeBeheerService {
           surveyKind: r.survey_kind,
           isTest: r.is_test,
           closesAt: iso(r.closes_at),
+          contractId: r.contract_id,
         };
       },
       'medewerker',
@@ -233,7 +251,8 @@ export class RondeBeheerService {
       async (tx) => {
         const huidige = await tx.execute<RunRij>(
           sql`SELECT r.run_id, r.template_id, t.name AS template_naam,
-                     r.status, r.survey_kind, r.is_test, r.closes_at
+                     r.status, r.survey_kind, r.is_test, r.closes_at,
+                     r.contract_id
                 FROM clm.survey_run r
                 JOIN clm.survey_template t ON t.template_id = r.template_id
                WHERE r.run_id = ${runId}`,
@@ -266,7 +285,7 @@ export class RondeBeheerService {
                  SET status = ${nieuweStatus}
                WHERE run_id = ${runId}
               RETURNING run_id, template_id, status, survey_kind, is_test,
-                        closes_at`,
+                        closes_at, contract_id`,
         );
 
         return this.naarGestart({
@@ -478,6 +497,7 @@ export class RondeBeheerService {
       surveyKind: r.survey_kind,
       isTest: r.is_test,
       closesAt: iso(r.closes_at),
+      contractId: r.contract_id,
     };
   }
 }

--- a/src/survey/ronde-invoer.ts
+++ b/src/survey/ronde-invoer.ts
@@ -71,6 +71,8 @@ export interface NieuweRonde {
   /** Wanneer de ronde sluit. Null betekent: geen sluitdatum. */
   closesAt: Date | null;
   isTest: boolean;
+  /** Op welk contract deze ronde betrekking heeft. Optioneel — zie migratie 0007. */
+  contractId: string | null;
 }
 
 export interface Uitnodigingen {
@@ -128,6 +130,10 @@ export function leesNieuweRonde(body: unknown): NieuweRonde {
     // gemarkeerd valt buiten de rapportage, en dat hoort een bewuste keuze te
     // zijn — niet het gevolg van een meegestuurde string "false".
     isTest: invoer.isTest === true,
+    contractId:
+      invoer.contractId === undefined || invoer.contractId === null
+        ? null
+        : leesUuid(invoer.contractId, 'contractId'),
   };
 }
 

--- a/src/survey/survey.module.ts
+++ b/src/survey/survey.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common';
 
 import { AuthModule } from '../auth/auth.module';
+import { ContractModule } from '../contract/contract.module';
 import { MailModule } from '../mail/mail.module';
 import { SurveyAuditService } from './survey-audit.service';
 import { SurveyResponseController } from './survey-response.controller';
@@ -40,7 +41,7 @@ import { VragenlijstLeesService } from './vragenlijst-lezen.service';
  * maar krijgt niemand ze — dat was de stand tot 2026-08-06.
  */
 @Module({
-  imports: [AuthModule, MailModule],
+  imports: [AuthModule, MailModule, ContractModule],
   controllers: [SurveyResponseController, VragenlijstBeheerController],
   providers: [
     SurveyAuditService,

--- a/src/survey/vragenlijst-beheer.controller.ts
+++ b/src/survey/vragenlijst-beheer.controller.ts
@@ -19,6 +19,7 @@ import {
   TenantContextGuard,
   type RequestMetSessie,
 } from '../auth/tenant-context.guard';
+import { ContractService } from '../contract/contract.service';
 import { ContractmanagerService } from './contractmanager.service';
 import { NotitieService } from './notitie.service';
 import { RondeBeheerService } from './ronde-beheer.service';
@@ -87,6 +88,7 @@ export class VragenlijstBeheerController {
     // Onderstreept om dezelfde reden als beoordelingen_.
     private readonly notities_: NotitieService,
     private readonly contractmanagers: ContractmanagerService,
+    private readonly contracten: ContractService,
   ) {}
 
   /** Alle vragenlijsten van deze tenant, met aantallen vragen en rondes. */
@@ -107,6 +109,19 @@ export class VragenlijstBeheerController {
     const sessie = request.sessie!;
 
     return this.beheer.detail(sessie.tenantId, id);
+  }
+
+  /** Leveranciers die op de wachtlijst staan voor de volgende ronde. */
+  @Get('templates/:id/wachtlijst')
+  async wachtlijst(@Req() request: RequestMetSessie, @Param('id') id: string) {
+    const sessie = request.sessie!;
+
+    const leveranciers = await this.contracten.wachtlijstVoorTemplate(
+      sessie.tenantId,
+      id,
+    );
+
+    return { leveranciers };
   }
 
   /** Alle rondes van deze tenant, met voortgang per ronde. */

--- a/src/tenant/tenant.controller.ts
+++ b/src/tenant/tenant.controller.ts
@@ -50,6 +50,18 @@ export class TenantController {
     return this.tenants.lezen(request.sessie!.tenantId);
   }
 
+  /**
+   * De gebruikers van de eigen tenant, voor een keuzelijst.
+   *
+   * Geen `@VereistRol`: het is een keuzelijst, geen gevoelige data — zelfde
+   * redenering als bij `lezen()` hierboven.
+   */
+  @Get('gebruikers')
+  async gebruikersLijst(@Req() request: RequestMetSessie) {
+    const gebruikers = await this.tenants.gebruikers(request.sessie!.tenantId);
+    return { gebruikers };
+  }
+
   @Patch('instellingen')
   @VereistRol('admin')
   async wijzigen(@Req() request: RequestMetSessie, @Body() body: unknown) {

--- a/src/tenant/tenant.service.ts
+++ b/src/tenant/tenant.service.ts
@@ -51,6 +51,12 @@ export interface TenantWijziging {
   readonly antwoordEmail?: string | null;
 }
 
+/** Een gebruiker van de tenant, voor een keuzelijst (bv. contractbeheerder). */
+export interface TenantGebruiker {
+  readonly userId: string;
+  readonly naam: string;
+}
+
 @Injectable()
 export class TenantService {
   constructor(private readonly db: DatabaseService) {}
@@ -142,6 +148,29 @@ export class TenantService {
         naam: rows[0].name,
         antwoordEmail: rows[0].antwoord_email,
       };
+    });
+  }
+
+  /**
+   * De gebruikers van de eigen tenant, voor een keuzelijst (bv. de
+   * contractbeheerder-dropdown). Alleen id en naam — geen e-mailadres of rol,
+   * dat is meer dan een dropdown nodig heeft.
+   */
+  async gebruikers(tenantId: string): Promise<TenantGebruiker[]> {
+    return this.db.withTenant(tenantId, async (tx) => {
+      const { rows } = await tx.execute<{
+        user_id: string;
+        full_name: string;
+      }>(
+        sql`SELECT user_id, full_name FROM clm."user"
+             WHERE deleted_at IS NULL
+             ORDER BY full_name`,
+      );
+
+      return rows.map((r) => ({
+        userId: r.user_id,
+        naam: r.full_name,
+      }));
     });
   }
 }

--- a/src/vendor/vendor-invoer.ts
+++ b/src/vendor/vendor-invoer.ts
@@ -28,6 +28,7 @@ import type {
 const MAX_NAAM = 200;
 const MAX_KORT = 100;
 const MAX_URL = 500;
+const MAX_NOTITIE = 2000;
 
 export class InvoerFout extends Error {
   constructor(
@@ -325,6 +326,13 @@ export function leesContact(
   }
   if ('jobTitle' in ruw) {
     invoer.jobTitle = optioneleTekst(ruw.jobTitle, 'Functie', MAX_KORT);
+  }
+  if ('roleDescription' in ruw) {
+    invoer.roleDescription = optioneleTekst(
+      ruw.roleDescription,
+      'Notitie',
+      MAX_NOTITIE,
+    );
   }
 
   if ('isPrimary' in ruw) {

--- a/src/vendor/vendor.service.ts
+++ b/src/vendor/vendor.service.ts
@@ -59,6 +59,8 @@ export interface Contactpersoon {
   email: string | null;
   phone: string | null;
   jobTitle: string | null;
+  /** Vrije notitie, bv. "is vervanger van X voor IT-zaken". */
+  roleDescription: string | null;
   isPrimary: boolean;
 }
 
@@ -118,6 +120,7 @@ export interface ContactInvoer {
   email?: string | null;
   phone?: string | null;
   jobTitle?: string | null;
+  roleDescription?: string | null;
   isPrimary?: boolean;
 }
 
@@ -155,6 +158,7 @@ interface ContactRij extends Record<string, unknown> {
   email: string | null;
   phone: string | null;
   job_title: string | null;
+  role_description: string | null;
   is_primary: boolean;
 }
 
@@ -530,14 +534,16 @@ export class VendorService {
         const resultaat = await tx.execute<ContactRij>(
           sql`INSERT INTO clm.vendor_contact
                 (vendor_id, tenant_id, full_name, email, phone, job_title,
-                 is_primary)
+                 role_description, is_primary)
             VALUES (${vendorId}, ${tenantId},
                     ${invoer.fullName!.trim()},
                     ${leegIsNull(invoer.email)},
                     ${leegIsNull(invoer.phone)},
                     ${leegIsNull(invoer.jobTitle)},
+                    ${leegIsNull(invoer.roleDescription)},
                     ${wordtPrimair})
-            RETURNING contact_id, full_name, email, phone, job_title, is_primary`,
+            RETURNING contact_id, full_name, email, phone, job_title,
+                      role_description, is_primary`,
         );
 
         const c = resultaat.rows[0];
@@ -549,6 +555,7 @@ export class VendorService {
           email: c.email,
           phone: c.phone,
           jobTitle: c.job_title,
+          roleDescription: c.role_description,
           isPrimary: c.is_primary,
         };
       },
@@ -601,6 +608,11 @@ export class VendorService {
         if (invoer.jobTitle !== undefined) {
           zetten.push(sql`job_title = ${leegIsNull(invoer.jobTitle)}`);
         }
+        if (invoer.roleDescription !== undefined) {
+          zetten.push(
+            sql`role_description = ${leegIsNull(invoer.roleDescription)}`,
+          );
+        }
         if (invoer.isPrimary !== undefined) {
           zetten.push(sql`is_primary = ${invoer.isPrimary}`);
         }
@@ -616,7 +628,8 @@ export class VendorService {
         }
 
         const resultaat = await tx.execute<ContactRij>(
-          sql`SELECT contact_id, full_name, email, phone, job_title, is_primary
+          sql`SELECT contact_id, full_name, email, phone, job_title,
+                     role_description, is_primary
               FROM clm.vendor_contact
              WHERE contact_id = ${contactId}`,
         );
@@ -629,6 +642,7 @@ export class VendorService {
           email: c.email,
           phone: c.phone,
           jobTitle: c.job_title,
+          roleDescription: c.role_description,
           isPrimary: c.is_primary,
         };
       },
@@ -711,7 +725,8 @@ export class VendorService {
     }
 
     const contacten = await tx.execute<ContactRij>(
-      sql`SELECT contact_id, full_name, email, phone, job_title, is_primary
+      sql`SELECT contact_id, full_name, email, phone, job_title,
+                 role_description, is_primary
             FROM clm.vendor_contact
            WHERE vendor_id = ${vendorId} AND deleted_at IS NULL
            ORDER BY is_primary DESC, full_name`,
@@ -737,6 +752,7 @@ export class VendorService {
         email: c.email,
         phone: c.phone,
         jobTitle: c.job_title,
+        roleDescription: c.role_description,
         isPrimary: c.is_primary,
       })),
     };

--- a/test/contract-routes.e2e-spec.ts
+++ b/test/contract-routes.e2e-spec.ts
@@ -1,0 +1,290 @@
+import { INestApplication } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import cookieParser from 'cookie-parser';
+import { Client } from 'pg';
+import request from 'supertest';
+import type { App } from 'supertest/types';
+
+import { AppModule } from '../src/app.module';
+import { SessieService } from '../src/auth/sessie.service';
+import { cookieInstellingen } from '../src/auth/sessie';
+import { TEST_IDS } from './test-ids';
+
+/**
+ * Contractroutes: tenantgrens en rolcontrole.
+ *
+ * Zelfde twee vragen als vendor-detail.e2e-spec.ts: kan een reviewer
+ * schrijven (moet niet), en kan tenant A bij de contracten van tenant B zien
+ * (moet niet).
+ */
+
+const { tenant, adminUser, reviewerUser, andereTenant, andereUser } =
+  TEST_IDS['contract-routes'];
+
+const STEMPEL = Date.now();
+const SUBJECT_ADMIN = `oid-contract-admin-${STEMPEL}`;
+const SUBJECT_REVIEWER = `oid-contract-reviewer-${STEMPEL}`;
+const SUBJECT_ANDER = `oid-contract-ander-${STEMPEL}`;
+
+interface ContractAntwoord {
+  contractId: string;
+  vendorId: string;
+  name: string;
+  contractNumber: string | null;
+  statusCode: string | null;
+}
+
+function alsContract(body: unknown): ContractAntwoord {
+  return body as ContractAntwoord;
+}
+
+/**
+ * Migratierol, altijd naar dezelfde database als DATABASE_URL.
+ *
+ * Nodig omdat clm_api_runtime sinds migratie 0027 geen DELETE meer heeft op
+ * clm.contract (NIET_VERWIJDEREN in rechten-contract.ts — een contract wordt
+ * zacht verwijderd, net als vendor). Testopruiming ruimt hard op en heeft
+ * daarom de migratierol nodig, zelfde patroon als platform-routes.e2e-spec.ts.
+ */
+function migratieUrl(): string {
+  const runtime = process.env.DATABASE_URL;
+  if (!runtime) throw new Error('DATABASE_URL ontbreekt.');
+
+  const doel = new URL(runtime);
+  const expliciet = process.env.MIGRATION_DATABASE_URL;
+
+  if (expliciet) {
+    const gegeven = new URL(expliciet);
+    if (gegeven.host === doel.host && gegeven.pathname === doel.pathname) {
+      return expliciet;
+    }
+  }
+
+  doel.username = 'clm_migrator';
+  return doel.toString();
+}
+
+async function verwijderTestdata(migratieClient: Client): Promise<void> {
+  for (const t of [tenant, andereTenant]) {
+    await migratieClient.query('BEGIN');
+    await migratieClient.query(`SET LOCAL app.current_tenant_id = '${t}'`);
+    await migratieClient.query('DELETE FROM clm.contract WHERE tenant_id = $1', [
+      t,
+    ]);
+    await migratieClient.query(
+      'DELETE FROM clm.vendor_contact WHERE tenant_id = $1',
+      [t],
+    );
+    await migratieClient.query('DELETE FROM clm.vendor WHERE tenant_id = $1', [
+      t,
+    ]);
+    await migratieClient.query(
+      'DELETE FROM clm.tenant_membership WHERE tenant_id = $1',
+      [t],
+    );
+    await migratieClient.query('DELETE FROM clm."user" WHERE tenant_id = $1', [
+      t,
+    ]);
+    await migratieClient.query('DELETE FROM clm.tenant WHERE tenant_id = $1', [
+      t,
+    ]);
+    await migratieClient.query('COMMIT');
+  }
+}
+
+describe('Contractroutes (e2e)', () => {
+  let app: INestApplication<App>;
+  let server: App;
+  let client: Client;
+  let migratieClient: Client;
+  let sessies: SessieService;
+
+  let adminCookie: string;
+  let reviewerCookie: string;
+  let vendorId: string;
+
+  const cookieNaam = cookieInstellingen().naam;
+
+  beforeAll(async () => {
+    client = new Client({ connectionString: process.env.DATABASE_URL });
+    await client.connect();
+
+    migratieClient = new Client({ connectionString: migratieUrl() });
+    await migratieClient.connect();
+
+    await verwijderTestdata(migratieClient);
+
+    await client.query('BEGIN');
+    await client.query(`SET LOCAL app.current_tenant_id = '${tenant}'`);
+    await client.query(
+      'INSERT INTO clm.tenant (tenant_id, name) VALUES ($1, $2)',
+      [tenant, 'contract-test'],
+    );
+    await client.query(
+      `INSERT INTO clm."user" (user_id, tenant_id, full_name, external_subject)
+       VALUES ($1, $2, $3, $4), ($5, $2, $6, $7)`,
+      [
+        adminUser,
+        tenant,
+        'Anna Admin',
+        SUBJECT_ADMIN,
+        reviewerUser,
+        'Rob Reviewer',
+        SUBJECT_REVIEWER,
+      ],
+    );
+    await client.query(
+      `INSERT INTO clm.tenant_membership (user_id, tenant_id, role)
+       VALUES ($1, $2, 'admin'), ($3, $2, 'reviewer')`,
+      [adminUser, tenant, reviewerUser],
+    );
+
+    const vendorResultaat = await client.query<{ vendor_id: string }>(
+      `INSERT INTO clm.vendor (tenant_id, name) VALUES ($1, $2)
+       RETURNING vendor_id`,
+      [tenant, `Testleverancier-${STEMPEL}`],
+    );
+    vendorId = vendorResultaat.rows[0].vendor_id;
+
+    await client.query('COMMIT');
+
+    const moduleRef = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleRef.createNestApplication();
+    app.use(cookieParser());
+    await app.init();
+    server = app.getHttpServer();
+
+    sessies = app.get(SessieService);
+
+    const adminSessie = await sessies.aanmaken(SUBJECT_ADMIN);
+    const reviewerSessie = await sessies.aanmaken(SUBJECT_REVIEWER);
+
+    adminCookie = `${cookieNaam}=${adminSessie!.token}`;
+    reviewerCookie = `${cookieNaam}=${reviewerSessie!.token}`;
+  });
+
+  afterAll(async () => {
+    await app.close();
+    await verwijderTestdata(migratieClient);
+    await client.end();
+    await migratieClient.end();
+  });
+
+  it('admin kan een contract aanmaken', async () => {
+    const respons = await request(server)
+      .post(`/vendors/${vendorId}/contracts`)
+      .set('Cookie', adminCookie)
+      .send({ name: 'Hosting 2024-2027', contractNumber: 'ERP-4711' });
+
+    expect(respons.status).toBe(201);
+    const contract = alsContract(respons.body);
+    expect(contract.name).toBe('Hosting 2024-2027');
+    expect(contract.contractNumber).toBe('ERP-4711');
+    expect(contract.vendorId).toBe(vendorId);
+  });
+
+  it('reviewer kan geen contract aanmaken (403)', async () => {
+    const respons = await request(server)
+      .post(`/vendors/${vendorId}/contracts`)
+      .set('Cookie', reviewerCookie)
+      .send({ name: 'Verboden contract' });
+
+    expect(respons.status).toBe(403);
+  });
+
+  it('admin kan de lijst met contracten van de leverancier ophalen', async () => {
+    const respons = await request(server)
+      .get(`/vendors/${vendorId}/contracts`)
+      .set('Cookie', adminCookie);
+
+    expect(respons.status).toBe(200);
+    expect(Array.isArray(respons.body.contracten)).toBe(true);
+    expect(respons.body.contracten.length).toBeGreaterThan(0);
+  });
+
+  it('reviewer kan de lijst wél lezen (alleen schrijven is geblokkeerd)', async () => {
+    const respons = await request(server)
+      .get(`/vendors/${vendorId}/contracts`)
+      .set('Cookie', reviewerCookie);
+
+    expect(respons.status).toBe(200);
+  });
+
+  it('een tweede tenant ziet de contracten van tenant A niet', async () => {
+    await client.query('BEGIN');
+    await client.query(`SET LOCAL app.current_tenant_id = '${andereTenant}'`);
+    await client.query(
+      'INSERT INTO clm.tenant (tenant_id, name) VALUES ($1, $2)',
+      [andereTenant, 'contract-test-ander'],
+    );
+    await client.query(
+      `INSERT INTO clm."user" (user_id, tenant_id, full_name, external_subject)
+       VALUES ($1, $2, $3, $4)`,
+      [andereUser, andereTenant, 'Bob Buiten', SUBJECT_ANDER],
+    );
+    await client.query(
+      `INSERT INTO clm.tenant_membership (user_id, tenant_id, role)
+       VALUES ($1, $2, 'admin')`,
+      [andereUser, andereTenant],
+    );
+    await client.query('COMMIT');
+
+    const andereSessie = await sessies.aanmaken(SUBJECT_ANDER);
+    const andereCookie = `${cookieNaam}=${andereSessie!.token}`;
+
+    // Directe vendor-id van tenant A opvragen vanuit tenant B: RLS filtert
+    // 'm weg, dus het scherm ziet niets — geen aparte foutmelding die zou
+    // verklappen dat de vendor elders wél bestaat.
+    const respons = await request(server)
+      .get(`/vendors/${vendorId}/contracts`)
+      .set('Cookie', andereCookie);
+
+    expect(respons.status).toBe(200);
+    expect(respons.body.contracten).toEqual([]);
+  });
+
+  it('wijzigen van een niet-bestaand contract geeft 404', async () => {
+    const respons = await request(server)
+      .patch(
+        `/vendors/${vendorId}/contracts/00000000-0000-0000-0000-000000000000`,
+      )
+      .set('Cookie', adminCookie)
+      .send({ name: 'Bestaat niet' });
+
+    expect(respons.status).toBe(404);
+  });
+
+  it('een contract aanmaken zonder naam geeft 400 met veldnaam', async () => {
+    const respons = await request(server)
+      .post(`/vendors/${vendorId}/contracts`)
+      .set('Cookie', adminCookie)
+      .send({});
+
+    expect(respons.status).toBe(400);
+    expect(respons.body.veld).toBe('Naam');
+  });
+
+  it('admin kan een contract verwijderen (soft delete)', async () => {
+    const aangemaakt = await request(server)
+      .post(`/vendors/${vendorId}/contracts`)
+      .set('Cookie', adminCookie)
+      .send({ name: 'Te verwijderen contract' });
+
+    const contractId = alsContract(aangemaakt.body).contractId;
+
+    const verwijderd = await request(server)
+      .delete(`/vendors/${vendorId}/contracts/${contractId}`)
+      .set('Cookie', adminCookie);
+
+    expect(verwijderd.status).toBe(204);
+
+    const opgehaald = await request(server)
+      .get(`/vendors/${vendorId}/contracts/${contractId}`)
+      .set('Cookie', adminCookie);
+
+    expect(opgehaald.status).toBe(404);
+  });
+});

--- a/test/contract-routes.e2e-spec.ts
+++ b/test/contract-routes.e2e-spec.ts
@@ -346,6 +346,47 @@ describe('Contractroutes (e2e)', () => {
     );
   });
 
+  it('zet en leest wachtlijstTemplateIds naast de gewone koppeling', async () => {
+    await client.query('BEGIN');
+    await client.query(`SET LOCAL app.current_tenant_id = '${tenant}'`);
+    const templateResultaat = await client.query<{ template_id: string }>(
+      `INSERT INTO clm.survey_template (tenant_id, name, version)
+       VALUES ($1, $2, 1) RETURNING template_id`,
+      [tenant, `Wachtlijsttest-${STEMPEL}`],
+    );
+    await client.query('COMMIT');
+    const templateId = templateResultaat.rows[0].template_id;
+
+    const aangemaakt = await request(server)
+      .post(`/vendors/${vendorId}/contracts`)
+      .set('Cookie', adminCookie)
+      .send({ name: 'Contract met wachtlijst' });
+    const contractId = alsContract(aangemaakt.body).contractId;
+
+    const gekoppeld = await request(server)
+      .put(`/vendors/${vendorId}/contracts/${contractId}/survey-templates`)
+      .set('Cookie', adminCookie)
+      .send({
+        templateIds: [templateId],
+        wachtlijstTemplateIds: [templateId],
+      });
+
+    expect(gekoppeld.status).toBe(200);
+    expect(
+      (gekoppeld.body as { wachtlijstTemplateIds: string[] })
+        .wachtlijstTemplateIds,
+    ).toEqual([templateId]);
+
+    const opgehaald = await request(server)
+      .get(`/vendors/${vendorId}/contracts/${contractId}/survey-templates`)
+      .set('Cookie', adminCookie);
+
+    expect(
+      (opgehaald.body as { wachtlijstTemplateIds: string[] })
+        .wachtlijstTemplateIds,
+    ).toEqual([templateId]);
+  });
+
   it('reviewer kan geen templates koppelen (403)', async () => {
     const aangemaakt = await request(server)
       .post(`/vendors/${vendorId}/contracts`)

--- a/test/contract-routes.e2e-spec.ts
+++ b/test/contract-routes.e2e-spec.ts
@@ -202,8 +202,9 @@ describe('Contractroutes (e2e)', () => {
       .set('Cookie', adminCookie);
 
     expect(respons.status).toBe(200);
-    expect(Array.isArray(respons.body.contracten)).toBe(true);
-    expect(respons.body.contracten.length).toBeGreaterThan(0);
+    const lijst = (respons.body as { contracten: unknown[] }).contracten;
+    expect(Array.isArray(lijst)).toBe(true);
+    expect(lijst.length).toBeGreaterThan(0);
   });
 
   it('reviewer kan de lijst wél lezen (alleen schrijven is geblokkeerd)', async () => {
@@ -244,7 +245,7 @@ describe('Contractroutes (e2e)', () => {
       .set('Cookie', andereCookie);
 
     expect(respons.status).toBe(200);
-    expect(respons.body.contracten).toEqual([]);
+    expect((respons.body as { contracten: unknown[] }).contracten).toEqual([]);
   });
 
   it('wijzigen van een niet-bestaand contract geeft 404', async () => {
@@ -265,7 +266,7 @@ describe('Contractroutes (e2e)', () => {
       .send({});
 
     expect(respons.status).toBe(400);
-    expect(respons.body.veld).toBe('Naam');
+    expect((respons.body as { veld: string }).veld).toBe('Naam');
   });
 
   it('admin kan een contract verwijderen (soft delete)', async () => {

--- a/test/contract-routes.e2e-spec.ts
+++ b/test/contract-routes.e2e-spec.ts
@@ -68,6 +68,16 @@ async function verwijderTestdata(migratieClient: Client): Promise<void> {
   for (const t of [tenant, andereTenant]) {
     await migratieClient.query('BEGIN');
     await migratieClient.query(`SET LOCAL app.current_tenant_id = '${t}'`);
+    // contract_survey_template en survey_template moeten eerst weg: FK naar
+    // clm.contract.
+    await migratieClient.query(
+      'DELETE FROM clm.contract_survey_template WHERE tenant_id = $1',
+      [t],
+    );
+    await migratieClient.query(
+      'DELETE FROM clm.survey_template WHERE tenant_id = $1',
+      [t],
+    );
     await migratieClient.query(
       'DELETE FROM clm.contract WHERE tenant_id = $1',
       [t],
@@ -288,5 +298,66 @@ describe('Contractroutes (e2e)', () => {
       .set('Cookie', adminCookie);
 
     expect(opgehaald.status).toBe(404);
+  });
+
+  it('koppelt en ontkoppelt vragenlijst-templates aan een contract', async () => {
+    await client.query('BEGIN');
+    await client.query(`SET LOCAL app.current_tenant_id = '${tenant}'`);
+    const templateResultaat = await client.query<{ template_id: string }>(
+      `INSERT INTO clm.survey_template (tenant_id, name, version)
+       VALUES ($1, $2, 1) RETURNING template_id`,
+      [tenant, `Testvragenlijst-${STEMPEL}`],
+    );
+    await client.query('COMMIT');
+    const templateId = templateResultaat.rows[0].template_id;
+
+    const aangemaakt = await request(server)
+      .post(`/vendors/${vendorId}/contracts`)
+      .set('Cookie', adminCookie)
+      .send({ name: 'Contract met vragenlijst' });
+    const contractId = alsContract(aangemaakt.body).contractId;
+
+    const gekoppeld = await request(server)
+      .put(`/vendors/${vendorId}/contracts/${contractId}/survey-templates`)
+      .set('Cookie', adminCookie)
+      .send({ templateIds: [templateId] });
+
+    expect(gekoppeld.status).toBe(200);
+    expect((gekoppeld.body as { templateIds: string[] }).templateIds).toEqual([
+      templateId,
+    ]);
+
+    const opgehaald = await request(server)
+      .get(`/vendors/${vendorId}/contracts/${contractId}/survey-templates`)
+      .set('Cookie', adminCookie);
+
+    expect((opgehaald.body as { templateIds: string[] }).templateIds).toEqual([
+      templateId,
+    ]);
+
+    const ontkoppeld = await request(server)
+      .put(`/vendors/${vendorId}/contracts/${contractId}/survey-templates`)
+      .set('Cookie', adminCookie)
+      .send({ templateIds: [] });
+
+    expect(ontkoppeld.status).toBe(200);
+    expect((ontkoppeld.body as { templateIds: string[] }).templateIds).toEqual(
+      [],
+    );
+  });
+
+  it('reviewer kan geen templates koppelen (403)', async () => {
+    const aangemaakt = await request(server)
+      .post(`/vendors/${vendorId}/contracts`)
+      .set('Cookie', adminCookie)
+      .send({ name: 'Contract zonder reviewer-koppeling' });
+    const contractId = alsContract(aangemaakt.body).contractId;
+
+    const respons = await request(server)
+      .put(`/vendors/${vendorId}/contracts/${contractId}/survey-templates`)
+      .set('Cookie', reviewerCookie)
+      .send({ templateIds: [] });
+
+    expect(respons.status).toBe(403);
   });
 });

--- a/test/contract-routes.e2e-spec.ts
+++ b/test/contract-routes.e2e-spec.ts
@@ -68,9 +68,10 @@ async function verwijderTestdata(migratieClient: Client): Promise<void> {
   for (const t of [tenant, andereTenant]) {
     await migratieClient.query('BEGIN');
     await migratieClient.query(`SET LOCAL app.current_tenant_id = '${t}'`);
-    await migratieClient.query('DELETE FROM clm.contract WHERE tenant_id = $1', [
-      t,
-    ]);
+    await migratieClient.query(
+      'DELETE FROM clm.contract WHERE tenant_id = $1',
+      [t],
+    );
     await migratieClient.query(
       'DELETE FROM clm.vendor_contact WHERE tenant_id = $1',
       [t],

--- a/test/ronde-beheer-routes.e2e-spec.ts
+++ b/test/ronde-beheer-routes.e2e-spec.ts
@@ -52,6 +52,7 @@ const {
   vendorB: VENDOR_B,
   vendorWeg: VENDOR_WEG,
   contract1: CONTRACT_1,
+  onbestaand: ONBESTAAND,
 } = TEST_IDS['ronde-beheer-routes'];
 
 const SUBJECT_ADMIN_A = `oid-rb-a-${Date.now()}`;
@@ -388,7 +389,7 @@ describe('Ronde-beheerroutes (e2e)', () => {
       .set('Cookie', cookieAdminA)
       .send({
         templateId: TEMPLATE_A,
-        contractId: '00000000-0000-0000-0000-000000000000',
+        contractId: ONBESTAAND,
       })
       .expect(404);
   });

--- a/test/ronde-beheer-routes.e2e-spec.ts
+++ b/test/ronde-beheer-routes.e2e-spec.ts
@@ -51,6 +51,7 @@ const {
   vendor3: VENDOR_3,
   vendorB: VENDOR_B,
   vendorWeg: VENDOR_WEG,
+  contract1: CONTRACT_1,
 } = TEST_IDS['ronde-beheer-routes'];
 
 const SUBJECT_ADMIN_A = `oid-rb-a-${Date.now()}`;
@@ -83,10 +84,45 @@ interface RondeAntwoord {
   surveyKind: string;
   isTest: boolean;
   closesAt: string | null;
+  contractId: string | null;
+}
+
+/**
+ * Migratierol, altijd naar dezelfde database als DATABASE_URL.
+ *
+ * Nodig omdat clm_api_runtime geen DELETE heeft op clm.contract
+ * (NIET_VERWIJDEREN in rechten-contract.ts — een contract wordt zacht
+ * verwijderd). Testopruiming ruimt hard op, dus heeft de migratierol nodig
+ * voor die ene tabel — zelfde patroon als contract-routes.e2e-spec.ts.
+ */
+function migratieUrl(): string {
+  const runtime = process.env.DATABASE_URL;
+  if (!runtime) throw new Error('DATABASE_URL ontbreekt.');
+  const doel = new URL(runtime);
+  const expliciet = process.env.MIGRATION_DATABASE_URL;
+  if (expliciet) {
+    const gegeven = new URL(expliciet);
+    if (gegeven.host === doel.host && gegeven.pathname === doel.pathname) {
+      return expliciet;
+    }
+  }
+  doel.username = 'clm_migrator';
+  return doel.toString();
 }
 
 async function verwijderTestdata(client: Client): Promise<void> {
+  const migratieClient = new Client({ connectionString: migratieUrl() });
+  await migratieClient.connect();
+
   for (const tenant of [tenantA, tenantB]) {
+    await migratieClient.query('BEGIN');
+    await migratieClient.query(`SET LOCAL app.current_tenant_id = '${tenant}'`);
+    await migratieClient.query(
+      'DELETE FROM clm.contract WHERE tenant_id = $1',
+      [tenant],
+    );
+    await migratieClient.query('COMMIT');
+
     await client.query('BEGIN');
     await client.query(`SET LOCAL app.current_tenant_id = '${tenant}'`);
     for (const tabel of [
@@ -107,6 +143,8 @@ async function verwijderTestdata(client: Client): Promise<void> {
     }
     await client.query('COMMIT');
   }
+
+  await migratieClient.end();
 }
 
 describe('Ronde-beheerroutes (e2e)', () => {
@@ -238,6 +276,13 @@ describe('Ronde-beheerroutes (e2e)', () => {
       [VENDOR_WEG],
     );
 
+    // Voor de contractId-koppeling: een contract bij VENDOR_1.
+    await client.query(
+      `INSERT INTO clm.contract (contract_id, tenant_id, vendor_id, name)
+       VALUES ($1, $2, $3, 'Testcontract voor rondes')`,
+      [CONTRACT_1, tenantA, VENDOR_1],
+    );
+
     await client.query('COMMIT');
 
     // Tenant B: eigen vragenlijst en eigen leverancier.
@@ -325,6 +370,27 @@ describe('Ronde-beheerroutes (e2e)', () => {
       .expect(201);
 
     expect((antwoord.body as RondeAntwoord).closesAt).not.toBeNull();
+  });
+
+  it('neemt een contractId over en geeft hem terug', async () => {
+    const antwoord = await request(server)
+      .post('/admin/survey/runs')
+      .set('Cookie', cookieAdminA)
+      .send({ templateId: TEMPLATE_A, contractId: CONTRACT_1 })
+      .expect(201);
+
+    expect((antwoord.body as RondeAntwoord).contractId).toBe(CONTRACT_1);
+  });
+
+  it('geeft 404 bij een onbekend contractId', async () => {
+    await request(server)
+      .post('/admin/survey/runs')
+      .set('Cookie', cookieAdminA)
+      .send({
+        templateId: TEMPLATE_A,
+        contractId: '00000000-0000-0000-0000-000000000000',
+      })
+      .expect(404);
   });
 
   it('weigert een sluitdatum in het verleden', async () => {

--- a/test/ronde-beheer-routes.e2e-spec.ts
+++ b/test/ronde-beheer-routes.e2e-spec.ts
@@ -912,4 +912,40 @@ describe('Ronde-beheerroutes (e2e)', () => {
     expect(body).not.toContain(uitnodigingen[0].token);
     expect(body).not.toContain('token');
   });
+
+  // ── Wachtlijst ───────────────────────────────────────────────────────────
+
+  it('geeft de leverancier terug die op de wachtlijst staat voor deze template', async () => {
+    await client.query('BEGIN');
+    await client.query(`SET LOCAL app.current_tenant_id = '${tenantA}'`);
+    await client.query(
+      `INSERT INTO clm.contract_survey_template
+         (contract_id, survey_template_id, tenant_id, wachtlijst)
+       VALUES ($1, $2, $3, true)`,
+      [CONTRACT_1, TEMPLATE_A, tenantA],
+    );
+    await client.query('COMMIT');
+
+    const antwoord = await request(server)
+      .get(`/admin/survey/templates/${TEMPLATE_A}/wachtlijst`)
+      .set('Cookie', cookieAdminA)
+      .expect(200);
+
+    const { leveranciers } = antwoord.body as {
+      leveranciers: { vendorId: string; vendorNaam: string }[];
+    };
+
+    expect(leveranciers.some((l) => l.vendorId === VENDOR_1)).toBe(true);
+  });
+
+  it('geeft een lege lijst als niemand op de wachtlijst staat', async () => {
+    const antwoord = await request(server)
+      .get(`/admin/survey/templates/${TEMPLATE_LEEG}/wachtlijst`)
+      .set('Cookie', cookieAdminA)
+      .expect(200);
+
+    expect((antwoord.body as { leveranciers: unknown[] }).leveranciers).toEqual(
+      [],
+    );
+  });
 });

--- a/test/tenant-gebruikers.e2e-spec.ts
+++ b/test/tenant-gebruikers.e2e-spec.ts
@@ -1,0 +1,149 @@
+import { INestApplication } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import cookieParser from 'cookie-parser';
+import { Client } from 'pg';
+import request from 'supertest';
+import type { App } from 'supertest/types';
+
+import { AppModule } from '../src/app.module';
+import { SessieService } from '../src/auth/sessie.service';
+import { cookieInstellingen } from '../src/auth/sessie';
+import { TEST_IDS } from './test-ids';
+
+/**
+ * GET /tenant/gebruikers: de keuzelijst voor bv. de contractbeheerder-
+ * dropdown. Zelfde twee vragen als de andere suites: mag een reviewer lezen
+ * (moet, het is geen gevoelige data), en werkt de sessiegrens.
+ */
+
+const { tenant, adminUser, reviewerUser, andereTenant } =
+  TEST_IDS['tenant-gebruikers'];
+
+const STEMPEL = Date.now();
+const SUBJECT_ADMIN = `oid-tg-admin-${STEMPEL}`;
+const SUBJECT_REVIEWER = `oid-tg-reviewer-${STEMPEL}`;
+
+/** Migratierol, altijd naar dezelfde database als DATABASE_URL. */
+function migratieUrl(): string {
+  const runtime = process.env.DATABASE_URL;
+  if (!runtime) throw new Error('DATABASE_URL ontbreekt.');
+  const doel = new URL(runtime);
+  const expliciet = process.env.MIGRATION_DATABASE_URL;
+  if (expliciet) {
+    const gegeven = new URL(expliciet);
+    if (gegeven.host === doel.host && gegeven.pathname === doel.pathname) {
+      return expliciet;
+    }
+  }
+  doel.username = 'clm_migrator';
+  return doel.toString();
+}
+
+async function opruimen(migratieClient: Client): Promise<void> {
+  for (const t of [tenant, andereTenant]) {
+    await migratieClient.query('BEGIN');
+    await migratieClient.query(`SET LOCAL app.current_tenant_id = '${t}'`);
+    await migratieClient.query(
+      'DELETE FROM clm.tenant_membership WHERE tenant_id = $1',
+      [t],
+    );
+    await migratieClient.query('DELETE FROM clm."user" WHERE tenant_id = $1', [
+      t,
+    ]);
+    await migratieClient.query('DELETE FROM clm.tenant WHERE tenant_id = $1', [
+      t,
+    ]);
+    await migratieClient.query('COMMIT');
+  }
+}
+
+describe('Tenant-gebruikers (e2e)', () => {
+  let app: INestApplication<App>;
+  let server: App;
+  let client: Client;
+  let migratieClient: Client;
+  let adminCookie: string;
+  const cookieNaam = cookieInstellingen().naam;
+
+  beforeAll(async () => {
+    client = new Client({ connectionString: process.env.DATABASE_URL });
+    await client.connect();
+    migratieClient = new Client({ connectionString: migratieUrl() });
+    await migratieClient.connect();
+    await opruimen(migratieClient);
+
+    await client.query('BEGIN');
+    await client.query(`SET LOCAL app.current_tenant_id = '${tenant}'`);
+    await client.query(
+      'INSERT INTO clm.tenant (tenant_id, name) VALUES ($1, $2)',
+      [tenant, 'tenant-gebruikers-test'],
+    );
+    await client.query(
+      `INSERT INTO clm."user" (user_id, tenant_id, full_name, external_subject)
+       VALUES ($1, $2, $3, $4), ($5, $2, $6, $7)`,
+      [
+        adminUser,
+        tenant,
+        'Anna Admin',
+        SUBJECT_ADMIN,
+        reviewerUser,
+        'Rob Reviewer',
+        SUBJECT_REVIEWER,
+      ],
+    );
+    await client.query(
+      `INSERT INTO clm.tenant_membership (user_id, tenant_id, role)
+       VALUES ($1, $2, 'admin'), ($3, $2, 'reviewer')`,
+      [adminUser, tenant, reviewerUser],
+    );
+    await client.query('COMMIT');
+
+    const moduleRef = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+    app = moduleRef.createNestApplication();
+    app.use(cookieParser());
+    await app.init();
+    server = app.getHttpServer();
+
+    const sessies = app.get(SessieService);
+    const adminSessie = await sessies.aanmaken(SUBJECT_ADMIN);
+    adminCookie = `${cookieNaam}=${adminSessie!.token}`;
+  });
+
+  afterAll(async () => {
+    await app.close();
+    await opruimen(migratieClient);
+    await client.end();
+    await migratieClient.end();
+  });
+
+  it('geeft de gebruikers van de eigen tenant, met naam', async () => {
+    const respons = await request(server)
+      .get('/tenant/gebruikers')
+      .set('Cookie', adminCookie);
+
+    expect(respons.status).toBe(200);
+    const namen = (
+      respons.body as { gebruikers: { naam: string }[] }
+    ).gebruikers.map((g) => g.naam);
+    expect(namen).toContain('Anna Admin');
+    expect(namen).toContain('Rob Reviewer');
+  });
+
+  it('reviewer mag ook lezen — het is een keuzelijst, geen gevoelige data', async () => {
+    const sessies = app.get(SessieService);
+    const reviewerSessie = await sessies.aanmaken(SUBJECT_REVIEWER);
+    const reviewerCookie = `${cookieNaam}=${reviewerSessie!.token}`;
+
+    const respons = await request(server)
+      .get('/tenant/gebruikers')
+      .set('Cookie', reviewerCookie);
+
+    expect(respons.status).toBe(200);
+  });
+
+  it('geeft 401 zonder sessie', async () => {
+    await request(server).get('/tenant/gebruikers').expect(401);
+  });
+});

--- a/test/test-ids.ts
+++ b/test/test-ids.ts
@@ -96,6 +96,13 @@ export const TEST_IDS = {
     andereTenant: id('8f'),
     andereUser: id('80'),
   },
+  'contract-routes': {
+    tenant: id('25'),
+    adminUser: id('26'),
+    reviewerUser: id('27'),
+    andereTenant: id('28'),
+    andereUser: id('29'),
+  },
   'tenant-context-guard': {
     tenantA: id('9a'),
     tenantB: id('9b'),

--- a/test/test-ids.ts
+++ b/test/test-ids.ts
@@ -170,6 +170,8 @@ export const TEST_IDS = {
     vendorB: '00000000-0000-0000-0000-0000000000d4',
     vendorWeg: '00000000-0000-0000-0000-0000000000d5',
     contract1: id('2e'),
+    /** Bewust nergens aangemaakt — gebruikt om "bestaat niet" te toetsen. */
+    onbestaand: id('2f'),
   },
   // Fase C2 — beoordelen. Staarten d6 t/m db; da is al vergeven, vandaar de
   // sprong. Gecontroleerd tegen alleTestIds(), niet gegokt.

--- a/test/test-ids.ts
+++ b/test/test-ids.ts
@@ -169,6 +169,7 @@ export const TEST_IDS = {
     vendor3: '00000000-0000-0000-0000-0000000000cf',
     vendorB: '00000000-0000-0000-0000-0000000000d4',
     vendorWeg: '00000000-0000-0000-0000-0000000000d5',
+    contract1: id('2e'),
   },
   // Fase C2 — beoordelen. Staarten d6 t/m db; da is al vergeven, vandaar de
   // sprong. Gecontroleerd tegen alleTestIds(), niet gegokt.

--- a/test/test-ids.ts
+++ b/test/test-ids.ts
@@ -103,6 +103,12 @@ export const TEST_IDS = {
     andereTenant: id('28'),
     andereUser: id('29'),
   },
+  'tenant-gebruikers': {
+    tenant: id('2a'),
+    adminUser: id('2b'),
+    reviewerUser: id('2c'),
+    andereTenant: id('2d'),
+  },
   'tenant-context-guard': {
     tenantA: id('9a'),
     tenantB: id('9b'),


### PR DESCRIPTION
## Samenvatting

Twee delen, sessies 22-08 en 23-08:

**22-08 — contractmanagement-basismodule (backend):**
- Migratie 0027 (`clm.contract`, `ref.contract_status`,
  `clm.contract_survey_template`) + 0028 (`wachtlijst`-vlag op de
  templatekoppeling)
- `ContractService`/`ContractController` — lijst, aanmaken, wijzigen,
  verwijderen, survey-templatekoppeling
- `survey_run.contract_id` daadwerkelijk gevuld (kolom bestond sinds
  migratie 0007, ongebruikt) — sluit het gat tussen een contract koppelen
  aan een survey-template en een echte uitnodiging
- `roleDescription` (notitie) op contactpersoon door de hele keten
- §1c toegevoegd aan `MCM2-CLAUDE.md` (dichtheidsregel, mini-intake per
  nieuw datascherm), `docs/architectuur/ui-beslissingen.md` en
  `evaluatie-schermen-2026-08-22.md` nieuw

**23-08 — spec en plan voor de UI-herziening (documentatie-only):**
- `docs/superpowers/specs/2026-08-23-leveranciersscherm-dichtheid-design.md`
- `docs/superpowers/plans/2026-08-23-leveranciersscherm-dichtheid.md`
- `docs/STATUS.md` bijgewerkt (git-status, blokkades, eerstvolgende stap)

De daadwerkelijke UI-implementatie op basis van deze spec/plan staat in
MCM2-frontend#15 (al gemerged).

## Test plan

- [x] Alle 34 e2e-suites groen (sessie 22-08, contractmanagement-module)
- [x] Documentatie-only sinds 23-08, geen nieuwe backend-codewijziging
- [x] CI groen (format/lint/typecheck, Docker-build, RLS-isolatietest)

Gerelateerde issues: #173 (Contract 360, later), #174 (opzegtermijn-veld,
eerstvolgende stap na deze PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)