### PR TITLE
feat(health): omgeving-veld op /health

### DIFF
--- a/deploy/docker-compose.omgeving.yml
+++ b/deploy/docker-compose.omgeving.yml
@@ -78,6 +78,9 @@ services:
       # ontbreekt in plaats van dat er niets afwijkt.
       IMAGE_DIGEST: ${IMAGE_DIGEST:-}
       FRONTEND_IMAGE_DIGEST: ${FRONTEND_IMAGE_DIGEST:-}
+      # Welke omgeving dit is (acceptatie/staging/productie), gezet door
+      # deploy.js. Meldt /health terug — zie health.controller.ts.
+      OMGEVING: ${OMGEVING:-}
       # Waar de database staat. Vóór 2026-08-11 stond hier een vaste
       # connectiestring naar de `db`-service hierboven; dat kon niet meer toen
       # staging erbij kwam, want die praat met Supabase.

--- a/scripts/demo-stack.js
+++ b/scripts/demo-stack.js
@@ -420,6 +420,10 @@ function backendStarten() {
       // gevolg is een 401 die zwijgt over de oorzaak.
       SESSIE_COOKIE_INSECURE: 'true',
       PORT: String(API_POORT),
+      // Meldt /health terug (health.controller.ts) — zodat de sidebar de
+      // lokale demo van staging/acceptatie kan onderscheiden, ook al draaien
+      // ze soms exact dezelfde code.
+      OMGEVING: 'lokale-demo',
     },
   });
 

--- a/scripts/deploy.js
+++ b/scripts/deploy.js
@@ -425,6 +425,7 @@ function start(omgeving, versie, frontendVersie, digests = {}) {
     `export FRONTEND_IMAGE=$(grep '^GHCR_FRONTEND=' ${omgeving.naam}.env | cut -d= -f2):${frontendVersie}`,
     `export IMAGE_DIGEST='${digests.api || ''}'`,
     `export FRONTEND_IMAGE_DIGEST='${digests.frontend || ''}'`,
+    `export OMGEVING='${omgeving.naam}'`,
     `docker compose --env-file ${omgeving.naam}.env -p ${omgeving.project} ${db} up -d ${schaal}`.trim(),
   ].join(' && ');
 

--- a/src/health/health.controller.ts
+++ b/src/health/health.controller.ts
@@ -8,7 +8,7 @@ import { Controller, Get } from '@nestjs/common';
  * *bedoelde* te starten, niemand weet wat er *staat*. Op 2026-08-10 draaide
  * saxombp dagenlang oudere code dan main zonder dat iets dat kon melden.
  *
- * Drie velden, twee herkomsten:
+ * Vier velden, drie herkomsten:
  *
  *   commit / gebouwdOp   In het image gebakken door CI (build-args in
  *                        ci.yml). Kunnen na het bouwen niet meer veranderen —
@@ -21,6 +21,14 @@ import { Controller, Get } from '@nestjs/common';
  *                        deploy/docker-compose.omgeving.yml — de frontend
  *                        heeft geen eigen meldpunt, dus dit endpoint geeft
  *                        ook diens digest door.
+ *   omgeving             Welke omgeving dit is (acceptatie/staging/productie/
+ *                        lokale-demo) — meegegeven door `deploy.js` resp.
+ *                        `demo-stack.js` bij het starten. Toegevoegd 2026-08-23
+ *                        zodat de frontend browsercontrole (lokale demo,
+ *                        staging via het sub-pad) van elkaar kan
+ *                        onderscheiden, iets wat commit/imageDigest niet
+ *                        laten zien — twee omgevingen kunnen precies dezelfde
+ *                        code draaien.
  *
  * `null` betekent: niet meegekregen. Dat is een geldige uitkomst (lokale
  * ontwikkelbuild, oude uitrol van vóór deze meting) en hoort zichtbaar te
@@ -37,6 +45,7 @@ export class HealthController {
       gebouwdOp: process.env.BUILD_TIJDSTIP ?? null,
       imageDigest: process.env.IMAGE_DIGEST ?? null,
       frontendImageDigest: process.env.FRONTEND_IMAGE_DIGEST ?? null,
+      omgeving: process.env.OMGEVING ?? null,
     };
   }
 }

--- a/test/health.e2e-spec.ts
+++ b/test/health.e2e-spec.ts
@@ -29,7 +29,7 @@ describe('HealthController (e2e)', () => {
       });
   });
 
-  // De vier velden bestaan altijd, ook zonder waarde. Een veld dat pas
+  // De vijf velden bestaan altijd, ook zonder waarde. Een veld dat pas
   // verschijnt wanneer het gevuld is, is voor verify-omgevingen.js niet te
   // onderscheiden van een oud image dat het veld nog niet kent — en dat
   // onderscheid is precies waarvoor deze velden bestaan.
@@ -43,6 +43,7 @@ describe('HealthController (e2e)', () => {
           'gebouwdOp',
           'imageDigest',
           'frontendImageDigest',
+          'omgeving',
         ]) {
           expect(res.body).toHaveProperty(veld);
         }


### PR DESCRIPTION
## Samenvatting

Voegt een `omgeving`-veld toe aan `GET /health`, gevuld door `deploy.js`
(acceptatie/staging/productie) resp. `demo-stack.js` (`lokale-demo`).

Aanleiding: tijdens handmatige verificatie van PR #15/#175 op staging bleek
er geen manier om in de sidebar te zien welke infrastructuur-omgeving je
bekijkt. De bestaande LIVE/MOCK-badge beantwoordt "praat dit met een echte
backend", `OmgevingBanner` beantwoordt "zit ik in een demo-tenant" — geen
van beide zegt "is dit staging, acceptatie, productie of de lokale demo".

Frontend-tegenhanger (Sidebar-label, alleen zichtbaar buiten productie)
staat in een aparte PR op MCM2-frontend.

## Test plan

- [x] `npm run typecheck` — schoon
- [x] `npm run lint:check` — schoon
- [x] `npm run format:check` — schoon
- [x] `test/health.e2e-spec.ts` tegen een wegwerpdatabase: 2/2 groen
- [x] Handmatig bevestigd op de lokale demo-stack: `/health` toont
      `"omgeving":"lokale-demo"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)