### PR TITLE
fix(contract,vendor): vijf Coupa-uitbreidingsvelden ontbraken volledig in de servicelaag

### DIFF
--- a/docs/frontend-veld-cross-reference.csv
+++ b/docs/frontend-veld-cross-reference.csv
@@ -1,0 +1,43 @@
+Scherm;Frontend-veldnaam;Databaseveld;Omschrijving;Transdev-veld (gap-analyse rev1)
+Leveranciers > Nieuwe leverancier (formulier);Naam;vendor.name;Naam van de leverancier. Verplicht.;Supplier Name
+Leveranciers > Nieuwe leverancier (formulier);KvK-nummer;vendor.kvk_number;Acht cijfers, volgens de hint in het formulier.;(geen)
+Leveranciers > Nieuwe leverancier (formulier);Plaats;vendor.city;(geen toelichting in de code);(geen)
+Leveranciers > Nieuwe leverancier (formulier);Website;vendor.website;(geen toelichting in de code);(geen)
+Leveranciers > Nieuwe leverancier (formulier);Categorie;vendor.category_code;Tenant-eigen categorielijst sinds migratie 0034 (voorheen platform-breed), beheerd via het Vendor-categorieën-scherm.;Classificatie
+Leveranciers > Nieuwe leverancier (formulier);Coupa-leveranciersnummer;vendor.coupa_supplier_number;Optioneel — matchsleutel tussen Coupa en MCM2 voor de (nog te bouwen) uploadtool #190.;Supplier Number (Coupa-interne sleutel — "de matching sleutel tussen Coupa en MCM2", toelichting eigenaar)
+Leveranciers > Nieuwe leverancier (formulier);Naam contactpersoon;vendor_contact.full_name;Verplichte eerste contactpersoon, nodig om een vragenlijst te kunnen versturen.;Contact Persoon / Contact Persoon Email
+Leveranciers > Nieuwe leverancier (formulier);E-mailadres (contactpersoon);vendor_contact.email;Idem, e-mailadres van dezelfde contactpersoon.;Contact Persoon / Contact Persoon Email
+Leveranciers > Detail > Stamgegevens;Naam;vendor.name;Zelfde veld als in het aanmaakformulier, hier bewerkbaar.;Supplier Name
+Leveranciers > Detail > Stamgegevens;Statutaire naam;vendor.statutory_name;Geen apart formulierveld in het aanmaakformulier — alleen hier bewerkbaar.;(geen)
+Leveranciers > Detail > Stamgegevens;KvK-nummer;vendor.kvk_number;Acht cijfers.;(geen)
+Leveranciers > Detail > Stamgegevens;Leveranciersnummer;vendor.vestigingsnummer;"Hint in de UI: ""voor matching met uw ERP-systeem"". Let op: het frontend-label ""Leveranciersnummer"" wijst naar de kolom vestigingsnummer, niet naar een apart leveranciersnummer-veld.";(geen — mogelijk gerelateerd aan Supplier Account #, maar die is expliciet "niet overnemen" in de gap-analyse)
+Leveranciers > Detail > Stamgegevens;Coupa-leveranciersnummer;vendor.coupa_supplier_number;Zelfde veld als in het aanmaakformulier.;Supplier Number
+Leveranciers > Detail > Stamgegevens;Plaats;vendor.city;;(geen)
+Leveranciers > Detail > Stamgegevens;Land;vendor.country;Database-default 'NL' als er niets wordt ingevuld. Geen apart veld in het aanmaakformulier.;(geen)
+Leveranciers > Detail > Stamgegevens;Website;vendor.website;;(geen)
+Leveranciers > Detail > Classificatiebadges (badge-strip);Compliancestatus (badge);vendor.compliance_status_code;Badge toont het label of "Geen compliancestatus". Klik opent hetzelfde bewerkveld als hieronder, of springt door naar de Contracten-sectie als onComplianceKlik is meegegeven.;ISO 27001 (gedeeltelijk — "past onder de bestaande compliance-status, maar die is nu één vrij veld", toelichting gap-analyse)
+Leveranciers > Detail > Classificatiebadges (bewerkveld);Compliancestatus;vendor.compliance_status_code;Bewerkveld-label is hier letterlijk "Compliancestatus" (badge en bewerkveld gebruiken dezelfde tekst).;ISO 27001 (zie hierboven)
+Leveranciers > Detail > Classificatiebadges (badge-strip);Cyber criticaliteit: [waarde] (badge);vendor.business_criticality_code;"Badge-tekst is samengesteld (""Cyber criticaliteit: "" + label). LET OP: het bewerkveld eronder heeft een ANDER label (""Bedrijfskritiek"") voor dezelfde kolom — inconsistentie in de UI zelf, niet in deze tabel.";Leverancier risico profiel
+Leveranciers > Detail > Classificatiebadges (bewerkveld);Bedrijfskritiek;vendor.business_criticality_code;Zie de opmerking hierboven — zelfde kolom als de "Cyber criticaliteit"-badge, ander label in het bewerkveld.;Leverancier risico profiel
+Leveranciers > Detail > Classificatiebadges (badge-strip + bewerkveld);Categorie;vendor.category_code;Zelfde veld als in het aanmaakformulier, hier ook los bewerkbaar via de badge.;Classificatie
+Leveranciers > Detail > Classificatiebadges (bewerkveld);Compliance-thema's;vendor_compliance_thema (koppeltabel, meerkeuze via zetComplianceThemas);Meerkeuzeveld, geen enkelvoudige kolom — een leverancier kan meerdere compliance-thema's hebben.;(geen directe match — mogelijk gerelateerd aan IB&P/MSR, geen 1-op-1)
+Leveranciers > Detail > Contactpersonen;Naam;vendor_contact.full_name;;Contact Persoon / Contact Persoon Email
+Leveranciers > Detail > Contactpersonen;E-mailadres;vendor_contact.email;;Contact Persoon / Contact Persoon Email
+Leveranciers > Detail > Contactpersonen;Functie;vendor_contact.job_title;;(geen)
+Leveranciers > Detail > Contactpersonen;Notitie;vendor_contact.role_description;"LET OP: het frontend-label ""Notitie"" wijst naar de kolom role_description, niet naar een apart notitieveld.";(geen)
+Leveranciers > Detail > Contactpersonen;Primaire contactpersoon;vendor_contact.is_primary;Checkbox. Toelichting in de UI: "krijgt de vragenlijst toegestuurd".;(geen)
+Leveranciers > Detail > Contracten (lijst + formulier);Naam;contract.name;;Contract Name
+Leveranciers > Detail > Contracten (lijst + formulier);Contractnummer;contract.contract_number;;Contract #
+Leveranciers > Detail > Contracten (lijst + formulier);Status;contract.status_code;Vaste keuzes in de UI: Actief/Verlopen/Opgezegd. Berekend, niet losstaand van de einddatum — zie contract.service.ts.;(geen directe match — Coupa's eigen "Status" is expliciet "niet overnemen", Coupa-workflowstatus)
+Leveranciers > Detail > Contracten (lijst + formulier);Begindatum;contract.start_date;;Starts
+Leveranciers > Detail > Contracten (lijst + formulier);Einddatum;contract.end_date;Bepaalt ook de "binnen 90 dagen"-indicator (#172).;Expires
+Leveranciers > Detail > Contracten (lijst + formulier);Waarde (EUR);contract.value_eur;;(geen directe match)
+Leveranciers > Detail > Contracten (formulier, tenzij verborgen);Contactpersoon;contract.vendor_contact_id;Dropdown met de contactpersonen van de betreffende leverancier. NULL betekent: gebruik de is_primary-contactpersoon van de vendor (applicatielogica, geen database-default).;Contact Persoon / Contact Persoon Email
+Leveranciers > Detail > Contracten (formulier);Contractbeheerder;contract.owner_user_id;Dropdown met tenant-gebruikers. Sinds 29-08 alleen gebruikers met een actief tenant_membership (zie mcm2-membership-filter-ontbreekt-op-vijf-plekken).;(geen directe match)
+Leveranciers > Detail > Contracten (formulier);Notitie;contract.note;Vrij tekstveld (textarea). LET OP: het label is hier "Notitie", niet "Opmerking" of "Remarks".;Remarks (deels — "logboek van uitvraag-updates", toelichting gap-analyse) / Description (deels, zie gap-analyse toelichting: "kan op note of eigen veld")
+Leveranciers > Detail > Contracten (formulier);Opzegtermijn (dagen);contract.notice_period_days;Opzegtermijn in dagen vóór end_date. Nullable. Gebouwd na de gap-analyse (migratie 0029).;Term of notice (date) / Term of notice (months)
+Leveranciers > Detail > Contracten (formulier);Waarschuwingstermijn (dagen);contract.warning_days_before;Hoeveel dagen vóór de referentiedatum gewaarschuwd wordt. Default 90. Gebouwd na de gap-analyse (migratie 0029).;(geen directe match — nieuw veld, niet in de oorspronkelijke Coupa-kolommen)
+Leveranciers > Detail > Contracten (formulier);Verlengt automatisch;contract.auto_renews;Ja/Nee/Onbekend, default Onbekend. Gebouwd na de gap-analyse (migratie 0029).;Automatic Renewal
+Leveranciers > Detail > Contracten (formulier, Classificatie-sectie);Contracttype;contract.contract_type;"Vrije tekst, hint: ""bijv. Raamovereenkomst"". Placeholder-veld (#187) tot MCM2 breder contractmanagement wordt.";Contract type
+Leveranciers > Detail > Contracten (formulier, Classificatie-sectie);Business-risk-tier;contract.business_risk_tier_code;Transdev's enterprise-brede business-risk-classificatie per contract (#188).;Contract classification
+Leveranciers > Detail > Contracten (formulier, Cybersecurity & IT-compliance-sectie);DPA aanwezig;contract.dpa_aanwezig;"Tri-state (Ja/Nee/onbekend — NULL bij aanmaken). Toelichting in de UI: ""alleen relevant voor cybersecurity/IT-contracten"". Het onderliggende document zelf is nog niet gebouwd — alleen de vlag.";DPA

--- a/src/contract/contract-invoer.ts
+++ b/src/contract/contract-invoer.ts
@@ -158,6 +158,23 @@ function optioneelAutoRenews(waarde: unknown, veld: string): string | null {
   return waarde;
 }
 
+/**
+ * Tri-state: null = onbekend, niet "nee" (#189). Geen tekst-encodering zoals
+ * autoRenews — de kolom is een echte boolean, en de frontend stuurt ook een
+ * echte boolean of null, nooit de string 'ja'/'nee'.
+ */
+function optioneelBoolean(waarde: unknown, veld: string): boolean | null {
+  if (waarde === undefined || waarde === null) {
+    return null;
+  }
+
+  if (typeof waarde !== 'boolean') {
+    throw new InvoerFout(veld, `${veld} moet ja of nee zijn.`);
+  }
+
+  return waarde;
+}
+
 function controleerDatumVolgorde(
   startDate: string | null,
   endDate: string | null,
@@ -209,6 +226,13 @@ export function leesNieuwContract(body: unknown): NieuwContract {
     // waarschuwingstermijn, nooit "geen".
     warningDaysBefore: warningDaysBefore ?? 90,
     autoRenews: optioneelAutoRenews(ruw.autoRenews, 'Verlengt automatisch'),
+    contractType: optioneleTekst(ruw.contractType, 'Contracttype', MAX_KORT),
+    dpaAanwezig: optioneelBoolean(ruw.dpaAanwezig, 'DPA aanwezig'),
+    businessRiskTierCode: optioneleTekst(
+      ruw.businessRiskTierCode,
+      'Business-risk-tier',
+      MAX_KORT,
+    ),
   };
 }
 
@@ -274,6 +298,23 @@ export function leesContractWijziging(body: unknown): ContractWijziging {
     wijziging.autoRenews = optioneelAutoRenews(
       ruw.autoRenews,
       'Verlengt automatisch',
+    );
+  }
+  if ('contractType' in ruw) {
+    wijziging.contractType = optioneleTekst(
+      ruw.contractType,
+      'Contracttype',
+      MAX_KORT,
+    );
+  }
+  if ('dpaAanwezig' in ruw) {
+    wijziging.dpaAanwezig = optioneelBoolean(ruw.dpaAanwezig, 'DPA aanwezig');
+  }
+  if ('businessRiskTierCode' in ruw) {
+    wijziging.businessRiskTierCode = optioneleTekst(
+      ruw.businessRiskTierCode,
+      'Business-risk-tier',
+      MAX_KORT,
     );
   }
 

--- a/src/contract/contract.service.ts
+++ b/src/contract/contract.service.ts
@@ -32,6 +32,9 @@ export interface ContractSamenvatting {
   noticePeriodDays: number | null;
   warningDaysBefore: number;
   autoRenews: string | null;
+  contractType: string | null;
+  dpaAanwezig: boolean | null;
+  businessRiskTierCode: string | null;
 }
 
 export interface ContractTenantBreed extends ContractSamenvatting {
@@ -53,6 +56,9 @@ export interface NieuwContract {
   noticePeriodDays?: number | null;
   warningDaysBefore?: number;
   autoRenews?: string | null;
+  contractType?: string | null;
+  dpaAanwezig?: boolean | null;
+  businessRiskTierCode?: string | null;
 }
 
 export interface ContractDetail {
@@ -74,6 +80,9 @@ export interface ContractDetail {
   noticePeriodDays: number | null;
   warningDaysBefore: number;
   autoRenews: string | null;
+  contractType: string | null;
+  dpaAanwezig: boolean | null;
+  businessRiskTierCode: string | null;
 }
 
 /**
@@ -94,6 +103,9 @@ export interface ContractWijziging {
   noticePeriodDays?: number | null;
   warningDaysBefore?: number;
   autoRenews?: string | null;
+  contractType?: string | null;
+  dpaAanwezig?: boolean | null;
+  businessRiskTierCode?: string | null;
 }
 
 interface ContractRij extends Record<string, unknown> {
@@ -111,6 +123,9 @@ interface ContractRij extends Record<string, unknown> {
   notice_period_days: number | null;
   warning_days_before: number;
   auto_renews: string | null;
+  contract_type: string | null;
+  dpa_aanwezig: boolean | null;
+  business_risk_tier_code: string | null;
 }
 
 interface ContractDetailRij extends Record<string, unknown> {
@@ -132,6 +147,9 @@ interface ContractDetailRij extends Record<string, unknown> {
   notice_period_days: number | null;
   warning_days_before: number;
   auto_renews: string | null;
+  contract_type: string | null;
+  dpa_aanwezig: boolean | null;
+  business_risk_tier_code: string | null;
 }
 
 function alsTekst(waarde: Date | string): string {
@@ -166,6 +184,7 @@ export class ContractService {
                      c.vendor_contact_id, c.owner_user_id, c.status_code,
                      c.start_date, c.end_date, c.created_at,
                      c.notice_period_days, c.warning_days_before, c.auto_renews,
+                     c.contract_type, c.dpa_aanwezig, c.business_risk_tier_code,
                      vc.full_name AS vendor_contact_naam,
                      u.full_name AS owner_naam
                 FROM clm.contract c
@@ -190,6 +209,9 @@ export class ContractService {
           noticePeriodDays: r.notice_period_days,
           warningDaysBefore: r.warning_days_before,
           autoRenews: r.auto_renews,
+          contractType: r.contract_type,
+          dpaAanwezig: r.dpa_aanwezig,
+          businessRiskTierCode: r.business_risk_tier_code,
         }));
       },
       'medewerker',
@@ -217,6 +239,7 @@ export class ContractService {
                      c.vendor_contact_id, c.owner_user_id, c.status_code,
                      c.value_eur, c.start_date, c.end_date, c.created_at,
                      c.notice_period_days, c.warning_days_before, c.auto_renews,
+                     c.contract_type, c.dpa_aanwezig, c.business_risk_tier_code,
                      vc.full_name AS vendor_contact_naam,
                      u.full_name AS owner_naam,
                      v.name AS vendor_naam
@@ -246,6 +269,9 @@ export class ContractService {
           noticePeriodDays: r.notice_period_days,
           warningDaysBefore: r.warning_days_before,
           autoRenews: r.auto_renews,
+          contractType: r.contract_type,
+          dpaAanwezig: r.dpa_aanwezig,
+          businessRiskTierCode: r.business_risk_tier_code,
         }));
       },
       'medewerker',
@@ -280,7 +306,8 @@ export class ContractService {
                 (tenant_id, vendor_id, name, contract_number,
                  vendor_contact_id, owner_user_id, status_code, value_eur,
                  start_date, end_date, note,
-                 notice_period_days, warning_days_before, auto_renews)
+                 notice_period_days, warning_days_before, auto_renews,
+                 contract_type, dpa_aanwezig, business_risk_tier_code)
               VALUES (${tenantId}, ${vendorId}, ${invoer.name.trim()},
                       ${leegIsNull(invoer.contractNumber)},
                       ${invoer.vendorContactId ?? null},
@@ -292,7 +319,10 @@ export class ContractService {
                       ${leegIsNull(invoer.note)},
                       ${invoer.noticePeriodDays ?? null},
                       ${invoer.warningDaysBefore ?? 90},
-                      ${invoer.autoRenews ?? null})
+                      ${invoer.autoRenews ?? null},
+                      ${leegIsNull(invoer.contractType)},
+                      ${invoer.dpaAanwezig ?? null},
+                      ${leegIsNull(invoer.businessRiskTierCode)})
               RETURNING contract_id`,
         );
 
@@ -381,6 +411,19 @@ export class ContractService {
         }
         if (wijziging.autoRenews !== undefined) {
           zetten.push(sql`auto_renews = ${wijziging.autoRenews}`);
+        }
+        if (wijziging.contractType !== undefined) {
+          zetten.push(
+            sql`contract_type = ${leegIsNull(wijziging.contractType)}`,
+          );
+        }
+        if (wijziging.dpaAanwezig !== undefined) {
+          zetten.push(sql`dpa_aanwezig = ${wijziging.dpaAanwezig}`);
+        }
+        if (wijziging.businessRiskTierCode !== undefined) {
+          zetten.push(
+            sql`business_risk_tier_code = ${leegIsNull(wijziging.businessRiskTierCode)}`,
+          );
         }
 
         if (zetten.length > 0) {
@@ -571,6 +614,7 @@ export class ContractService {
                  c.vendor_contact_id, c.owner_user_id, c.status_code,
                  c.value_eur, c.start_date, c.end_date, c.note,
                  c.notice_period_days, c.warning_days_before, c.auto_renews,
+                 c.contract_type, c.dpa_aanwezig, c.business_risk_tier_code,
                  c.created_at, c.updated_at,
                  vc.full_name AS vendor_contact_naam,
                  u.full_name AS owner_naam
@@ -607,6 +651,9 @@ export class ContractService {
       noticePeriodDays: rij.notice_period_days,
       warningDaysBefore: rij.warning_days_before,
       autoRenews: rij.auto_renews,
+      contractType: rij.contract_type,
+      dpaAanwezig: rij.dpa_aanwezig,
+      businessRiskTierCode: rij.business_risk_tier_code,
     };
   }
 }

--- a/src/vendor/vendor-invoer.ts
+++ b/src/vendor/vendor-invoer.ts
@@ -180,6 +180,12 @@ export function leesNieuweVendor(body: unknown): NieuweVendor {
     city: optioneleTekst(ruw.city, 'Plaats', MAX_KORT),
     country: optioneleTekst(ruw.country, 'Land', MAX_KORT),
     website: optioneleTekst(ruw.website, 'Website', MAX_URL),
+    categoryCode: optioneleTekst(ruw.categoryCode, 'Categorie', MAX_KORT),
+    coupaSupplierNumber: optioneleTekst(
+      ruw.coupaSupplierNumber,
+      'Coupa-leveranciersnummer',
+      MAX_KORT,
+    ),
   };
 
   const contact = ruw.contact;
@@ -288,6 +294,13 @@ export function leesVendorWijziging(body: unknown): VendorWijziging {
     wijziging.complianceStatusCode = optioneleTekst(
       ruw.complianceStatusCode,
       'Compliancestatus',
+      MAX_KORT,
+    );
+  }
+  if ('coupaSupplierNumber' in ruw) {
+    wijziging.coupaSupplierNumber = optioneleTekst(
+      ruw.coupaSupplierNumber,
+      'Coupa-leveranciersnummer',
       MAX_KORT,
     );
   }

--- a/src/vendor/vendor.service.ts
+++ b/src/vendor/vendor.service.ts
@@ -52,6 +52,8 @@ export interface NieuweVendor {
   city?: string | null;
   country?: string | null;
   website?: string | null;
+  categoryCode?: string | null;
+  coupaSupplierNumber?: string | null;
   contact?: {
     fullName: string;
     email?: string | null;
@@ -98,6 +100,7 @@ export interface VendorDetail {
   categoryCode: string | null;
   businessCriticalityCode: string | null;
   complianceStatusCode: string | null;
+  coupaSupplierNumber: string | null;
   createdAt: string;
   updatedAt: string | null;
   contacten: Contactpersoon[];
@@ -128,6 +131,7 @@ export interface VendorWijziging {
   categoryCode?: string | null;
   businessCriticalityCode?: string | null;
   complianceStatusCode?: string | null;
+  coupaSupplierNumber?: string | null;
 }
 
 /** Wat er nodig is om een contactpersoon toe te voegen of te wijzigen. */
@@ -168,6 +172,7 @@ interface VendorDetailRij extends Record<string, unknown> {
   category_code: string | null;
   business_criticality_code: string | null;
   compliance_status_code: string | null;
+  coupa_supplier_number: string | null;
   created_at: Date | string;
   updated_at: Date | string | null;
 }
@@ -319,13 +324,17 @@ export class VendorService {
           vendor_id: string;
           name: string;
         }>(
-          sql`INSERT INTO clm.vendor (tenant_id, name, kvk_number, city, country, website)
+          sql`INSERT INTO clm.vendor
+                (tenant_id, name, kvk_number, city, country, website,
+                 category_code, coupa_supplier_number)
             VALUES (${tenantId},
                     ${invoer.name.trim()},
                     ${kvk},
                     ${leegIsNull(invoer.city)},
                     ${leegIsNull(invoer.country) ?? 'NL'},
-                    ${leegIsNull(invoer.website)})
+                    ${leegIsNull(invoer.website)},
+                    ${leegIsNull(invoer.categoryCode)},
+                    ${leegIsNull(invoer.coupaSupplierNumber)})
             RETURNING vendor_id, name`,
         );
 
@@ -478,6 +487,11 @@ export class VendorService {
         if (wijziging.complianceStatusCode !== undefined) {
           zetten.push(
             sql`compliance_status_code = ${leegIsNull(wijziging.complianceStatusCode)}`,
+          );
+        }
+        if (wijziging.coupaSupplierNumber !== undefined) {
+          zetten.push(
+            sql`coupa_supplier_number = ${leegIsNull(wijziging.coupaSupplierNumber)}`,
           );
         }
 
@@ -765,7 +779,8 @@ export class VendorService {
       sql`SELECT vendor_id, name, kvk_number, vestigingsnummer,
                  statutory_name, city, country, website,
                  category_code, business_criticality_code,
-                 compliance_status_code, created_at, updated_at
+                 compliance_status_code, coupa_supplier_number,
+                 created_at, updated_at
             FROM clm.vendor
            WHERE vendor_id = ${vendorId} AND deleted_at IS NULL`,
     );
@@ -802,6 +817,7 @@ export class VendorService {
       categoryCode: rij.category_code,
       businessCriticalityCode: rij.business_criticality_code,
       complianceStatusCode: rij.compliance_status_code,
+      coupaSupplierNumber: rij.coupa_supplier_number,
       createdAt: alsTekst(rij.created_at),
       updatedAt: alsTekstOfNull(rij.updated_at),
       contacten: contacten.rows.map((c) => ({

--- a/test/contract-routes.e2e-spec.ts
+++ b/test/contract-routes.e2e-spec.ts
@@ -403,6 +403,111 @@ describe('Contractroutes (e2e)', () => {
     expect((gewijzigd.body as { autoRenews: string }).autoRenews).toBe('nee');
   });
 
+  // Gevonden 2026-08-30: contractType, dpaAanwezig en businessRiskTierCode
+  // stonden sinds de Coupa-schema-uitbreiding (#187-#189) al op het
+  // contractformulier en in de database, maar contract.service.ts las, sloeg
+  // op noch gaf ze terug — in geen enkele van de drie routes. Alles wat een
+  // gebruiker op die velden invulde ging stilzwijgend verloren. Geen
+  // bestaande test dekte dit.
+  it('admin kan contractType, dpaAanwezig en businessRiskTierCode meegeven bij aanmaken', async () => {
+    const respons = await request(server)
+      .post(`/vendors/${vendorId}/contracts`)
+      .set('Cookie', adminCookie)
+      .send({
+        name: 'Contract met Coupa-classificatie',
+        contractType: 'Raamovereenkomst',
+        dpaAanwezig: true,
+        businessRiskTierCode: 'tier_1',
+      });
+
+    expect(respons.status).toBe(201);
+    expect((respons.body as { contractType: string }).contractType).toBe(
+      'Raamovereenkomst',
+    );
+    expect((respons.body as { dpaAanwezig: boolean }).dpaAanwezig).toBe(true);
+    expect(
+      (respons.body as { businessRiskTierCode: string }).businessRiskTierCode,
+    ).toBe('tier_1');
+  });
+
+  it('contractType, dpaAanwezig en businessRiskTierCode zijn null wanneer niet meegegeven', async () => {
+    const respons = await request(server)
+      .post(`/vendors/${vendorId}/contracts`)
+      .set('Cookie', adminCookie)
+      .send({ name: 'Contract zonder classificatie' });
+
+    expect(respons.status).toBe(201);
+    expect(
+      (respons.body as { contractType: string | null }).contractType,
+    ).toBeNull();
+    expect(
+      (respons.body as { dpaAanwezig: boolean | null }).dpaAanwezig,
+    ).toBeNull();
+    expect(
+      (
+        respons.body as {
+          businessRiskTierCode: string | null;
+        }
+      ).businessRiskTierCode,
+    ).toBeNull();
+  });
+
+  it('admin kan contractType, dpaAanwezig en businessRiskTierCode wijzigen op een bestaand contract', async () => {
+    const aangemaakt = await request(server)
+      .post(`/vendors/${vendorId}/contracts`)
+      .set('Cookie', adminCookie)
+      .send({ name: 'Wijzigtest classificatie' });
+
+    const contractId = alsContract(aangemaakt.body).contractId;
+
+    const gewijzigd = await request(server)
+      .patch(`/vendors/${vendorId}/contracts/${contractId}`)
+      .set('Cookie', adminCookie)
+      .send({
+        contractType: 'Dienstenovereenkomst',
+        dpaAanwezig: false,
+        businessRiskTierCode: 'tier_2',
+      });
+
+    expect(gewijzigd.status).toBe(200);
+    expect((gewijzigd.body as { contractType: string }).contractType).toBe(
+      'Dienstenovereenkomst',
+    );
+    expect((gewijzigd.body as { dpaAanwezig: boolean }).dpaAanwezig).toBe(
+      false,
+    );
+    expect(
+      (gewijzigd.body as { businessRiskTierCode: string }).businessRiskTierCode,
+    ).toBe('tier_2');
+
+    // Teruglezen via GET, niet alleen de PATCH-respons vertrouwen — zelfde
+    // discipline als "vertrouw geen enkele geruststellende melding".
+    const opgehaald = await request(server)
+      .get(`/vendors/${vendorId}/contracts/${contractId}`)
+      .set('Cookie', adminCookie);
+
+    expect(opgehaald.status).toBe(200);
+    expect((opgehaald.body as { contractType: string }).contractType).toBe(
+      'Dienstenovereenkomst',
+    );
+    expect((opgehaald.body as { dpaAanwezig: boolean }).dpaAanwezig).toBe(
+      false,
+    );
+    expect(
+      (opgehaald.body as { businessRiskTierCode: string }).businessRiskTierCode,
+    ).toBe('tier_2');
+  });
+
+  it('weigert een niet-boolean dpaAanwezig', async () => {
+    const respons = await request(server)
+      .post(`/vendors/${vendorId}/contracts`)
+      .set('Cookie', adminCookie)
+      .send({ name: 'Hosting', dpaAanwezig: 'ja' });
+
+    expect(respons.status).toBe(400);
+    expect((respons.body as { veld: string }).veld).toBe('DPA aanwezig');
+  });
+
   it('koppelt en ontkoppelt vragenlijst-templates aan een contract', async () => {
     await client.query('BEGIN');
     await client.query(`SET LOCAL app.current_tenant_id = '${tenant}'`);

--- a/test/vendor-detail.e2e-spec.ts
+++ b/test/vendor-detail.e2e-spec.ts
@@ -48,6 +48,7 @@ interface DetailAntwoord {
   city: string | null;
   website: string | null;
   categoryCode: string | null;
+  coupaSupplierNumber: string | null;
   updatedAt: string | null;
   contacten: ContactAntwoord[];
 }
@@ -291,6 +292,29 @@ describe('Vendordetail en contactpersonen (e2e)', () => {
         .set('Cookie', adminCookie)
         .send({ categoryCode: 'bestaat-niet' })
         .expect(400);
+    });
+
+    // Gevonden 2026-08-30: coupaSupplierNumber ontbrak volledig in
+    // vendor.service.ts — niet in VendorDetail, niet in VendorWijziging, niet
+    // in de UPDATE-statement, niet in de detail-SELECT. Een wijziging op dit
+    // veld werd stilzwijgend genegeerd.
+    it('wijzigt en leest coupaSupplierNumber', async () => {
+      const gewijzigd = await request(server)
+        .patch(`/vendors/${vendorId}`)
+        .set('Cookie', adminCookie)
+        .send({ coupaSupplierNumber: 'SUP-00099' })
+        .expect(200);
+
+      expect(alsDetail(gewijzigd.body).coupaSupplierNumber).toBe('SUP-00099');
+
+      // Teruglezen via een aparte GET — niet alleen de PATCH-respons
+      // vertrouwen.
+      const opgehaald = await request(server)
+        .get(`/vendors/${vendorId}`)
+        .set('Cookie', adminCookie)
+        .expect(200);
+
+      expect(alsDetail(opgehaald.body).coupaSupplierNumber).toBe('SUP-00099');
     });
 
     it('geeft 404 voor een leverancier van een andere tenant', async () => {

--- a/test/vendor-routes.e2e-spec.ts
+++ b/test/vendor-routes.e2e-spec.ts
@@ -229,6 +229,35 @@ describe('Vendorroutes (e2e)', () => {
 
       expect(alsAangemaakt(aanmaak.body).contactId).toBeNull();
     });
+
+    // Gevonden 2026-08-30: categoryCode en coupaSupplierNumber stonden al op
+    // het aanmaakformulier, maar leesNieuweVendor() las ze niet uit de body en
+    // de INSERT nam ze niet mee. Wijzigen achteraf (PATCH) werkte voor
+    // categoryCode al wel — alleen het aanmaakpad was stuk. Teruglezen via
+    // GET, niet via de POST-respons: AanmaakAntwoord heeft alleen vendorId/
+    // name/contactId.
+    it('slaat categoryCode en coupaSupplierNumber op bij aanmaken', async () => {
+      const aanmaak = await request(server)
+        .post('/vendors')
+        .set('Cookie', cookieA)
+        .send({
+          name: 'Met Coupa-koppeling B.V.',
+          coupaSupplierNumber: 'SUP-00042',
+        })
+        .expect(201);
+
+      const vendorId = alsAangemaakt(aanmaak.body).vendorId;
+
+      const detail = await request(server)
+        .get(`/vendors/${vendorId}`)
+        .set('Cookie', cookieA)
+        .expect(200);
+
+      expect(
+        (detail.body as { coupaSupplierNumber: string | null })
+          .coupaSupplierNumber,
+      ).toBe('SUP-00042');
+    });
   });
 
   describe('de tenantgrens houdt stand', () => {


### PR DESCRIPTION
## Bug

Sinds de Coupa-schema-uitbreiding (#187-#189, migratie 0034) staan `contractType`, `dpaAanwezig`, `businessRiskTierCode`, `coupaSupplierNumber` en `categoryCode` (bij aanmaken) al op het formulier en in de database, maar de servicelaag las, sloeg op noch gaf ze terug. Alles wat een gebruiker op die velden invulde ging stilzwijgend verloren.

Gevonden bij het opbouwen van een frontend-veld-cross-reference voor de handmatige Transdev-datavulling.

## Fix

**`contract.service.ts` / `contract-invoer.ts`**: `contractType`, `dpaAanwezig`, `businessRiskTierCode` ontbraken in `NieuwContract`, `ContractDetail`, `ContractWijziging`, `ContractRij`, `ContractDetailRij`, alle SELECT/INSERT/UPDATE-queries, en de invoervalidatie. Nu volledig toegevoegd, inclusief een nieuwe `optioneelBoolean()` voor `dpaAanwezig`.

**`vendor.service.ts` / `vendor-invoer.ts`**: `coupaSupplierNumber` ontbrak volledig. `categoryCode` ontbrak specifiek bij **aanmaken** van een nieuwe leverancier (wijzigen achteraf werkte al wel).

## Nieuwe tests

Geen enkele bestaande test dekte deze velden — dat verklaart waarom het onopgemerkt bleef:
- `contract-routes.e2e-spec.ts`: aanmaken/wijzigen/teruglezen, plus validatie van een niet-boolean `dpaAanwezig`.
- `vendor-routes.e2e-spec.ts`: `coupaSupplierNumber` bij aanmaken.
- `vendor-detail.e2e-spec.ts`: `coupaSupplierNumber` wijzigen en teruglezen.

## Verificatie

`npm run verify:volledig`: GROEN (96 passed, 3 skipped, inclusief browsertest en schema-conformiteit).

Ook toegevoegd: `docs/frontend-veld-cross-reference.csv`, de aanleiding voor deze bevinding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)