### PR TITLE
docs(architectuur): besluiten 23-08 op gap-analyse + pilot-versus-roadmap

### DIFF
--- a/docs/architectuur/gap-analyse-mvm2-v2.md
+++ b/docs/architectuur/gap-analyse-mvm2-v2.md
@@ -25,6 +25,29 @@ Haalbaarheid wordt beoordeeld op drie niveaus, conform
 
 ---
 
+## Besluiten van de eigenaar (23-08, na eerste lezing)
+
+Vastgelegd zodat ze niet opnieuw gesteld worden. Verwerkt in de secties
+hieronder en in de prioriteitentabel.
+
+| Gap | Besluit |
+|---|---|
+| §9 Granulaire rolmatrix | Later — bevestigd, geen concreet scenario met 3+ rollen nu. |
+| §3 Interne leveranciersbeoordeling | **Haalbaarheid herzien: Middel, niet Groot.** Als dit met een tokenlink werkt — de interne Transdev-beoordelaars hoeven **geen** tenant-gebruiker/Entra-account te zijn — hergebruikt dit het bestaande, al gebouwde tokenmechanisme (issue #8) in plaats van een nieuw permissiemodel te vergen. Zie herziene paragraaf hieronder. |
+| §6 AI Document Interrogation | Later — bevestigd. |
+| §2 Contract 360 / CATS-levenscyclus | De levenscyclus-balk (Initiatie/Implementatie/Uitvoering/Monitoring/Beëindiging) is een **nice-to-have**, niet nu nodig. Kerngegevens + gerelateerde contracten (zonder de fase-balk) blijven wel de moeite waard — zie herziene paragraaf. |
+| §4b Certificeringen-sectie | **Scope bevestigd en verbreed.** Vendor IT hangt samen met NIS2-certificering; de verwachting is dat andere normen (ISO27001, BIO, VCA, …) ook tot bewaking én een eigen "survey" gaan leiden, onder verantwoordelijkheid van de contractbeheerder — niet alleen een statusveld maar een eigen bewakings-/beoordelingsstroom per norm. Dit maakt §4b zwaarder dan oorspronkelijk ingeschat; zie herziene paragraaf. |
+
+**Open vraag van de eigenaar, apart behandeld:** hoe verhoudt deze roadmap
+zich tot de korte-termijn pilot (een beperkt aantal Transdev-medewerkers en
+hun leveranciers zien de app voor het eerst)? Dat is een andere toets dan
+"is dit uiteindelijk de juiste richting" — zie
+**`docs/architectuur/pilot-versus-roadmap.md`** voor die afweging. De
+roadmap-issues in dit document zijn niet automatisch pilot-issues, en
+omgekeerd.
+
+---
+
 ## 1. Dashboard — ontbreekt volledig in MCM2
 
 **MVM_V2:** `/dashboard` toont vier KPI-tegels (aantal leveranciers,
@@ -82,14 +105,18 @@ leverancier als geheel. Een eigen pagina geeft ruimte voor die diepte
 zonder de leverancierspagina te verdrukken.
 
 **Haalbaarheid: Middel tot Groot, gefaseerd.** Dit is al vastgelegd als
-apart issue (#173). Kerngegevens + levenscyclus-balk zijn **Klein**: een
-nieuwe `cats_phase`-kolom (enum) op `clm.contract`, een nieuwe route
+apart issue (#173). Kerngegevens zijn **Klein**: een nieuwe route
 `/contracten/[id]`, hergebruik van bestaande contract-service-data. Overleg-
 log, issues, documenten en leveranciersbeoordeling zijn elk **Middel**:
 nieuwe tabellen (`contract_overleg`, `contract_issue`, geen
 documentopslag-infrastructuur vandaag — zie §6). Aanrader: eerst
-kerngegevens + levenscyclus + gerelateerde contracten bouwen (hergebruikt
-bestaande data), overleg/issues/documenten als losse vervolgissues.
+kerngegevens + gerelateerde contracten bouwen (hergebruikt bestaande data),
+overleg/issues/documenten als losse vervolgissues.
+
+> **Besluit 23-08: de levenscyclus-balk (CATS-fases) is een nice-to-have,
+> niet nu nodig.** De `cats_phase`-kolom en de fase-balk zelf vervallen uit
+> de eerste versie van Contract 360 — dat scheelt een nieuw enum-concept
+> zonder dat het de kerngegevens-pagina blokkeert.
 
 ---
 
@@ -115,15 +142,21 @@ ze bewust in aparte navigatie-items (Survey vs. Controls) omdat de
 respondent en het doel verschillen: intern oordeel over
 leveranciersprestatie versus extern bewijs van compliance.
 
-**Haalbaarheid: Groot.** Dit is een nieuw subsysteem, geen uitbreiding van
-`clm.survey_*` — die tabellen zijn ingericht op "vragenlijst naar de
-leverancier", niet "collega's beoordelen leverancier op score-schaal met
-subcategorieën en NPS". Vergt eigen tabellen
-(`vendor_review_round`, `vendor_review_response`, `vendor_review_score`),
-een eigen scherm, en een besluit of dit nu prioriteit heeft — de vraag is
-niet triviaal: bewaakt de tool nu al genoeg met vragenlijst + contract-
-waarschuwing, of is interne beoordeling een reëel gemis? Dit is een
-product-beslissing voor de eigenaar, geen technische.
+**Haalbaarheid: Middel (herzien 23-08, was Groot).** De oorspronkelijke
+inschatting ging ervan uit dat interne beoordelaars als tenant-gebruiker
+zouden inloggen (MVM_V2's "Platformgebruiker"-optie) — dat vergt een nieuw
+stuk rechtenmodel. De eigenaar heeft dit gecorrigeerd: de Transdev-
+collega's die de beoordeling uitvoeren **hoeven geen gebruiker in de
+tenant te zijn**. Met een tokenlink-only aanpak (net als de bestaande
+vragenlijst-flow) hergebruikt dit het al gebouwde, tijdgebonden en
+niet-raadbare tokenmechanisme (issue #8) in plaats van een nieuw
+permissiemodel te vergen. Dat verlaagt de zwaarte aanzienlijk: het blijft
+een nieuw subsysteem — geen uitbreiding van `clm.survey_*`, want die
+tabellen zijn ingericht op "vragenlijst naar de leverancier", niet
+"collega's beoordelen leverancier op score-schaal met subcategorieën en
+NPS" — maar wel eigen tabellen (`vendor_review_round`,
+`vendor_review_response`, `vendor_review_score`) die het bestaande
+tokenpatroon volgen in plaats van een nieuw toegangsconcept.
 
 ---
 
@@ -154,10 +187,19 @@ certificaten kan hebben die niet aan één specifiek contract hangen.
   hij al gebruikt wordt voordat er iets nieuws bijkomt.
 - **Jaarlijkse spend, KvK, website**: **Klein**. Nieuwe kolommen op
   `clm.vendor`, geen nieuwe tabel.
-- **Certificeringen-sectie**: **Middel**. Nieuwe tabel
-  (`vendor_certification`: naam, status, vervaldatum), eigen
-  vervalbewaking analoog aan `contractWaarschuwing.ts` (het patroon is nu
-  al herbruikbaar — pure functie, geen React/fetch-afhankelijkheid).
+- **Certificeringen-sectie**: **Middel, scope verbreed (besluit 23-08)**.
+  Vendor IT hangt samen met NIS2-certificering, en de verwachting is dat
+  andere normen (ISO27001, BIO, VCA, …) hetzelfde patroon gaan volgen: niet
+  alleen een statusveld, maar een eigen bewakings- én beoordelingsstroom
+  per norm, onder verantwoordelijkheid van de contractbeheerder. Dat is
+  inhoudelijk dichter bij §3 (interne beoordeling, tokenlink-gedreven) dan
+  bij een simpel "status + vervaldatum"-veld — een certificering per norm
+  kan zelf weer een "survey" nodig hebben (bijv. een periodieke controle-
+  vragenlijst per certificeringstype). Eerste versie: nieuwe tabel
+  (`vendor_certification`: norm, status, vervaldatum), eigen vervalbewaking
+  analoog aan `contractWaarschuwing.ts` (herbruikbaar patroon). De
+  koppeling met een norm-specifieke bewakings-/surveystroom is een
+  vervolgstap, niet iets voor de eerste versie.
 - **Open taken-widget**: **Groot** — vergt een taken-concept dat vandaag
   nergens in MCM2 bestaat (geen `task`-tabel, geen toewijzing, geen
   status). Zou een eigen mini-project zijn, niet een velduitbreiding.
@@ -316,24 +358,36 @@ er een concreet scenario is met meer dan de huidige twee rollen (bijv.
 een "alleen-lezen"-rol, of de eerder genoemde accountmanager-over-alle-
 contracten-rol uit de leveranciersscherm-dichtheid-sessie).
 
+> **Besluit 23-08: later.** Bevestigd door de eigenaar — geen concreet
+> scenario met 3+ rollen op dit moment.
+
 ---
 
 ## Samenvattend prioriteitenoverzicht
 
-| # | Gap | Haalbaarheid | Advies volgorde |
-|---|---|---|---|
-| 5 | Contractenlijst tenant-breed + eigen nav-item | Klein–Middel | **Eerst** — data bestaat al, sluit direct aan op #171/#172 |
-| 2 | Contract 360 (kerngegevens + levenscyclus) | Middel | **Tweede** — al belegd in #173, eigenaar wil dit expliciet |
-| 1 | Dashboard met KPI-tegels | Middel | **Derde** — hergebruikt #174's waarschuwingslogica |
-| 4a | Vrije tags, spend/KvK/website-velden | Klein | Kan meelopen met bovenstaande, lage kosten |
-| 8 | Instellingenscherm (drempelwaarden, labels) | Middel | Na de eerste drie — bouwt op wat dan al bestaat |
-| 4b | Certificeringen-sectie | Middel | Losse vervolgstap, eigen tabel |
-| 2b | Contract 360: overleg/issues/documenten | Middel–Groot | Losse vervolgstappen op Contract 360 |
-| 3 | Interne leveranciersbeoordeling | Groot | Aparte productbeslissing eerst — is dit nodig? |
-| 7 | Samengesteld compliance/risicocijfer | Middel + ontwerpvraag | Eerst brainstormen, past het bij "waarschuwen niet blokkeren"? |
-| 9 | Granulaire rolmatrix | Groot (architectuur) | Alleen bij concreet scenario met 3+ rollen |
-| 4c | Open taken-widget | Groot | Nieuw concept, geen bestaande bouwstenen |
-| 6 | AI Document Interrogation | Groot + externe afhankelijkheid | Laatst — vergt S3-achtige opslag, eigen brainstorm |
+**Bijgewerkt 23-08** na de besluiten van de eigenaar (zie boven). Kolom
+"Wijziging" toont alleen de rijen waar het besluit de eerdere inschatting
+heeft veranderd.
+
+| # | Gap | Haalbaarheid | Advies volgorde | Wijziging 23-08 |
+|---|---|---|---|---|
+| 5 | Contractenlijst tenant-breed + eigen nav-item | Klein–Middel | **Eerst** — data bestaat al, sluit direct aan op #171/#172 | — |
+| 2 | Contract 360 (kerngegevens, zonder levenscyclus-balk) | Klein–Middel | **Tweede** — al belegd in #173, eigenaar wil dit expliciet | CATS-fase geschrapt uit eerste versie |
+| 1 | Dashboard met KPI-tegels | Middel | **Derde** — hergebruikt #174's waarschuwingslogica | — |
+| 3 | Interne leveranciersbeoordeling (tokenlink, geen tenant-account) | Middel | Kan naar voren — hergebruikt het bestaande tokenmechanisme (#8) | **Groot → Middel** |
+| 4a | Vrije tags, spend/KvK/website-velden | Klein | Kan meelopen met bovenstaande, lage kosten | — |
+| 8 | Instellingenscherm (drempelwaarden, labels) | Middel | Na de eerste drie — bouwt op wat dan al bestaat | — |
+| 4b | Certificeringen-sectie (meerdere normen, eigen bewaking) | Middel–Groot | Losse vervolgstap; scope is breder dan gedacht | Verbreed: meerdere normen, eigen surveystroom per norm |
+| 2b | Contract 360: overleg/issues/documenten | Middel–Groot | Losse vervolgstappen op Contract 360 | — |
+| 7 | Samengesteld compliance/risicocijfer | Middel + ontwerpvraag | Eerst brainstormen, past het bij "waarschuwen niet blokkeren"? | — |
+| 9 | Granulaire rolmatrix | Groot (architectuur) | **Later** — bevestigd, geen scenario met 3+ rollen | Bevestigd: later |
+| 4c | Open taken-widget | Groot | Nieuw concept, geen bestaande bouwstenen | — |
+| 6 | AI Document Interrogation | Groot + externe afhankelijkheid | **Later** — bevestigd | Bevestigd: later |
+
+**Zie ook** `docs/architectuur/pilot-versus-roadmap.md` — deze tabel is de
+roadmap-toets ("is dit de juiste productrichting"); de pilot voor een
+beperkt aantal Transdev-leveranciers vraagt een andere toets en staat
+apart.
 
 ## Wat dit niet is
 

--- a/docs/architectuur/pilot-versus-roadmap.md
+++ b/docs/architectuur/pilot-versus-roadmap.md
@@ -1,0 +1,92 @@
+# Pilot versus roadmap
+
+> Vastgelegd 2026-08-23, naar aanleiding van een vraag van de eigenaar bij
+> het lezen van `docs/architectuur/gap-analyse-mvm2-v2.md`: hoe verhoudt
+> die roadmap zich tot een korte-termijn pilot van de vragenlijst-flow op
+> een aantal Transdev-leveranciers?
+
+## Waarom dit een apart document is, geen sectie in de roadmap
+
+De gap-analyse toetst op één vraag: **is dit uiteindelijk de juiste
+richting voor het product?** De pilot toetst op een andere vraag:
+**overleeft dit het eerste echte contact met een paar Transdev-mensen en
+hun leveranciers, zonder gênant te zijn of vast te lopen?**
+
+Die twee toetsen geven regelmatig een tegenovergesteld antwoord op
+dezelfde vraag "moet dit nu gebouwd worden?":
+
+- **Contract 360** (roadmap-prioriteit 2, zie de gap-analyse) is voor de
+  pilot niet nodig — de pilot draait om de vragenlijst-flow naar de
+  leverancier, niet om hoe rijk een contractscherm is voor de interne
+  beheerder.
+- Omgekeerd staat er in eerdere, allang gesloten issues (#8 token-
+  mechanisme, #9 certificaat-upload, #43 portal-rendering-bug) precies het
+  soort werk dat wél "voor de pilot" was en niets met de MVM_V2-gap-
+  analyse te maken heeft.
+
+Dit patroon bestond al vóór deze sessie: het label `priority:before-pilot`
+("Aantoonbaar nodig voor de Transdev-survey-slice") staat al op issue #58
+(back-up onafhankelijk van de ontwikkellaptop). Dit document maakt dat
+onderscheid alleen expliciet en herhaalbaar, in plaats van het aan
+losse labels over te laten.
+
+## De pilot: wat er op het spel staat
+
+Dit is de **eerste keer dat de app door anderen gezien wordt**: een paar
+Transdev-medewerkers (intern, als beheerder/beoordelaar) en de
+leveranciers die de vragenlijst ontvangen (extern, geen account, via
+token). Twee verschillende doelgroepen, twee verschillende soorten risico:
+
+- **Transdev-medewerkers** zien het beheerscherm. Een ruwe rand hier is
+  vervelend maar herstelbaar — het zijn mensen die weten dat het een
+  vroege versie is.
+- **Leveranciers** zien alleen het vragenlijst-portaal via een tokenlink.
+  Zij weten niet dat het een pilot is. Een fout hier (een link die niet
+  werkt, een formulier dat data verliest, een afzender die onbetrouwbaar
+  oogt) is geen bug-report — het is een eerste indruk van Transdev als
+  opdrachtgever, niet alleen van de tool.
+
+Dat asymmetrische risico bepaalt de prioriteit: **de leveranciers-kant
+van de flow (het portaal, het token, het formulier, de afzender) weegt
+zwaarder dan de interne beheerkant**, ook al is de interne kant waar de
+meeste roadmap-aandacht naartoe gaat.
+
+## Wat de pilot nodig heeft — een voorlopige lijst
+
+Dit is geen uitputtende lijst maar een eerste aanzet, bedoeld om samen
+met de eigenaar aan te vullen in een apart issue (zie onderaan). Puur wat
+al zichtbaar is vanuit bestaande, deels al open issues:
+
+| Onderwerp | Status | Issue |
+|---|---|---|
+| Backup onafhankelijk van de ontwikkellaptop | Open, al pilot-gelabeld | #58 |
+| Vragenlijst toont geen contact-/afzenderinfo voor de leverancier | Open | #153 |
+| Uitnodigingen versturen — handpicked en in bulk | Open | #77 |
+| E-mailinstellingen (SMTP) per tenant | Open | #76 |
+| Backup/restore-test daadwerkelijk uitgevoerd | Open | #19 |
+| Logging/monitoring-basislaag vóór de pilot | Open | #17 |
+| Resterende open Transdev-klantvragen (OV-4, OV-6 t/m OV-9) | Open | #15 |
+
+Wat nog **niet** als issue bestaat en wel relevant lijkt voor de pilot,
+puur op basis van "wat ziet een leverancier voor het eerst":
+- Foutafhandeling in het portaal: wat ziet een leverancier als een token
+  verlopen is, een upload mislukt, of het formulier al is ingediend?
+  (Vergelijkbaar met de al gesloten #42/#43, maar dan als bewuste
+  eindtoets in plaats van losse bugfixes.)
+- Of de afzender/het e-mailadres van de uitnodiging er voor een externe
+  ontvanger professioneel en herkenbaar uitziet (raakt #153 en #76).
+
+## Hoe dit issue-technisch te structureren
+
+**Voorstel:** één nieuw issue, `priority:before-pilot`-gelabeld, met deze
+lijst als startpunt — geen losse issues per punt totdat de scope met de
+eigenaar is vastgesteld. De bestaande #58/#153/#77/#76/#19/#17/#15 blijven
+zelfstandige issues (ze bestonden al), maar krijgen (voor zover nog niet
+gebeurd) het `priority:before-pilot`-label zodat ze in GitHub's filter samen
+opduiken als "wat moet er vóór de pilot staan", los van de roadmap-issues
+uit de gap-analyse.
+
+**Wat dit niet is:** dit document beslist niet welke van bovenstaande
+punten daadwerkelijk vóór de pilot moeten — dat is aan de eigenaar. Het
+legt vast waarom de twee lijsten (roadmap, pilot) een aparte toets
+verdienen, en geeft een startpunt zodat de eigenaar niet bij nul begint.


### PR DESCRIPTION
## Samenvatting

Verwerkt zes besluiten van de eigenaar na eerste lezing van de gap-analyse
(#178/#179), en legt het onderscheid tussen roadmap en pilot vast als
apart document.

- §9 rolmatrix, §6 AI document interrogation: bevestigd als "later"
- §3 interne leveranciersbeoordeling: haalbaarheid herzien van Groot naar
  Middel — tokenlink i.p.v. tenant-account voor de beoordelaars, hergebruikt
  het bestaande tokenmechanisme (#8)
- §2 Contract 360: CATS-levenscyclusbalk als nice-to-have geschrapt uit de
  eerste versie
- §4b certificeringen: scope verbreed naar meerdere normen met een eigen
  bewakings-/surveystroom per norm

Nieuw: `docs/architectuur/pilot-versus-roadmap.md` — de roadmap toetst
"juiste productrichting", de korte-termijn pilot (Transdev-medewerkers +
hun leveranciers, eerste externe blootstelling) toetst iets anders. Issue
#180 aangemaakt als verzamelpunt voor de pilot-scope.

## Test Plan

- [x] Document leesbaar, geen placeholders
- [x] Prioriteitentabel consistent met de herziene secties

🤖 Generated with [Claude Code](https://claude.com/claude-code)