### PR TITLE
feat(contract): opzegtermijn, waarschuwingstermijn, verlengt-automatisch (#174)

### DIFF
--- a/docs/architectuur/ui-beslissingen.md
+++ b/docs/architectuur/ui-beslissingen.md
@@ -14,13 +14,21 @@
 
 | Datum | Beslissing |
 |---|---|
+| 2026-08-23 | Een rij in een lijst (contactpersoon, contract) is zelf klikbaar om de bijbehorende bewerkactie te openen — niet alleen een klein icoon ernaast. Vastgesteld nadat de eigenaar tijdens een preview de bewerkknop van een contactpersoon over het hoofd zag: de intuïtie is "klik op de naam", consistent met hoe de contractrij al werkte. Icoon/knop mag blijven staan voor wie expliciet wil klikken, maar is niet de enige weg. |
 | 2026-08-22 | Tabelrijen voor lijsten van entiteiten (contracten, leveranciers) gebruiken een `<table>`, niet een `<ul>`/`<li>`-lijst — meer informatie per rij op minder hoogte. Kolommen tonen de kernvelden direct (naam, contractnummer, contactpersoon, contractbeheerder, status, begin–einde) in plaats van pas na een klik. |
 
 ## Formulierpatronen
 
 | Datum | Beslissing |
 |---|---|
+| 2026-08-23 | Contactpersoon toevoegen/bewerken gaat via een modal, niet een inline "fold out" — patroon overgenomen van MVM_V2 (`VendorContactsPanel.tsx`) na expliciete vergelijking. Eén modal-component voor zowel aanmaken als bewerken (bewerken=aanmaken-symmetrie). |
 | 2026-08-22 | Een detailscherm dat een record bewerkt, moet alle bestaande waarden vooringevuld tonen én dezelfde acties toestaan die bij aanmaken beschikbaar zijn (bijvoorbeeld: een nieuwe contactpersoon aanmaken vanuit het bewerkformulier van een contract, niet alleen vanuit het aanmaakformulier). |
+
+## Regels en waarschuwingen
+
+| Datum | Beslissing |
+|---|---|
+| 2026-08-23 | Waarschuwen, niet blokkeren, bij een risicovolle maar legitieme actie (bijv. de enige primaire contactpersoon niet-primair maken). Expliciet principe van de eigenaar: de beheerder is een zelfstandig werkende professional die met veel verschillende leveranciers/contracten/omstandigheden omgaat — een te hard afgedwongen regel duwt hem terug naar Excel. Een bevestigingsvraag (`window.confirm` of gelijkwaardig) die de consequentie benoemt is de standaardvorm; een harde blokkade is de uitzondering, niet de default. |
 
 ## Navigatie & vervolgstappen
 
@@ -28,17 +36,18 @@
 |---|---|
 | 2026-08-22 | Een gekoppelde actie (survey aan contract koppelen) krijgt een zichtbaar, direct pad naar de vervolgstap (een "nu uitnodigen"-link per gekoppelde template) — niet alleen een vlag die passief elders afgelezen moet worden. |
 
-## Open punten — nog niet als vaste regel vastgelegd
+## Afgeronde punten (was: open, zie git-historie voor de context)
 
-Vastgesteld maar nog niet doorvertaald naar een concrete, herbruikbare
-regel; oppakken zodra de bijbehorende schermen herzien worden.
+Alle vier onderstaande punten stonden hier eerder als "nog niet
+vastgelegd" en zijn inmiddels gebouwd — de bijbehorende regel staat nu in
+de tabellen hierboven, niet meer hier.
 
-- Contactpersoon-toevoegformulier moet een inklapbare "fold out" zijn,
-  niet standaard open.
-- Contractrijen in de lijst moeten direct openklikbaar zijn (niet alleen
-  via een aparte bewerk-knop) en dan alle bestaande én toekomstige velden
-  tonen.
-- Onderscheid tussen "survey gekoppeld aan contract" en "op de
-  wachtlijst voor de volgende ronde" is functioneel duidelijk maar visueel
-  nog verwarrend — een checkbox die default uit staat wordt als afwezige
-  koppeling gelezen. Oplossing nog niet gekozen.
+- ~~Contactpersoon-toevoegformulier moet een inklapbare "fold out" zijn~~
+  — opgelost via een modal (zie Formulierpatronen, 2026-08-23).
+- ~~Contractrijen in de lijst moeten direct openklikbaar zijn~~ — opgelost,
+  de rij zelf is de trigger (zie Layout & dichtheid, 2026-08-22/23).
+- ~~Onderscheid tussen "survey gekoppeld" en "op de wachtlijst" was
+  visueel verwarrend~~ — opgelost met een expliciet "wachtlijst AAN/UIT"-
+  label i.p.v. een stille checkbox.
+- ~~Geen manier om een primaire contactpersoon terug naar niet-primair te
+  zetten~~ — opgelost, zie Regels en waarschuwingen (2026-08-23).

--- a/docs/runbooks/backup-verwachting.json
+++ b/docs/runbooks/backup-verwachting.json
@@ -13,8 +13,8 @@
     "",
     "Zie docs/superpowers/specs/2026-08-04-backupcontrole-en-signalering.md, paragraaf 4."
   ],
-  "bijgewerkt": "2026-08-22",
-  "migratiestand": "0028_contract_survey_wachtlijst",
+  "bijgewerkt": "2026-08-23",
+  "migratiestand": "0029_contract_opzegtermijn",
   "tabellen": [
     "audit.audit_event",
     "clm.contract",

--- a/docs/superpowers/plans/2026-08-23-contract-opzegtermijn.md
+++ b/docs/superpowers/plans/2026-08-23-contract-opzegtermijn.md
@@ -1,0 +1,1375 @@
+# Contract opzegtermijn, waarschuwingstermijn, verlengt-automatisch Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Drie nieuwe velden op `clm.contract` (opzegtermijn, waarschuwingstermijn, verlengt-automatisch), een nieuwe, herbruikbare waarschuwingsberekening die de bestaande urgentiekleur-tussenoplossing vervangt, en de bijbehorende UI, conform
+`docs/superpowers/specs/2026-08-23-contract-opzegtermijn-design.md`.
+
+**Architecture:** Backend (`MCM2`): migratie 0029, uitbreiding van `ContractService`/`contract-invoer.ts`/e2e-suite. Frontend (`MCM2-frontend`): `contractUrgentie.ts` wordt vervangen door `contractWaarschuwing.ts` (pure functie, geen React), het contractmodel en -formulier krijgen de drie nieuwe velden, `Contracten.tsx` toont de nieuwe waarschuwingsstaat.
+
+**Tech Stack:** NestJS/Drizzle (handgeschreven migratie) backend, Next.js/React frontend — zelfde stack als de rest van het project, geen nieuwe dependencies.
+
+---
+
+## Bestandsoverzicht
+
+| Bestand | Actie | Verantwoordelijkheid |
+|---|---|---|
+| `drizzle/0029_contract_opzegtermijn.sql` | Nieuw | Migratie: drie kolommen + CHECK-constraint |
+| `drizzle/meta/_journal.json` | Wijzigen | Journal-entry voor migratie 0029 |
+| `docs/runbooks/backup-verwachting.json` | Wijzigen | Migratiestand bijwerken naar 0029 |
+| `src/contract/contract.service.ts` | Wijzigen | Nieuwe velden in interfaces, SELECT, INSERT, UPDATE |
+| `src/contract/contract-invoer.ts` | Wijzigen | Validatie van de drie nieuwe velden |
+| `src/contract/contract-invoer.spec.ts` | Wijzigen | Unittests voor de nieuwe validatie |
+| `test/contract-routes.e2e-spec.ts` | Wijzigen | E2e-dekking: aanmaken/wijzigen met de nieuwe velden |
+| `MCM2-frontend/src/core/models/contract.ts` | Wijzigen | Nieuwe velden op `Contract`/`ContractInvoer` |
+| `MCM2-frontend/src/app/beheer/leveranciers/[id]/contractWaarschuwing.ts` | Nieuw (vervangt `contractUrgentie.ts`) | De herbruikbare berekenfunctie |
+| `MCM2-frontend/src/app/beheer/leveranciers/[id]/contractUrgentie.ts` | Verwijderen | Vervangen door `contractWaarschuwing.ts` |
+| `MCM2-frontend/src/app/beheer/leveranciers/[id]/Contracten.tsx` | Wijzigen | Nieuwe velden in formulier, nieuwe waarschuwingsweergave in de rij |
+| `MCM2-frontend/e2e/contracten.spec.ts` | Wijzigen | E2e-dekking voor de nieuwe velden/weergave |
+
+---
+
+### Task 1: Migratie 0029 — drie nieuwe kolommen
+
+**Files:**
+- Create: `drizzle/0029_contract_opzegtermijn.sql`
+- Modify: `drizzle/meta/_journal.json`
+
+- [ ] **Step 1: Schrijf de migratie**
+
+```sql
+-- =============================================================================
+-- clm.contract — opzegtermijn, waarschuwingstermijn, verlengt-automatisch.
+--
+-- Ontwerp: docs/superpowers/specs/2026-08-23-contract-opzegtermijn-design.md
+-- Aanleiding: issue #174 — de kale-einddatum-urgentiekleur (tussenoplossing
+-- van 23-08) kan geen "opzegtermijn verstreken"-waarschuwing geven zonder
+-- deze velden.
+--
+-- auto_renews krijgt bewust GEEN eigen ref-tabel (anders dan
+-- ref.contract_status): drie vaste, niet-tenant-configureerbare waarden
+-- rechtvaardigen geen aparte tabel. Zie de spec §3 voor de volledige
+-- afweging.
+-- =============================================================================
+
+ALTER TABLE clm.contract
+    ADD COLUMN notice_period_days  integer,
+    ADD COLUMN warning_days_before integer NOT NULL DEFAULT 90,
+    ADD COLUMN auto_renews         text;--> statement-breakpoint
+
+ALTER TABLE clm.contract
+    ADD CONSTRAINT contract_auto_renews_check
+    CHECK (auto_renews IN ('ja', 'nee', 'onbekend') OR auto_renews IS NULL);--> statement-breakpoint
+
+COMMENT ON COLUMN clm.contract.notice_period_days IS
+    'Opzegtermijn in dagen vóór end_date. Nullable: niet elk contract heeft dit bekend.';--> statement-breakpoint
+COMMENT ON COLUMN clm.contract.warning_days_before IS
+    'Hoeveel dagen vóór de referentiedatum (opzegdatum, of end_date zonder opzegtermijn) gewaarschuwd wordt. Instelbaar per contract, default 90.';--> statement-breakpoint
+COMMENT ON COLUMN clm.contract.auto_renews IS
+    'ja/nee/onbekend — door de contractbeheerder zelf vastgesteld, geen afgeleide waarde. Default onbekend (NULL) bij aanmaken.';
+```
+
+- [ ] **Step 2: Voeg de journal-entry toe**
+
+In `drizzle/meta/_journal.json`, na de entry met `"idx": 28`:
+
+```json
+    {
+      "idx": 29,
+      "version": "7",
+      "when": 1787068800003,
+      "tag": "0029_contract_opzegtermijn",
+      "breakpoints": true
+    }
+```
+
+- [ ] **Step 3: Toets de migratie op een verse wegwerpcontainer**
+
+```powershell
+docker run -d --name mcm2test29 -e POSTGRES_PASSWORD=pw -p 127.0.0.1:55442:5432 postgres:17.6
+docker exec mcm2test29 pg_isready -U postgres
+Get-Content db\roles\bootstrap-roles.sql | docker exec -i mcm2test29 psql -U postgres -q
+docker exec mcm2test29 psql -U postgres -d postgres -c "ALTER ROLE clm_migrator WITH PASSWORD 'pw'; ALTER ROLE clm_api_runtime WITH PASSWORD 'pw';"
+```
+
+```powershell
+$env:MIGRATION_DATABASE_URL="postgresql://clm_migrator:pw@localhost:55442/postgres"
+npm run migrate:deploy
+Remove-Item Env:\MIGRATION_DATABASE_URL
+```
+
+Expected: het script meldt de migratie draait tegen `localhost` (niet
+`supabase.com`), en "Migraties voltooid".
+
+- [ ] **Step 4: Bevestig in de database dat de kolommen echt bestaan**
+
+```powershell
+docker exec mcm2test29 psql -U postgres -d postgres -t -c "SELECT column_name, data_type, column_default FROM information_schema.columns WHERE table_schema='clm' AND table_name='contract' AND column_name IN ('notice_period_days','warning_days_before','auto_renews') ORDER BY column_name;"
+```
+
+Expected: drie rijen — `auto_renews|text|`,
+`notice_period_days|integer|`, `warning_days_before|integer|90`.
+
+- [ ] **Step 5: Markeer de container als wegwerp en draai de bestaande e2e-suite erop**
+
+```powershell
+node scripts/markeer-wegwerp.js "toets migratie 0029"
+```
+
+```powershell
+$env:DATABASE_URL="postgresql://clm_api_runtime:pw@localhost:55442/postgres"
+npx jest --config test/jest-e2e.json contract-routes --forceExit
+Remove-Item Env:\DATABASE_URL
+```
+
+Expected: alle bestaande contract-tests slagen nog (de nieuwe kolommen
+hebben een default of zijn nullable, dus bestaande INSERT/UPDATE-paden
+breken niet).
+
+- [ ] **Step 6: Ruim de toetscontainer op, commit**
+
+```powershell
+docker rm -f mcm2test29
+```
+
+```bash
+git add drizzle/0029_contract_opzegtermijn.sql drizzle/meta/_journal.json
+git commit -m "feat(contract): migratie 0029 — opzegtermijn, waarschuwingstermijn, verlengt-automatisch"
+```
+
+---
+
+### Task 2: `contract-invoer.ts` — validatie van de drie nieuwe velden
+
+**Files:**
+- Modify: `src/contract/contract-invoer.ts`
+- Test: `src/contract/contract-invoer.spec.ts`
+
+- [ ] **Step 1: Schrijf de falende tests eerst**
+
+Voeg toe aan `src/contract/contract-invoer.spec.ts`, na de bestaande
+`describe('leesNieuwContract', ...)`-tests:
+
+```ts
+describe('leesNieuwContract — opzegtermijn en verlengt-automatisch', () => {
+  it('accepteert een geldige noticePeriodDays', () => {
+    const invoer = leesNieuwContract({
+      name: 'Hosting',
+      noticePeriodDays: '90',
+    });
+    expect(invoer.noticePeriodDays).toBe(90);
+  });
+
+  it('laat noticePeriodDays leeg zonder invoer', () => {
+    const invoer = leesNieuwContract({ name: 'Hosting' });
+    expect(invoer.noticePeriodDays).toBeNull();
+  });
+
+  it('weigert een negatieve noticePeriodDays', () => {
+    expect(() =>
+      leesNieuwContract({ name: 'Hosting', noticePeriodDays: '-5' }),
+    ).toThrow(InvoerFout);
+  });
+
+  it('weigert een niet-numerieke noticePeriodDays', () => {
+    expect(() =>
+      leesNieuwContract({ name: 'Hosting', noticePeriodDays: 'abc' }),
+    ).toThrow(InvoerFout);
+  });
+
+  it('vult warningDaysBefore met 90 als het ontbreekt', () => {
+    const invoer = leesNieuwContract({ name: 'Hosting' });
+    expect(invoer.warningDaysBefore).toBe(90);
+  });
+
+  it('accepteert een expliciete warningDaysBefore', () => {
+    const invoer = leesNieuwContract({
+      name: 'Hosting',
+      warningDaysBefore: '30',
+    });
+    expect(invoer.warningDaysBefore).toBe(30);
+  });
+
+  it('weigert een negatieve warningDaysBefore', () => {
+    expect(() =>
+      leesNieuwContract({ name: 'Hosting', warningDaysBefore: '-1' }),
+    ).toThrow(InvoerFout);
+  });
+
+  it('accepteert ja/nee/onbekend voor autoRenews', () => {
+    for (const waarde of ['ja', 'nee', 'onbekend']) {
+      const invoer = leesNieuwContract({ name: 'Hosting', autoRenews: waarde });
+      expect(invoer.autoRenews).toBe(waarde);
+    }
+  });
+
+  it('laat autoRenews null zonder invoer (onbekend is de default)', () => {
+    const invoer = leesNieuwContract({ name: 'Hosting' });
+    expect(invoer.autoRenews).toBeNull();
+  });
+
+  it('weigert een ongeldige waarde voor autoRenews', () => {
+    expect(() =>
+      leesNieuwContract({ name: 'Hosting', autoRenews: 'misschien' }),
+    ).toThrow(InvoerFout);
+  });
+});
+```
+
+- [ ] **Step 2: Draai de tests, verwacht FAIL**
+
+Run: `npx jest contract-invoer`
+Expected: FAIL — `invoer.noticePeriodDays` is `undefined` (property bestaat
+nog niet op `NieuwContract`), TypeScript-compilatiefouten in de testfile
+zelf zijn ook een verwacht "fail"-signaal hier.
+
+- [ ] **Step 3: Voeg de validatiefuncties toe aan `contract-invoer.ts`**
+
+Na `optioneelBedrag`, vóór `controleerDatumVolgorde`:
+
+```ts
+function optioneelPositiefGeheelGetal(
+  waarde: unknown,
+  veld: string,
+): number | null {
+  if (waarde === undefined || waarde === null || waarde === '') {
+    return null;
+  }
+
+  const getal =
+    typeof waarde === 'number' ? waarde : Number.parseInt(String(waarde), 10);
+
+  if (
+    !Number.isInteger(getal) ||
+    getal < 0 ||
+    String(waarde).trim() !== String(getal)
+  ) {
+    throw new InvoerFout(veld, `${veld} moet een positief geheel getal zijn.`);
+  }
+
+  return getal;
+}
+
+const AUTO_RENEWS_WAARDEN = ['ja', 'nee', 'onbekend'] as const;
+
+function optioneelAutoRenews(waarde: unknown, veld: string): string | null {
+  if (waarde === undefined || waarde === null || waarde === '') {
+    return null;
+  }
+
+  if (
+    typeof waarde !== 'string' ||
+    !AUTO_RENEWS_WAARDEN.includes(waarde as (typeof AUTO_RENEWS_WAARDEN)[number])
+  ) {
+    throw new InvoerFout(veld, `${veld} moet ja, nee of onbekend zijn.`);
+  }
+
+  return waarde;
+}
+```
+
+- [ ] **Step 4: Werk `leesNieuwContract` bij**
+
+```ts
+export function leesNieuwContract(body: unknown): NieuwContract {
+  if (typeof body !== 'object' || body === null) {
+    throw new InvoerFout('body', 'Er is geen contract meegestuurd.');
+  }
+
+  const ruw = body as Record<string, unknown>;
+
+  const startDate = optioneleDatum(ruw.startDate, 'Begindatum');
+  const endDate = optioneleDatum(ruw.endDate, 'Einddatum');
+  controleerDatumVolgorde(startDate, endDate);
+
+  const warningDaysBefore = optioneelPositiefGeheelGetal(
+    ruw.warningDaysBefore,
+    'Waarschuwingstermijn',
+  );
+
+  return {
+    name: verplichteTekst(ruw.name, 'Naam', MAX_NAAM),
+    contractNumber: optioneleTekst(
+      ruw.contractNumber,
+      'Contractnummer',
+      MAX_KORT,
+    ),
+    vendorContactId: optioneleUuid(ruw.vendorContactId, 'Contactpersoon'),
+    ownerUserId: optioneleUuid(ruw.ownerUserId, 'Contractbeheerder'),
+    statusCode: optioneleTekst(ruw.statusCode, 'Status', MAX_KORT),
+    valueEur: optioneelBedrag(ruw.valueEur, 'Waarde'),
+    startDate,
+    endDate,
+    note: optioneleTekst(ruw.note, 'Notitie', MAX_NOTITIE),
+    noticePeriodDays: optioneelPositiefGeheelGetal(
+      ruw.noticePeriodDays,
+      'Opzegtermijn',
+    ),
+    // Default 90 wanneer niet meegestuurd — de spec (§3) eist dat elk
+    // contract een waarschuwingstermijn heeft, nooit "geen".
+    warningDaysBefore: warningDaysBefore ?? 90,
+    autoRenews: optioneelAutoRenews(ruw.autoRenews, 'Verlengt automatisch'),
+  };
+}
+```
+
+- [ ] **Step 5: Werk `leesContractWijziging` bij**
+
+Voeg toe, ná het `note`-blok en vóór `controleerDatumVolgorde(...)`:
+
+```ts
+  if ('noticePeriodDays' in ruw) {
+    wijziging.noticePeriodDays = optioneelPositiefGeheelGetal(
+      ruw.noticePeriodDays,
+      'Opzegtermijn',
+    );
+  }
+  if ('warningDaysBefore' in ruw) {
+    wijziging.warningDaysBefore = optioneelPositiefGeheelGetal(
+      ruw.warningDaysBefore,
+      'Waarschuwingstermijn',
+    );
+  }
+  if ('autoRenews' in ruw) {
+    wijziging.autoRenews = optioneelAutoRenews(
+      ruw.autoRenews,
+      'Verlengt automatisch',
+    );
+  }
+```
+
+- [ ] **Step 6: Draai de tests opnieuw, verwacht PASS**
+
+Run: `npx jest contract-invoer`
+Expected: alle tests slagen, inclusief de nieuwe uit Step 1.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/contract/contract-invoer.ts src/contract/contract-invoer.spec.ts
+git commit -m "feat(contract): validatie voor opzegtermijn, waarschuwingstermijn, verlengt-automatisch"
+```
+
+---
+
+### Task 3: `contract.service.ts` — de drie velden door de hele service
+
+**Files:**
+- Modify: `src/contract/contract.service.ts`
+
+- [ ] **Step 1: Werk de interfaces bij**
+
+`NieuwContract` (na `note?: string | null;`):
+
+```ts
+  noticePeriodDays?: number | null;
+  warningDaysBefore?: number;
+  autoRenews?: string | null;
+```
+
+`ContractWijziging` (zelfde toevoeging als `NieuwContract`, alle optioneel
+inclusief `warningDaysBefore`):
+
+```ts
+  noticePeriodDays?: number | null;
+  warningDaysBefore?: number;
+  autoRenews?: string | null;
+```
+
+`ContractDetail` (na `note: string | null;`):
+
+```ts
+  noticePeriodDays: number | null;
+  warningDaysBefore: number;
+  autoRenews: string | null;
+```
+
+`ContractSamenvatting` (na `endDate: string | null;` — nodig voor de
+waarschuwingsstaat in de lijstweergave zónder een extra detail-aanroep per
+rij):
+
+```ts
+  noticePeriodDays: number | null;
+  warningDaysBefore: number;
+  autoRenews: string | null;
+```
+
+`ContractRij` (na `end_date: string | null;`):
+
+```ts
+  notice_period_days: number | null;
+  warning_days_before: number;
+  auto_renews: string | null;
+```
+
+`ContractDetailRij` (na `end_date: string | null;`):
+
+```ts
+  notice_period_days: number | null;
+  warning_days_before: number;
+  auto_renews: string | null;
+```
+
+- [ ] **Step 2: Werk `lijst()` bij — SELECT en mapping**
+
+```ts
+  async lijst(
+    tenantId: string,
+    vendorId: string,
+  ): Promise<ContractSamenvatting[]> {
+    return this.db.withTenant(
+      tenantId,
+      async (tx) => {
+        const resultaat = await tx.execute<ContractRij>(
+          sql`SELECT c.contract_id, c.name, c.contract_number, c.status_code,
+                     c.start_date, c.end_date, c.created_at,
+                     c.notice_period_days, c.warning_days_before, c.auto_renews,
+                     vc.full_name AS vendor_contact_naam,
+                     u.full_name AS owner_naam
+                FROM clm.contract c
+                LEFT JOIN clm.vendor_contact vc ON vc.contact_id = c.vendor_contact_id
+                LEFT JOIN clm."user" u ON u.user_id = c.owner_user_id
+               WHERE c.vendor_id = ${vendorId} AND c.deleted_at IS NULL
+               ORDER BY c.created_at DESC`,
+        );
+
+        return resultaat.rows.map((r) => ({
+          contractId: r.contract_id,
+          name: r.name,
+          contractNumber: r.contract_number,
+          statusCode: r.status_code,
+          startDate: r.start_date,
+          endDate: r.end_date,
+          vendorContactNaam: r.vendor_contact_naam,
+          ownerGebruikerNaam: r.owner_naam,
+          createdAt: alsTekst(r.created_at),
+          noticePeriodDays: r.notice_period_days,
+          warningDaysBefore: r.warning_days_before,
+          autoRenews: r.auto_renews,
+        }));
+      },
+      'medewerker',
+    );
+  }
+```
+
+- [ ] **Step 3: Werk `maakAan()` bij — INSERT**
+
+```ts
+  async maakAan(
+    tenantId: string,
+    vendorId: string,
+    invoer: NieuwContract,
+  ): Promise<ContractDetail | null> {
+    return this.db.withTenant(
+      tenantId,
+      async (tx) => {
+        const vendorBestaat = await tx.execute<{ vendor_id: string }>(
+          sql`SELECT vendor_id FROM clm.vendor
+             WHERE vendor_id = ${vendorId} AND deleted_at IS NULL`,
+        );
+
+        if (vendorBestaat.rows.length === 0) {
+          return null;
+        }
+
+        const resultaat = await tx.execute<{ contract_id: string }>(
+          sql`INSERT INTO clm.contract
+                (tenant_id, vendor_id, name, contract_number,
+                 vendor_contact_id, owner_user_id, status_code, value_eur,
+                 start_date, end_date, note,
+                 notice_period_days, warning_days_before, auto_renews)
+              VALUES (${tenantId}, ${vendorId}, ${invoer.name.trim()},
+                      ${leegIsNull(invoer.contractNumber)},
+                      ${invoer.vendorContactId ?? null},
+                      ${invoer.ownerUserId ?? null},
+                      ${leegIsNull(invoer.statusCode)},
+                      ${invoer.valueEur ?? null},
+                      ${invoer.startDate ?? null},
+                      ${invoer.endDate ?? null},
+                      ${leegIsNull(invoer.note)},
+                      ${invoer.noticePeriodDays ?? null},
+                      ${invoer.warningDaysBefore ?? 90},
+                      ${invoer.autoRenews ?? null})
+              RETURNING contract_id`,
+        );
+
+        const contractId = resultaat.rows[0].contract_id;
+
+        this.logger.log(`Contract aangemaakt (${contractId}).`);
+
+        return this.detailBinnenTransactie(tx, vendorId, contractId);
+      },
+      'medewerker',
+    );
+  }
+```
+
+- [ ] **Step 4: Werk `wijzig()` bij — UPDATE**
+
+Voeg toe aan de `zetten`-array-opbouw, ná het `note`-blok:
+
+```ts
+        if (wijziging.noticePeriodDays !== undefined) {
+          zetten.push(
+            sql`notice_period_days = ${wijziging.noticePeriodDays}`,
+          );
+        }
+        if (wijziging.warningDaysBefore !== undefined) {
+          zetten.push(
+            sql`warning_days_before = ${wijziging.warningDaysBefore}`,
+          );
+        }
+        if (wijziging.autoRenews !== undefined) {
+          zetten.push(sql`auto_renews = ${wijziging.autoRenews}`);
+        }
+```
+
+- [ ] **Step 5: Werk `detailBinnenTransactie()` bij — SELECT en mapping**
+
+```ts
+  private async detailBinnenTransactie(
+    tx: Parameters<Parameters<DatabaseService['withTenant']>[1]>[0],
+    vendorId: string,
+    contractId: string,
+  ): Promise<ContractDetail | null> {
+    const resultaat = await tx.execute<ContractDetailRij>(
+      sql`SELECT c.contract_id, c.vendor_id, c.name, c.contract_number,
+                 c.vendor_contact_id, c.owner_user_id, c.status_code,
+                 c.value_eur, c.start_date, c.end_date, c.note,
+                 c.notice_period_days, c.warning_days_before, c.auto_renews,
+                 c.created_at, c.updated_at,
+                 vc.full_name AS vendor_contact_naam,
+                 u.full_name AS owner_naam
+            FROM clm.contract c
+            LEFT JOIN clm.vendor_contact vc ON vc.contact_id = c.vendor_contact_id
+            LEFT JOIN clm."user" u ON u.user_id = c.owner_user_id
+           WHERE c.contract_id = ${contractId}
+             AND c.vendor_id = ${vendorId}
+             AND c.deleted_at IS NULL`,
+    );
+
+    const rij = resultaat.rows[0];
+
+    if (!rij) {
+      return null;
+    }
+
+    return {
+      contractId: rij.contract_id,
+      vendorId: rij.vendor_id,
+      name: rij.name,
+      contractNumber: rij.contract_number,
+      vendorContactId: rij.vendor_contact_id,
+      vendorContactNaam: rij.vendor_contact_naam,
+      ownerUserId: rij.owner_user_id,
+      ownerGebruikerNaam: rij.owner_naam,
+      statusCode: rij.status_code,
+      valueEur: rij.value_eur,
+      startDate: rij.start_date,
+      endDate: rij.end_date,
+      note: rij.note,
+      createdAt: alsTekst(rij.created_at),
+      updatedAt: alsTekstOfNull(rij.updated_at),
+      noticePeriodDays: rij.notice_period_days,
+      warningDaysBefore: rij.warning_days_before,
+      autoRenews: rij.auto_renews,
+    };
+  }
+```
+
+- [ ] **Step 6: Typecheck**
+
+Run: `npm run typecheck`
+Expected: geen fouten.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/contract/contract.service.ts
+git commit -m "feat(contract): opzegtermijn, waarschuwingstermijn, verlengt-automatisch door de service"
+```
+
+---
+
+### Task 4: E2e-dekking backend
+
+**Files:**
+- Modify: `test/contract-routes.e2e-spec.ts`
+
+- [ ] **Step 1: Bekijk het bestaande patroon rond regel 187 ("admin kan een contract aanmaken")**
+
+Voeg na die test (en vóór "reviewer kan geen contract aanmaken") een nieuwe
+test toe:
+
+```ts
+  it('admin kan opzegtermijn, waarschuwingstermijn en verlengt-automatisch meegeven', async () => {
+    const response = await request(app.getHttpServer() as Server)
+      .post(`/vendors/${vendorId}/contracts`)
+      .set('Cookie', adminCookie)
+      .send({
+        name: 'Hosting met opzegtermijn',
+        endDate: '2027-12-31',
+        noticePeriodDays: '90',
+        warningDaysBefore: '30',
+        autoRenews: 'ja',
+      })
+      .expect(201);
+
+    expect(response.body.noticePeriodDays).toBe(90);
+    expect(response.body.warningDaysBefore).toBe(30);
+    expect(response.body.autoRenews).toBe('ja');
+  });
+
+  it('warningDaysBefore is 90 wanneer niet meegegeven', async () => {
+    const response = await request(app.getHttpServer() as Server)
+      .post(`/vendors/${vendorId}/contracts`)
+      .set('Cookie', adminCookie)
+      .send({ name: 'Hosting zonder opgave' })
+      .expect(201);
+
+    expect(response.body.warningDaysBefore).toBe(90);
+    expect(response.body.noticePeriodDays).toBeNull();
+    expect(response.body.autoRenews).toBeNull();
+  });
+
+  it('weigert een ongeldige autoRenews-waarde', async () => {
+    const response = await request(app.getHttpServer() as Server)
+      .post(`/vendors/${vendorId}/contracts`)
+      .set('Cookie', adminCookie)
+      .send({ name: 'Hosting', autoRenews: 'misschien' })
+      .expect(400);
+
+    expect(response.body.veld ?? response.body.message).toBeDefined();
+  });
+
+  it('admin kan autoRenews wijzigen op een bestaand contract', async () => {
+    const aangemaakt = await request(app.getHttpServer() as Server)
+      .post(`/vendors/${vendorId}/contracts`)
+      .set('Cookie', adminCookie)
+      .send({ name: 'Wijzigtest', autoRenews: 'onbekend' })
+      .expect(201);
+
+    const gewijzigd = await request(app.getHttpServer() as Server)
+      .patch(`/vendors/${vendorId}/contracts/${aangemaakt.body.contractId}`)
+      .set('Cookie', adminCookie)
+      .send({ autoRenews: 'nee' })
+      .expect(200);
+
+    expect(gewijzigd.body.autoRenews).toBe('nee');
+  });
+```
+
+**Let op:** de exacte vorm van `request(...).set('Cookie', adminCookie)` en
+de variabelenamen (`vendorId`, `adminCookie`) moeten overeenkomen met wat
+er al in het bestand staat — lees de bestaande tests in
+`test/contract-routes.e2e-spec.ts` (regel 106–200) voor de precieze
+opzet-/cookie-variabelen vóórdat je deze vier tests toevoegt, en pas de
+namen aan naar wat daar al gebruikt wordt.
+
+- [ ] **Step 2: Draai de suite tegen een wegwerpdatabase**
+
+```powershell
+$env:DATABASE_URL="postgresql://clm_api_runtime:pw@localhost:55442/postgres"
+npx jest --config test/jest-e2e.json contract-routes --forceExit
+Remove-Item Env:\DATABASE_URL
+```
+
+Expected: alle tests slagen, inclusief de vier nieuwe.
+
+- [ ] **Step 3: Draai de VOLLEDIGE e2e-suite (niet alleen deze)**
+
+```powershell
+$env:DATABASE_URL="postgresql://clm_api_runtime:pw@localhost:55442/postgres"
+npx jest --config test/jest-e2e.json --forceExit
+Remove-Item Env:\DATABASE_URL
+```
+
+Expected: geen regressie in andere suites — dit is de stap die botsingen
+tussen suites vindt (zie MCM2-CLAUDE.md, "Een nieuwe e2e-suite schrijven").
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add test/contract-routes.e2e-spec.ts
+git commit -m "test(contract): e2e-dekking voor opzegtermijn, waarschuwingstermijn, verlengt-automatisch"
+```
+
+---
+
+### Task 5: `backup-verwachting.json` bijwerken
+
+**Files:**
+- Modify: `docs/runbooks/backup-verwachting.json`
+
+- [ ] **Step 1: Werk het `migratiestand`-veld bij**
+
+```json
+  "migratiestand": "0029_contract_opzegtermijn",
+```
+
+`clm.contract` staat al in de tabellenlijst (sinds migratie 0027) — deze
+migratie voegt kolommen toe, geen tabel, dus de tabellenlijst zelf
+verandert niet.
+
+- [ ] **Step 2: Draai de onderhoudscontrole**
+
+```powershell
+npm run verify:onderhoud
+```
+
+Expected: geen klacht over een verouderde migratiestand.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/runbooks/backup-verwachting.json
+git commit -m "chore(backup): backup-verwachting.json bijgewerkt naar migratie 0029"
+```
+
+---
+
+### Task 6: Frontend — `contract.ts`-model uitbreiden
+
+**Files:**
+- Modify: `MCM2-frontend/src/core/models/contract.ts`
+
+- [ ] **Step 1: Werk `Contract` bij**
+
+Na `note: string | null;`:
+
+```ts
+  noticePeriodDays: number | null;
+  warningDaysBefore: number;
+  autoRenews: string | null;
+```
+
+- [ ] **Step 2: Werk `ContractInvoer` bij**
+
+Na `note?: string | null;`:
+
+```ts
+  noticePeriodDays?: number | null;
+  warningDaysBefore?: number;
+  autoRenews?: string | null;
+```
+
+- [ ] **Step 3: Typecheck**
+
+Run: `cd MCM2-frontend && npx tsc --noEmit`
+Expected: fouten in `Contracten.tsx` waar `uitContract()` het nieuwe
+`ContractInvoer`-type nog niet vult — dat lost Task 8 op. Bevestig hier
+alleen dat de foutmeldingen in dat ene bestand zitten, nergens anders.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/core/models/contract.ts
+git commit -m "feat(contract): opzegtermijn, waarschuwingstermijn, verlengt-automatisch op het model"
+```
+
+---
+
+### Task 7: `contractWaarschuwing.ts` — de nieuwe berekenfunctie
+
+**Files:**
+- Create: `MCM2-frontend/src/app/beheer/leveranciers/[id]/contractWaarschuwing.ts`
+- Delete: `MCM2-frontend/src/app/beheer/leveranciers/[id]/contractUrgentie.ts`
+
+- [ ] **Step 1: Maak `contractWaarschuwing.ts`**
+
+```ts
+/**
+ * Waarschuwingslogica voor een aflopend contract.
+ *
+ * Vervangt contractUrgentie.ts volledig (spec 2026-08-23, §4) — geen twee
+ * aparte lagen. Kernprincipe: de tool bewaakt tijdigheid (waarschuwt dat
+ * een moment nadert), niet of het contract daadwerkelijk automatisch
+ * verlengt — dat is een apart, door de beheerder ingevuld feit
+ * (`auto_renews`), zie `Contracten.tsx`.
+ *
+ * Bewust een pure functie zonder React/fetch-afhankelijkheden: issue #148
+ * (notificaties per tenant) kan deze berekening later hergebruiken vanuit
+ * een backend-notificatiejob. `vandaag` is injecteerbaar in plaats van
+ * `new Date()` hardcoded, zodat zowel deze module als een toekomstige
+ * server-kant dezelfde functie met een vaste datum kunnen testen/aanroepen.
+ */
+
+export type ContractWaarschuwingStaat = 'neutraal' | 'waarschuwing' | 'alarm';
+
+/** Vaste, niet-instelbare grens voor de "bijna te laat"-staat. */
+export const ALARM_DREMPEL_DAGEN = 14;
+
+export interface ContractWaarschuwingInvoer {
+  endDate: string | null;
+  noticePeriodDays: number | null;
+  warningDaysBefore: number;
+}
+
+export interface ContractWaarschuwingUitkomst {
+  staat: ContractWaarschuwingStaat;
+  /** Dagen tot de referentiedatum; negatief als die al voorbij is. Null zonder endDate. */
+  dagenTotReferentie: number | null;
+  /** Of de referentiedatum de opzegdatum is (true) of de kale endDate (false). */
+  heeftOpzegtermijn: boolean;
+  /** Vaste, korte tekst die het "waarom" benoemt — leeg bij 'neutraal'. */
+  tekst: string;
+}
+
+function dagenTussen(vandaag: Date, doel: Date): number {
+  const verschil =
+    doel.getTime() - new Date(vandaag).setHours(0, 0, 0, 0);
+  return Math.round(verschil / (1000 * 60 * 60 * 24));
+}
+
+/** De referentiedatum: de opzegdatum als noticePeriodDays bekend is, anders endDate zelf. */
+function referentiedatum(
+  endDate: string,
+  noticePeriodDays: number | null,
+): Date {
+  const eind = new Date(endDate);
+
+  if (noticePeriodDays === null) {
+    return eind;
+  }
+
+  const opzegdatum = new Date(eind);
+  opzegdatum.setDate(opzegdatum.getDate() - noticePeriodDays);
+  return opzegdatum;
+}
+
+export function berekenContractWaarschuwing(
+  invoer: ContractWaarschuwingInvoer,
+  vandaag: Date = new Date(),
+): ContractWaarschuwingUitkomst {
+  const { endDate, noticePeriodDays, warningDaysBefore } = invoer;
+
+  if (!endDate) {
+    return {
+      staat: 'neutraal',
+      dagenTotReferentie: null,
+      heeftOpzegtermijn: noticePeriodDays !== null,
+      tekst: '',
+    };
+  }
+
+  const heeftOpzegtermijn = noticePeriodDays !== null;
+  const referentie = referentiedatum(endDate, noticePeriodDays);
+  const dagen = dagenTussen(vandaag, referentie);
+
+  let staat: ContractWaarschuwingStaat;
+  if (dagen <= ALARM_DREMPEL_DAGEN) {
+    staat = 'alarm';
+  } else if (dagen <= warningDaysBefore) {
+    staat = 'waarschuwing';
+  } else {
+    staat = 'neutraal';
+  }
+
+  const tekst = tekstVoor(staat, heeftOpzegtermijn, dagen);
+
+  return { staat, dagenTotReferentie: dagen, heeftOpzegtermijn, tekst };
+}
+
+function tekstVoor(
+  staat: ContractWaarschuwingStaat,
+  heeftOpzegtermijn: boolean,
+  dagen: number,
+): string {
+  if (staat === 'neutraal') {
+    return '';
+  }
+
+  if (heeftOpzegtermijn) {
+    if (dagen < 0) return 'opzegtermijn verstreken';
+    if (staat === 'alarm') return 'opzegtermijn bijna verstreken';
+    return 'opzegtermijn nadert';
+  }
+
+  if (dagen < 0) return 'einddatum verstreken';
+  if (staat === 'alarm') return 'geen opzegtermijn bekend — einddatum bijna daar';
+  return 'geen opzegtermijn bekend — einddatum nadert';
+}
+
+export const WAARSCHUWING_TEKSTKLEUR: Record<ContractWaarschuwingStaat, string> = {
+  neutraal: 'text-ink-muted',
+  waarschuwing: 'text-amber-700',
+  alarm: 'text-red-700',
+};
+```
+
+- [ ] **Step 2: Verifieer de logica handmatig** (geen Jest in deze repo, zie
+  de precedent uit het vorige plan — Task 5 daar)
+
+Create: `C:\Users\cmali\AppData\Local\Temp\claude\<sessiepad>\scratchpad\tmp-verifieer-waarschuwing.mjs`
+(gebruik de scratchpad-directory uit de omgeving van de uitvoerende sessie)
+
+```js
+// Wegwerpscript: verifieert contractWaarschuwing.ts logica handmatig.
+function dagenTussen(vandaag, doel) {
+  return Math.round((doel.getTime() - new Date(vandaag).setHours(0,0,0,0)) / 86400000);
+}
+function referentiedatum(endDate, noticePeriodDays) {
+  const eind = new Date(endDate);
+  if (noticePeriodDays === null) return eind;
+  const d = new Date(eind);
+  d.setDate(d.getDate() - noticePeriodDays);
+  return d;
+}
+function bereken({ endDate, noticePeriodDays, warningDaysBefore }, vandaag = new Date()) {
+  if (!endDate) return { staat: 'neutraal', dagen: null };
+  const ref = referentiedatum(endDate, noticePeriodDays);
+  const dagen = dagenTussen(vandaag, ref);
+  let staat;
+  if (dagen <= 14) staat = 'alarm';
+  else if (dagen <= warningDaysBefore) staat = 'waarschuwing';
+  else staat = 'neutraal';
+  return { staat, dagen };
+}
+function datumOver(d) { const x = new Date(); x.setDate(x.getDate() + d); return x.toISOString().slice(0,10); }
+
+const gevallen = [
+  // Geen opzegtermijn: referentie = endDate zelf
+  [{ endDate: datumOver(120), noticePeriodDays: null, warningDaysBefore: 90 }, 'neutraal'],
+  [{ endDate: datumOver(45), noticePeriodDays: null, warningDaysBefore: 90 }, 'waarschuwing'],
+  [{ endDate: datumOver(10), noticePeriodDays: null, warningDaysBefore: 90 }, 'alarm'],
+  [{ endDate: datumOver(-5), noticePeriodDays: null, warningDaysBefore: 90 }, 'alarm'],
+  // Met opzegtermijn: referentie = endDate - noticePeriodDays
+  // endDate over 200 dagen, opzegtermijn 90 -> referentie over 110 dagen -> neutraal (warning=90)
+  [{ endDate: datumOver(200), noticePeriodDays: 90, warningDaysBefore: 90 }, 'neutraal'],
+  // endDate over 150 dagen, opzegtermijn 90 -> referentie over 60 dagen -> waarschuwing
+  [{ endDate: datumOver(150), noticePeriodDays: 90, warningDaysBefore: 90 }, 'waarschuwing'],
+  // endDate over 100 dagen, opzegtermijn 90 -> referentie over 10 dagen -> alarm
+  [{ endDate: datumOver(100), noticePeriodDays: 90, warningDaysBefore: 90 }, 'alarm'],
+  // endDate over 80 dagen, opzegtermijn 90 -> referentie -10 dagen (al verstreken) -> alarm
+  [{ endDate: datumOver(80), noticePeriodDays: 90, warningDaysBefore: 90 }, 'alarm'],
+  // aangepaste warningDaysBefore: referentie over 60 dagen, warning=30 -> neutraal
+  [{ endDate: datumOver(60), noticePeriodDays: 0, warningDaysBefore: 30 }, 'neutraal'],
+];
+
+let fouten = 0;
+for (const [invoer, verwacht] of gevallen) {
+  const { staat, dagen } = bereken(invoer);
+  const ok = staat === verwacht;
+  if (!ok) fouten++;
+  console.log(`${ok ? 'OK  ' : 'FOUT'} endDate=${invoer.endDate} notice=${invoer.noticePeriodDays} warn=${invoer.warningDaysBefore} -> ${staat} (dagen=${dagen}, verwacht ${verwacht})`);
+}
+process.exit(fouten > 0 ? 1 : 0);
+```
+
+Run: `node tmp-verifieer-waarschuwing.mjs`
+Expected: alle negen gevallen "OK". Verwijder het script na een geslaagde
+run.
+
+- [ ] **Step 3: Verwijder `contractUrgentie.ts`**
+
+```bash
+rm src/app/beheer/leveranciers/[id]/contractUrgentie.ts
+```
+
+- [ ] **Step 4: Typecheck en lint**
+
+Run: `npx tsc --noEmit && npx eslint "src/app/beheer/leveranciers/[id]/" --max-warnings 0`
+Expected: fouten in `Contracten.tsx` (importeert het verwijderde bestand)
+— dat lost Task 8 op.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add "src/app/beheer/leveranciers/[id]/contractWaarschuwing.ts" "src/app/beheer/leveranciers/[id]/contractUrgentie.ts"
+git commit -m "feat(contract): contractWaarschuwing.ts vervangt contractUrgentie.ts
+
+Logica handmatig geverifieerd (9 gevallen, allemaal OK). Geen Jest in deze
+repo — zie precedent in het vorige plan."
+```
+
+---
+
+### Task 8: `Contracten.tsx` — formulier en weergave bijwerken
+
+**Files:**
+- Modify: `MCM2-frontend/src/app/beheer/leveranciers/[id]/Contracten.tsx`
+
+Dit bestand bevat: `EindeIndicator` (te vervangen), `uitContract()` (uit te
+breiden), `ContractRijen` (de compacte + uitgeklapte weergave, aan te
+passen), `ContractFormuliervelden` (drie nieuwe velden), en de
+import-regel bovenaan.
+
+- [ ] **Step 1: Werk de import bovenaan bij**
+
+Vervang:
+
+```ts
+import {
+  contractUrgentie,
+  dagenTotEinde,
+  URGENTIE_TEKSTKLEUR,
+} from './contractUrgentie';
+```
+
+Door:
+
+```ts
+import {
+  berekenContractWaarschuwing,
+  WAARSCHUWING_TEKSTKLEUR,
+} from './contractWaarschuwing';
+```
+
+- [ ] **Step 2: Vervang `EindeIndicator`**
+
+Was:
+
+```tsx
+function EindeIndicator({ endDate }: { endDate: string | null }) {
+  const dagen = dagenTotEinde(endDate);
+  if (dagen === null) return null;
+
+  const urgentie = contractUrgentie(endDate);
+  if (urgentie === 'neutraal') return null;
+
+  const tekst = dagen < 0 ? `${Math.abs(dagen)}d verlopen` : `nog ${dagen}d`;
+
+  return (
+    <span className={`block text-[10px] ${URGENTIE_TEKSTKLEUR[urgentie]}`}>
+      {tekst}
+    </span>
+  );
+}
+```
+
+Wordt:
+
+```tsx
+function WaarschuwingIndicator({
+  endDate,
+  noticePeriodDays,
+  warningDaysBefore,
+}: {
+  endDate: string | null;
+  noticePeriodDays: number | null;
+  warningDaysBefore: number;
+}) {
+  const uitkomst = berekenContractWaarschuwing({
+    endDate,
+    noticePeriodDays,
+    warningDaysBefore,
+  });
+
+  if (uitkomst.staat === 'neutraal') return null;
+
+  return (
+    <span
+      className={`block text-[10px] ${WAARSCHUWING_TEKSTKLEUR[uitkomst.staat]}`}
+    >
+      {uitkomst.tekst}
+    </span>
+  );
+}
+```
+
+- [ ] **Step 3: Werk `uitContract()` bij**
+
+Was:
+
+```ts
+function uitContract(contract: Contract): ContractInvoer {
+  return {
+    name: contract.name,
+    contractNumber: contract.contractNumber ?? '',
+    vendorContactId: contract.vendorContactId ?? '',
+    ownerUserId: contract.ownerUserId ?? '',
+    statusCode: contract.statusCode ?? '',
+    valueEur: contract.valueEur ?? '',
+    startDate: contract.startDate ?? '',
+    endDate: contract.endDate ?? '',
+    note: contract.note ?? '',
+  };
+}
+```
+
+Wordt:
+
+```ts
+function uitContract(contract: Contract): ContractInvoer {
+  return {
+    name: contract.name,
+    contractNumber: contract.contractNumber ?? '',
+    vendorContactId: contract.vendorContactId ?? '',
+    ownerUserId: contract.ownerUserId ?? '',
+    statusCode: contract.statusCode ?? '',
+    valueEur: contract.valueEur ?? '',
+    startDate: contract.startDate ?? '',
+    endDate: contract.endDate ?? '',
+    note: contract.note ?? '',
+    noticePeriodDays: contract.noticePeriodDays,
+    warningDaysBefore: contract.warningDaysBefore,
+    autoRenews: contract.autoRenews ?? '',
+  };
+}
+```
+
+- [ ] **Step 4: Werk de compacte rij in `ContractRijen` bij**
+
+Vind de `<td>` met de einddatumkleur (zoekpatroon:
+`contractUrgentie(contract.endDate)` in de JSX van de niet-uitgeklapte
+rij). Was:
+
+```tsx
+        <td className="px-4 py-2">
+          <span
+            className={URGENTIE_TEKSTKLEUR[contractUrgentie(contract.endDate)]}
+          >
+            {contract.endDate ?? '—'}
+          </span>
+          <EindeIndicator endDate={contract.endDate} />
+        </td>
+```
+
+Wordt:
+
+```tsx
+        <td className="px-4 py-2">
+          <span
+            className={
+              WAARSCHUWING_TEKSTKLEUR[
+                berekenContractWaarschuwing({
+                  endDate: contract.endDate,
+                  noticePeriodDays: contract.noticePeriodDays,
+                  warningDaysBefore: contract.warningDaysBefore,
+                }).staat
+              ]
+            }
+          >
+            {contract.endDate ?? '—'}
+          </span>
+          <WaarschuwingIndicator
+            endDate={contract.endDate}
+            noticePeriodDays={contract.noticePeriodDays}
+            warningDaysBefore={contract.warningDaysBefore}
+          />
+        </td>
+```
+
+- [ ] **Step 5: Voeg de drie nieuwe velden toe aan `ContractFormuliervelden`**
+
+Na het `note`-veld (het `<div className="sm:col-span-3">`-blok met de
+`<textarea>`), vóór de sluitende `</div>` van de grid:
+
+```tsx
+      <Veld
+        id={`${idPrefix}-noticePeriodDays`}
+        label="Opzegtermijn (dagen)"
+        type="number"
+        waarde={waarden.noticePeriodDays?.toString() ?? ''}
+        onWijzig={(w) =>
+          onWijzig({
+            ...waarden,
+            noticePeriodDays: w === '' ? null : Number.parseInt(w, 10),
+          })
+        }
+        fout={foutVoor('Opzegtermijn')}
+      />
+      <Veld
+        id={`${idPrefix}-warningDaysBefore`}
+        label="Waarschuwingstermijn (dagen)"
+        type="number"
+        waarde={(waarden.warningDaysBefore ?? 90).toString()}
+        onWijzig={(w) =>
+          onWijzig({
+            ...waarden,
+            warningDaysBefore: w === '' ? 90 : Number.parseInt(w, 10),
+          })
+        }
+        fout={foutVoor('Waarschuwingstermijn')}
+      />
+      <Keuzeveld
+        id={`${idPrefix}-autoRenews`}
+        label="Verlengt automatisch"
+        waarde={waarden.autoRenews ?? ''}
+        keuzes={[
+          { code: 'ja', label: 'Ja' },
+          { code: 'nee', label: 'Nee' },
+          { code: 'onbekend', label: 'Onbekend' },
+        ]}
+        onWijzig={(w) => onWijzig({ ...waarden, autoRenews: w })}
+      />
+```
+
+**Let op:** `Veld`'s `waarde`-prop verwacht `string`, dus
+`noticePeriodDays` (een `number | null | undefined` in `ContractInvoer`)
+moet hier expliciet naar string omgezet worden — geen kale
+`waarden.noticePeriodDays` doorgeven.
+
+- [ ] **Step 6: Voeg de drie velden toe aan de uitgeklapte detailweergave**
+
+In het niet-bewerkstand-blok van `ContractRijen` (het `<div
+className="mb-3 grid grid-cols-3 gap-3">`-blok met Contractnummer/
+Begindatum/Contactpersoon/Waarde/Notitie), voeg twee `<div>`'s toe naast
+de bestaande:
+
+```tsx
+                  <div>
+                    <span className="text-ink-muted">Opzegtermijn</span>
+                    <br />
+                    {contract.noticePeriodDays !== null
+                      ? `${contract.noticePeriodDays} dagen`
+                      : '—'}
+                  </div>
+                  <div>
+                    <span className="text-ink-muted">Verlengt automatisch</span>
+                    <br />
+                    {contract.autoRenews === 'ja' && 'Ja'}
+                    {contract.autoRenews === 'nee' && 'Nee'}
+                    {(contract.autoRenews === null ||
+                      contract.autoRenews === 'onbekend') &&
+                      'Onbekend'}
+                  </div>
+```
+
+- [ ] **Step 7: Typecheck en lint**
+
+Run: `npx tsc --noEmit && npx eslint "src/app/beheer/leveranciers/[id]/" --max-warnings 0`
+Expected: schoon.
+
+- [ ] **Step 8: Prettier**
+
+Run: `npx prettier --check "src/app/beheer/leveranciers/[id]/Contracten.tsx"`
+Bij afwijking: `npx prettier --write` op datzelfde pad, dan opnieuw
+`--check`.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add "src/app/beheer/leveranciers/[id]/Contracten.tsx"
+git commit -m "feat(contract): opzegtermijn, waarschuwingstermijn, verlengt-automatisch in formulier en weergave"
+```
+
+---
+
+### Task 9: E2e-dekking frontend
+
+**Files:**
+- Modify: `MCM2-frontend/e2e/contracten.spec.ts`
+
+- [ ] **Step 1: Voeg een test toe die de nieuwe velden invult en de
+  weergave controleert**
+
+Naar het patroon van de bestaande "toont status en einddatum-indicator"-
+test (zoek die op in het bestand voor de exacte `maakEnOpen`/selector-stijl
+en volg die precies):
+
+```ts
+  test('toont de waarschuwingstekst bij een naderende opzegtermijn', async ({
+    page,
+  }) => {
+    await maakEnOpen(page);
+
+    const naam = `Contract-opzeg-${Date.now()}`;
+    const eindDatum = new Date(Date.now() + 100 * 86400000)
+      .toISOString()
+      .slice(0, 10);
+
+    await page.locator('#nieuw-contract-name').fill(naam);
+    await page.locator('#nieuw-contract-endDate').fill(eindDatum);
+    await page
+      .locator('#nieuw-contract-noticePeriodDays')
+      .fill('90');
+    await page.getByTestId('voeg-contract-toe').click();
+
+    // endDate over 100 dagen, opzegtermijn 90 -> referentiedatum over 10
+    // dagen -> alarm-staat.
+    await expect(page.getByTestId('contract-rij').first()).toContainText(
+      'opzegtermijn bijna verstreken',
+    );
+  });
+
+  test('toont "Onbekend" als default voor verlengt automatisch', async ({
+    page,
+  }) => {
+    await maakEnOpen(page);
+
+    const naam = `Contract-onbekend-${Date.now()}`;
+    await page.locator('#nieuw-contract-name').fill(naam);
+    await page.getByTestId('voeg-contract-toe').click();
+    await expect(page.getByTestId('contract-rij').first()).toContainText(naam);
+
+    await page.getByTestId('contract-rij').first().click();
+    await expect(page.getByTestId('contract-detail')).toContainText(
+      'Onbekend',
+    );
+  });
+```
+
+- [ ] **Step 2: Draai de suite volledig**
+
+```powershell
+$env:BEHEER_COOKIE = ... # zoals de bestaande suite-instructies bovenaan het bestand aangeven
+npx playwright test e2e/contracten.spec.ts
+```
+
+Expected: alle tests slagen, inclusief de twee nieuwe.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add e2e/contracten.spec.ts
+git commit -m "test(contract): e2e-dekking voor opzegtermijn-waarschuwing en verlengt-automatisch"
+```
+
+---
+
+### Task 10: Preview en handmatige controle
+
+**Files:** geen bestandswijziging — verificatiestap.
+
+- [ ] **Step 1: Herstart de lokale demo-stack met de gewijzigde backend en
+  frontend**
+
+De backend-migratie moet vóór het starten al toegepast zijn op de
+demo-database (via `npm run demo -- --vers` als de demo-database opnieuw
+opgebouwd moet worden, of via een los `migrate:deploy` tegen de bestaande
+demo-database als die blijft staan — kies op basis van wat sneller is,
+beide zijn geldig).
+
+```powershell
+npm run demo
+```
+
+- [ ] **Step 2: Loop de spec-punten handmatig na**
+
+- Een contract aanmaken met opzegtermijn 90 en een einddatum over 100
+  dagen toont "opzegtermijn bijna verstreken" in rood.
+- Een contract zonder opzegtermijn en een einddatum over 40 dagen toont
+  "geen opzegtermijn bekend — einddatum nadert" in oranje (bij
+  waarschuwingstermijn 90).
+- "Verlengt automatisch" staat standaard op "Onbekend" bij een nieuw
+  contract, en is te wijzigen naar Ja/Nee in de uitgeklapte rij.
+- De waarschuwingstermijn is aanpasbaar per contract en verandert
+  zichtbaar het moment waarop de kleur omslaat.
+
+- [ ] **Step 3: Meld het resultaat**
+
+Terugkoppelen aan de eigenaar of de preview klopt met de spec, vóór er
+gemerged wordt (git-ritueel: pushen → mergen of bewust parkeren, zowel
+backend als frontend apart).
+
+---
+
+## Self-review — dekking tegen de spec
+
+- **§3 Datamodel:** Task 1 — gedekt.
+- **§4 Waarschuwingslogica (referentiedatum, drie staten, teksten):**
+  Task 7 — gedekt, inclusief de vaste 14-dagen-alarmdrempel.
+- **§5 `auto_renews` apart getoond:** Task 8 Step 6 — gedekt.
+- **§6 UI (formulier + rij + uitgeklapte rij):** Task 8 — gedekt.
+- **§7 Herbruikbaarheid voor #148:** Task 7 — de functie accepteert
+  primitieve waarden en een injecteerbare `vandaag`-parameter, geen
+  React/fetch-afhankelijkheden — gedekt.
+- **§8 Wat ongewijzigd blijft (routes, rest van het scherm):** geen taak
+  raakt de routes of de badge-strip/modal/uitklap-structuur — bevestigd,
+  geen aparte taak nodig.
+- **§9 Test/verificatiestrategie:** Task 2 (unittests), Task 4 (backend
+  e2e), Task 7 Step 2 (handmatige verificatie berekenfunctie), Task 9
+  (frontend e2e), Task 5 (`backup-verwachting.json`) — gedekt.

--- a/docs/superpowers/specs/2026-08-23-contract-opzegtermijn-design.md
+++ b/docs/superpowers/specs/2026-08-23-contract-opzegtermijn-design.md
@@ -1,0 +1,204 @@
+# Contract: opzegtermijn, waarschuwingstermijn, verlengt-automatisch
+
+**Status:** ontwerp goedgekeurd, klaar voor implementatieplan
+**Datum:** 2026-08-23
+**Issue:** [#174](https://github.com/AlingAdvies/MCM2/issues/174)
+**Vervolg op:** de urgentiekleur-tussenoplossing uit
+`docs/superpowers/specs/2026-08-23-leveranciersscherm-dichtheid-design.md`
+§5, die dit ontwerp vervangt.
+
+---
+
+## 1. Aanleiding
+
+Bij het bouwen van de urgentiekleur-tussenoplossing (23-08, ochtend) merkte
+de eigenaar op dat voor een contractbeheerder twee dingen het belangrijkst
+zijn: compliance-status en tijdige waarschuwing vóór de einddatum. Er treedt
+veel schade op door onbedoelde stilzwijgende verlenging van contracten. De
+tussenoplossing (kleur op de kale `end_date`, drempels 90/30 dagen, geen
+opzegtermijn-correctie) was bewust een eerste stap; dit ontwerp levert de
+echte, opzegtermijn-bewuste waarschuwing.
+
+**Correctie op een eerdere aanname.** Issue #174 stelde dat MVM_V2 dit al
+had opgelost (`noticePeriodDays`, `daysUntilExpiry`). Bij nadere
+bestudering tijdens deze brainstorm bleek dat niet zo: MVM_V2 toont
+`noticePeriodDays` alleen als los informatief veld naast de einddatum,
+zonder een berekening die de opzegdatum zelf (einddatum − opzegtermijn)
+afzet tegen vandaag, en zonder waarschuwingslogica. De waarschuwingslogica
+in dit ontwerp is dus nieuw, niet overgenomen.
+
+**Kernprincipe, expliciet door de eigenaar vastgesteld:** de tool bewaakt
+*tijdigheid* — waarschuwt dat een moment nadert — maar beslist niet wát er
+moet gebeuren. Of een contract daadwerkelijk automatisch verlengt, staat
+vaak niet gestructureerd vastgelegd (verspreid over de organisatie); dat is
+een apart, door de beheerder zelf in te vullen feit, geen afgeleide waarde.
+
+---
+
+## 2. Scope
+
+**In scope:**
+- Drie nieuwe velden op `clm.contract`: opzegtermijn, waarschuwingstermijn
+  (instelbaar per contract, default 90 dagen), verlengt-automatisch
+  (ja/nee/onbekend, default onbekend).
+- Nieuwe waarschuwingslogica die de bestaande urgentiekleur-tussenoplossing
+  (`contractUrgentie.ts`) **vervangt**, geen aparte laag ernaast.
+- Contractformulier (aanmaken + bewerken): de drie nieuwe velden.
+- Contractrij: toont de nieuwe waarschuwingsstaat met een tekst die het
+  "waarom" benoemt.
+- Berekenfunctie geïsoleerd (geen React-afhankelijkheden) zodat een latere
+  backend-notificatie (issue #148) dezelfde regel kan herimplementeren
+  zonder te gokken wat de frontend precies doet.
+
+**Bewust buiten scope:**
+- De notificatiefunctie zelf (issue #148) — dit ontwerp legt alleen de
+  herbruikbare berekening vast, bouwt geen notificatiekanaal.
+- Een instellingenscherm voor een tenant-brede default-waarschuwingstermijn
+  — de instelling is per contract, niet per tenant, in deze ronde.
+
+---
+
+## 3. Datamodel — migratie 0029 op `clm.contract`
+
+```sql
+ALTER TABLE clm.contract
+  ADD COLUMN notice_period_days  integer,
+  ADD COLUMN warning_days_before integer NOT NULL DEFAULT 90,
+  ADD COLUMN auto_renews         text;
+
+ALTER TABLE clm.contract
+  ADD CONSTRAINT contract_auto_renews_check
+  CHECK (auto_renews IN ('ja', 'nee', 'onbekend') OR auto_renews IS NULL);
+```
+
+- **`notice_period_days`** (nullable): opzegtermijn in dagen. Niet elk
+  contract heeft deze bekend — nullable is de correcte modellering, geen
+  lege string.
+- **`warning_days_before`** (NOT NULL, default 90): hoeveel dagen vóór de
+  referentiedatum (zie §4) gewaarschuwd wordt. Instelbaar per contract, niet
+  per tenant. Bestaande rijen krijgen de default via `ADD COLUMN ...
+  DEFAULT`, geen aparte UPDATE nodig.
+- **`auto_renews`** (nullable, CHECK i.p.v. een aparte ref-tabel): drie
+  vaste waarden die nooit per tenant configureerbaar worden — een aparte
+  `ref.contract_auto_renews`-tabel zoals `ref.contract_status` zou hier
+  overbodige indirectie zijn voor een gesloten, niet-uitbreidbare lijst.
+  Bewuste afwijking van het `contract_status`-patroon; opgeschreven zodat
+  een volgende sessie niet per ongeluk "consistentie" afdwingt door alsnog
+  een ref-tabel toe te voegen.
+- **Default van `auto_renews` bij aanmaken is `NULL`** (weergegeven als
+  "Onbekend" in de UI), niet een verplicht in te vullen veld — eerlijk over
+  wat nog niet uitgezocht is.
+
+---
+
+## 4. Waarschuwingslogica
+
+Vervangt `contractUrgentie.ts` in zijn geheel. Blijft een pure functie
+(geen React, geen fetch) — dat is de eis voor herbruikbaarheid richting
+issue #148.
+
+### Referentiedatum
+
+```
+referentiedatum = notice_period_days is ingevuld
+  ? end_date − notice_period_days dagen   (de opzegdatum)
+  : end_date                              (geen opzegtermijn bekend, dus de
+                                            einddatum zelf is het laatste
+                                            moment dat ertoe doet)
+```
+
+### Staten, in volgorde van toenemende urgentie
+
+| Staat | Voorwaarde | Betekenis |
+|---|---|---|
+| `neutraal` | referentiedatum ligt meer dan `warning_days_before` dagen in de toekomst | geen actie nodig |
+| `waarschuwing` | referentiedatum ligt binnen `warning_days_before` dagen, maar meer dan 14 dagen weg | tijd om uit te zoeken/te handelen |
+| `alarm` | referentiedatum ligt binnen 14 dagen, of is al verstreken | bijna te laat — vaste, niet-instelbare drempel, los van `warning_days_before` |
+
+De 14-dagen-alarmdrempel is bewust vast (niet instelbaar): dat is de "dit
+wordt nu echt urgent"-grens, onafhankelijk van hoe ruim de beheerder zijn
+eigen waarschuwingstermijn heeft gezet.
+
+### Tekst bij de staat (het "waarom")
+
+- Met `notice_period_days` ingevuld: *"opzegtermijn nadert"* /
+  *"opzegtermijn bijna verstreken"* / *"opzegtermijn verstreken"*
+- Zonder `notice_period_days`: *"geen opzegtermijn bekend — einddatum
+  nadert"* / *"geen opzegtermijn bekend — einddatum bijna daar"* /
+  *"einddatum verstreken"*
+
+Geen claim over automatische verlenging in deze tekst zelf — dat is precies
+waar `auto_renews` apart voor bestaat (zie §5).
+
+---
+
+## 5. `auto_renews` — apart getoond, niet vermengd met de waarschuwing
+
+- Toont als eigen label naast (niet in plaats van) de waarschuwingsstaat:
+  "Verlengt automatisch: Ja" / "Nee" / "Onbekend".
+- Bij `onbekend` én een `waarschuwing`/`alarm`-staat: dit is het moment
+  waarop het voor de beheerder het meest waardevol is om dat uit te zoeken
+  — geen automatische actie, wel de twee signalen naast elkaar zodat de
+  samenhang zichtbaar is.
+- Bewerkbaar in het contractformulier als een simpele driekeuze
+  (Ja/Nee/Onbekend), default Onbekend bij aanmaken.
+
+---
+
+## 6. UI
+
+### Contractformulier (aanmaken + bewerken)
+Drie nieuwe velden, in de bestaande `ContractFormuliervelden`-component:
+- Opzegtermijn (dagen) — getal, leeg toegestaan
+- Waarschuwingstermijn (dagen) — getal, voorgevuld met 90 bij aanmaken
+- Verlengt automatisch — Ja / Nee / Onbekend, voorgevuld Onbekend bij
+  aanmaken
+
+### Contractrij (compact) en uitgeklapte rij (detail)
+- Compacte rij: vervangt de huidige kale-einddatum-kleur door de nieuwe
+  waarschuwingsstaat-kleur, met de korte "waarom"-tekst eronder (zoals
+  `EindeIndicator` nu al doet, alleen met de nieuwe logica).
+- Uitgeklapte rij: toont opzegtermijn, waarschuwingstermijn en
+  verlengt-automatisch als velden, naast de bestaande contractvelden.
+
+---
+
+## 7. Herbruikbaarheid voor issue #148
+
+De berekenfunctie (`contractWaarschuwing.ts`, vervangt
+`contractUrgentie.ts`) accepteert alleen primitieve waarden (`endDate`,
+`noticePeriodDays`, `warningDaysBefore`, een referentiedatum voor "vandaag"
+— injecteerbaar, niet `new Date()` hardcoded, zodat een latere
+backend-implementatie of een test dezelfde functie met een vaste datum kan
+aanroepen). Geen afhankelijkheid van React, fetch, of de DOM. Dat maakt het
+een kandidaat om ongewijzigd te kopiëren naar een toekomstige
+notificatiejob, of — als de architectuur van #148 dat vraagt — te
+verplaatsen naar een gedeeld pakket. Die verplaatsing zelf is geen
+onderdeel van dit issue.
+
+---
+
+## 8. Wat ongewijzigd blijft
+
+- Backend-routes (`POST/PATCH /vendors/:vendorId/contracts/...`) — de
+  nieuwe velden gaan gewoon mee in de bestaande `ContractInvoer`/
+  `ContractWijziging`-vorm, geen nieuwe route.
+- De rest van het leveranciersscherm (badge-strip, modal, uitklapbare rij
+  als mechanisme) — dit ontwerp verandert alleen wát er in de rij getoond
+  wordt, niet de structuur eromheen.
+
+---
+
+## 9. Test- en verificatiestrategie
+
+- Backend: `contract-invoer.spec.ts` uitbreiden (validatie van de drie
+  nieuwe velden), `test/contract-routes.e2e-spec.ts` uitbreiden (aanmaken/
+  wijzigen met de nieuwe velden, tegen een wegwerpdatabase).
+- Frontend: de berekenfunctie krijgt handmatige verificatie zoals
+  `contractUrgentie.ts` deed (geen Jest in deze repo — zie de
+  toelichting in het vorige plan), met een reeks vaste datums die elke
+  staat-grens raken (net binnen `warning_days_before`, net binnen 14 dagen,
+  net verstreken, met en zonder `notice_period_days`).
+- E2e (Playwright): contractrij toont de juiste tekst/kleur voor een
+  contract met een bekende einddatum en opzegtermijn.
+- `backup-verwachting.json` bijwerken naar migratie 0029.

--- a/drizzle/0029_contract_opzegtermijn.sql
+++ b/drizzle/0029_contract_opzegtermijn.sql
@@ -1,0 +1,29 @@
+-- =============================================================================
+-- clm.contract — opzegtermijn, waarschuwingstermijn, verlengt-automatisch.
+--
+-- Ontwerp: docs/superpowers/specs/2026-08-23-contract-opzegtermijn-design.md
+-- Aanleiding: issue #174 — de kale-einddatum-urgentiekleur (tussenoplossing
+-- van 23-08) kan geen "opzegtermijn verstreken"-waarschuwing geven zonder
+-- deze velden.
+--
+-- auto_renews krijgt bewust GEEN eigen ref-tabel (anders dan
+-- ref.contract_status): drie vaste, niet-tenant-configureerbare waarden
+-- rechtvaardigen geen aparte tabel. Zie de spec §3 voor de volledige
+-- afweging.
+-- =============================================================================
+
+ALTER TABLE clm.contract
+    ADD COLUMN notice_period_days  integer,
+    ADD COLUMN warning_days_before integer NOT NULL DEFAULT 90,
+    ADD COLUMN auto_renews         text;--> statement-breakpoint
+
+ALTER TABLE clm.contract
+    ADD CONSTRAINT contract_auto_renews_check
+    CHECK (auto_renews IN ('ja', 'nee', 'onbekend') OR auto_renews IS NULL);--> statement-breakpoint
+
+COMMENT ON COLUMN clm.contract.notice_period_days IS
+    'Opzegtermijn in dagen vóór end_date. Nullable: niet elk contract heeft dit bekend.';--> statement-breakpoint
+COMMENT ON COLUMN clm.contract.warning_days_before IS
+    'Hoeveel dagen vóór de referentiedatum (opzegdatum, of end_date zonder opzegtermijn) gewaarschuwd wordt. Instelbaar per contract, default 90.';--> statement-breakpoint
+COMMENT ON COLUMN clm.contract.auto_renews IS
+    'ja/nee/onbekend — door de contractbeheerder zelf vastgesteld, geen afgeleide waarde. Default onbekend (NULL) bij aanmaken.';

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -204,6 +204,13 @@
       "when": 1787068800002,
       "tag": "0028_contract_survey_wachtlijst",
       "breakpoints": true
+    },
+    {
+      "idx": 29,
+      "version": "7",
+      "when": 1787068800003,
+      "tag": "0029_contract_opzegtermijn",
+      "breakpoints": true
     }
   ]
 }

--- a/src/contract/contract-invoer.spec.ts
+++ b/src/contract/contract-invoer.spec.ts
@@ -65,3 +65,67 @@ describe('leesNieuwContract', () => {
     ).toThrow(InvoerFout);
   });
 });
+
+describe('leesNieuwContract — opzegtermijn en verlengt-automatisch', () => {
+  it('accepteert een geldige noticePeriodDays', () => {
+    const invoer = leesNieuwContract({
+      name: 'Hosting',
+      noticePeriodDays: '90',
+    });
+    expect(invoer.noticePeriodDays).toBe(90);
+  });
+
+  it('laat noticePeriodDays leeg zonder invoer', () => {
+    const invoer = leesNieuwContract({ name: 'Hosting' });
+    expect(invoer.noticePeriodDays).toBeNull();
+  });
+
+  it('weigert een negatieve noticePeriodDays', () => {
+    expect(() =>
+      leesNieuwContract({ name: 'Hosting', noticePeriodDays: '-5' }),
+    ).toThrow(InvoerFout);
+  });
+
+  it('weigert een niet-numerieke noticePeriodDays', () => {
+    expect(() =>
+      leesNieuwContract({ name: 'Hosting', noticePeriodDays: 'abc' }),
+    ).toThrow(InvoerFout);
+  });
+
+  it('vult warningDaysBefore met 90 als het ontbreekt', () => {
+    const invoer = leesNieuwContract({ name: 'Hosting' });
+    expect(invoer.warningDaysBefore).toBe(90);
+  });
+
+  it('accepteert een expliciete warningDaysBefore', () => {
+    const invoer = leesNieuwContract({
+      name: 'Hosting',
+      warningDaysBefore: '30',
+    });
+    expect(invoer.warningDaysBefore).toBe(30);
+  });
+
+  it('weigert een negatieve warningDaysBefore', () => {
+    expect(() =>
+      leesNieuwContract({ name: 'Hosting', warningDaysBefore: '-1' }),
+    ).toThrow(InvoerFout);
+  });
+
+  it('accepteert ja/nee/onbekend voor autoRenews', () => {
+    for (const waarde of ['ja', 'nee', 'onbekend']) {
+      const invoer = leesNieuwContract({ name: 'Hosting', autoRenews: waarde });
+      expect(invoer.autoRenews).toBe(waarde);
+    }
+  });
+
+  it('laat autoRenews null zonder invoer (onbekend is de default)', () => {
+    const invoer = leesNieuwContract({ name: 'Hosting' });
+    expect(invoer.autoRenews).toBeNull();
+  });
+
+  it('weigert een ongeldige waarde voor autoRenews', () => {
+    expect(() =>
+      leesNieuwContract({ name: 'Hosting', autoRenews: 'misschien' }),
+    ).toThrow(InvoerFout);
+  });
+});

--- a/src/contract/contract-invoer.ts
+++ b/src/contract/contract-invoer.ts
@@ -148,7 +148,9 @@ function optioneelAutoRenews(waarde: unknown, veld: string): string | null {
 
   if (
     typeof waarde !== 'string' ||
-    !AUTO_RENEWS_WAARDEN.includes(waarde as (typeof AUTO_RENEWS_WAARDEN)[number])
+    !AUTO_RENEWS_WAARDEN.includes(
+      waarde as (typeof AUTO_RENEWS_WAARDEN)[number],
+    )
   ) {
     throw new InvoerFout(veld, `${veld} moet ja, nee of onbekend zijn.`);
   }
@@ -263,8 +265,10 @@ export function leesContractWijziging(body: unknown): ContractWijziging {
     // Geen NULL-betekenis voor dit veld — de kolom is NOT NULL DEFAULT 90.
     // Leeg meesturen valt terug op 90, net als bij aanmaken.
     wijziging.warningDaysBefore =
-      optioneelPositiefGeheelGetal(ruw.warningDaysBefore, 'Waarschuwingstermijn') ??
-      90;
+      optioneelPositiefGeheelGetal(
+        ruw.warningDaysBefore,
+        'Waarschuwingstermijn',
+      ) ?? 90;
   }
   if ('autoRenews' in ruw) {
     wijziging.autoRenews = optioneelAutoRenews(

--- a/src/contract/contract-invoer.ts
+++ b/src/contract/contract-invoer.ts
@@ -125,14 +125,14 @@ function optioneelPositiefGeheelGetal(
     return null;
   }
 
-  const getal =
-    typeof waarde === 'number' ? waarde : Number.parseInt(String(waarde), 10);
+  if (typeof waarde !== 'number' && typeof waarde !== 'string') {
+    throw new InvoerFout(veld, `${veld} moet een positief geheel getal zijn.`);
+  }
 
-  if (
-    !Number.isInteger(getal) ||
-    getal < 0 ||
-    String(waarde).trim() !== String(getal)
-  ) {
+  const tekst = typeof waarde === 'number' ? String(waarde) : waarde.trim();
+  const getal = Number.parseInt(tekst, 10);
+
+  if (!Number.isInteger(getal) || getal < 0 || tekst !== String(getal)) {
     throw new InvoerFout(veld, `${veld} moet een positief geheel getal zijn.`);
   }
 

--- a/src/contract/contract-invoer.ts
+++ b/src/contract/contract-invoer.ts
@@ -260,10 +260,11 @@ export function leesContractWijziging(body: unknown): ContractWijziging {
     );
   }
   if ('warningDaysBefore' in ruw) {
-    wijziging.warningDaysBefore = optioneelPositiefGeheelGetal(
-      ruw.warningDaysBefore,
-      'Waarschuwingstermijn',
-    );
+    // Geen NULL-betekenis voor dit veld — de kolom is NOT NULL DEFAULT 90.
+    // Leeg meesturen valt terug op 90, net als bij aanmaken.
+    wijziging.warningDaysBefore =
+      optioneelPositiefGeheelGetal(ruw.warningDaysBefore, 'Waarschuwingstermijn') ??
+      90;
   }
   if ('autoRenews' in ruw) {
     wijziging.autoRenews = optioneelAutoRenews(

--- a/src/contract/contract-invoer.ts
+++ b/src/contract/contract-invoer.ts
@@ -117,6 +117,45 @@ function optioneelBedrag(waarde: unknown, veld: string): string | null {
   return waarde;
 }
 
+function optioneelPositiefGeheelGetal(
+  waarde: unknown,
+  veld: string,
+): number | null {
+  if (waarde === undefined || waarde === null || waarde === '') {
+    return null;
+  }
+
+  const getal =
+    typeof waarde === 'number' ? waarde : Number.parseInt(String(waarde), 10);
+
+  if (
+    !Number.isInteger(getal) ||
+    getal < 0 ||
+    String(waarde).trim() !== String(getal)
+  ) {
+    throw new InvoerFout(veld, `${veld} moet een positief geheel getal zijn.`);
+  }
+
+  return getal;
+}
+
+const AUTO_RENEWS_WAARDEN = ['ja', 'nee', 'onbekend'] as const;
+
+function optioneelAutoRenews(waarde: unknown, veld: string): string | null {
+  if (waarde === undefined || waarde === null || waarde === '') {
+    return null;
+  }
+
+  if (
+    typeof waarde !== 'string' ||
+    !AUTO_RENEWS_WAARDEN.includes(waarde as (typeof AUTO_RENEWS_WAARDEN)[number])
+  ) {
+    throw new InvoerFout(veld, `${veld} moet ja, nee of onbekend zijn.`);
+  }
+
+  return waarde;
+}
+
 function controleerDatumVolgorde(
   startDate: string | null,
   endDate: string | null,
@@ -141,6 +180,11 @@ export function leesNieuwContract(body: unknown): NieuwContract {
   const endDate = optioneleDatum(ruw.endDate, 'Einddatum');
   controleerDatumVolgorde(startDate, endDate);
 
+  const warningDaysBefore = optioneelPositiefGeheelGetal(
+    ruw.warningDaysBefore,
+    'Waarschuwingstermijn',
+  );
+
   return {
     name: verplichteTekst(ruw.name, 'Naam', MAX_NAAM),
     contractNumber: optioneleTekst(
@@ -155,6 +199,14 @@ export function leesNieuwContract(body: unknown): NieuwContract {
     startDate,
     endDate,
     note: optioneleTekst(ruw.note, 'Notitie', MAX_NOTITIE),
+    noticePeriodDays: optioneelPositiefGeheelGetal(
+      ruw.noticePeriodDays,
+      'Opzegtermijn',
+    ),
+    // Default 90 wanneer niet meegestuurd — elk contract heeft een
+    // waarschuwingstermijn, nooit "geen".
+    warningDaysBefore: warningDaysBefore ?? 90,
+    autoRenews: optioneelAutoRenews(ruw.autoRenews, 'Verlengt automatisch'),
   };
 }
 
@@ -200,6 +252,24 @@ export function leesContractWijziging(body: unknown): ContractWijziging {
   }
   if ('note' in ruw) {
     wijziging.note = optioneleTekst(ruw.note, 'Notitie', MAX_NOTITIE);
+  }
+  if ('noticePeriodDays' in ruw) {
+    wijziging.noticePeriodDays = optioneelPositiefGeheelGetal(
+      ruw.noticePeriodDays,
+      'Opzegtermijn',
+    );
+  }
+  if ('warningDaysBefore' in ruw) {
+    wijziging.warningDaysBefore = optioneelPositiefGeheelGetal(
+      ruw.warningDaysBefore,
+      'Waarschuwingstermijn',
+    );
+  }
+  if ('autoRenews' in ruw) {
+    wijziging.autoRenews = optioneelAutoRenews(
+      ruw.autoRenews,
+      'Verlengt automatisch',
+    );
   }
 
   controleerDatumVolgorde(

--- a/src/contract/contract.service.ts
+++ b/src/contract/contract.service.ts
@@ -27,6 +27,9 @@ export interface ContractSamenvatting {
   vendorContactNaam: string | null;
   ownerGebruikerNaam: string | null;
   createdAt: string;
+  noticePeriodDays: number | null;
+  warningDaysBefore: number;
+  autoRenews: string | null;
 }
 
 export interface NieuwContract {
@@ -39,6 +42,9 @@ export interface NieuwContract {
   startDate?: string | null;
   endDate?: string | null;
   note?: string | null;
+  noticePeriodDays?: number | null;
+  warningDaysBefore?: number;
+  autoRenews?: string | null;
 }
 
 export interface ContractDetail {
@@ -57,6 +63,9 @@ export interface ContractDetail {
   note: string | null;
   createdAt: string;
   updatedAt: string | null;
+  noticePeriodDays: number | null;
+  warningDaysBefore: number;
+  autoRenews: string | null;
 }
 
 /**
@@ -74,6 +83,9 @@ export interface ContractWijziging {
   startDate?: string | null;
   endDate?: string | null;
   note?: string | null;
+  noticePeriodDays?: number | null;
+  warningDaysBefore?: number;
+  autoRenews?: string | null;
 }
 
 interface ContractRij extends Record<string, unknown> {
@@ -86,6 +98,9 @@ interface ContractRij extends Record<string, unknown> {
   vendor_contact_naam: string | null;
   owner_naam: string | null;
   created_at: Date | string;
+  notice_period_days: number | null;
+  warning_days_before: number;
+  auto_renews: string | null;
 }
 
 interface ContractDetailRij extends Record<string, unknown> {
@@ -104,6 +119,9 @@ interface ContractDetailRij extends Record<string, unknown> {
   note: string | null;
   created_at: Date | string;
   updated_at: Date | string | null;
+  notice_period_days: number | null;
+  warning_days_before: number;
+  auto_renews: string | null;
 }
 
 function alsTekst(waarde: Date | string): string {
@@ -136,6 +154,7 @@ export class ContractService {
         const resultaat = await tx.execute<ContractRij>(
           sql`SELECT c.contract_id, c.name, c.contract_number, c.status_code,
                      c.start_date, c.end_date, c.created_at,
+                     c.notice_period_days, c.warning_days_before, c.auto_renews,
                      vc.full_name AS vendor_contact_naam,
                      u.full_name AS owner_naam
                 FROM clm.contract c
@@ -155,6 +174,9 @@ export class ContractService {
           vendorContactNaam: r.vendor_contact_naam,
           ownerGebruikerNaam: r.owner_naam,
           createdAt: alsTekst(r.created_at),
+          noticePeriodDays: r.notice_period_days,
+          warningDaysBefore: r.warning_days_before,
+          autoRenews: r.auto_renews,
         }));
       },
       'medewerker',
@@ -188,7 +210,8 @@ export class ContractService {
           sql`INSERT INTO clm.contract
                 (tenant_id, vendor_id, name, contract_number,
                  vendor_contact_id, owner_user_id, status_code, value_eur,
-                 start_date, end_date, note)
+                 start_date, end_date, note,
+                 notice_period_days, warning_days_before, auto_renews)
               VALUES (${tenantId}, ${vendorId}, ${invoer.name.trim()},
                       ${leegIsNull(invoer.contractNumber)},
                       ${invoer.vendorContactId ?? null},
@@ -197,7 +220,10 @@ export class ContractService {
                       ${invoer.valueEur ?? null},
                       ${invoer.startDate ?? null},
                       ${invoer.endDate ?? null},
-                      ${leegIsNull(invoer.note)})
+                      ${leegIsNull(invoer.note)},
+                      ${invoer.noticePeriodDays ?? null},
+                      ${invoer.warningDaysBefore ?? 90},
+                      ${invoer.autoRenews ?? null})
               RETURNING contract_id`,
         );
 
@@ -275,6 +301,19 @@ export class ContractService {
         }
         if (wijziging.note !== undefined) {
           zetten.push(sql`note = ${leegIsNull(wijziging.note)}`);
+        }
+        if (wijziging.noticePeriodDays !== undefined) {
+          zetten.push(
+            sql`notice_period_days = ${wijziging.noticePeriodDays}`,
+          );
+        }
+        if (wijziging.warningDaysBefore !== undefined) {
+          zetten.push(
+            sql`warning_days_before = ${wijziging.warningDaysBefore}`,
+          );
+        }
+        if (wijziging.autoRenews !== undefined) {
+          zetten.push(sql`auto_renews = ${wijziging.autoRenews}`);
         }
 
         if (zetten.length > 0) {
@@ -464,6 +503,7 @@ export class ContractService {
       sql`SELECT c.contract_id, c.vendor_id, c.name, c.contract_number,
                  c.vendor_contact_id, c.owner_user_id, c.status_code,
                  c.value_eur, c.start_date, c.end_date, c.note,
+                 c.notice_period_days, c.warning_days_before, c.auto_renews,
                  c.created_at, c.updated_at,
                  vc.full_name AS vendor_contact_naam,
                  u.full_name AS owner_naam
@@ -497,6 +537,9 @@ export class ContractService {
       note: rij.note,
       createdAt: alsTekst(rij.created_at),
       updatedAt: alsTekstOfNull(rij.updated_at),
+      noticePeriodDays: rij.notice_period_days,
+      warningDaysBefore: rij.warning_days_before,
+      autoRenews: rij.auto_renews,
     };
   }
 }

--- a/src/contract/contract.service.ts
+++ b/src/contract/contract.service.ts
@@ -310,9 +310,7 @@ export class ContractService {
           zetten.push(sql`note = ${leegIsNull(wijziging.note)}`);
         }
         if (wijziging.noticePeriodDays !== undefined) {
-          zetten.push(
-            sql`notice_period_days = ${wijziging.noticePeriodDays}`,
-          );
+          zetten.push(sql`notice_period_days = ${wijziging.noticePeriodDays}`);
         }
         if (wijziging.warningDaysBefore !== undefined) {
           zetten.push(

--- a/src/contract/contract.service.ts
+++ b/src/contract/contract.service.ts
@@ -21,6 +21,8 @@ export interface ContractSamenvatting {
   contractId: string;
   name: string;
   contractNumber: string | null;
+  vendorContactId: string | null;
+  ownerUserId: string | null;
   statusCode: string | null;
   startDate: string | null;
   endDate: string | null;
@@ -92,6 +94,8 @@ interface ContractRij extends Record<string, unknown> {
   contract_id: string;
   name: string;
   contract_number: string | null;
+  vendor_contact_id: string | null;
+  owner_user_id: string | null;
   status_code: string | null;
   start_date: string | null;
   end_date: string | null;
@@ -152,7 +156,8 @@ export class ContractService {
       tenantId,
       async (tx) => {
         const resultaat = await tx.execute<ContractRij>(
-          sql`SELECT c.contract_id, c.name, c.contract_number, c.status_code,
+          sql`SELECT c.contract_id, c.name, c.contract_number,
+                     c.vendor_contact_id, c.owner_user_id, c.status_code,
                      c.start_date, c.end_date, c.created_at,
                      c.notice_period_days, c.warning_days_before, c.auto_renews,
                      vc.full_name AS vendor_contact_naam,
@@ -168,6 +173,8 @@ export class ContractService {
           contractId: r.contract_id,
           name: r.name,
           contractNumber: r.contract_number,
+          vendorContactId: r.vendor_contact_id,
+          ownerUserId: r.owner_user_id,
           statusCode: r.status_code,
           startDate: r.start_date,
           endDate: r.end_date,

--- a/test/contract-routes.e2e-spec.ts
+++ b/test/contract-routes.e2e-spec.ts
@@ -217,6 +217,39 @@ describe('Contractroutes (e2e)', () => {
     expect(lijst.length).toBeGreaterThan(0);
   });
 
+  it('de lijst bevat vendorContactId en ownerUserId, niet alleen de namen', async () => {
+    // Regressietest: ContractSamenvatting had tot 2026-08-23 wel de namen
+    // (vendorContactNaam, ownerGebruikerNaam) maar niet de id's, waardoor
+    // het bewerkformulier in de frontend de dropdowns niet kon voorinvullen
+    // — de waarde kwam wel op het scherm te staan (via de naam), maar de
+    // <select> kon 'm niet matchen zonder de id.
+    const contact = await request(server)
+      .post(`/vendors/${vendorId}/contacts`)
+      .set('Cookie', adminCookie)
+      .send({ fullName: 'Lijst-test contact' });
+    const contactId = (contact.body as { contactId: string }).contactId;
+
+    const aangemaakt = await request(server)
+      .post(`/vendors/${vendorId}/contracts`)
+      .set('Cookie', adminCookie)
+      .send({ name: 'Lijst-test contract', vendorContactId: contactId });
+
+    const respons = await request(server)
+      .get(`/vendors/${vendorId}/contracts`)
+      .set('Cookie', adminCookie);
+
+    const lijst = (
+      respons.body as {
+        contracten: { contractId: string; vendorContactId: string | null }[];
+      }
+    ).contracten;
+    const gevonden = lijst.find(
+      (c) => c.contractId === (aangemaakt.body as { contractId: string }).contractId,
+    );
+
+    expect(gevonden?.vendorContactId).toBe(contactId);
+  });
+
   it('reviewer kan de lijst wél lezen (alleen schrijven is geblokkeerd)', async () => {
     const respons = await request(server)
       .get(`/vendors/${vendorId}/contracts`)

--- a/test/contract-routes.e2e-spec.ts
+++ b/test/contract-routes.e2e-spec.ts
@@ -244,7 +244,8 @@ describe('Contractroutes (e2e)', () => {
       }
     ).contracten;
     const gevonden = lijst.find(
-      (c) => c.contractId === (aangemaakt.body as { contractId: string }).contractId,
+      (c) =>
+        c.contractId === (aangemaakt.body as { contractId: string }).contractId,
     );
 
     expect(gevonden?.vendorContactId).toBe(contactId);
@@ -346,9 +347,9 @@ describe('Contractroutes (e2e)', () => {
       });
 
     expect(respons.status).toBe(201);
-    expect((respons.body as { noticePeriodDays: number }).noticePeriodDays).toBe(
-      90,
-    );
+    expect(
+      (respons.body as { noticePeriodDays: number }).noticePeriodDays,
+    ).toBe(90);
     expect(
       (respons.body as { warningDaysBefore: number }).warningDaysBefore,
     ).toBe(30);
@@ -368,7 +369,9 @@ describe('Contractroutes (e2e)', () => {
     expect(
       (respons.body as { noticePeriodDays: number | null }).noticePeriodDays,
     ).toBeNull();
-    expect((respons.body as { autoRenews: string | null }).autoRenews).toBeNull();
+    expect(
+      (respons.body as { autoRenews: string | null }).autoRenews,
+    ).toBeNull();
   });
 
   it('weigert een ongeldige autoRenews-waarde', async () => {
@@ -378,7 +381,9 @@ describe('Contractroutes (e2e)', () => {
       .send({ name: 'Hosting', autoRenews: 'misschien' });
 
     expect(respons.status).toBe(400);
-    expect((respons.body as { veld: string }).veld).toBe('Verlengt automatisch');
+    expect((respons.body as { veld: string }).veld).toBe(
+      'Verlengt automatisch',
+    );
   });
 
   it('admin kan autoRenews wijzigen op een bestaand contract', async () => {

--- a/test/contract-routes.e2e-spec.ts
+++ b/test/contract-routes.e2e-spec.ts
@@ -300,6 +300,71 @@ describe('Contractroutes (e2e)', () => {
     expect(opgehaald.status).toBe(404);
   });
 
+  it('admin kan opzegtermijn, waarschuwingstermijn en verlengt-automatisch meegeven', async () => {
+    const respons = await request(server)
+      .post(`/vendors/${vendorId}/contracts`)
+      .set('Cookie', adminCookie)
+      .send({
+        name: 'Hosting met opzegtermijn',
+        endDate: '2027-12-31',
+        noticePeriodDays: '90',
+        warningDaysBefore: '30',
+        autoRenews: 'ja',
+      });
+
+    expect(respons.status).toBe(201);
+    expect((respons.body as { noticePeriodDays: number }).noticePeriodDays).toBe(
+      90,
+    );
+    expect(
+      (respons.body as { warningDaysBefore: number }).warningDaysBefore,
+    ).toBe(30);
+    expect((respons.body as { autoRenews: string }).autoRenews).toBe('ja');
+  });
+
+  it('warningDaysBefore is 90 wanneer niet meegegeven', async () => {
+    const respons = await request(server)
+      .post(`/vendors/${vendorId}/contracts`)
+      .set('Cookie', adminCookie)
+      .send({ name: 'Hosting zonder opgave' });
+
+    expect(respons.status).toBe(201);
+    expect(
+      (respons.body as { warningDaysBefore: number }).warningDaysBefore,
+    ).toBe(90);
+    expect(
+      (respons.body as { noticePeriodDays: number | null }).noticePeriodDays,
+    ).toBeNull();
+    expect((respons.body as { autoRenews: string | null }).autoRenews).toBeNull();
+  });
+
+  it('weigert een ongeldige autoRenews-waarde', async () => {
+    const respons = await request(server)
+      .post(`/vendors/${vendorId}/contracts`)
+      .set('Cookie', adminCookie)
+      .send({ name: 'Hosting', autoRenews: 'misschien' });
+
+    expect(respons.status).toBe(400);
+    expect((respons.body as { veld: string }).veld).toBe('Verlengt automatisch');
+  });
+
+  it('admin kan autoRenews wijzigen op een bestaand contract', async () => {
+    const aangemaakt = await request(server)
+      .post(`/vendors/${vendorId}/contracts`)
+      .set('Cookie', adminCookie)
+      .send({ name: 'Wijzigtest', autoRenews: 'onbekend' });
+
+    const contractId = alsContract(aangemaakt.body).contractId;
+
+    const gewijzigd = await request(server)
+      .patch(`/vendors/${vendorId}/contracts/${contractId}`)
+      .set('Cookie', adminCookie)
+      .send({ autoRenews: 'nee' });
+
+    expect(gewijzigd.status).toBe(200);
+    expect((gewijzigd.body as { autoRenews: string }).autoRenews).toBe('nee');
+  });
+
   it('koppelt en ontkoppelt vragenlijst-templates aan een contract', async () => {
     await client.query('BEGIN');
     await client.query(`SET LOCAL app.current_tenant_id = '${tenant}'`);


### PR DESCRIPTION
## Samenvatting

Sluit issue #174. Drie nieuwe velden op `clm.contract` (migratie 0029):

- `notice_period_days` — opzegtermijn in dagen (nullable)
- `warning_days_before` — waarschuwingstermijn, instelbaar per contract (default 90)
- `auto_renews` — ja/nee/onbekend, door de beheerder zelf vastgesteld (default onbekend)

Vervangt de kale-einddatum-urgentiekleur-tussenoplossing (van eerder
23-08) door een echte, opzegtermijn-bewuste waarschuwing. Kernprincipe uit
de brainstorm: de tool bewaakt tijdigheid (waarschuwt dat een moment
nadert), niet of een contract daadwerkelijk automatisch verlengt — dat
staat vaak niet gestructureerd vast en is een apart, door de beheerder
in te vullen feit.

Onderweg een echte bug gevonden en gefixt: `ContractSamenvatting` (de
lijst-route) had wel `vendorContactNaam`/`ownerGebruikerNaam` maar niet de
bijbehorende id's — het bewerkformulier in de frontend kon de
contactpersoon/contractbeheerder-dropdowns daardoor niet voorinvullen.

Spec: `docs/superpowers/specs/2026-08-23-contract-opzegtermijn-design.md`
Plan: `docs/superpowers/plans/2026-08-23-contract-opzegtermijn.md`

## Test plan

- [x] Migratie getoetst op een verse wegwerpdatabase
- [x] `contract-invoer.spec.ts`: 30/30 unittests groen
- [x] `contract-routes.e2e-spec.ts`: 16/16 groen (incl. nieuwe
      regressietest voor de vendorContactId/ownerUserId-fix)
- [x] Volledige e2e-suite: 519/519 groen (37 suites)
- [x] `verify:onderhoud` groen na `backup-verwachting.json`-update

Frontend-tegenhanger: AlingAdvies/MCM2-frontend#17

🤖 Generated with [Claude Code](https://claude.com/claude-code)