### PR TITLE
fix(db): schema.ts gesynchroniseerd met de database + preventietest tegen drift

### DIFF
--- a/docs/transdev-veld-cross-reference.csv
+++ b/docs/transdev-veld-cross-reference.csv
@@ -1,0 +1,26 @@
+Transdev-veldnaam (gap-analyse);Omschrijving;Databaseveld;Frontend-veldnaam
+Ondersteuning kern activiteiten;Los risicocriterium, geen equivalent. Vraagt eigen veld of hergebruik van businessCriticality?;(nog niet gebouwd);(nog niet gebouwd)
+Data gevoeligheid;Geen exacte match — riskScore is numeriek, dit is een schaal (Geen/Beperkt/...). Check of dit hetzelfde concept is.;vendor.risk_score;(geen — geen formulierveld in de frontend)
+Leverancier risico profiel;Ligt dicht bij de bestaande criticality-codelijst — waarden vergelijken vóór mapping.;vendor.business_criticality_code;Cyber criticaliteit
+Hosting locatie;Geen veld op vendor of contract. NIS2-relevant (dataresidentie).;(nog niet gebouwd);(nog niet gebouwd)
+Classificatie;"Naam suggereert overlap — waarden in de sample (High/Medium/Low) zijn geen categorie maar impact. Mogelijk toch nieuw veld. Toelichting eigenaar: dit is de Transdev-interne classificatie, conclusie van de IT risk analyse uit de rijen hierboven.";vendor.category_code;Categorie
+IB&P;Informatiebeveiliging & Privacy-classificatie (High/Medium/Low). Kernveld voor NIS2, nog geen plek.;(nog niet gebouwd);(nog niet gebouwd)
+MSR;Minimum Security Requirements ondertekend (Ja/Nee) — leverancierscompliance, geen equivalent.;(nog niet gebouwd);(nog niet gebouwd)
+ISO 27001;Past onder de bestaande compliance-status, maar die is nu één vrij veld — dit is één specifiek certificaat ernaast.;vendor.compliance_status_code;Compliancestatus
+Contract Name;Directe match.;contract.name;Naam
+Contract #;Directe match.;contract.contract_number;Contractnummer
+Supplier Name;Sleutel voor matching/aanmaken van de vendor bij import.;vendor.name;Naam
+Starts;Directe match.;contract.start_date;Begindatum
+Expires;Directe match. Bepaalt ook de "binnen 90 dagen"-indicator (#172).;contract.end_date;Einddatum
+Contact Persoon / Contact Persoon Email;Vraagt matching-logica: bestaande vendorContact vinden of nieuwe aanmaken bij import. Kan contactpersoon zijn op vendor-niveau of op contract-niveau.;contract.vendor_contact_id;Contactpersoon
+Description;Vrije tekst, vaak inhoudelijk (zie sample: scope-omschrijvingen). Kan op note of eigen veld. Toelichting eigenaar: beschrijvend, contracttype en omschrijving.;(nog niet gebouwd — mogelijk samen met Remarks in contract.note);(geen eigen veld — zie Notitie)
+Remarks;In de sample: logboek van uitvraag-updates. Eén vrij tekstveld bestaat al — past inhoud of is dit een apart historie-veld? Toelichting eigenaar: opmerking.;contract.note;Notitie
+Term of notice (date) / Term of notice (months);Opzegtermijn — inmiddels gebouwd na de gap-analyse (migratie 0029).;contract.notice_period_days;Opzegtermijn (dagen)
+(afgeleid van Term of notice) waarschuwingstermijn;Niet in de oorspronkelijke Coupa-kolom, bijgebouwd samen met de opzegtermijn.;contract.warning_days_before;Waarschuwingstermijn (dagen)
+Automatic Renewal;Ja/Nee — mogelijk relevant, maar overlapt met opzegtermijn-spec. Inmiddels gebouwd (migratie 0029) als apart drieslag-veld (ja/nee/onbekend).;contract.auto_renews;Verlengt automatisch
+Pilot Survey Proces;Ja/Nee-vlag of contract al in een surveyproces zit — koppeltabel bestaat, deze vlag niet.;contract_survey_template (koppeltabel, geen losse vlag);(nog niet gebouwd als los veld)
+Compliance Docu via web verkrijgbaar;URL naar leverancierscertificeringen (trust center e.d.). Nuttig veld, nog geen plek.;(nog niet gebouwd);(nog niet gebouwd)
+DPA;"Verwerkersovereenkomst-vlag — overlapt met ""Compliance Docu""/ISO-thema. Toelichting eigenaar: kan een geüpload document zijn, moet in de app terugvindbaar zijn.";contract.dpa_aanwezig (tri-state: onbekend/ja/nee — het onderliggende document zelf is nog niet gebouwd);DPA aanwezig
+Contract type;"Coupa-contractsoort (Raamovereenkomst/Dienstenovereenkomst). Toelichting eigenaar: is wel handig. Inmiddels gebouwd (#187) als vrij tekstveld, placeholder tot MCM2 breder contractmanagement wordt.";contract.contract_type;Contracttype
+Contract classification;"Coupa Tier 1/2/3 — overlapt met ""Leverancier risico profiel"". Inmiddels gebouwd (#188) als Transdev-brede business-risk-classificatie per contract.";contract.business_risk_tier_code;Business-risk-tier
+Commodity;Transdev-inkoopcategorie (ICT/HR/CAPEX). Toelichting eigenaar: akkoord, zie commentaar in de gap-analyse voor context.;(nog niet gebouwd);(nog niet gebouwd)

--- a/scripts/otap-doorloop.js
+++ b/scripts/otap-doorloop.js
@@ -451,17 +451,24 @@ async function main() {
   // ── 9-10. Frontend ──────────────────────────────────────────────────────
   kop('Frontend-image draait en serveert het portaal');
 
-  const home = await http(FRONTEND);
+  // /beheer, niet /: sinds 2026-08-29 stuurt / bewust door (307) naar
+  // /beheer, het scherm waarmee de app opent (de oude placeholderpagina met
+  // de "Live backend"-tekst bestaat niet meer).
+  const home = await http(`${FRONTEND}/beheer`);
   if (home.status === 200) {
     ok('startpagina antwoordt 200');
   } else {
     fout(`startpagina gaf ${home.status}`);
   }
 
-  if (home.tekst.includes('Live backend')) {
+  // beheer/page.tsx toont data-testid="mock-melding" alléén als
+  // gebruiktMockData waar is — de omgekeerde bewijsvorm van de oude
+  // "Live backend"-tekst, maar hetzelfde doel: aantonen dat er geen
+  // NEXT_PUBLIC_API_URL ontbreekt.
+  if (!home.tekst.includes('data-testid="mock-melding"')) {
     ok('frontend draait op de echte backend, niet op mock data');
   } else {
-    fout('frontend draait op mock data — NEXT_PUBLIC_MOCK_DATA staat aan');
+    fout('frontend draait op mock data — NEXT_PUBLIC_API_URL ontbreekt');
   }
 
   // Het doorgeefluik zelf (Issue #51). De controle hierboven bewijst alleen dat

--- a/scripts/verify-volledig.js
+++ b/scripts/verify-volledig.js
@@ -124,9 +124,19 @@ function wachtOpStack(maxSeconden = 120) {
       ['-s', '-o', isWindows ? 'NUL' : '/dev/null', '-w', '%{http_code}', 'http://localhost:5001/health'],
       { stil: true },
     );
+    // /beheer, niet /: sinds 2026-08-29 stuurt / bewust door (307) naar
+    // /beheer, het scherm waarmee de app opent. Zelfde correctie als eerder
+    // op de frontend-CI-check, deploy.js's rookproef en de AWS ALB.
     const web = draai(
       'curl',
-      ['-s', '-o', isWindows ? 'NUL' : '/dev/null', '-w', '%{http_code}', 'http://localhost:3000/'],
+      [
+        '-s',
+        '-o',
+        isWindows ? 'NUL' : '/dev/null',
+        '-w',
+        '%{http_code}',
+        'http://localhost:3000/beheer',
+      ],
       { stil: true },
     );
 

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -86,6 +86,10 @@ export const tenant = clm.table(
     createdAt: timestamp('created_at', { withTimezone: true })
       .notNull()
       .defaultNow(),
+    // Migratie 0033. Soft-delete: NULL = actief. Een gedeactiveerde tenant
+    // kan niet meer inloggen (sessie_aanmaken, sessie_wisselen) en verdwijnt
+    // uit clm.tenant_register. Geen reactiveren-pad.
+    deletedAt: timestamp('deleted_at', { withTimezone: true }),
   },
   (t) => [
     uniqueIndex('tenant_name_key').on(t.name),
@@ -114,6 +118,10 @@ export const user = clm.table(
     // Migratie 0023. Tot wanneer een oid aan deze rij gekoppeld mag worden bij
     // de eerste login. NULL is de veilige stand: niet koppelbaar.
     koppelbaarTot: timestamp('koppelbaar_tot', { withTimezone: true }),
+    // Migratie 0024. SHA-256 van het uitnodigingstoken, hex. NULL betekent:
+    // geen openstaande uitnodiging. Wordt gewist zodra de koppeling gelukt
+    // is — een token werkt precies één keer.
+    uitnodigingHash: text('uitnodiging_hash'),
     createdAt: timestamp('created_at', { withTimezone: true })
       .notNull()
       .defaultNow(),
@@ -124,6 +132,9 @@ export const user = clm.table(
     uniqueIndex('user_external_subject_key')
       .on(t.externalSubject)
       .where(sql`${t.externalSubject} IS NOT NULL`),
+    uniqueIndex('user_uitnodiging_hash_key')
+      .on(t.uitnodigingHash)
+      .where(sql`${t.uitnodigingHash} IS NOT NULL`),
   ],
 );
 
@@ -446,6 +457,18 @@ export const contract = clm.table(
       () => businessRiskTier.code,
       { onDelete: 'set null' },
     ),
+    // Migratie 0029. Opzegtermijn in dagen vóór end_date. Nullable: niet elk
+    // contract heeft dit bekend.
+    noticePeriodDays: integer('notice_period_days'),
+    // Migratie 0029. Hoeveel dagen vóór de referentiedatum (opzegdatum, of
+    // end_date zonder opzegtermijn) gewaarschuwd wordt. Instelbaar per
+    // contract, default 90.
+    warningDaysBefore: integer('warning_days_before').notNull().default(90),
+    // Migratie 0029. ja/nee/onbekend — door de contractbeheerder zelf
+    // vastgesteld, geen afgeleide waarde. Default onbekend (NULL) bij
+    // aanmaken. CHECK in de database, bewust geen ref-tabel (drie vaste,
+    // niet-tenant-configureerbare waarden).
+    autoRenews: text('auto_renews'),
     createdAt: timestamp('created_at', { withTimezone: true })
       .notNull()
       .defaultNow(),
@@ -910,6 +933,10 @@ export const responseNote = clm.table(
       .defaultNow(),
     // Intrekken kan wel, wissen niet — net als bij een oordeel.
     deletedAt: timestamp('deleted_at', { withTimezone: true }),
+    // Migratie 0030. werk: losse werkaantekening. vastgesteld: een na overleg
+    // met de leverancier overeengekomen wijziging, vastgelegd naast het
+    // onaangetaste oorspronkelijke antwoord. CHECK in de database.
+    soort: text('soort').notNull().default('werk'),
   },
   (t) => [
     index('response_note_tenant_id_idx').on(t.tenantId),

--- a/test/schema-conformiteit.e2e-spec.ts
+++ b/test/schema-conformiteit.e2e-spec.ts
@@ -379,6 +379,74 @@ describe('Schema-conformiteit (e2e)', () => {
     expect(ontbrekend).toEqual([]);
   });
 
+  it('heeft op elke tabel exact de kolommen die het schema verwacht', async () => {
+    // Bewaakt de andere kant van 2026-08-29's bevinding: een handgeschreven
+    // migratie kan de database prima wijzigen zonder dat schema.ts ooit
+    // wordt bijgewerkt (drizzle-kit generate is stuk, zie Issue #96) — de
+    // applicatie leest schema.ts namelijk nergens voor haar eigen queries
+    // (die schrijven kolomnamen rechtstreeks in SQL). Vier kolommen waren zo
+    // jarenlang onopgemerkt uit de pas gelopen: contract.notice_period_days/
+    // warning_days_before/auto_renews (migratie 0029), response_note.soort
+    // (0030), tenant.deleted_at (0033), user.uitnodiging_hash (0024).
+    //
+    // pg_attribute/pg_class/pg_namespace, niet information_schema.columns —
+    // zelfde reden als de DEFAULT-test hierboven: clm.sessie is voor de
+    // huidige rol soms wél, soms niet leesbaar via information_schema,
+    // afhankelijk van de rol waarmee dit script draait. pg_attribute toont
+    // de kolom onafhankelijk van GRANT's.
+    const { rows } = await client.query<{
+      volledige_naam: string;
+      column_name: string;
+    }>(
+      `SELECT n.nspname || '.' || c.relname AS volledige_naam,
+              a.attname                     AS column_name
+         FROM pg_attribute a
+         JOIN pg_class c     ON c.oid = a.attrelid
+         JOIN pg_namespace n ON n.oid = c.relnamespace
+        WHERE n.nspname IN ('clm', 'ref', 'audit')
+          AND c.relkind = 'r'
+          AND a.attnum > 0
+          AND NOT a.attisdropped`,
+    );
+
+    const kolommenInDbPerTabel = new Map<string, Set<string>>();
+    for (const r of rows) {
+      const set = kolommenInDbPerTabel.get(r.volledige_naam) ?? new Set();
+      set.add(r.column_name);
+      kolommenInDbPerTabel.set(r.volledige_naam, set);
+    }
+
+    const ontbrekendInSchema: string[] = [];
+    const ontbrekendInDb: string[] = [];
+
+    for (const tabel of verwachteTabellen) {
+      const kolommenInDb = kolommenInDbPerTabel.get(tabel.volledigeNaam);
+      // Een tabel die niet bestaat, is al gemeld door de test hierboven
+      // ("bevat elke tabel uit het schema ook daadwerkelijk in de
+      // database") — hier alleen kolomverschillen op tabellen die wél in
+      // beide voorkomen, anders dubbel gemeld.
+      if (!kolommenInDb) continue;
+
+      const kolommenInSchema = new Set(tabel.kolommen.map((k) => k.naam));
+
+      for (const kolom of kolommenInDb) {
+        if (!kolommenInSchema.has(kolom)) {
+          ontbrekendInSchema.push(`${tabel.volledigeNaam}.${kolom}`);
+        }
+      }
+      for (const kolom of kolommenInSchema) {
+        if (!kolommenInDb.has(kolom)) {
+          ontbrekendInDb.push(`${tabel.volledigeNaam}.${kolom}`);
+        }
+      }
+    }
+
+    expect({ ontbrekendInSchema, ontbrekendInDb }).toEqual({
+      ontbrekendInSchema: [],
+      ontbrekendInDb: [],
+    });
+  });
+
   it('draait niet als een rol die RLS omzeilt', async () => {
     const { rows } = await client.query<{ rolbypassrls: boolean }>(
       'SELECT rolbypassrls FROM pg_roles WHERE rolname = current_user',


### PR DESCRIPTION
## Bevinding

Bij het opzoeken van velden voor een Transdev-cross-reference bleek `clm.contract` drie kolommen te hebben (`notice_period_days`, `warning_days_before`, `auto_renews`, migratie 0029) die nergens in `src/db/schema.ts` stonden. Onschuldig voor de applicatie zelf — geen bestand in `src/` importeert `schema.ts`, alles gaat via ruwe `sql`-tagged queries — maar wel een leugentje op de enige plattegrond die er is (Issue #96: `db:generate` is stuk sinds migratie 0008, `schema.ts` wordt sindsdien alleen nog handmatig, en dus soms niet, bijgewerkt).

## Wat er is gecorrigeerd

Systematisch nagemeten (alle 29 tabellen/228 kolommen, verse wegwerpdatabase met alle 35 migraties, Drizzle's eigen `getTableConfig()`) — vier drifts gevonden en gecorrigeerd:
- `contract.notice_period_days`/`warning_days_before`/`auto_renews` (migratie 0029)
- `response_note.soort` (migratie 0030)
- `tenant.deleted_at` (migratie 0033)
- `user.uitnodiging_hash` + unieke index (migratie 0024)

## Preventie

`test/schema-conformiteit.e2e-spec.ts` krijgt een nieuwe test die dezelfde vergelijking bij elke run doet, in beide richtingen. Draait al in CI via de bestaande 'RLS tenant-isolatietest'-job — geen aparte CI-wijziging nodig. Zelf getoetst: een kolom tijdelijk verwijderd liet de test correct falen met een leesbare melding.

## Bijvangst

Twee extra plekken gevonden die nog op de oude `/`-route (vóór de redirect naar `/beheer` van 2026-08-29) rekenden en `verify:volledig` rood trokken:
- `scripts/verify-volledig.js`: stackcheck verwachtte 200 op `/`, kreeg 307
- `scripts/otap-doorloop.js`: verwachtte de tekst 'Live backend' die met de oude placeholderpagina verdwenen is; omgedraaid naar een check op afwezigheid van de mock-melding op `/beheer`

Ook toegevoegd: `docs/transdev-veld-cross-reference.csv`, een invulhulpmiddel voor de handmatige Transdev-datavulling.

## Verificatie

`npm run verify:volledig`: GROEN — 93 passed, 6 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)