### PR TITLE
fix(tenant): ingetrokken lid niet meer kiesbaar als contractbeheerder

### DIFF
--- a/src/tenant/tenant.service.ts
+++ b/src/tenant/tenant.service.ts
@@ -162,9 +162,19 @@ export class TenantService {
         user_id: string;
         full_name: string;
       }>(
-        sql`SELECT user_id, full_name FROM clm."user"
-             WHERE deleted_at IS NULL
-             ORDER BY full_name`,
+        // `deleted_at IS NULL` op clm."user" filtert alleen verwijderde
+        // personen, niet een ingetrokken tenant_membership (migratie 0004:
+        // RLS isoleert op tenant_id, zacht verwijderen is een zaak van de
+        // query). Zonder de join op tenant_membership bleef een lid met
+        // ingetrokken toegang hier gewoon kiesbaar als contractbeheerder —
+        // gevonden 2026-08-29 bij Transdev, Kees Aling.
+        sql`SELECT u.user_id, u.full_name FROM clm."user" u
+             JOIN clm.tenant_membership m
+               ON m.user_id = u.user_id
+              AND m.tenant_id = ${tenantId}
+              AND m.deleted_at IS NULL
+             WHERE u.deleted_at IS NULL
+             ORDER BY u.full_name`,
       );
 
       return rows.map((r) => ({


### PR DESCRIPTION
## Bug

Bij Transdev: nadat Kees Aling's tenant-toegang werd ingetrokken, bleef hij gewoon kiesbaar als contractbeheerder bij een nieuw contract — terwijl hij feitelijk niet meer kan inloggen.

## Oorzaak

`TenantService.gebruikers()` (bron van `GET /tenant/gebruikers`, de contractbeheerder-dropdown) filterde alleen `clm."user".deleted_at IS NULL`. Dat is de user-laag, niet de `tenant_membership`-laag die daadwerkelijk bepaalt of iemand nog toegang tot déze tenant heeft. `gebruiker_bij_subject()` (login) filtert daar al wel correct op — deze keuzelijst niet.

## Fix

Join met `tenant_membership` en filter op `deleted_at IS NULL` daar.

## Bewust NIET aangepast

Bestaande `contract.owner_user_id`-koppelingen tonen de naam nog gewoon via een `LEFT JOIN` zonder membership-check — op uitdrukkelijk verzoek van de eigenaar: een naam mag blijven staan tot handmatige vervanging, alleen de *keuze* voor een nieuwe/gewijzigde toewijzing moet een ingetrokken lid uitsluiten. De bredere vraag (moet een bestaande naam een 'geen toegang meer'-markering krijgen) is issue #192.

## Verificatie

`npm run verify:volledig`: groen (96 passed, 3 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)