### PR TITLE
fix(tenant-leden): uitnodigingslink leest UITNODIGING_BASIS_URL i.p.v. ongebruikte APP_BASE_URL

### DIFF
--- a/src/tenant/tenant-leden.service.ts
+++ b/src/tenant/tenant-leden.service.ts
@@ -292,8 +292,18 @@ export class TenantLedenService {
     }
   }
 
+  /**
+   * Zelfde variabele en fallback als PlatformService.uitnodigingsLink
+   * (src/platform/platform.controller.ts) — dat is de plek waar
+   * deploy-inrichten.js / docker-compose.omgeving.yml de basis-URL per
+   * omgeving neerzetten. Deze methode las tot 2026-08-29 per ongeluk
+   * `APP_BASE_URL`, een variabele die nergens werd ingericht, waardoor elke
+   * tenant-uitnodiging op elke omgeving terugviel op `localhost:3000`.
+   */
   private uitnodigingsLink(token: string): string {
-    const basis = process.env.APP_BASE_URL ?? 'http://localhost:3000';
+    const basis = (
+      process.env.UITNODIGING_BASIS_URL ?? 'http://localhost:3000'
+    ).replace(/\/+$/, '');
     return `${basis}/api/backend/auth/login?uitnodiging=${encodeURIComponent(token)}`;
   }
 }


### PR DESCRIPTION
## Bug

Bij het uitnodigen van een nieuwe tenant-gebruiker (Gebruikers-scherm binnen een tenant) wees de gegenereerde link naar `http://localhost:3000` — ook op productie, waar een externe ontvanger daar natuurlijk niet bij kan.

## Oorzaak

`TenantLedenService.uitnodigingsLink()` las `process.env.APP_BASE_URL`, een variabele die nergens wordt ingericht (niet in `deploy-inrichten.js`, niet in `docker-compose.omgeving.yml`, niet in de AWS-productie task-definitie). Viel daardoor altijd stil terug op de hardcoded `http://localhost:3000`.

`PlatformService.uitnodigingsLink()` (platformbeheerder-uitnodigingen) gebruikt voor exact hetzelfde doel al de juiste variabele: `UITNODIGING_BASIS_URL`.

## Fix

`tenant-leden.service.ts` leest nu ook `UITNODIGING_BASIS_URL`, met dezelfde trailing-slash-behandeling als de platformcontroller.

## Verificatie

- Gecontroleerd tegen de draaiende AWS-productie task-definitie (`default-mcm2-api`, revisie 24): `UITNODIGING_BASIS_URL` staat daar al correct op `https://clm.alingadvies.nl`; `APP_BASE_URL` bestaat niet. Dit is dus een pure code-fix, geen infrastructuurwijziging nodig.
- `npm run verify:volledig`: groen (95 passed, 4 skipped), inclusief `tenant-leden.spec.ts` en `uitnodigen.spec.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)