### PR TITLE
fix(deploy): rookproef test /beheer i.p.v. /, na de redirect-wijziging

### DIFF
--- a/scripts/deploy.js
+++ b/scripts/deploy.js
@@ -295,8 +295,10 @@ function rookproef(omgeving) {
     ...(FRONTEND_MEE
       ? [
           {
+            // Getest wordt /beheer, niet /: sinds 2026-08-29 stuurt / bewust
+            // door (307) naar /beheer, het scherm waarmee de app opent.
             wat: 'frontend serveert een pagina',
-            commando: `curl -s -o /dev/null -w '%{http_code}' --max-time 10 http://localhost:${omgeving.frontendPoort}/`,
+            commando: `curl -s -o /dev/null -w '%{http_code}' --max-time 10 http://localhost:${omgeving.frontendPoort}/beheer`,
             verwacht: (uit) => uit === '200',
           },
           {


### PR DESCRIPTION
## Bug

De staging-uitrol van de nieuwe frontend (PR #18, root-redirect naar /beheer) faalde op de eigen rookproef van `deploy.js`:

```
FOUT frontend serveert een pagina — kreeg '307'
```

## Oorzaak

Zelfde patroon als de frontend-CI-healthcheck die in PR #18 al gecorrigeerd is: `/` stuurt sinds die wijziging bewust door (307) naar `/beheer`. Deze rookproef in `deploy.js` had dezelfde, nu verouderde aanname dat `/` een 200 teruggeeft.

De container zelf draaide overigens prima — backend-health, doorgeefluik naar backend en de beheerroute-guard waren alle drie OK. Alleen deze ene check faalde op een gezonde redirect.

## Fix

Test `/beheer` in plaats van `/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)