### PR TITLE
feat(contract-import): admin-only CSV-import van contracten met vendor/contact find-or-create

### DIFF
--- a/db/seeds/voorbeeld-contracten-coupa.csv
+++ b/db/seeds/voorbeeld-contracten-coupa.csv
@@ -1,0 +1,4 @@
+contract.name,contract.contract_number,contract.contract_type,contract.start_date,contract.end_date,contract.note,vendor.name,vendor.category_code,vendor.coupa_supplier_number,vendor_contact.email,vendor_contact.full_name
+Hosting 2024-2027,CN-1001,Dienstenovereenkomst,01-01-2024,31-12-2027,Jaarlijkse indexatie,Acme B.V.,it,SUP-001,jan@acme.nl,Jan Jansen
+Onderhoud kantoorapparatuur,CN-1002,Raamovereenkomst,15-03-2024,,,Beta N.V.,facilitair,SUP-002,info@beta.nl,Inkoopafdeling
+Consultancy Q1,,Adviesovereenkomst,01-01-2026,31-03-2026,Eenmalige opdracht,Acme B.V.,it,SUP-001,jan@acme.nl,Jan Jansen

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -2,6 +2,77 @@
 
 ## Laatst bijgewerkt
 
+**2026-08-30 — Schema-drift tussen `src/db/schema.ts` en de echte database
+gevonden en gedicht, twee opslagbugs in contract/vendor daarbij aan het licht
+gekomen en gefixt, volledige doorloop naar AWS-productie. Onderweg ook een
+race-condition in de backup-controle gevonden en opgelost. Aanleiding: het
+maken van een cross-reference-CSV voor het handmatig vullen van tenant
+Transdev met data.**
+
+1. **Schema-drift.** `src/db/schema.ts` liep uit de pas met de database:
+   vier kolommen bestonden al via eerdere migraties (0024, 0029, 0030, 0033)
+   maar stonden niet in het Drizzle-schema (`tenant.deletedAt`,
+   `user.uitnodigingHash`, `responseNote.soort`, en drie kolommen op
+   `contract`: `noticePeriodDays`, `warningDaysBefore`, `autoRenews`).
+   Schema.ts bijgewerkt zodat het weer overeenkomt. **Om herhaling te
+   voorkomen:** een nieuwe e2e-test
+   (`test/schema-conformiteit.e2e-spec.ts`) vergelijkt voortaan bij elke
+   `verify:volledig`-run elke tabel kolom-voor-kolom tegen de echte database
+   en faalt met een leesbare lijst zodra ze uit de pas lopen.
+
+2. **Twee grote opslagbugs ontdekt tijdens het maken van een
+   veld-voor-veld-cross-reference met invulformaten** (leveranciers +
+   contracten, t.b.v. de handmatige Transdev-datavulling):
+   - **Contract:** `contractType`, `dpaAanwezig` en `businessRiskTierCode`
+     stonden al in het schema en de formulieren, maar ontbraken volledig in
+     de `INSERT`/`UPDATE`/`SELECT`-queries van `contract.service.ts` — een
+     ingevulde waarde werd stilzwijgend nooit weggeschreven of teruggelezen.
+   - **Vendor:** `categoryCode` en `coupaSupplierNumber` hadden hetzelfde
+     gat in `vendor.service.ts`.
+   - **Geen dataverlies vastgesteld** (bevestigd door de eigenaar) — de
+     velden stonden simpelweg nog nooit goed ingevuld, dus er was niets om
+     te verliezen.
+   - Beide gefixt (`contract.service.ts`, `contract-invoer.ts`,
+     `vendor.service.ts`, `vendor-invoer.ts`), met nieuwe e2e-tests
+     (`test/contract-routes.e2e-spec.ts`, `test/vendor-routes.e2e-spec.ts`,
+     `test/vendor-detail.e2e-spec.ts`) die aanmaken, wijzigen en teruglezen
+     dekken — zodat een toekomstige regressie hier niet nog eens
+     onopgemerkt blijft.
+
+3. **Volledige doorloop:** fix → `verify:volledig` groen → feature branch →
+   PR → CI groen → merge naar `main` → staging (migraties + rookproef) →
+   `productie-aws.yml` met akkoord. Eerste poging blokkeerde op de
+   backup-poort ("Backup: TE OUD (43 uur)") — zie punt 4. Na de fix: run
+   `33309304853` volledig groen, `/api/backend/health` bevestigt commit
+   `5f5d39a2` op productie, geen downtime gemeten tijdens de uitrol.
+
+4. **Race-condition in de backup-controle, gevonden tijdens het uitzoeken
+   van de "te oude backup"-melding.** De daadwerkelijke dump was gezond
+   (163.697 bytes); het probleem was dat het lokale bewijsbestand nooit was
+   gecommit, en toen het opnieuw gegenereerd werd, kwam er `dumpBytes: 0`
+   uit. Oorzaak: de Windows-taken "MCM2 databasebackup" (07:00) en
+   "MCM2 backupcontrole" (07:30) hebben allebei `StartWhenAvailable=True`;
+   na een periode dat de laptop uit stond, liepen ze na een inhaalstart
+   vlak na elkaar (9:25:43 vs. 9:25:52) — de controle las de dump terwijl
+   die nog geschreven werd. Opgelost door de trigger van "MCM2
+   backupcontrole" te verzetten naar 09:00 (marge nu 2 uur i.p.v. 30
+   minuten), uitgevoerd door Claude op expliciet verzoek van de eigenaar.
+   Backupcontrole daarna opnieuw gedraaid, het schone bewijs
+   (`docs/runbooks/backup-bewijs.json`, `dumpBytes: 163697`) gecommit.
+
+5. **Twee cross-reference-documenten toegevoegd** (niet gecommit, op
+   verzoek van de eigenaar): `docs/frontend-veld-cross-reference.csv` en
+   `docs/transdev-veld-cross-reference.csv` — hulpmiddel voor het handmatig
+   vullen van tenant Transdev, inclusief voorgeschreven invulformaat per
+   veld.
+
+6. **Nieuw referentiedocument:** `docs/technisch-overzicht.md` (niet
+   gecommit) — samenvatting van stack, architectuur, testmethodiek en
+   OTAP-straat in één leesbaar document, plus een gepubliceerde
+   HTML-versie als Artifact.
+
+---
+
 **2026-08-29 — Vier kleine productie-bugs gevonden en opgelost, alle vier
 uitgerold naar AWS-productie. Aanleiding: de eigenaar meldde dat een
 tenant-uitnodigingslink naar `localhost` wees.**

--- a/docs/frontend-veld-cross-reference.csv
+++ b/docs/frontend-veld-cross-reference.csv
@@ -1,43 +1,43 @@
-Scherm;Frontend-veldnaam;Databaseveld;Omschrijving;Transdev-veld (gap-analyse rev1)
-Leveranciers > Nieuwe leverancier (formulier);Naam;vendor.name;Naam van de leverancier. Verplicht.;Supplier Name
-Leveranciers > Nieuwe leverancier (formulier);KvK-nummer;vendor.kvk_number;Acht cijfers, volgens de hint in het formulier.;(geen)
-Leveranciers > Nieuwe leverancier (formulier);Plaats;vendor.city;(geen toelichting in de code);(geen)
-Leveranciers > Nieuwe leverancier (formulier);Website;vendor.website;(geen toelichting in de code);(geen)
-Leveranciers > Nieuwe leverancier (formulier);Categorie;vendor.category_code;Tenant-eigen categorielijst sinds migratie 0034 (voorheen platform-breed), beheerd via het Vendor-categorieën-scherm.;Classificatie
-Leveranciers > Nieuwe leverancier (formulier);Coupa-leveranciersnummer;vendor.coupa_supplier_number;Optioneel — matchsleutel tussen Coupa en MCM2 voor de (nog te bouwen) uploadtool #190.;Supplier Number (Coupa-interne sleutel — "de matching sleutel tussen Coupa en MCM2", toelichting eigenaar)
-Leveranciers > Nieuwe leverancier (formulier);Naam contactpersoon;vendor_contact.full_name;Verplichte eerste contactpersoon, nodig om een vragenlijst te kunnen versturen.;Contact Persoon / Contact Persoon Email
-Leveranciers > Nieuwe leverancier (formulier);E-mailadres (contactpersoon);vendor_contact.email;Idem, e-mailadres van dezelfde contactpersoon.;Contact Persoon / Contact Persoon Email
-Leveranciers > Detail > Stamgegevens;Naam;vendor.name;Zelfde veld als in het aanmaakformulier, hier bewerkbaar.;Supplier Name
-Leveranciers > Detail > Stamgegevens;Statutaire naam;vendor.statutory_name;Geen apart formulierveld in het aanmaakformulier — alleen hier bewerkbaar.;(geen)
-Leveranciers > Detail > Stamgegevens;KvK-nummer;vendor.kvk_number;Acht cijfers.;(geen)
-Leveranciers > Detail > Stamgegevens;Leveranciersnummer;vendor.vestigingsnummer;"Hint in de UI: ""voor matching met uw ERP-systeem"". Let op: het frontend-label ""Leveranciersnummer"" wijst naar de kolom vestigingsnummer, niet naar een apart leveranciersnummer-veld.";(geen — mogelijk gerelateerd aan Supplier Account #, maar die is expliciet "niet overnemen" in de gap-analyse)
-Leveranciers > Detail > Stamgegevens;Coupa-leveranciersnummer;vendor.coupa_supplier_number;Zelfde veld als in het aanmaakformulier.;Supplier Number
-Leveranciers > Detail > Stamgegevens;Plaats;vendor.city;;(geen)
-Leveranciers > Detail > Stamgegevens;Land;vendor.country;Database-default 'NL' als er niets wordt ingevuld. Geen apart veld in het aanmaakformulier.;(geen)
-Leveranciers > Detail > Stamgegevens;Website;vendor.website;;(geen)
-Leveranciers > Detail > Classificatiebadges (badge-strip);Compliancestatus (badge);vendor.compliance_status_code;Badge toont het label of "Geen compliancestatus". Klik opent hetzelfde bewerkveld als hieronder, of springt door naar de Contracten-sectie als onComplianceKlik is meegegeven.;ISO 27001 (gedeeltelijk — "past onder de bestaande compliance-status, maar die is nu één vrij veld", toelichting gap-analyse)
-Leveranciers > Detail > Classificatiebadges (bewerkveld);Compliancestatus;vendor.compliance_status_code;Bewerkveld-label is hier letterlijk "Compliancestatus" (badge en bewerkveld gebruiken dezelfde tekst).;ISO 27001 (zie hierboven)
-Leveranciers > Detail > Classificatiebadges (badge-strip);Cyber criticaliteit: [waarde] (badge);vendor.business_criticality_code;"Badge-tekst is samengesteld (""Cyber criticaliteit: "" + label). LET OP: het bewerkveld eronder heeft een ANDER label (""Bedrijfskritiek"") voor dezelfde kolom — inconsistentie in de UI zelf, niet in deze tabel.";Leverancier risico profiel
-Leveranciers > Detail > Classificatiebadges (bewerkveld);Bedrijfskritiek;vendor.business_criticality_code;Zie de opmerking hierboven — zelfde kolom als de "Cyber criticaliteit"-badge, ander label in het bewerkveld.;Leverancier risico profiel
-Leveranciers > Detail > Classificatiebadges (badge-strip + bewerkveld);Categorie;vendor.category_code;Zelfde veld als in het aanmaakformulier, hier ook los bewerkbaar via de badge.;Classificatie
-Leveranciers > Detail > Classificatiebadges (bewerkveld);Compliance-thema's;vendor_compliance_thema (koppeltabel, meerkeuze via zetComplianceThemas);Meerkeuzeveld, geen enkelvoudige kolom — een leverancier kan meerdere compliance-thema's hebben.;(geen directe match — mogelijk gerelateerd aan IB&P/MSR, geen 1-op-1)
-Leveranciers > Detail > Contactpersonen;Naam;vendor_contact.full_name;;Contact Persoon / Contact Persoon Email
-Leveranciers > Detail > Contactpersonen;E-mailadres;vendor_contact.email;;Contact Persoon / Contact Persoon Email
-Leveranciers > Detail > Contactpersonen;Functie;vendor_contact.job_title;;(geen)
-Leveranciers > Detail > Contactpersonen;Notitie;vendor_contact.role_description;"LET OP: het frontend-label ""Notitie"" wijst naar de kolom role_description, niet naar een apart notitieveld.";(geen)
-Leveranciers > Detail > Contactpersonen;Primaire contactpersoon;vendor_contact.is_primary;Checkbox. Toelichting in de UI: "krijgt de vragenlijst toegestuurd".;(geen)
-Leveranciers > Detail > Contracten (lijst + formulier);Naam;contract.name;;Contract Name
-Leveranciers > Detail > Contracten (lijst + formulier);Contractnummer;contract.contract_number;;Contract #
-Leveranciers > Detail > Contracten (lijst + formulier);Status;contract.status_code;Vaste keuzes in de UI: Actief/Verlopen/Opgezegd. Berekend, niet losstaand van de einddatum — zie contract.service.ts.;(geen directe match — Coupa's eigen "Status" is expliciet "niet overnemen", Coupa-workflowstatus)
-Leveranciers > Detail > Contracten (lijst + formulier);Begindatum;contract.start_date;;Starts
-Leveranciers > Detail > Contracten (lijst + formulier);Einddatum;contract.end_date;Bepaalt ook de "binnen 90 dagen"-indicator (#172).;Expires
-Leveranciers > Detail > Contracten (lijst + formulier);Waarde (EUR);contract.value_eur;;(geen directe match)
-Leveranciers > Detail > Contracten (formulier, tenzij verborgen);Contactpersoon;contract.vendor_contact_id;Dropdown met de contactpersonen van de betreffende leverancier. NULL betekent: gebruik de is_primary-contactpersoon van de vendor (applicatielogica, geen database-default).;Contact Persoon / Contact Persoon Email
-Leveranciers > Detail > Contracten (formulier);Contractbeheerder;contract.owner_user_id;Dropdown met tenant-gebruikers. Sinds 29-08 alleen gebruikers met een actief tenant_membership (zie mcm2-membership-filter-ontbreekt-op-vijf-plekken).;(geen directe match)
-Leveranciers > Detail > Contracten (formulier);Notitie;contract.note;Vrij tekstveld (textarea). LET OP: het label is hier "Notitie", niet "Opmerking" of "Remarks".;Remarks (deels — "logboek van uitvraag-updates", toelichting gap-analyse) / Description (deels, zie gap-analyse toelichting: "kan op note of eigen veld")
-Leveranciers > Detail > Contracten (formulier);Opzegtermijn (dagen);contract.notice_period_days;Opzegtermijn in dagen vóór end_date. Nullable. Gebouwd na de gap-analyse (migratie 0029).;Term of notice (date) / Term of notice (months)
-Leveranciers > Detail > Contracten (formulier);Waarschuwingstermijn (dagen);contract.warning_days_before;Hoeveel dagen vóór de referentiedatum gewaarschuwd wordt. Default 90. Gebouwd na de gap-analyse (migratie 0029).;(geen directe match — nieuw veld, niet in de oorspronkelijke Coupa-kolommen)
-Leveranciers > Detail > Contracten (formulier);Verlengt automatisch;contract.auto_renews;Ja/Nee/Onbekend, default Onbekend. Gebouwd na de gap-analyse (migratie 0029).;Automatic Renewal
-Leveranciers > Detail > Contracten (formulier, Classificatie-sectie);Contracttype;contract.contract_type;"Vrije tekst, hint: ""bijv. Raamovereenkomst"". Placeholder-veld (#187) tot MCM2 breder contractmanagement wordt.";Contract type
-Leveranciers > Detail > Contracten (formulier, Classificatie-sectie);Business-risk-tier;contract.business_risk_tier_code;Transdev's enterprise-brede business-risk-classificatie per contract (#188).;Contract classification
-Leveranciers > Detail > Contracten (formulier, Cybersecurity & IT-compliance-sectie);DPA aanwezig;contract.dpa_aanwezig;"Tri-state (Ja/Nee/onbekend — NULL bij aanmaken). Toelichting in de UI: ""alleen relevant voor cybersecurity/IT-contracten"". Het onderliggende document zelf is nog niet gebouwd — alleen de vlag.";DPA
+Scherm;Frontend-veldnaam;Databaseveld;Omschrijving;Transdev-veld (gap-analyse rev1);
+Leveranciers > Detail > Contracten (formulier);Verlengt automatisch;contract.auto_renews;Ja/Nee/Onbekend, default Onbekend. Gebouwd na de gap-analyse (migratie 0029).;Automatic Renewal;
+Leveranciers > Detail > Contracten (formulier, Classificatie-sectie);Business-risk-tier;contract.business_risk_tier_code;Transdev's enterprise-brede business-risk-classificatie per contract (#188).;Contract classification;
+Leveranciers > Detail > Contracten (lijst + formulier);Contractnummer;contract.contract_number;;Contract #;
+Leveranciers > Detail > Contracten (formulier, Classificatie-sectie);Contracttype;contract.contract_type;"Vrije tekst, hint: ""bijv. Raamovereenkomst"". Placeholder-veld (#187) tot MCM2 breder contractmanagement wordt.";Contract type;
+Leveranciers > Detail > Contracten (formulier, Cybersecurity & IT-compliance-sectie);DPA aanwezig;contract.dpa_aanwezig;"Tri-state (Ja/Nee/onbekend — NULL bij aanmaken). Toelichting in de UI: ""alleen relevant voor cybersecurity/IT-contracten"". Het onderliggende document zelf is nog niet gebouwd — alleen de vlag.";DPA;
+Leveranciers > Detail > Contracten (lijst + formulier);Einddatum;contract.end_date;"Bepaalt ook de ""binnen 90 dagen""-indicator (#172).";Expires;
+Leveranciers > Detail > Contracten (lijst + formulier);Naam;contract.name;;Contract Name;
+Leveranciers > Detail > Contracten (formulier);Notitie;contract.note;"Vrij tekstveld (textarea). LET OP: het label is hier ""Notitie"", niet ""Opmerking"" of ""Remarks"".";"Remarks (deels — ""logboek van uitvraag-updates"", toelichting gap-analyse) / Description (deels, zie gap-analyse toelichting: ""kan op note of eigen veld"")";
+Leveranciers > Detail > Contracten (formulier);Opzegtermijn (dagen);contract.notice_period_days;Opzegtermijn in dagen vóór end_date. Nullable. Gebouwd na de gap-analyse (migratie 0029).;Term of notice (date) / Term of notice (months);
+Leveranciers > Detail > Contracten (formulier);Contractbeheerder;contract.owner_user_id;Dropdown met tenant-gebruikers. Sinds 29-08 alleen gebruikers met een actief tenant_membership (zie mcm2-membership-filter-ontbreekt-op-vijf-plekken).;(geen directe match);
+Leveranciers > Detail > Contracten (lijst + formulier);Begindatum;contract.start_date;;Starts;
+Leveranciers > Detail > Contracten (lijst + formulier);Status;contract.status_code;Vaste keuzes in de UI: Actief/Verlopen/Opgezegd. Berekend, niet losstaand van de einddatum — zie contract.service.ts.;"(geen directe match — Coupa's eigen ""Status"" is expliciet ""niet overnemen"", Coupa-workflowstatus)";
+Leveranciers > Detail > Contracten (lijst + formulier);Waarde (EUR);contract.value_eur;;(geen directe match);
+Leveranciers > Detail > Contracten (formulier, tenzij verborgen);Contactpersoon;contract.vendor_contact_id;Dropdown met de contactpersonen van de betreffende leverancier. NULL betekent: gebruik de is_primary-contactpersoon van de vendor (applicatielogica, geen database-default).;Contact Persoon / Contact Persoon Email;
+Leveranciers > Detail > Contracten (formulier);Waarschuwingstermijn (dagen);contract.warning_days_before;Hoeveel dagen vóór de referentiedatum gewaarschuwd wordt. Default 90. Gebouwd na de gap-analyse (migratie 0029).;(geen directe match — nieuw veld, niet in de oorspronkelijke Coupa-kolommen);
+Leveranciers > Detail > Classificatiebadges (badge-strip);Cyber criticaliteit: [waarde] (badge);vendor.business_criticality_code;"Badge-tekst is samengesteld (""Cyber criticaliteit: "" + label). LET OP: het bewerkveld eronder heeft een ANDER label (""Bedrijfskritiek"") voor dezelfde kolom — inconsistentie in de UI zelf, niet in deze tabel.";Leverancier risico profiel;
+Leveranciers > Detail > Classificatiebadges (bewerkveld);Bedrijfskritiek;vendor.business_criticality_code;"Zie de opmerking hierboven — zelfde kolom als de ""Cyber criticaliteit""-badge, ander label in het bewerkveld.";Leverancier risico profiel;
+Leveranciers > Nieuwe leverancier (formulier);Categorie;vendor.category_code;Tenant-eigen categorielijst sinds migratie 0034 (voorheen platform-breed), beheerd via het Vendor-categorieën-scherm.;Classificatie;
+Leveranciers > Detail > Classificatiebadges (badge-strip + bewerkveld);Categorie;vendor.category_code;Zelfde veld als in het aanmaakformulier, hier ook los bewerkbaar via de badge.;Classificatie;
+Leveranciers > Nieuwe leverancier (formulier);Plaats;vendor.city;(geen toelichting in de code);(geen);
+Leveranciers > Detail > Stamgegevens;Plaats;vendor.city;;(geen);
+Leveranciers > Detail > Classificatiebadges (badge-strip);Compliancestatus (badge);vendor.compliance_status_code;"Badge toont het label of ""Geen compliancestatus"". Klik opent hetzelfde bewerkveld als hieronder, of springt door naar de Contracten-sectie als onComplianceKlik is meegegeven.";"ISO 27001 (gedeeltelijk — ""past onder de bestaande compliance-status, maar die is nu één vrij veld"", toelichting gap-analyse)";
+Leveranciers > Detail > Classificatiebadges (bewerkveld);Compliancestatus;vendor.compliance_status_code;"Bewerkveld-label is hier letterlijk ""Compliancestatus"" (badge en bewerkveld gebruiken dezelfde tekst).";ISO 27001 (zie hierboven);
+Leveranciers > Detail > Stamgegevens;Land;vendor.country;Database-default 'NL' als er niets wordt ingevuld. Geen apart veld in het aanmaakformulier.;(geen);
+Leveranciers > Nieuwe leverancier (formulier);Coupa-leveranciersnummer;vendor.coupa_supplier_number;Optioneel — matchsleutel tussen Coupa en MCM2 voor de (nog te bouwen) uploadtool #190.;"Supplier Number (Coupa-interne sleutel — ""de matching sleutel tussen Coupa en MCM2"", toelichting eigenaar)";
+Leveranciers > Detail > Stamgegevens;Coupa-leveranciersnummer;vendor.coupa_supplier_number;Zelfde veld als in het aanmaakformulier.;Supplier Number;
+Leveranciers > Nieuwe leverancier (formulier);KvK-nummer;vendor.kvk_number;Acht cijfers, volgens de hint in het formulier.;(geen);
+Leveranciers > Detail > Stamgegevens;KvK-nummer;vendor.kvk_number;Acht cijfers.;(geen);
+Leveranciers > Nieuwe leverancier (formulier);Naam;vendor.name;Naam van de leverancier. Verplicht.;Supplier Name;
+Leveranciers > Detail > Stamgegevens;Naam;vendor.name;Zelfde veld als in het aanmaakformulier, hier bewerkbaar.;Supplier Name;
+Leveranciers > Detail > Stamgegevens;Statutaire naam;vendor.statutory_name;Geen apart formulierveld in het aanmaakformulier — alleen hier bewerkbaar.;(geen);
+Leveranciers > Detail > Stamgegevens;Leveranciersnummer;vendor.vestigingsnummer;"Hint in de UI: ""voor matching met uw ERP-systeem"". Let op: het frontend-label ""Leveranciersnummer"" wijst naar de kolom vestigingsnummer, niet naar een apart leveranciersnummer-veld.";"(geen — mogelijk gerelateerd aan Supplier Account #, maar die is expliciet ""niet overnemen"" in de gap-analyse)";
+Leveranciers > Nieuwe leverancier (formulier);Website;vendor.website;(geen toelichting in de code);(geen);
+Leveranciers > Detail > Stamgegevens;Website;vendor.website;;(geen);
+Leveranciers > Detail > Classificatiebadges (bewerkveld);Compliance-thema's;vendor_compliance_thema (koppeltabel, meerkeuze via zetComplianceThemas);Meerkeuzeveld, geen enkelvoudige kolom — een leverancier kan meerdere compliance-thema's hebben.;(geen directe match — mogelijk gerelateerd aan IB&P/MSR, geen 1-op-1);
+Leveranciers > Nieuwe leverancier (formulier);E-mailadres (contactpersoon);vendor_contact.email;Idem, e-mailadres van dezelfde contactpersoon.;Contact Persoon / Contact Persoon Email;
+Leveranciers > Detail > Contactpersonen;E-mailadres;vendor_contact.email;;Contact Persoon / Contact Persoon Email;
+Leveranciers > Nieuwe leverancier (formulier);Naam contactpersoon;vendor_contact.full_name;Verplichte eerste contactpersoon, nodig om een vragenlijst te kunnen versturen.;Contact Persoon / Contact Persoon Email;
+Leveranciers > Detail > Contactpersonen;Naam;vendor_contact.full_name;;Contact Persoon / Contact Persoon Email;
+Leveranciers > Detail > Contactpersonen;Primaire contactpersoon;vendor_contact.is_primary;"Checkbox. Toelichting in de UI: ""krijgt de vragenlijst toegestuurd"".";(geen);
+Leveranciers > Detail > Contactpersonen;Functie;vendor_contact.job_title;;(geen);
+Leveranciers > Detail > Contactpersonen;Notitie;vendor_contact.role_description;"LET OP: het frontend-label ""Notitie"" wijst naar de kolom role_description, niet naar een apart notitieveld.";(geen);

--- a/docs/runbooks/backup-bewijs.json
+++ b/docs/runbooks/backup-bewijs.json
@@ -1,5 +1,5 @@
 {
-  "gecontroleerdOp": "2026-08-30T11:34:26.333Z",
+  "gecontroleerdOp": "2026-08-31T07:00:04.387Z",
   "dumpGemaaktOp": "2026-08-30T07:25:50.958Z",
   "dumpNaam": "mcm2-2026-08-30_07-25-44.dump",
   "dumpBytes": 163697,
@@ -7,11 +7,12 @@
     "A",
     "B"
   ],
-  "goed": true,
-  "problemen": [],
+  "goed": false,
+  "problemen": [
+    "docker_uit"
+  ],
   "bevindingen": [
-    "Laatste dump: mcm2-2026-08-30_07-25-44.dump (4 uur oud)",
-    "saxombp: 7 uur oud, 8 dump(s) bewaard",
-    "Compleet: 30 tabellen"
+    "Laatste dump: mcm2-2026-08-30_07-25-44.dump (23 uur oud)",
+    "saxombp: 2 uur oud, 9 dump(s) bewaard"
   ]
 }

--- a/docs/runbooks/backup-verwachting.json
+++ b/docs/runbooks/backup-verwachting.json
@@ -57,14 +57,18 @@
     "nieuwe dump is gemaakt — dat is normaal, verwacht gedrag, geen kip-ei.",
     "",
     "Migratie 0035 (31-08, admin-only contract-import, #198) voegt",
-    "clm.import_job en clm.import_row toe."
+    "clm.import_job en clm.import_row toe.",
+    "",
+    "Migratie 0036 (31-08, zelfde feature, bevindingen na het eerste gebruik",
+    "met echt Transdev-testbestand) voegt clm.import_extra_contact toe."
   ],
   "bijgewerkt": "2026-08-31",
-  "migratiestand": "0035_contract_import",
+  "migratiestand": "0036_contract_import_extra_contact",
   "tabellen": [
     "audit.audit_event",
     "clm.contract",
     "clm.contract_survey_template",
+    "clm.import_extra_contact",
     "clm.import_job",
     "clm.import_row",
     "clm.omgeving",

--- a/docs/runbooks/backup-verwachting.json
+++ b/docs/runbooks/backup-verwachting.json
@@ -54,14 +54,19 @@
     "eerste daadwerkelijke wijziging aan vendor_category, dus productie bleef",
     "steeds op migratiestand 0033 tot deze succesvolle uitrol. De eerstvolgende",
     "backupcontrole zal ref.business_risk_tier terecht missen totdat er een",
-    "nieuwe dump is gemaakt — dat is normaal, verwacht gedrag, geen kip-ei."
+    "nieuwe dump is gemaakt — dat is normaal, verwacht gedrag, geen kip-ei.",
+    "",
+    "Migratie 0035 (31-08, admin-only contract-import, #198) voegt",
+    "clm.import_job en clm.import_row toe."
   ],
-  "bijgewerkt": "2026-08-28",
-  "migratiestand": "0034_coupa_schema_uitbreiding",
+  "bijgewerkt": "2026-08-31",
+  "migratiestand": "0035_contract_import",
   "tabellen": [
     "audit.audit_event",
     "clm.contract",
     "clm.contract_survey_template",
+    "clm.import_job",
+    "clm.import_row",
     "clm.omgeving",
     "clm.platform_admin",
     "clm.response_note",

--- a/docs/superpowers/specs/2026-08-31-contract-import-design.md
+++ b/docs/superpowers/specs/2026-08-31-contract-import-design.md
@@ -1,0 +1,242 @@
+# Contract-import met vendor/contact find-or-create — design
+
+**Datum:** 2026-08-31
+**Aanleiding:** `docs/import_functie_prompt_1_0.txt` (oorspronkelijk gevraagd als
+admin-only vendor-CSV-import), herzien nadat bleek dat de eerste echte
+kolommenlijst een contract-import is met negen kolommen verspreid over
+`contract`, `vendor` en `vendor_contact`.
+
+**Status:** vastgesteld, klaar om te bouwen.
+
+---
+
+## 0. Scope-correctie t.o.v. de oorspronkelijke briefing
+
+De oorspronkelijke vraag ("start uitsluitend met import van
+leveranciers/vendors") paste niet meer zodra de daadwerkelijke
+kolommenlijst bekend werd:
+
+```
+contract.contract_number   contract.contract_type   contract.end_date
+contract.name               contract.note             contract.start_date
+contract.vendor_contact_id
+vendor.category_code   vendor.coupa_supplier_number   vendor.name
+vendor_contact.email   vendor_contact.full_name
+```
+
+`contract.vendor_id` is `notNull()` — elke rij vereist dus een
+gevonden-of-aangemaakte vendor. `vendor_contact_id` is nullable en wijst
+naar een bestaande `vendor_contact`-rij; de CSV levert email+naam los, dus
+ook daar is find-or-create nodig. Dit is per saldo een **contract-import
+met vendor- en contactpersoon-koppeling als bijproduct**, niet een
+vendor-import.
+
+## 1. Matchbeslissingen (bevestigd door de eigenaar)
+
+| Entiteit | Matchsleutel | Bij geen match | Bij match met afwijkende gegevens |
+|---|---|---|---|
+| **Vendor** | `coupa_supplier_number`, binnen de tenant | Nieuwe vendor (`name`, `coupaSupplierNumber`, `categoryCode`) | Nooit bijwerken — waarschuwing `vendor_afwijkt` |
+| **Vendor_contact** | `email` + `full_name` samen, binnen die vendor | Nieuwe contactpersoon bij die vendor | n.v.t. (geen ander veld om af te wijken) |
+| **Contract** | — (altijd nieuw) | create_only | n.v.t. |
+
+**Geen matchsleutel voor vendor beschikbaar** (leeg `coupa_supplier_number`
+in de CSV): elke zo'n rij maakt een **nieuwe** vendor aan — bewust geen
+terugval op naam-matching (schrijfvarianten zijn onbetrouwbaar). Preview
+toont hierbij een waarschuwing.
+
+**Contactpersoon-model:** een via deze import aangemaakte `vendor_contact`
+verschijnt op het bestaande leverancier-detailscherm, kaart
+"Contactpersonen" — bevestigd door de eigenaar, geen apart concept nodig.
+Losstaand, niet in scope van deze import: de spec-intentie dat een lege
+`contract.vendor_contact_id` automatisch de primaire (`is_primary`)
+contactpersoon van de vendor gebruikt (`2026-08-22-contractmanagement-design.md`
+§2.1) bleek bij onderzoek **niet geïmplementeerd** in `ContractService` —
+een gat tussen ontwerp en code, hier alleen gedocumenteerd, niet opgelost.
+
+## 2. CSV-contract v1
+
+| CSV-kolom | Doel-veld | Verplicht | Validatie |
+|---|---|---|---|
+| `contract.name` | `contract.name` | **Ja**, blokkerend | niet-lege tekst |
+| `contract.contract_number` | `contract.contractNumber` | Nee | vrije tekst |
+| `contract.contract_type` | `contract.contractType` | Nee | vrije tekst |
+| `contract.start_date` | `contract.startDate` | Nee | `DD-MM-YYYY`, waarschuwing bij ongeldig |
+| `contract.end_date` | `contract.endDate` | Nee | idem |
+| `contract.note` | `contract.note` | Nee | vrije tekst |
+| `vendor.name` | matchcontext / nieuwe vendor.name | **Ja**, blokkerend | niet-lege tekst |
+| `vendor.category_code` | vendor.categoryCode | Nee | moet bestaan in `ref.vendor_category` voor de tenant; anders waarschuwing `categorie_onbekend`, veld blijft leeg |
+| `vendor.coupa_supplier_number` | matchsleutel + vendor.coupaSupplierNumber | Nee | leeg ⇒ altijd nieuwe vendor + waarschuwing |
+| `vendor_contact.email` | matchsleutel-deel + vendor_contact.email | Nee, maar samen met full_name | grove e-mailvorm |
+| `vendor_contact.full_name` | matchsleutel-deel + vendor_contact.fullName | Nee, maar samen met email | niet-lege tekst indien email ingevuld |
+
+**Bevindingcodes (nieuw t.o.v. `leverancier-import-schema.ts`):**
+- `vendor_afwijkt` (niet-blokkerend)
+- `categorie_onbekend` (niet-blokkerend)
+- `contactgegevens_onvolledig` (niet-blokkerend) — alleen email óf alleen
+  full_name ingevuld
+
+## 3. Datamodel
+
+```sql
+CREATE TABLE clm.import_job (
+    job_id              uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenant_id           uuid NOT NULL REFERENCES clm.tenant(tenant_id),
+    import_type         text NOT NULL,              -- 'contract' in v1
+    created_by_user_id  uuid NOT NULL REFERENCES clm."user"(user_id),
+    filename            text NOT NULL,
+    file_hash           text NOT NULL,
+    row_count           integer NOT NULL,
+    status              text NOT NULL,              -- 'preview' | 'bevestigd'
+    created_at          timestamptz NOT NULL DEFAULT now(),
+    confirmed_at        timestamptz
+);
+
+CREATE TABLE clm.import_row (
+    row_id              uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenant_id           uuid NOT NULL REFERENCES clm.tenant(tenant_id),
+    job_id              uuid NOT NULL REFERENCES clm.import_job(job_id) ON DELETE CASCADE,
+    row_number          integer NOT NULL,
+    raw_data            jsonb NOT NULL,
+    normalized_data     jsonb NOT NULL,
+    findings            jsonb NOT NULL,
+    importable          boolean NOT NULL,
+    result              text,                       -- 'created' | 'skipped' | 'failed'
+    created_contract_id uuid REFERENCES clm.contract(contract_id),
+    created_vendor_id   uuid REFERENCES clm.vendor(vendor_id),
+    matched_vendor_id   uuid REFERENCES clm.vendor(vendor_id),
+    created_contact_id  uuid REFERENCES clm.vendor_contact(contact_id),
+    matched_contact_id  uuid REFERENCES clm.vendor_contact(contact_id)
+);
+```
+
+Vier aparte kolommen voor vendor/contact (created vs. matched) — bewust
+gekozen zodat preview én resultaatscherm expliciet kunnen tonen wat nieuw
+is versus hergebruikt (eigenaar-besluit).
+
+RLS: `ENABLE`/`FORCE ROW LEVEL SECURITY` + `USING/WITH CHECK (tenant_id =
+clm.current_tenant_id())` op beide tabellen, naar het patroon van
+`ref.vendor_category` (migratie 0034). Verplichte regels in
+`src/db/rechten-contract.ts` voor beide tabellen.
+
+**Audit:** `ContractImportAuditService.leg(tx, { tenantId, actie:
+'contract_import_bevestigd', entityId: jobId, details: {
+aangemaakteContracten, aangemaakteVendors, hergebruikteVendors,
+aangemaakteContacten, hergebruikteContacten, overgeslagen } })` — binnen
+dezelfde transactie als de bevestiging, naar `survey-audit.service.ts`.
+
+## 4. Verwerking per rij (bevestigen)
+
+Eén transactie voor de **hele** job (niet per batch) — bevestigd door de
+eigenaar. Bij een fout: volledige rollback, `import_job.status` blijft
+`'preview'`.
+
+```
+per rij, binnen dezelfde tx:
+  1. vind vendor op coupa_supplier_number (indien ingevuld)
+     → gevonden: vergelijk name/category_code → evt. vendor_afwijkt-waarschuwing, GEEN update
+     → niet ingevuld of niet gevonden: nieuwe vendor
+  2. als email én full_name ingevuld:
+     vind vendor_contact op (vendor_id, email, full_name)
+     → gevonden: hergebruik
+     → niet gevonden: nieuwe vendor_contact bij deze vendor
+     als maar één van beide ingevuld: contactgegevens_onvolledig-waarschuwing, geen contact gekoppeld
+  3. maak het contract aan (altijd nieuw) met vendor_id uit stap 1,
+     vendor_contact_id uit stap 2 (of null)
+```
+
+Matches van eerdere rijen in dezelfde import moeten zichtbaar zijn voor
+latere rijen (rij 5 vindt een vendor die rij 2 in dezelfde batch aanmaakte)
+— werkt vanzelf binnen één doorlopende transactie, expliciet getest.
+
+## 5. Autorisatie en tenantkeuze
+
+Geen nieuw mechanisme. Platformbeheerder wisselt eerst naar de doeltenant
+via het bestaande `POST /platform/sessie/wisselen`. De import-routes
+draaien op `@UseGuards(TenantContextGuard, PlatformAdminGuard)` en werken
+op `sessie.tenantId` — geen `tenantId`-veld in de import-request zelf
+(MCM2-CLAUDE.md §6).
+
+## 6. Frontend
+
+Eén pagina, drie stappen zonder aparte wizard-component:
+
+1. **Bestand kiezen** — kaal `<input type="file" accept=".csv">` + knop
+   "Bestand analyseren" → `POST /admin/contract-import/preview`.
+2. **Preview** — platte tabel (regel, contract, vendor, status), rood voor
+   geblokkeerd, amber voor waarschuwing, geen kleur voor OK. Knop "N rijen
+   importeren" → `POST /admin/contract-import/:jobId/bevestigen`.
+3. **Resultaat** — samenvatting uit de audit-details (aantallen
+   aangemaakt/hergebruikt per entiteit), knoppen terug naar leveranciers of
+   nieuwe import.
+
+Route: `/beheer/platform/contract-import` (platform-namespace, want dit is
+platformbeheer-only). Geen kolom-mapping-UI, geen inline rij-bewerking,
+geen geschiedenispagina in v1 — audit blijft wel in de database voor
+later gebruik.
+
+**Nieuwe frontend-bestanden:**
+```
+src/app/beheer/platform/contract-import/page.tsx
+src/core/services/contractImportService.ts
+src/core/models/contractImport.ts
+```
+
+## 7. Bestanden — backend
+
+**Nieuw:**
+```
+drizzle/0035_contract_import.sql
+src/contract-import/contract-import.module.ts
+src/contract-import/contract-import.controller.ts
+src/contract-import/contract-import.service.ts
+src/contract-import/contract-import-schema.ts
+src/contract-import/contract-import-audit.service.ts
+test/contract-import-preview.e2e-spec.ts
+test/contract-import-bevestigen.e2e-spec.ts
+test/contract-import-matching.e2e-spec.ts
+test/contract-import-autorisatie.e2e-spec.ts
+db/seeds/voorbeeld-contracten-coupa.csv
+```
+
+**Wijzigen:**
+```
+src/db/schema.ts               — importJob, importRow
+src/db/rechten-contract.ts     — regels voor beide nieuwe tabellen
+src/app.module.ts              — ContractImportModule registreren
+drizzle/meta/_journal.json     — entry voor 0035
+```
+
+**Niet aangeraakt:** `vendor.service.ts`, `contract.service.ts`,
+`leverancier-import-schema.ts`, `csv-lezer.ts` (laatste twee blijven
+bestaan voor een eventuele toekomstige vendor-only-import, zie §9).
+
+## 8. Testplan
+
+- **Matching:** dubbele coupa_supplier_number binnen één import (hergebruik
+  binnen dezelfde tx), afwijkende naam bij match (waarschuwing, geen
+  update), twee contacten met gelijk email maar andere naam (twee rijen),
+  identieke email+naam (één rij, twee contracten eraan), ontbrekend
+  coupa-nummer (altijd nieuwe vendor), onvolledige contactgegevens.
+- **Autorisatie:** geen platformbeheerder → 403; ingetrokken
+  platformbeheerder binnen dezelfde sessie → 403 op de eerstvolgende
+  aanroep.
+- **Tenantisolatie:** import-job van tenant A niet zichtbaar/leesbaar
+  vanuit tenant B.
+- **Rollback:** gesimuleerde fout halverwege bevestigen → nul nieuwe
+  rijen, job blijft `'preview'`.
+- **Idempotency:** tweede bevestiging op dezelfde job → 409.
+- **Validatie:** blokkerende/niet-blokkerende bevindingen, lege
+  koprij-herkenning (hergebruik van bestaande CSV-lezer-tests).
+- **Vanzelf meelopend:** `schema-conformiteit.e2e-spec.ts`,
+  `rechten-contract.e2e-spec.ts`.
+
+## 9. Niet in scope van dit issue
+
+- Vendor-only-import (het oorspronkelijke eerste ontwerp) — `csv-lezer.ts`
+  en `leverancier-import-schema.ts` blijven ongebruikt maar intact voor
+  wanneer die apart gebouwd wordt.
+- De ontbrekende "primaire contactpersoon als fallback"-logica in
+  `ContractService` (spec-gat, alleen gedocumenteerd in §1).
+- Tenant-admin (niet-platformbeheerder) zelf laten importeren — v1 is
+  platformbeheerder-only, conform de oorspronkelijke briefing.
+- Kolom-mapping-UI, geschiedenispagina van eerdere imports.

--- a/docs/superpowers/specs/2026-08-31-contract-import-design.md
+++ b/docs/superpowers/specs/2026-08-31-contract-import-design.md
@@ -6,7 +6,9 @@ admin-only vendor-CSV-import), herzien nadat bleek dat de eerste echte
 kolommenlijst een contract-import is met negen kolommen verspreid over
 `contract`, `vendor` en `vendor_contact`.
 
-**Status:** vastgesteld, klaar om te bouwen.
+**Status:** v1 gebouwd en getest tegen een gefabriceerd voorbeeldbestand.
+Bij het eerste gebruik tegen een echt Transdev-testbestand (31-08, na
+publicatie van v1) bleken drie punten niet te kloppen — zie §10.
 
 ---
 
@@ -240,3 +242,149 @@ bestaan voor een eventuele toekomstige vendor-only-import, zie §9).
 - Tenant-admin (niet-platformbeheerder) zelf laten importeren — v1 is
   platformbeheerder-only, conform de oorspronkelijke briefing.
 - Kolom-mapping-UI, geschiedenispagina van eerdere imports.
+
+## 10. Bevindingen bij het eerste echte gebruik (31-08) en de fixes
+
+Getest tegen een echt Transdev-testbestand (`Transdev_Test_upload_02.csv`,
+puntkomma-gescheiden, negen rijen). Drie punten bleken niet te kloppen:
+
+**10.1 Datumformaat te strikt — FOUT, gefixt.**
+`leesContractDatum()` eiste `\d{2}-\d{2}-\d{4}` (verplichte voorloopnul).
+Een echte export schrijft zonder voorloopnul (`1-4-2019`, `9-5-2025`). Regex
+verruimd naar `\d{1,2}-\d{1,2}-\d{4}`, ISO-opbouw via `padStart(2, '0')`.
+Regressietest toegevoegd.
+
+**10.2 Onbekende categorie — gedrag herzien.**
+v1 liet `vendor.category_code` stilzwijgend leeg als de code niet bestond
+in `ref.vendor_category` voor de tenant (zichtbaar noch in preview, noch in
+het resultaat). Bij een echte export (`ICT`, `Vastgoed & Facility
+Management`) is dat vrijwel altijd het geval — de bron gebruikt vrije
+tekst, de tenant-tabel gebruikt korte codes. **Besluit eigenaar (31-08):
+een onbekende categorie wordt automatisch aangemaakt** in
+`ref.vendor_category` voor de tenant (code = genormaliseerde slug van de
+tekst, label = de originele tekst), in plaats van genegeerd. Een mens kan
+later opschonen/samenvoegen via het bestaande `/vendor-categories`-scherm.
+
+**10.3 Meerdere contactgegevens per contract — nieuw, apart vastgelegd.**
+Het CSV-contract (§7) ging uit van precies één e-mail + één naam per
+contract. Een echte export heeft vaak meerdere contactkanalen: een
+persoon-e-mail, een afdelings-e-mail, een compliance-URL. Volledig
+"meerdere contactpersonen per contract" bouwen (nieuw datamodel) is bewust
+**niet** in deze ronde gedaan — besluit eigenaar: "een upload zal meestal
+tijdens een onboarding gebeuren [...] we kunnen volstaan met een
+waarschuwing en een hulptabel om de extra contactpersonen per contract op
+te lijsten, zodat deze handmatig kunnen worden toegevoegd."
+
+**Gekozen CSV-conventie:** genummerde kolommen —
+`vendor_contact.email_2`, `vendor_contact.full_name_2` (en `_3`, `_4`, ...)
+naast het bestaande primaire paar (`vendor_contact.email`,
+`vendor_contact.full_name`, zonder suffix).
+
+**Nieuwe tabel `clm.import_extra_contact`:** per `import_row`, de
+extra contactgegevens die niet in het primaire paar pasten (e-mail en/of
+naam, als tekst — geen `vendor_contact`-rij, geen koppeling). Zichtbaar na
+bevestigen als aparte lijst ("N extra contactgegevens gevonden, handmatig
+te verwerken"), buiten het reguliere find-or-create-pad.
+
+**Aanvankelijk niet opgelost, later alsnog** (zie §11): het testbestand had
+ook dubbele, niet-genummerde kopnamen (`vendor_contact.email` twee keer) —
+die kregen bij deze eerste ronde nog "laatste wint, onzichtbaar"-gedrag.
+Na een tweede preview-poging met de eigenaar bleek dit gedrag te grof; §11
+beschrijft de definitieve oplossing (laatste voorkomen = primair, eerdere
+voorkomens = zichtbaar in extraContacten).
+
+## 11. Tweede ronde bevindingen (31-08, na de eerste preview met de eigenaar)
+
+Bij het daadwerkelijk previewen van het herstelde §10-gedrag tegen hetzelfde
+Transdev-testbestand bleken drie punten nog niet te kloppen.
+
+**11.1 Alleen-email of alleen-naam werd nog steeds overgeslagen — FOUT,
+gecorrigeerd.** §10 loste de datum/categorie/extra-contact-punten op, maar
+de oorspronkelijke v1-regel — een contactpersoon met alleen email óf alleen
+naam is "onvolledig" en wordt niet aangemaakt — stond nog overeind. Besluit
+eigenaar: **beide gevallen moeten gewoon een contactpersoon opleveren.**
+`contactgegevens_onvolledig` is verwijderd als bevindingcode.
+
+Gevolg: `clm.vendor_contact.full_name` is `NOT NULL` (bestaand schema, niet
+gewijzigd) — alleen-email kan dus niet als een kale `full_name: null`-rij
+worden opgeslagen. Opgelost door bij het ontbreken van een naam het
+e-mailadres zelf als voorlopige naam te gebruiken (`vindOfMaakContact()`),
+met een `IS NOT DISTINCT FROM`-matchquery zodat een NULL-e-mailveld (bij
+alleen-naam-rijen) de hergebruik-matching niet breekt — `=` geeft bij NULL
+altijd NULL, nooit true, en zou elke import een nieuw contact hebben laten
+aanmaken in plaats van het bestaande te hergebruiken.
+
+**11.2 `contract.vendor_contact_id` bevat in de praktijk een naam, geen
+ID — nieuwe alias toegevoegd.** De kolom is voor een echte ID-verwijzing
+bedoeld (en heet zo, correct, naar de databasekolom
+`clm.contract.vendor_contact_id`), maar Transdev's export vult hem met een
+naam ("Bart Philips"). Besluit eigenaar: **alleen gebruiken als
+`vendor_contact.full_name` zelf leeg is, en alleen als de waarde geen
+geldig UUID is** (anders zou het een echte, toekomstige ID-verwijzing
+kunnen zijn). Geïmplementeerd als naverwerking in `maakInvoer()`, ná de
+gewone kolomdoorloop — de conditie ("is `contactFullName` al gevuld door
+een andere kolom") is pas dan bekend.
+
+**11.3 Dubbele `vendor_contact.email`-kolommen: eerste of laatste is
+primair? Omgedraaid van eerste naar LAATSTE.** De eerste implementatie
+(§10.3) liet het eerste voorkomen primair blijven. Bij het echte
+Transdev-bestand bleek dat averechts: de eerste van twee gelijknamige
+kolommen is daar meestal leeg of een compliance-URL, de tweede bevat het
+echte adres. Besluit eigenaar: **het laatste voorkomen van een dubbele
+kopnaam is primair**, elk eerder voorkomen wordt een genummerd extra
+contact (`extraContacten`). Technisch: eerst een volledige doorloop van de
+koprij om alle indexen per veld te verzamelen (pass 1), dan pas toewijzen
+op basis van welke index de laatste is (pass 2) — dat kon niet in één
+doorloop, want bij de eerste kolom is nog niet bekend of er nog een tweede
+komt.
+
+**Resultaat op het echte testbestand** (9 rijen): van "9 importeerbaar, 7
+met waarschuwing" (§10-stand, met email/naam als afzonderlijke, vaak
+'onvolledige' velden) naar dezelfde 9 importeerbaar maar nu met correcte
+matching — 7 rijen met een geldig of invalide e-mailadres, 4 rijen met een
+herkende naam (via `contract.vendor_contact_id` of het reguliere
+naamveld), en de resterende brondatafouten (compliance-URL's in een
+e-mailveld, een tekstlabel i.p.v. adres) blijven zichtbaar als
+`email_ongeldig`-waarschuwing in plaats van stilzwijgend verloren te gaan
+of de rij te blokkeren.
+
+## 12. Derde ronde bevindingen (31-08, na functioneel testen van het scherm)
+
+Bij het daadwerkelijk doorlopen van preview → bevestigen → contractdetail
+in de browser bleken twee losse punten niet te kloppen.
+
+**12.1 `vendor.business_criticality_code` en `contract.business_risk_tier_code`
+werden helemaal niet geïmporteerd — ontbrekend, niet gebouwd.** Deze twee
+kolommen staan wel in het originele Transdev-testbestand en in het
+databaseschema (beide bestaande velden, elders al gebruikt), maar stonden
+gewoonweg niet in `KOLOM_ALIASSEN` — een omissie bij het bouwen van v1, geen
+regressie.
+
+**Belangrijk verschil met vendor-categorie (§10.2):** beide referentietabellen
+(`ref.business_criticality`, `ref.business_risk_tier`) zijn **platform-breed**
+(geen `tenant_id`, geen RLS) — de import mag hier dus, anders dan bij
+vendor-categorie, **geen nieuwe waarden aanmaken**. Besluit eigenaar:
+losse duidingsfuncties per veld op basis van sleutelwoorden/patroon:
+- `duidBusinessCriticality()`: 'Hoog'/'High' → `high`, 'Gemiddeld'/'Midden'/
+  'Medium' → `medium`, 'Laag'/'Low' → `low`, 'Kritiek'/'Critical' → `critical`.
+- `duidBusinessRiskTier()`: zoekt het patroon `Tier\s*([123])` in de tekst en
+  gebruikt alleen het cijfer — 'Tier 2  Medium impact' → `tier_2`, de rest
+  van de tekst wordt genegeerd.
+
+Een niet-herkende waarde blokkeert de rij niet — het veld blijft leeg, met
+een nieuwe, niet-blokkerende bevindingcode (`business_criticality_onbekend`,
+`business_risk_tier_onbekend`) zodat het zichtbaar is in de preview.
+
+**12.2 Het contract-bewerkformulier toonde Contracttype/Business-risk-tier/
+DPA altijd leeg — een pre-existing frontend-bug, los van de import.** Bij
+het narekenen bleek de backend het veld wél correct op te slaan en terug te
+geven (geverifieerd rechtstreeks in de database); het probleem zat in
+`uitContract()` in `MCM2-frontend/.../Contracten.tsx` — die conversiefunctie
+(database-object → formulierwaarden) mapte `contractType`,
+`businessRiskTierCode` en `dpaAanwezig` nooit door, ondanks dat het
+`Contract`/`ContractInvoer`-model deze drie velden al langer kende (sinds de
+Coupa-schema-uitbreiding, migratie 0034, 28-08). Dit gat bestond dus al vóór
+de contract-import er was — het viel alleen nooit op omdat er nog nooit
+data met deze drie velden was ingevoerd om het bewerkformulier mee te
+testen. Gefixt door de drie ontbrekende regels toe te voegen aan
+`uitContract()`.

--- a/drizzle/0035_contract_import.sql
+++ b/drizzle/0035_contract_import.sql
@@ -1,0 +1,142 @@
+-- =============================================================================
+-- clm.import_job / clm.import_row — admin-only contract-import (#198).
+--
+-- Ontwerp: docs/superpowers/specs/2026-08-31-contract-import-design.md.
+-- Vervolg op #190 (contractdata-uploadtool) — de daadwerkelijke kolommenlijst
+-- bleek een contract-import met find-or-create op vendor + vendor_contact,
+-- niet een vendor-only-import zoals oorspronkelijk gevraagd.
+--
+-- import_type staat al op de job (v1: uitsluitend 'contract') zodat een
+-- toekomstig tweede importtype geen migratie op deze tabel vraagt, alleen een
+-- nieuwe waarde en een eigen verwerkingsmodule.
+-- =============================================================================
+
+CREATE TABLE clm.import_job (
+    job_id              uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenant_id           uuid NOT NULL,
+    import_type         text NOT NULL,
+    created_by_user_id  uuid NOT NULL,
+    filename            text NOT NULL,
+    file_hash           text NOT NULL,
+    row_count           integer NOT NULL,
+    status              text NOT NULL,
+    created_at          timestamptz NOT NULL DEFAULT now(),
+    confirmed_at        timestamptz,
+    CONSTRAINT import_job_status_check
+        CHECK (status IN ('preview', 'bevestigd'))
+);--> statement-breakpoint
+
+ALTER TABLE clm.import_job
+    ADD CONSTRAINT import_job_tenant_id_tenant_tenant_id_fk
+    FOREIGN KEY (tenant_id) REFERENCES clm.tenant(tenant_id)
+    ON DELETE cascade;--> statement-breakpoint
+
+ALTER TABLE clm.import_job
+    ADD CONSTRAINT import_job_created_by_user_id_user_user_id_fk
+    FOREIGN KEY (created_by_user_id) REFERENCES clm."user"(user_id)
+    ON DELETE restrict;--> statement-breakpoint
+
+CREATE INDEX import_job_tenant_id_idx
+    ON clm.import_job USING btree (tenant_id);--> statement-breakpoint
+
+-- ── import_row ───────────────────────────────────────────────────────────────
+--
+-- created_*/matched_* zijn bewust vier aparte kolommen (twee per entiteit) in
+-- plaats van één: het resultaatscherm moet apart kunnen tonen wat déze import
+-- nieuw aanmaakte versus hergebruikte (besluit eigenaar, 2026-08-31).
+
+CREATE TABLE clm.import_row (
+    row_id              uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenant_id           uuid NOT NULL,
+    job_id              uuid NOT NULL,
+    row_number          integer NOT NULL,
+    raw_data            jsonb NOT NULL,
+    normalized_data     jsonb NOT NULL,
+    findings            jsonb NOT NULL,
+    importable          boolean NOT NULL,
+    result              text,
+    created_contract_id uuid,
+    created_vendor_id   uuid,
+    matched_vendor_id   uuid,
+    created_contact_id  uuid,
+    matched_contact_id  uuid,
+    CONSTRAINT import_row_result_check
+        CHECK (result IS NULL OR result IN ('created', 'skipped', 'failed'))
+);--> statement-breakpoint
+
+ALTER TABLE clm.import_row
+    ADD CONSTRAINT import_row_tenant_id_tenant_tenant_id_fk
+    FOREIGN KEY (tenant_id) REFERENCES clm.tenant(tenant_id)
+    ON DELETE cascade;--> statement-breakpoint
+
+ALTER TABLE clm.import_row
+    ADD CONSTRAINT import_row_job_id_import_job_job_id_fk
+    FOREIGN KEY (job_id) REFERENCES clm.import_job(job_id)
+    ON DELETE cascade;--> statement-breakpoint
+
+ALTER TABLE clm.import_row
+    ADD CONSTRAINT import_row_created_contract_id_contract_contract_id_fk
+    FOREIGN KEY (created_contract_id) REFERENCES clm.contract(contract_id)
+    ON DELETE set null;--> statement-breakpoint
+
+ALTER TABLE clm.import_row
+    ADD CONSTRAINT import_row_created_vendor_id_vendor_vendor_id_fk
+    FOREIGN KEY (created_vendor_id) REFERENCES clm.vendor(vendor_id)
+    ON DELETE set null;--> statement-breakpoint
+
+ALTER TABLE clm.import_row
+    ADD CONSTRAINT import_row_matched_vendor_id_vendor_vendor_id_fk
+    FOREIGN KEY (matched_vendor_id) REFERENCES clm.vendor(vendor_id)
+    ON DELETE set null;--> statement-breakpoint
+
+ALTER TABLE clm.import_row
+    ADD CONSTRAINT import_row_created_contact_id_vendor_contact_contact_id_fk
+    FOREIGN KEY (created_contact_id) REFERENCES clm.vendor_contact(contact_id)
+    ON DELETE set null;--> statement-breakpoint
+
+ALTER TABLE clm.import_row
+    ADD CONSTRAINT import_row_matched_contact_id_vendor_contact_contact_id_fk
+    FOREIGN KEY (matched_contact_id) REFERENCES clm.vendor_contact(contact_id)
+    ON DELETE set null;--> statement-breakpoint
+
+CREATE INDEX import_row_tenant_id_idx
+    ON clm.import_row USING btree (tenant_id);--> statement-breakpoint
+
+CREATE INDEX import_row_job_id_idx
+    ON clm.import_row USING btree (job_id);--> statement-breakpoint
+
+-- ── RLS — zelfde vorm als ref.vendor_category (migratie 0034) ─────────────────
+
+ALTER TABLE clm.import_job ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+ALTER TABLE clm.import_job FORCE ROW LEVEL SECURITY;--> statement-breakpoint
+
+CREATE POLICY import_job_isolation ON clm.import_job
+    USING (tenant_id = clm.current_tenant_id())
+    WITH CHECK (tenant_id = clm.current_tenant_id());--> statement-breakpoint
+
+ALTER TABLE clm.import_row ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+ALTER TABLE clm.import_row FORCE ROW LEVEL SECURITY;--> statement-breakpoint
+
+CREATE POLICY import_row_isolation ON clm.import_row
+    USING (tenant_id = clm.current_tenant_id())
+    WITH CHECK (tenant_id = clm.current_tenant_id());--> statement-breakpoint
+
+COMMENT ON TABLE clm.import_job IS
+    'Eén CSV-importpoging (preview of bevestigd). import_type onderscheidt toekomstige importsoorten; v1 kent alleen ''contract''. Zie docs/superpowers/specs/2026-08-31-contract-import-design.md.';--> statement-breakpoint
+
+COMMENT ON TABLE clm.import_row IS
+    'Eén brondrij van een import_job: ruwe cellen, genormaliseerde waarden, bevindingen, en na bevestiging het resultaat. created_*/matched_* houden apart bij wat déze import nieuw aanmaakte versus hergebruikte.';--> statement-breakpoint
+
+-- REVOKE vóór GRANT, conform migratie 0027 (src/db/rechten-contract.ts): een
+-- kale GRANT beperkt niets, want ALTER DEFAULT PRIVILEGES (migratie 0001)
+-- geeft clm_api via het lidmaatschap van clm_api_runtime al SELECT, INSERT,
+-- UPDATE, DELETE op elke nieuwe tabel in clm. Zonder de REVOKE hieronder zou
+-- clm_api_runtime dus ook DELETE krijgen — ruimer dan bedoeld.
+--
+-- Geen DELETE nodig: een import-job/-rij is het traceerbaarheidsspoor van de
+-- import en wordt door de applicatie niet verwijderd.
+REVOKE ALL ON clm.import_job FROM clm_api, clm_admin, clm_readonly;--> statement-breakpoint
+GRANT SELECT, INSERT, UPDATE ON clm.import_job TO clm_api, clm_admin;--> statement-breakpoint
+
+REVOKE ALL ON clm.import_row FROM clm_api, clm_admin, clm_readonly;--> statement-breakpoint
+GRANT SELECT, INSERT, UPDATE ON clm.import_row TO clm_api, clm_admin;

--- a/drizzle/0036_contract_import_extra_contact.sql
+++ b/drizzle/0036_contract_import_extra_contact.sql
@@ -1,0 +1,56 @@
+-- =============================================================================
+-- clm.import_extra_contact — extra contactgegevens per import-rij (#198,
+-- vervolg op migratie 0035, bevindingen bij het eerste echte gebruik 31-08).
+--
+-- Ontwerp: docs/superpowers/specs/2026-08-31-contract-import-design.md §10.3.
+--
+-- Waarom een aparte tabel en geen extra kolommen op import_row: een rij kan
+-- een onbepaald aantal extra contactkanalen hebben (email_2, email_3, ...),
+-- en dat past niet in vaste kolommen zonder een migratie per extra kanaal.
+-- Bewust GEEN vendor_contact-rij en GEEN koppeling: dit is een hulptabel om
+-- na de import handmatig te verwerken, geen automatisch aangemaakt contact
+-- (besluit eigenaar: "een hulptabel om de extra contactpersonen per contract
+-- op te lijsten, zodat deze handmatig kunnen worden toegevoegd").
+-- =============================================================================
+
+CREATE TABLE clm.import_extra_contact (
+    extra_contact_id    uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenant_id           uuid NOT NULL,
+    row_id              uuid NOT NULL,
+    -- Volgnummer uit de kolomnaam (email_2 -> 2, full_name_3 -> 3), zodat
+    -- email_2 en full_name_2 bij elkaar horen ook als er maar één van de
+    -- twee is ingevuld.
+    volgnummer          integer NOT NULL,
+    email               text,
+    full_name           text
+);--> statement-breakpoint
+
+ALTER TABLE clm.import_extra_contact
+    ADD CONSTRAINT import_extra_contact_tenant_id_tenant_tenant_id_fk
+    FOREIGN KEY (tenant_id) REFERENCES clm.tenant(tenant_id)
+    ON DELETE cascade;--> statement-breakpoint
+
+ALTER TABLE clm.import_extra_contact
+    ADD CONSTRAINT import_extra_contact_row_id_import_row_row_id_fk
+    FOREIGN KEY (row_id) REFERENCES clm.import_row(row_id)
+    ON DELETE cascade;--> statement-breakpoint
+
+CREATE INDEX import_extra_contact_tenant_id_idx
+    ON clm.import_extra_contact USING btree (tenant_id);--> statement-breakpoint
+
+CREATE INDEX import_extra_contact_row_id_idx
+    ON clm.import_extra_contact USING btree (row_id);--> statement-breakpoint
+
+ALTER TABLE clm.import_extra_contact ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+ALTER TABLE clm.import_extra_contact FORCE ROW LEVEL SECURITY;--> statement-breakpoint
+
+CREATE POLICY import_extra_contact_isolation ON clm.import_extra_contact
+    USING (tenant_id = clm.current_tenant_id())
+    WITH CHECK (tenant_id = clm.current_tenant_id());--> statement-breakpoint
+
+COMMENT ON TABLE clm.import_extra_contact IS
+    'Extra contactgegevens (email_2, full_name_2, ...) uit een contract-import die niet in het primaire email/naam-paar pasten. Geen vendor_contact-rij, geen koppeling — een hulplijst om na de import handmatig te verwerken. Zie docs/superpowers/specs/2026-08-31-contract-import-design.md §10.3.';--> statement-breakpoint
+
+-- REVOKE vóór GRANT, zelfde patroon als migratie 0035.
+REVOKE ALL ON clm.import_extra_contact FROM clm_api, clm_admin, clm_readonly;--> statement-breakpoint
+GRANT SELECT, INSERT ON clm.import_extra_contact TO clm_api, clm_admin;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -246,6 +246,13 @@
       "when": 1787068800008,
       "tag": "0034_coupa_schema_uitbreiding",
       "breakpoints": true
+    },
+    {
+      "idx": 35,
+      "version": "7",
+      "when": 1787068800009,
+      "tag": "0035_contract_import",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -253,6 +253,13 @@
       "when": 1787068800009,
       "tag": "0035_contract_import",
       "breakpoints": true
+    },
+    {
+      "idx": 36,
+      "version": "7",
+      "when": 1787068800010,
+      "tag": "0036_contract_import_extra_contact",
+      "breakpoints": true
     }
   ]
 }

--- a/scripts/demo-stack.js
+++ b/scripts/demo-stack.js
@@ -527,7 +527,10 @@ function wachtOpStack(maxSeconden = 120) {
 
   while (Date.now() < einde) {
     const api = httpCode(`http://localhost:${API_POORT}/health`);
-    const web = httpCode(`http://localhost:${WEB_POORT}/`);
+    // '/' redirect sinds 29-08 (307) naar '/beheer' — zie de andere drie
+    // plekken die dezelfde aanname hadden (CI, verify-volledig.js, de AWS
+    // ALB-targetgroup). Dit is de vierde.
+    const web = httpCode(`http://localhost:${WEB_POORT}/beheer`);
 
     if (api === '200' && web === '200') {
       return { ok: true };
@@ -1021,7 +1024,7 @@ function status() {
     ]).uitvoer) === DEMO_CONTAINER;
 
   const api = httpCode(`http://localhost:${API_POORT}/health`);
-  const web = httpCode(`http://localhost:${WEB_POORT}/`);
+  const web = httpCode(`http://localhost:${WEB_POORT}/beheer`);
 
   console.log('');
   console.log(`  database   ${draaitDb ? 'draait' : 'staat uit'} (poort ${DB_POORT})`);

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { AuthModule } from './auth/auth.module';
+import { ContractImportModule } from './contract-import/contract-import.module';
 import { ContractModule } from './contract/contract.module';
 import { DatabaseModule } from './db/database.module';
 import { HealthModule } from './health/health.module';
@@ -21,6 +22,7 @@ import { VendorModule } from './vendor/vendor.module';
     VendorModule,
     VendorCategoryModule,
     ContractModule,
+    ContractImportModule,
     MailModule,
     PlatformModule,
     TenantModule,

--- a/src/contract-import/contract-import-audit.service.ts
+++ b/src/contract-import/contract-import-audit.service.ts
@@ -1,0 +1,42 @@
+import { Injectable } from '@nestjs/common';
+import { sql } from 'drizzle-orm';
+
+import type { TenantTransaction } from '../db/database.service';
+
+/** Gebeurtenissen rond een contract-import (#198). */
+export type ContractImportAuditActie = 'contract_import_bevestigd';
+
+/**
+ * Legt gebeurtenissen rond een contract-import vast in `audit.audit_event`.
+ * Naar het patroon van `survey-audit.service.ts`: schrijft binnen de
+ * transactie van de aanroeper, zodat een rollback de auditregel meeneemt —
+ * een auditregel voor een import die niet gebeurd is, is erger dan geen
+ * auditregel.
+ */
+@Injectable()
+export class ContractImportAuditService {
+  async leg(
+    tx: TenantTransaction,
+    gegevens: {
+      tenantId: string;
+      actie: ContractImportAuditActie;
+      jobId: string;
+      details: {
+        aangemaakteContracten: number;
+        aangemaakteVendors: number;
+        hergebruikteVendors: number;
+        aangemaakteContacten: number;
+        hergebruikteContacten: number;
+        overgeslagen: number;
+      };
+    },
+  ): Promise<void> {
+    await tx.execute(
+      sql`INSERT INTO audit.audit_event
+            (tenant_id, action_type, entity_type, entity_id, new_values)
+          VALUES (${gegevens.tenantId}, ${gegevens.actie}, 'import_job',
+                  ${gegevens.jobId},
+                  ${JSON.stringify(gegevens.details)}::jsonb)`,
+    );
+  }
+}

--- a/src/contract-import/contract-import-audit.service.ts
+++ b/src/contract-import/contract-import-audit.service.ts
@@ -27,6 +27,8 @@ export class ContractImportAuditService {
         hergebruikteVendors: number;
         aangemaakteContacten: number;
         hergebruikteContacten: number;
+        aangemaakteCategorieen: number;
+        extraContactenGevonden: number;
         overgeslagen: number;
       };
     },

--- a/src/contract-import/contract-import-schema.spec.ts
+++ b/src/contract-import/contract-import-schema.spec.ts
@@ -1,5 +1,7 @@
 import {
   beoordeelContractImportbestand,
+  duidBusinessCriticality,
+  duidBusinessRiskTier,
   emailGeldig,
   isBlokkerend,
   leesContractDatum,
@@ -14,6 +16,20 @@ describe('leesContractDatum', () => {
   it('zet DD-MM-JJJJ om naar ISO', () => {
     expect(leesContractDatum('01-01-2024')).toEqual({
       waarde: '2024-01-01',
+      geldig: true,
+    });
+  });
+
+  it('zet D-M-JJJJ (zonder voorloopnul, zoals een echte Coupa-export) om naar ISO', () => {
+    // Regressietest: de eerste versie van deze functie eiste \d{2} en wees
+    // dit realistische formaat af als "geen geldige datum" (gevonden 31-08
+    // bij het eerste gebruik van het echte Transdev-testbestand).
+    expect(leesContractDatum('1-4-2019')).toEqual({
+      waarde: '2019-04-01',
+      geldig: true,
+    });
+    expect(leesContractDatum('9-5-2025')).toEqual({
+      waarde: '2025-05-09',
       geldig: true,
     });
   });
@@ -63,6 +79,46 @@ describe('emailGeldig', () => {
   });
 });
 
+describe('duidBusinessCriticality', () => {
+  it('herkent de Nederlandse waarden', () => {
+    expect(duidBusinessCriticality('Hoog')).toBe('high');
+    expect(duidBusinessCriticality('Gemiddeld')).toBe('medium');
+    expect(duidBusinessCriticality('Laag')).toBe('low');
+    expect(duidBusinessCriticality('Kritiek')).toBe('critical');
+  });
+
+  it('herkent de Engelse waarden', () => {
+    expect(duidBusinessCriticality('High')).toBe('high');
+    expect(duidBusinessCriticality('Medium')).toBe('medium');
+    expect(duidBusinessCriticality('Low')).toBe('low');
+    expect(duidBusinessCriticality('Critical')).toBe('critical');
+  });
+
+  it('geeft null bij leeg of onbekend', () => {
+    expect(duidBusinessCriticality(null)).toBeNull();
+    expect(duidBusinessCriticality('')).toBeNull();
+    expect(duidBusinessCriticality('onbekende waarde')).toBeNull();
+  });
+});
+
+describe('duidBusinessRiskTier', () => {
+  it('herkent het tier-cijfer, ongeacht de rest van de tekst', () => {
+    // Zoals een echte Transdev-export het schrijft: 'Tier 2  Medium impact',
+    // 'Tier 1  High impact (Strategisch)' — alleen het cijfer telt.
+    expect(duidBusinessRiskTier('Tier 1  High impact (Strategisch)')).toBe(
+      'tier_1',
+    );
+    expect(duidBusinessRiskTier('Tier 2  Medium impact')).toBe('tier_2');
+    expect(duidBusinessRiskTier('Tier 3  Low impact')).toBe('tier_3');
+  });
+
+  it('geeft null bij leeg of onbekend', () => {
+    expect(duidBusinessRiskTier(null)).toBeNull();
+    expect(duidBusinessRiskTier('')).toBeNull();
+    expect(duidBusinessRiskTier('geen tier hier')).toBeNull();
+  });
+});
+
 describe('isBlokkerend', () => {
   it('blokkeert een ontbrekende contractnaam', () => {
     expect(isBlokkerend('contract_naam_ontbreekt')).toBe(true);
@@ -78,11 +134,13 @@ describe('isBlokkerend', () => {
 
   it('blokkeert geen waarschuwingen', () => {
     expect(isBlokkerend('vendor_afwijkt')).toBe(false);
-    expect(isBlokkerend('categorie_onbekend')).toBe(false);
-    expect(isBlokkerend('contactgegevens_onvolledig')).toBe(false);
+    expect(isBlokkerend('categorie_wordt_aangemaakt')).toBe(false);
     expect(isBlokkerend('vendor_geen_matchsleutel')).toBe(false);
+    expect(isBlokkerend('extra_contactgegevens_gevonden')).toBe(false);
     expect(isBlokkerend('email_ongeldig')).toBe(false);
     expect(isBlokkerend('datum_ongeldig')).toBe(false);
+    expect(isBlokkerend('business_criticality_onbekend')).toBe(false);
+    expect(isBlokkerend('business_risk_tier_onbekend')).toBe(false);
   });
 });
 
@@ -150,26 +208,30 @@ describe('beoordeelContractImportbestand', () => {
     );
   });
 
-  it('waarschuwt bij alleen een e-mailadres zonder naam', () => {
+  it('accepteert alleen een e-mailadres zonder naam, zonder waarschuwing', () => {
+    // Besluit eigenaar 31-08: een contactpersoon met alleen email of alleen
+    // naam wordt gewoon aangemaakt — eerdere versie behandelde dit als
+    // 'onvolledig' en sloeg de contactpersoon over, wat te streng bleek.
     const resultaat = beoordeelContractImportbestand(
       bestand('Hosting,CN-1,,,,,Acme B.V.,,SUP-1,jan@acme.nl,'),
     );
 
     expect(resultaat.rijen[0].importeerbaar).toBe(true);
-    expect(resultaat.rijen[0].bevindingen.map((b) => b.code)).toContain(
+    expect(resultaat.rijen[0].invoer.contactEmail).toBe('jan@acme.nl');
+    expect(resultaat.rijen[0].invoer.contactFullName).toBeNull();
+    expect(resultaat.rijen[0].bevindingen.map((b) => b.code)).not.toContain(
       'contactgegevens_onvolledig',
     );
   });
 
-  it('waarschuwt bij alleen een naam zonder e-mailadres', () => {
+  it('accepteert alleen een naam zonder e-mailadres, zonder waarschuwing', () => {
     const resultaat = beoordeelContractImportbestand(
       bestand('Hosting,CN-1,,,,,Acme B.V.,,SUP-1,,Jan Jansen'),
     );
 
     expect(resultaat.rijen[0].importeerbaar).toBe(true);
-    expect(resultaat.rijen[0].bevindingen.map((b) => b.code)).toContain(
-      'contactgegevens_onvolledig',
-    );
+    expect(resultaat.rijen[0].invoer.contactEmail).toBeNull();
+    expect(resultaat.rijen[0].invoer.contactFullName).toBe('Jan Jansen');
   });
 
   it('zet startDate/endDate om naar ISO in de genormaliseerde invoer', () => {
@@ -193,5 +255,104 @@ describe('beoordeelContractImportbestand', () => {
     expect(resultaat.rijen[0].invoer.rawAttributes['extra_kolom']).toBe(
       'een waarde',
     );
+  });
+
+  describe('contract.vendor_contact_id als naam (besluit eigenaar 31-08)', () => {
+    it('gebruikt de waarde als naam wanneer vendor_contact.full_name leeg is en de waarde geen UUID is', () => {
+      const koppen =
+        'contract.name;contract.contract_number;contract.contract_type;contract.start_date;contract.end_date;contract.note;vendor.name;vendor.category_code;vendor.coupa_supplier_number;vendor_contact.email;vendor_contact.email;contract.vendor_contact_id';
+      const rij =
+        'Hosting;CN-1;;;;;Acme B.V.;;SUP-1;;bart@b4ict.nl;Bart Philips';
+      const resultaat = beoordeelContractImportbestand(
+        [koppen, rij].join('\n'),
+      );
+
+      expect(resultaat.rijen[0].invoer.contactFullName).toBe('Bart Philips');
+    });
+
+    it('negeert de waarde als vendor_contact.full_name al gevuld is', () => {
+      const koppen =
+        'contract.name;contract.contract_number;vendor.name;vendor.coupa_supplier_number;vendor_contact.email;vendor_contact.full_name;contract.vendor_contact_id';
+      const rij =
+        'Hosting;CN-1;Acme B.V.;SUP-1;jan@acme.nl;Jan Jansen;Andere Naam';
+      const resultaat = beoordeelContractImportbestand(
+        [koppen, rij].join('\n'),
+      );
+
+      expect(resultaat.rijen[0].invoer.contactFullName).toBe('Jan Jansen');
+    });
+
+    it('negeert de waarde als het een geldig UUID is', () => {
+      const koppen =
+        'contract.name;contract.contract_number;vendor.name;vendor.coupa_supplier_number;vendor_contact.email;vendor_contact.full_name;contract.vendor_contact_id';
+      const rij =
+        'Hosting;CN-1;Acme B.V.;SUP-1;;;12345678-1234-1234-1234-123456789012';
+      const resultaat = beoordeelContractImportbestand(
+        [koppen, rij].join('\n'),
+      );
+
+      expect(resultaat.rijen[0].invoer.contactFullName).toBeNull();
+    });
+  });
+
+  describe('dubbele primaire contactkolommen (besluit eigenaar 31-08)', () => {
+    it('houdt het LAATSTE voorkomen van vendor_contact.email aan als primair, eerdere als extra contact', () => {
+      // Besluit eigenaar: in de praktijk staat het betrouwbare adres vaak in
+      // de laatste van meerdere gelijknamige kolommen (een echt
+      // Transdev-testbestand had de eerste leeg of gevuld met een
+      // compliance-URL, de tweede met het echte adres).
+      const koppen =
+        'contract.name;contract.contract_number;vendor.name;vendor.coupa_supplier_number;vendor_contact.email;vendor_contact.email';
+      const rij =
+        'Hosting;CN-1;Acme B.V.;SUP-1;https://klant.afas.nl/certificeringen;jan@acme.nl';
+      const resultaat = beoordeelContractImportbestand(
+        [koppen, rij].join('\n'),
+      );
+
+      expect(resultaat.rijen[0].invoer.contactEmail).toBe('jan@acme.nl');
+      expect(resultaat.rijen[0].invoer.extraContacten).toHaveLength(1);
+      expect(resultaat.rijen[0].invoer.extraContacten[0].email).toBe(
+        'https://klant.afas.nl/certificeringen',
+      );
+    });
+  });
+
+  describe('business_criticality en business_risk_tier (gevonden 31-08, ontbraken volledig)', () => {
+    const koppen =
+      'contract.name;contract.contract_number;vendor.name;vendor.coupa_supplier_number;vendor.business_criticality_code;contract.business_risk_tier_code';
+
+    it('duidt beide velden tegen hun vaste waardenlijst', () => {
+      const rij = 'Hosting;CN-1;Acme B.V.;SUP-1;Hoog;Tier 2  Medium impact';
+      const resultaat = beoordeelContractImportbestand(
+        [koppen, rij].join('\n'),
+      );
+
+      expect(resultaat.rijen[0].invoer.vendorBusinessCriticalityCode).toBe(
+        'high',
+      );
+      expect(resultaat.rijen[0].invoer.contractBusinessRiskTierCode).toBe(
+        'tier_2',
+      );
+      expect(resultaat.rijen[0].bevindingen).toHaveLength(0);
+    });
+
+    it('waarschuwt bij een niet-herkende waarde, blokkeert niet', () => {
+      const rij = 'Hosting;CN-1;Acme B.V.;SUP-1;Onduidelijk;Geen idee';
+      const resultaat = beoordeelContractImportbestand(
+        [koppen, rij].join('\n'),
+      );
+
+      expect(resultaat.rijen[0].importeerbaar).toBe(true);
+      expect(
+        resultaat.rijen[0].invoer.vendorBusinessCriticalityCode,
+      ).toBeNull();
+      expect(resultaat.rijen[0].invoer.contractBusinessRiskTierCode).toBeNull();
+      expect(resultaat.rijen[0].bevindingen.map((b) => b.code)).toEqual(
+        expect.arrayContaining([
+          'business_criticality_onbekend',
+          'business_risk_tier_onbekend',
+        ]),
+      );
+    });
   });
 });

--- a/src/contract-import/contract-import-schema.spec.ts
+++ b/src/contract-import/contract-import-schema.spec.ts
@@ -1,0 +1,197 @@
+import {
+  beoordeelContractImportbestand,
+  emailGeldig,
+  isBlokkerend,
+  leesContractDatum,
+} from './contract-import-schema';
+
+/**
+ * Unittests op een pure functie: geen database, geen HTTP, geen tenant.
+ * Zelfde opzet als `vendor/leverancier-import-schema.spec.ts`.
+ */
+
+describe('leesContractDatum', () => {
+  it('zet DD-MM-JJJJ om naar ISO', () => {
+    expect(leesContractDatum('01-01-2024')).toEqual({
+      waarde: '2024-01-01',
+      geldig: true,
+    });
+  });
+
+  it('geeft null bij een leeg veld', () => {
+    expect(leesContractDatum(null)).toEqual({ waarde: null, geldig: true });
+    expect(leesContractDatum('')).toEqual({ waarde: null, geldig: true });
+    expect(leesContractDatum('  ')).toEqual({ waarde: null, geldig: true });
+  });
+
+  it('verwerpt een ISO-datum (dit bestand verwacht DD-MM-JJJJ)', () => {
+    expect(leesContractDatum('2024-01-01').geldig).toBe(false);
+  });
+
+  it('verwerpt een niet-bestaande datum (31 februari)', () => {
+    expect(leesContractDatum('31-02-2026').geldig).toBe(false);
+  });
+
+  it('verwerpt willekeurige tekst', () => {
+    expect(leesContractDatum('volgende week').geldig).toBe(false);
+  });
+
+  it('accepteert een geldige schrikkeldag', () => {
+    expect(leesContractDatum('29-02-2024')).toEqual({
+      waarde: '2024-02-29',
+      geldig: true,
+    });
+  });
+
+  it('verwerpt een schrikkeldag in een niet-schrikkeljaar', () => {
+    expect(leesContractDatum('29-02-2026').geldig).toBe(false);
+  });
+});
+
+describe('emailGeldig', () => {
+  it('accepteert een gewoon adres', () => {
+    expect(emailGeldig('jan@acme.nl')).toBe(true);
+  });
+
+  it('accepteert leeg', () => {
+    expect(emailGeldig(null)).toBe(true);
+    expect(emailGeldig('')).toBe(true);
+  });
+
+  it('verwerpt een adres zonder @', () => {
+    expect(emailGeldig('jan-acme.nl')).toBe(false);
+  });
+});
+
+describe('isBlokkerend', () => {
+  it('blokkeert een ontbrekende contractnaam', () => {
+    expect(isBlokkerend('contract_naam_ontbreekt')).toBe(true);
+  });
+
+  it('blokkeert een ontbrekende vendornaam', () => {
+    expect(isBlokkerend('vendor_naam_ontbreekt')).toBe(true);
+  });
+
+  it('blokkeert een ongeldige datumvolgorde', () => {
+    expect(isBlokkerend('datum_volgorde_ongeldig')).toBe(true);
+  });
+
+  it('blokkeert geen waarschuwingen', () => {
+    expect(isBlokkerend('vendor_afwijkt')).toBe(false);
+    expect(isBlokkerend('categorie_onbekend')).toBe(false);
+    expect(isBlokkerend('contactgegevens_onvolledig')).toBe(false);
+    expect(isBlokkerend('vendor_geen_matchsleutel')).toBe(false);
+    expect(isBlokkerend('email_ongeldig')).toBe(false);
+    expect(isBlokkerend('datum_ongeldig')).toBe(false);
+  });
+});
+
+describe('beoordeelContractImportbestand', () => {
+  const KOPPEN =
+    'contract.name,contract.contract_number,contract.contract_type,contract.start_date,contract.end_date,contract.note,vendor.name,vendor.category_code,vendor.coupa_supplier_number,vendor_contact.email,vendor_contact.full_name';
+
+  function bestand(...rijen: string[]): string {
+    return [KOPPEN, ...rijen].join('\n');
+  }
+
+  it('herkent alle negen kolommen op hun punt-notatie', () => {
+    const resultaat = beoordeelContractImportbestand(
+      bestand(
+        'Hosting,CN-1,Dienstenovereenkomst,01-01-2024,31-12-2027,Toelichting,Acme B.V.,it,SUP-1,jan@acme.nl,Jan Jansen',
+      ),
+    );
+
+    expect(Object.keys(resultaat.herkendeKolommen)).toHaveLength(11);
+    expect(resultaat.onbekendeKolommen).toEqual([]);
+    expect(resultaat.rijen[0].importeerbaar).toBe(true);
+  });
+
+  it('blokkeert een rij zonder contractnaam', () => {
+    const resultaat = beoordeelContractImportbestand(
+      bestand(',CN-1,,,,,Acme B.V.,,,,'),
+    );
+
+    expect(resultaat.rijen[0].importeerbaar).toBe(false);
+    expect(resultaat.rijen[0].bevindingen.map((b) => b.code)).toContain(
+      'contract_naam_ontbreekt',
+    );
+  });
+
+  it('blokkeert een rij zonder vendornaam', () => {
+    const resultaat = beoordeelContractImportbestand(
+      bestand('Hosting,CN-1,,,,,,,,,'),
+    );
+
+    expect(resultaat.rijen[0].importeerbaar).toBe(false);
+    expect(resultaat.rijen[0].bevindingen.map((b) => b.code)).toContain(
+      'vendor_naam_ontbreekt',
+    );
+  });
+
+  it('waarschuwt bij een ontbrekend coupa-nummer, blokkeert niet', () => {
+    const resultaat = beoordeelContractImportbestand(
+      bestand('Hosting,CN-1,,,,,Acme B.V.,,,,'),
+    );
+
+    expect(resultaat.rijen[0].importeerbaar).toBe(true);
+    expect(resultaat.rijen[0].bevindingen.map((b) => b.code)).toContain(
+      'vendor_geen_matchsleutel',
+    );
+  });
+
+  it('blokkeert wanneer de einddatum vóór de begindatum ligt', () => {
+    const resultaat = beoordeelContractImportbestand(
+      bestand('Hosting,CN-1,,31-12-2027,01-01-2024,,Acme B.V.,,SUP-1,,'),
+    );
+
+    expect(resultaat.rijen[0].importeerbaar).toBe(false);
+    expect(resultaat.rijen[0].bevindingen.map((b) => b.code)).toContain(
+      'datum_volgorde_ongeldig',
+    );
+  });
+
+  it('waarschuwt bij alleen een e-mailadres zonder naam', () => {
+    const resultaat = beoordeelContractImportbestand(
+      bestand('Hosting,CN-1,,,,,Acme B.V.,,SUP-1,jan@acme.nl,'),
+    );
+
+    expect(resultaat.rijen[0].importeerbaar).toBe(true);
+    expect(resultaat.rijen[0].bevindingen.map((b) => b.code)).toContain(
+      'contactgegevens_onvolledig',
+    );
+  });
+
+  it('waarschuwt bij alleen een naam zonder e-mailadres', () => {
+    const resultaat = beoordeelContractImportbestand(
+      bestand('Hosting,CN-1,,,,,Acme B.V.,,SUP-1,,Jan Jansen'),
+    );
+
+    expect(resultaat.rijen[0].importeerbaar).toBe(true);
+    expect(resultaat.rijen[0].bevindingen.map((b) => b.code)).toContain(
+      'contactgegevens_onvolledig',
+    );
+  });
+
+  it('zet startDate/endDate om naar ISO in de genormaliseerde invoer', () => {
+    const resultaat = beoordeelContractImportbestand(
+      bestand('Hosting,CN-1,,01-01-2024,31-12-2027,,Acme B.V.,,SUP-1,,'),
+    );
+
+    expect(resultaat.rijen[0].invoer.startDate).toBe('2024-01-01');
+    expect(resultaat.rijen[0].invoer.endDate).toBe('2027-12-31');
+  });
+
+  it('bewaart onbekende kolommen in rawAttributes zonder ze te blokkeren', () => {
+    const resultaat = beoordeelContractImportbestand(
+      [
+        KOPPEN + ',extra_kolom',
+        'Hosting,CN-1,,,,,Acme B.V.,,SUP-1,,,een waarde',
+      ].join('\n'),
+    );
+
+    expect(resultaat.onbekendeKolommen).toContain('extra_kolom');
+    expect(resultaat.rijen[0].invoer.rawAttributes['extra_kolom']).toBe(
+      'een waarde',
+    );
+  });
+});

--- a/src/contract-import/contract-import-schema.ts
+++ b/src/contract-import/contract-import-schema.ts
@@ -1,0 +1,389 @@
+import { bepaalScheidingsteken, leesCsv } from '../vendor/csv-lezer';
+
+/**
+ * Een contract-CSV inlezen, herkennen en beoordelen — zonder iets weg te
+ * schrijven. Zelfde opzet als `vendor/leverancier-import-schema.ts` (pure
+ * functie, geen database, geen NestJS, geen tenant), maar een ander
+ * kolommencontract: negen kolommen verspreid over `contract`, `vendor` en
+ * `vendor_contact` (#198).
+ *
+ * ── Waarom dit GEEN hergebruik is van leverancier-import-schema.ts ─────────
+ * Die module is gebouwd voor een rijke vendor-only-import (KvK, land, stad,
+ * website, jaarbedrag, impact...). Geen van die velden komt voor in deze
+ * negen kolommen — alleen `vendor.name`, `vendor.category_code` en
+ * `vendor.coupa_supplier_number` zijn gedeeld, en die spelen hier een andere
+ * rol: matchcontext voor een find-or-create, niet velden om rijkelijk te
+ * vullen. Zie docs/superpowers/specs/2026-08-31-contract-import-design.md §0.
+ *
+ * De CSV-lezer zelf (`csv-lezer.ts`) is wel hergebruikt — dat stuk is
+ * generiek (RFC4180) en heeft niets met vendors of contracten te maken.
+ */
+
+/** De velden die MCM2 uit een contract-importbestand haalt. */
+export interface ContractImportInvoer {
+  contractName: string;
+  contractNumber: string | null;
+  contractType: string | null;
+  /** ISO-vorm (JJJJ-MM-DD) ná omzetting, ongeacht bronformaat. */
+  startDate: string | null;
+  endDate: string | null;
+  note: string | null;
+  vendorName: string;
+  vendorCategoryCode: string | null;
+  vendorCoupaSupplierNumber: string | null;
+  contactEmail: string | null;
+  contactFullName: string | null;
+  /** Elke kolom uit het bestand, ongewijzigd, op de originele kopnaam. */
+  rawAttributes: Record<string, string>;
+}
+
+/** Waarom een rij niet gebruikt kan worden, of aandacht vraagt. */
+export type ContractBevindingCode =
+  | 'contract_naam_ontbreekt'
+  | 'vendor_naam_ontbreekt'
+  | 'datum_ongeldig'
+  | 'datum_volgorde_ongeldig'
+  | 'email_ongeldig'
+  | 'vendor_geen_matchsleutel'
+  | 'vendor_afwijkt'
+  | 'categorie_onbekend'
+  | 'contactgegevens_onvolledig';
+
+/** Blokkerend = deze rij kan niet geïmporteerd worden. */
+const BLOKKEREND: ReadonlySet<ContractBevindingCode> =
+  new Set<ContractBevindingCode>([
+    'contract_naam_ontbreekt',
+    'vendor_naam_ontbreekt',
+    'datum_volgorde_ongeldig',
+  ]);
+
+export interface ContractBevinding {
+  code: ContractBevindingCode;
+  /** Voor een mens leesbaar, in het Nederlands. */
+  melding: string;
+  blokkerend: boolean;
+}
+
+export interface BeoordeeldeContractRij {
+  /** Regelnummer in het bestand, koprij meegeteld. */
+  regel: number;
+  invoer: ContractImportInvoer;
+  bevindingen: ContractBevinding[];
+  importeerbaar: boolean;
+}
+
+export interface ContractImportBeoordeling {
+  koppen: string[];
+  herkendeKolommen: Record<string, string>;
+  onbekendeKolommen: string[];
+  scheidingsteken: string;
+  rijen: BeoordeeldeContractRij[];
+  samenvatting: {
+    totaal: number;
+    importeerbaar: number;
+    geblokkeerd: number;
+    metWaarschuwing: number;
+    perCode: Record<string, number>;
+  };
+}
+
+/**
+ * Kopnaam → veld. Nederlandse namen plus de vorm die de gap-analyse-export
+ * gebruikt (punt-notatie zoals `contract.name`). Kleine letters, want
+ * kopteksten variëren in schrijfwijze.
+ */
+const KOLOM_ALIASSEN: Record<
+  string,
+  keyof Omit<ContractImportInvoer, 'rawAttributes'>
+> = {
+  'contract.name': 'contractName',
+  contractnaam: 'contractName',
+  'naam contract': 'contractName',
+
+  'contract.contract_number': 'contractNumber',
+  contractnummer: 'contractNumber',
+
+  'contract.contract_type': 'contractType',
+  contracttype: 'contractType',
+
+  'contract.start_date': 'startDate',
+  startdatum: 'startDate',
+
+  'contract.end_date': 'endDate',
+  einddatum: 'endDate',
+
+  'contract.note': 'note',
+  notitie: 'note',
+  toelichting: 'note',
+
+  'vendor.name': 'vendorName',
+  leverancier: 'vendorName',
+  leveranciersnaam: 'vendorName',
+
+  'vendor.category_code': 'vendorCategoryCode',
+  categorie: 'vendorCategoryCode',
+
+  'vendor.coupa_supplier_number': 'vendorCoupaSupplierNumber',
+  'coupa supplier number': 'vendorCoupaSupplierNumber',
+  coupanummer: 'vendorCoupaSupplierNumber',
+
+  'vendor_contact.email': 'contactEmail',
+  'contact email': 'contactEmail',
+  contactpersoon_email: 'contactEmail',
+
+  'vendor_contact.full_name': 'contactFullName',
+  'contact naam': 'contactFullName',
+  contactpersoon_naam: 'contactFullName',
+};
+
+/**
+ * Grove vormcontrole op een e-mailadres. Zelfde regel als
+ * `leverancier-import-schema.ts`.
+ */
+export function emailGeldig(ruw: string | null): boolean {
+  if (ruw === null || ruw.trim() === '') return true;
+  const t = ruw.trim();
+  return /^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(t);
+}
+
+/**
+ * Zet een `DD-MM-YYYY`-datum (het bronformaat van deze CSV, besluit
+ * eigenaar 2026-08-31) om naar ISO (`JJJJ-MM-DD`), zoals de rest van de
+ * applicatie verwacht (`contract-invoer.ts`'s `optioneleDatum`).
+ *
+ * Geeft `null` bij een leeg veld, en `{ geldig: false }` bij een niet te
+ * herkennen formaat — nooit een gok naar een andere datum.
+ */
+export function leesContractDatum(ruw: string | null): {
+  waarde: string | null;
+  geldig: boolean;
+} {
+  if (ruw === null) return { waarde: null, geldig: true };
+
+  const schoon = ruw.trim();
+  if (schoon === '') return { waarde: null, geldig: true };
+
+  const match = /^(\d{2})-(\d{2})-(\d{4})$/.exec(schoon);
+  if (!match) {
+    return { waarde: null, geldig: false };
+  }
+
+  const [, dag, maand, jaar] = match;
+  const iso = `${jaar}-${maand}-${dag}`;
+
+  // Bouw de datum terug en vergelijk: verwerpt 31-02-2026, niet alleen de
+  // vorm. new Date met een month-index (maand - 1) rondt anders stilzwijgend
+  // af naar de eerstvolgende geldige datum.
+  const dagGetal = Number(dag);
+  const maandGetal = Number(maand);
+  const jaarGetal = Number(jaar);
+  const gecontroleerd = new Date(Date.UTC(jaarGetal, maandGetal - 1, dagGetal));
+
+  const geldig =
+    gecontroleerd.getUTCFullYear() === jaarGetal &&
+    gecontroleerd.getUTCMonth() === maandGetal - 1 &&
+    gecontroleerd.getUTCDate() === dagGetal;
+
+  return geldig
+    ? { waarde: iso, geldig: true }
+    : { waarde: null, geldig: false };
+}
+
+/** Alleen voor tests en foutmeldingen: welke bevindingcodes blokkeren. */
+export function isBlokkerend(code: ContractBevindingCode): boolean {
+  return BLOKKEREND.has(code);
+}
+
+/**
+ * Leest de tekst in en beoordeelt elke rij. Schrijft niets weg, doet geen
+ * databasequery — vendor/contact-matching gebeurt pas bij het bevestigen
+ * (`contract-import.service.ts`), binnen de tenanttransactie. Deze functie
+ * kan daarom niet de `vendor_afwijkt`/`categorie_onbekend`-bevindingen
+ * vaststellen (die vragen een databaseraadpleging) — die worden tijdens het
+ * bevestigen toegevoegd aan het resultaat, niet hier tijdens de preview.
+ */
+export function beoordeelContractImportbestand(
+  tekst: string,
+): ContractImportBeoordeling {
+  const inhoud = leesCsv(tekst);
+
+  const herkendeKolommen: Record<string, string> = {};
+  const onbekendeKolommen: string[] = [];
+
+  const veldPerIndex: (
+    keyof Omit<ContractImportInvoer, 'rawAttributes'> | null
+  )[] = inhoud.koppen.map((kop) => {
+    const veld = KOLOM_ALIASSEN[kop.toLowerCase()] ?? null;
+    if (veld) herkendeKolommen[kop] = veld;
+    else if (kop.trim() !== '') onbekendeKolommen.push(kop);
+    return veld;
+  });
+
+  const rijen: BeoordeeldeContractRij[] = inhoud.rijen.map((cellen, index) => {
+    const regel = index + 2; // koprij is regel 1
+    const invoer = maakInvoer(cellen, inhoud.koppen, veldPerIndex);
+    const bevindingen: ContractBevinding[] = [];
+
+    if (invoer.contractName.trim() === '') {
+      bevindingen.push({
+        code: 'contract_naam_ontbreekt',
+        melding: 'Deze rij heeft geen contractnaam.',
+        blokkerend: true,
+      });
+    }
+
+    if (invoer.vendorName.trim() === '') {
+      bevindingen.push({
+        code: 'vendor_naam_ontbreekt',
+        melding: 'Deze rij heeft geen leveranciersnaam.',
+        blokkerend: true,
+      });
+    }
+
+    if (
+      invoer.vendorCoupaSupplierNumber === null ||
+      invoer.vendorCoupaSupplierNumber.trim() === ''
+    ) {
+      bevindingen.push({
+        code: 'vendor_geen_matchsleutel',
+        melding:
+          'Geen Coupa-leveranciersnummer: deze rij maakt altijd een nieuwe leverancier aan, ook als er al een leverancier met deze naam bestaat.',
+        blokkerend: false,
+      });
+    }
+
+    const startResultaat = leesContractDatum(invoer.startDate);
+    if (!startResultaat.geldig) {
+      bevindingen.push({
+        code: 'datum_ongeldig',
+        melding: `'${invoer.startDate}' is geen geldige datum (verwacht DD-MM-JJJJ).`,
+        blokkerend: false,
+      });
+    }
+
+    const eindResultaat = leesContractDatum(invoer.endDate);
+    if (!eindResultaat.geldig) {
+      bevindingen.push({
+        code: 'datum_ongeldig',
+        melding: `'${invoer.endDate}' is geen geldige datum (verwacht DD-MM-JJJJ).`,
+        blokkerend: false,
+      });
+    }
+
+    if (
+      startResultaat.geldig &&
+      eindResultaat.geldig &&
+      startResultaat.waarde &&
+      eindResultaat.waarde &&
+      startResultaat.waarde > eindResultaat.waarde
+    ) {
+      bevindingen.push({
+        code: 'datum_volgorde_ongeldig',
+        melding: 'De einddatum ligt vóór de begindatum.',
+        blokkerend: true,
+      });
+    }
+
+    if (!emailGeldig(invoer.contactEmail)) {
+      bevindingen.push({
+        code: 'email_ongeldig',
+        melding: `'${invoer.contactEmail}' lijkt geen e-mailadres.`,
+        blokkerend: false,
+      });
+    }
+
+    const heeftEmail =
+      invoer.contactEmail !== null && invoer.contactEmail.trim() !== '';
+    const heeftNaam =
+      invoer.contactFullName !== null && invoer.contactFullName.trim() !== '';
+
+    if (heeftEmail !== heeftNaam) {
+      bevindingen.push({
+        code: 'contactgegevens_onvolledig',
+        melding:
+          'Alleen e-mailadres of alleen naam ingevuld: dit contract wordt aangemaakt zonder contactpersoon.',
+        blokkerend: false,
+      });
+    }
+
+    // Genormaliseerde datums teruggeven in ISO, ongeacht of ze geldig waren
+    // (bij ongeldig blijft de waarde null — de bevinding hierboven maakt
+    // duidelijk waarom).
+    invoer.startDate = startResultaat.waarde;
+    invoer.endDate = eindResultaat.waarde;
+
+    return {
+      regel,
+      invoer,
+      bevindingen,
+      importeerbaar: !bevindingen.some((b) => b.blokkerend),
+    };
+  });
+
+  const perCode: Record<string, number> = {};
+  for (const rij of rijen) {
+    for (const b of rij.bevindingen) {
+      perCode[b.code] = (perCode[b.code] ?? 0) + 1;
+    }
+  }
+
+  return {
+    koppen: inhoud.koppen,
+    herkendeKolommen,
+    onbekendeKolommen,
+    scheidingsteken: inhoud.scheidingsteken,
+    rijen,
+    samenvatting: {
+      totaal: rijen.length,
+      importeerbaar: rijen.filter((r) => r.importeerbaar).length,
+      geblokkeerd: rijen.filter((r) => !r.importeerbaar).length,
+      metWaarschuwing: rijen.filter(
+        (r) => r.importeerbaar && r.bevindingen.length > 0,
+      ).length,
+      perCode,
+    },
+  };
+}
+
+function maakInvoer(
+  cellen: string[],
+  koppen: string[],
+  veldPerIndex: (keyof Omit<ContractImportInvoer, 'rawAttributes'> | null)[],
+): ContractImportInvoer {
+  const invoer: ContractImportInvoer = {
+    contractName: '',
+    contractNumber: null,
+    contractType: null,
+    startDate: null,
+    endDate: null,
+    note: null,
+    vendorName: '',
+    vendorCategoryCode: null,
+    vendorCoupaSupplierNumber: null,
+    contactEmail: null,
+    contactFullName: null,
+    rawAttributes: {},
+  };
+
+  cellen.forEach((cel, i) => {
+    const waarde = cel.trim();
+
+    const kop = koppen[i];
+    if (kop !== undefined && kop.trim() !== '') {
+      invoer.rawAttributes[kop] = waarde;
+    }
+
+    const veld = veldPerIndex[i];
+    if (!veld) return;
+
+    if (veld === 'contractName' || veld === 'vendorName') {
+      invoer[veld] = waarde;
+    } else {
+      invoer[veld] = waarde === '' ? null : waarde;
+    }
+  });
+
+  return invoer;
+}
+
+export { bepaalScheidingsteken, leesCsv };

--- a/src/contract-import/contract-import-schema.ts
+++ b/src/contract-import/contract-import-schema.ts
@@ -19,6 +19,18 @@ import { bepaalScheidingsteken, leesCsv } from '../vendor/csv-lezer';
  * generiek (RFC4180) en heeft niets met vendors of contracten te maken.
  */
 
+/**
+ * Een extra contactkanaal naast het primaire paar — uit een genummerde
+ * kolom (`vendor_contact.email_2`, `vendor_contact.full_name_2`, ...). Zie
+ * design-document §10.3: bewust geen vendor_contact-rij, alleen een
+ * hulplijst om na de import handmatig te verwerken.
+ */
+export interface ExtraContactInvoer {
+  volgnummer: number;
+  email: string | null;
+  fullName: string | null;
+}
+
 /** De velden die MCM2 uit een contract-importbestand haalt. */
 export interface ContractImportInvoer {
   contractName: string;
@@ -31,8 +43,13 @@ export interface ContractImportInvoer {
   vendorName: string;
   vendorCategoryCode: string | null;
   vendorCoupaSupplierNumber: string | null;
+  /** Geduid tegen de vaste, platform-brede waardenlijst (ref.business_criticality). */
+  vendorBusinessCriticalityCode: string | null;
+  /** Geduid tegen de vaste, platform-brede waardenlijst (ref.business_risk_tier). */
+  contractBusinessRiskTierCode: string | null;
   contactEmail: string | null;
   contactFullName: string | null;
+  extraContacten: ExtraContactInvoer[];
   /** Elke kolom uit het bestand, ongewijzigd, op de originele kopnaam. */
   rawAttributes: Record<string, string>;
 }
@@ -46,8 +63,10 @@ export type ContractBevindingCode =
   | 'email_ongeldig'
   | 'vendor_geen_matchsleutel'
   | 'vendor_afwijkt'
-  | 'categorie_onbekend'
-  | 'contactgegevens_onvolledig';
+  | 'categorie_wordt_aangemaakt'
+  | 'business_criticality_onbekend'
+  | 'business_risk_tier_onbekend'
+  | 'extra_contactgegevens_gevonden';
 
 /** Blokkerend = deze rij kan niet geïmporteerd worden. */
 const BLOKKEREND: ReadonlySet<ContractBevindingCode> =
@@ -94,7 +113,7 @@ export interface ContractImportBeoordeling {
  */
 const KOLOM_ALIASSEN: Record<
   string,
-  keyof Omit<ContractImportInvoer, 'rawAttributes'>
+  keyof Omit<ContractImportInvoer, 'rawAttributes' | 'extraContacten'>
 > = {
   'contract.name': 'contractName',
   contractnaam: 'contractName',
@@ -127,6 +146,14 @@ const KOLOM_ALIASSEN: Record<
   'coupa supplier number': 'vendorCoupaSupplierNumber',
   coupanummer: 'vendorCoupaSupplierNumber',
 
+  'vendor.business_criticality_code': 'vendorBusinessCriticalityCode',
+  criticaliteit: 'vendorBusinessCriticalityCode',
+  'cyber criticaliteit': 'vendorBusinessCriticalityCode',
+
+  'contract.business_risk_tier_code': 'contractBusinessRiskTierCode',
+  'business risk tier': 'contractBusinessRiskTierCode',
+  risicoclassificatie: 'contractBusinessRiskTierCode',
+
   'vendor_contact.email': 'contactEmail',
   'contact email': 'contactEmail',
   contactpersoon_email: 'contactEmail',
@@ -147,9 +174,55 @@ export function emailGeldig(ruw: string | null): boolean {
 }
 
 /**
- * Zet een `DD-MM-YYYY`-datum (het bronformaat van deze CSV, besluit
+ * Duidt `vendor.business_criticality_code` tegen de vaste, platform-brede
+ * waardenlijst (`ref.business_criticality`: critical/high/medium/low).
+ * Anders dan vendor-categorie mag dit veld GEEN nieuwe waarden aanmaken —
+ * het is platform-breed, niet tenant-eigen. `null` bij een niet-herkende
+ * tekst; de rij blokkeert daar niet op, het veld blijft dan leeg.
+ */
+export function duidBusinessCriticality(
+  ruw: string | null,
+): 'critical' | 'high' | 'medium' | 'low' | null {
+  if (ruw === null) return null;
+  const t = ruw.trim().toLowerCase();
+  if (t === '') return null;
+  if (t.startsWith('krit') || t.startsWith('critical')) return 'critical';
+  if (t.startsWith('hoog') || t.startsWith('high')) return 'high';
+  if (
+    t.startsWith('gemidd') ||
+    t.startsWith('midden') ||
+    t.startsWith('medium')
+  )
+    return 'medium';
+  if (t.startsWith('laag') || t.startsWith('low')) return 'low';
+  return null;
+}
+
+/**
+ * Duidt `contract.business_risk_tier_code` tegen de vaste, platform-brede
+ * waardenlijst (`ref.business_risk_tier`: tier_1/tier_2/tier_3). Een echte
+ * export schrijft de rest van de tekst erbij ('Tier 2  Medium impact') —
+ * alleen het cijfer bepaalt de match, de rest van de tekst wordt genegeerd.
+ */
+export function duidBusinessRiskTier(
+  ruw: string | null,
+): 'tier_1' | 'tier_2' | 'tier_3' | null {
+  if (ruw === null) return null;
+  const match = /tier\s*([123])/i.exec(ruw);
+  if (!match) return null;
+  return `tier_${match[1]}` as const as 'tier_1' | 'tier_2' | 'tier_3';
+}
+
+/**
+ * Zet een `D(D)-M(M)-YYYY`-datum (het bronformaat van deze CSV, besluit
  * eigenaar 2026-08-31) om naar ISO (`JJJJ-MM-DD`), zoals de rest van de
  * applicatie verwacht (`contract-invoer.ts`'s `optioneleDatum`).
+ *
+ * Dag en maand mogen zowel `1` als `01` zijn: een échte Transdev-export
+ * (Coupa/Excel) schrijft standaard zonder voorloopnul (`1-4-2019`), en een
+ * regex die alleen `\d{2}` toestond wees zulke — geldige — datums af als
+ * "onbekend formaat" (gevonden bij het eerste gebruik van deze import,
+ * 2026-08-31).
  *
  * Geeft `null` bij een leeg veld, en `{ geldig: false }` bij een niet te
  * herkennen formaat — nooit een gok naar een andere datum.
@@ -163,13 +236,13 @@ export function leesContractDatum(ruw: string | null): {
   const schoon = ruw.trim();
   if (schoon === '') return { waarde: null, geldig: true };
 
-  const match = /^(\d{2})-(\d{2})-(\d{4})$/.exec(schoon);
+  const match = /^(\d{1,2})-(\d{1,2})-(\d{4})$/.exec(schoon);
   if (!match) {
     return { waarde: null, geldig: false };
   }
 
   const [, dag, maand, jaar] = match;
-  const iso = `${jaar}-${maand}-${dag}`;
+  const iso = `${jaar}-${maand.padStart(2, '0')}-${dag.padStart(2, '0')}`;
 
   // Bouw de datum terug en vergelijk: verwerpt 31-02-2026, niet alleen de
   // vorm. new Date met een month-index (maand - 1) rondt anders stilzwijgend
@@ -202,6 +275,50 @@ export function isBlokkerend(code: ContractBevindingCode): boolean {
  * vaststellen (die vragen een databaseraadpleging) — die worden tijdens het
  * bevestigen toegevoegd aan het resultaat, niet hier tijdens de preview.
  */
+const UUID_REGEX_LOKAAL =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/**
+ * Kopnaam van een kolom die `contract.vendor_contact_id` (of een schrijfvariant
+ * daarvan) heet. Een echte Transdev-export vult deze kolom in de praktijk met
+ * een NAAM ("Bart Philips") in plaats van een ID — de kolom is voor een
+ * toekomstige, correcte koppeling naar een bestaand contactpersoon-ID bedoeld,
+ * maar wordt in de praktijk als naamveld gebruikt (gevonden 31-08, besluit
+ * eigenaar: alleen gebruiken als `vendor_contact.full_name` zelf leeg is, en
+ * alleen als de waarde geen geldig UUID is — anders zou het een echte
+ * ID-verwijzing kunnen zijn).
+ */
+function isVendorContactIdKolom(kopKleineLetters: string): boolean {
+  return (
+    kopKleineLetters === 'contract.vendor_contact_id' ||
+    kopKleineLetters === 'vendor_contact_id'
+  );
+}
+
+/**
+ * Herkent `vendor_contact.email_2`, `vendor_contact.full_name_3`, enz. —
+ * genummerde kolommen voor extra contactkanalen naast het primaire paar
+ * (design-document §10.3). `null` als de kop geen genummerde
+ * contact-kolom is.
+ */
+function herkenExtraContactKolom(
+  kopKleineLetters: string,
+): { soort: 'email' | 'fullName'; volgnummer: number } | null {
+  const match = /^vendor_contact\.(email|full_name)_(\d+)$/.exec(
+    kopKleineLetters,
+  );
+  if (!match) return null;
+
+  const [, soort, volgnummerRuw] = match;
+  const volgnummer = Number(volgnummerRuw);
+
+  // _1 zou het primaire paar dupliceren (dat heeft al geen suffix) — niet
+  // als extra kolom behandelen, gewoon als onbekende kolom laten vallen.
+  if (volgnummer < 2) return null;
+
+  return { soort: soort === 'email' ? 'email' : 'fullName', volgnummer };
+}
+
 export function beoordeelContractImportbestand(
   tekst: string,
 ): ContractImportBeoordeling {
@@ -210,18 +327,111 @@ export function beoordeelContractImportbestand(
   const herkendeKolommen: Record<string, string> = {};
   const onbekendeKolommen: string[] = [];
 
+  // Index -> extra-contact-plek, apart van veldPerIndex: een genummerde
+  // kolom hoort niet bij een vast ContractImportInvoer-veld maar bij een
+  // dynamische lijst (extraContacten).
+  const extraContactPerIndex: ReturnType<typeof herkenExtraContactKolom>[] = [];
   const veldPerIndex: (
-    keyof Omit<ContractImportInvoer, 'rawAttributes'> | null
-  )[] = inhoud.koppen.map((kop) => {
-    const veld = KOLOM_ALIASSEN[kop.toLowerCase()] ?? null;
-    if (veld) herkendeKolommen[kop] = veld;
-    else if (kop.trim() !== '') onbekendeKolommen.push(kop);
-    return veld;
+    keyof Omit<ContractImportInvoer, 'rawAttributes' | 'extraContacten'> | null
+  )[] = [];
+
+  // Index van de 'contract.vendor_contact_id'-kolom, indien aanwezig — apart
+  // van veldPerIndex omdat de conditie (leeg + geen UUID) pas ná de volledige
+  // rij bekend is, zie maakInvoer().
+  let vendorContactIdKolomIndex: number | null = null;
+
+  // Meerdere kolommen met dezelfde kopnaam voor het PRIMAIRE contactpaar
+  // (`vendor_contact.email` twee keer, zoals een echt Transdev-testbestand
+  // had) mogen het primaire veld niet stilzwijgend overschrijven. Besluit
+  // eigenaar 31-08: het LAATSTE voorkomen is primair (in de praktijk staat
+  // het echte adres/de echte naam vaak in de laatste van zulke kolommen,
+  // de eerdere zijn leeg of bevatten een compliance-URL) — alle eerdere
+  // voorkomens worden genummerde extra contacten. Daarom eerst alle indexen
+  // per veld verzamelen (pass 1), dan pas toewijzen (pass 2).
+  const indexenPerContactVeld: Record<
+    'contactEmail' | 'contactFullName',
+    number[]
+  > = { contactEmail: [], contactFullName: [] };
+
+  inhoud.koppen.forEach((kop, index) => {
+    const kopKleineLetters = kop.toLowerCase();
+    if (isVendorContactIdKolom(kopKleineLetters)) return;
+    const veld = KOLOM_ALIASSEN[kopKleineLetters] ?? null;
+    if (veld === 'contactEmail' || veld === 'contactFullName') {
+      indexenPerContactVeld[veld].push(index);
+    }
+  });
+
+  let volgendVrijVolgnummer = 2;
+
+  inhoud.koppen.forEach((kop, index) => {
+    const kopKleineLetters = kop.toLowerCase();
+
+    if (isVendorContactIdKolom(kopKleineLetters)) {
+      herkendeKolommen[kop] = 'contactFullName (indien geen UUID)';
+      vendorContactIdKolomIndex = index;
+      extraContactPerIndex.push(null);
+      veldPerIndex.push(null);
+      return;
+    }
+
+    const veld = KOLOM_ALIASSEN[kopKleineLetters] ?? null;
+
+    if (veld === 'contactEmail' || veld === 'contactFullName') {
+      const indexen = indexenPerContactVeld[veld];
+      const primaireIndex = indexen[indexen.length - 1];
+
+      if (index !== primaireIndex) {
+        // Niet het laatste (= primaire) voorkomen: naar extraContacten.
+        // Elke zo'n kolom krijgt een eigen volgnummer — twee dubbele
+        // kolommen (email + naam) in hetzelfde bestand komen dus in APARTE
+        // extra contacten terecht, niet per se bij elkaar. Bewuste,
+        // eenvoudige keuze: zonder een suffix in de kopnaam is er geen
+        // manier om vast te stellen dat twee dubbele kolommen bij dezelfde
+        // extra persoon horen.
+        const soort = veld === 'contactEmail' ? 'email' : 'fullName';
+        const eigenVolgnummer = volgendVrijVolgnummer++;
+        herkendeKolommen[kop] = `extraContact.${soort}_${eigenVolgnummer}`;
+        extraContactPerIndex.push({ soort, volgnummer: eigenVolgnummer });
+        veldPerIndex.push(null);
+        return;
+      }
+    }
+
+    if (veld) {
+      herkendeKolommen[kop] = veld;
+      extraContactPerIndex.push(null);
+      veldPerIndex.push(veld);
+      return;
+    }
+
+    const extraContact = herkenExtraContactKolom(kopKleineLetters);
+    if (extraContact) {
+      herkendeKolommen[kop] =
+        `extraContact.${extraContact.soort}_${extraContact.volgnummer}`;
+      extraContactPerIndex.push(extraContact);
+      veldPerIndex.push(null);
+      volgendVrijVolgnummer = Math.max(
+        volgendVrijVolgnummer,
+        extraContact.volgnummer + 1,
+      );
+      return;
+    }
+
+    extraContactPerIndex.push(null);
+    veldPerIndex.push(null);
+    if (kop.trim() !== '') onbekendeKolommen.push(kop);
   });
 
   const rijen: BeoordeeldeContractRij[] = inhoud.rijen.map((cellen, index) => {
     const regel = index + 2; // koprij is regel 1
-    const invoer = maakInvoer(cellen, inhoud.koppen, veldPerIndex);
+    const invoer = maakInvoer(
+      cellen,
+      inhoud.koppen,
+      veldPerIndex,
+      extraContactPerIndex,
+      vendorContactIdKolomIndex,
+    );
     const bevindingen: ContractBevinding[] = [];
 
     if (invoer.contractName.trim() === '') {
@@ -292,19 +502,47 @@ export function beoordeelContractImportbestand(
       });
     }
 
-    const heeftEmail =
-      invoer.contactEmail !== null && invoer.contactEmail.trim() !== '';
-    const heeftNaam =
-      invoer.contactFullName !== null && invoer.contactFullName.trim() !== '';
-
-    if (heeftEmail !== heeftNaam) {
+    if (invoer.extraContacten.length > 0) {
       bevindingen.push({
-        code: 'contactgegevens_onvolledig',
-        melding:
-          'Alleen e-mailadres of alleen naam ingevuld: dit contract wordt aangemaakt zonder contactpersoon.',
+        code: 'extra_contactgegevens_gevonden',
+        melding: `${invoer.extraContacten.length} extra contactgegeven(s) gevonden — worden niet automatisch verwerkt, zie de lijst na bevestigen.`,
         blokkerend: false,
       });
     }
+
+    // Duiding tegen de vaste, platform-brede waardenlijsten. Kan hier al
+    // gebeuren (geen databasequery nodig, anders dan vendor-categorie) —
+    // een niet-herkende tekst wordt gemeld en het veld blijft leeg, in
+    // plaats van te blokkeren.
+    const ruweBusinessCriticality = invoer.vendorBusinessCriticalityCode;
+    const geduideCriticality = duidBusinessCriticality(ruweBusinessCriticality);
+    if (
+      ruweBusinessCriticality !== null &&
+      ruweBusinessCriticality.trim() !== '' &&
+      geduideCriticality === null
+    ) {
+      bevindingen.push({
+        code: 'business_criticality_onbekend',
+        melding: `'${ruweBusinessCriticality}' is geen herkende cyber-criticaliteit (verwacht Hoog/Gemiddeld/Laag/Kritiek).`,
+        blokkerend: false,
+      });
+    }
+    invoer.vendorBusinessCriticalityCode = geduideCriticality;
+
+    const ruweRiskTier = invoer.contractBusinessRiskTierCode;
+    const geduideRiskTier = duidBusinessRiskTier(ruweRiskTier);
+    if (
+      ruweRiskTier !== null &&
+      ruweRiskTier.trim() !== '' &&
+      geduideRiskTier === null
+    ) {
+      bevindingen.push({
+        code: 'business_risk_tier_onbekend',
+        melding: `'${ruweRiskTier}' is geen herkende risicoclassificatie (verwacht Tier 1/2/3).`,
+        blokkerend: false,
+      });
+    }
+    invoer.contractBusinessRiskTierCode = geduideRiskTier;
 
     // Genormaliseerde datums teruggeven in ISO, ongeacht of ze geldig waren
     // (bij ongeldig blijft de waarde null — de bevinding hierboven maakt
@@ -348,7 +586,11 @@ export function beoordeelContractImportbestand(
 function maakInvoer(
   cellen: string[],
   koppen: string[],
-  veldPerIndex: (keyof Omit<ContractImportInvoer, 'rawAttributes'> | null)[],
+  veldPerIndex: (
+    keyof Omit<ContractImportInvoer, 'rawAttributes' | 'extraContacten'> | null
+  )[],
+  extraContactPerIndex: ReturnType<typeof herkenExtraContactKolom>[],
+  vendorContactIdKolomIndex: number | null,
 ): ContractImportInvoer {
   const invoer: ContractImportInvoer = {
     contractName: '',
@@ -360,10 +602,18 @@ function maakInvoer(
     vendorName: '',
     vendorCategoryCode: null,
     vendorCoupaSupplierNumber: null,
+    vendorBusinessCriticalityCode: null,
+    contractBusinessRiskTierCode: null,
     contactEmail: null,
     contactFullName: null,
+    extraContacten: [],
     rawAttributes: {},
   };
+
+  // volgnummer -> plek in extraContacten, zodat email_2 en full_name_2 in
+  // hetzelfde ExtraContactInvoer-object landen, ook als ze niet naast
+  // elkaar in de koprij staan.
+  const extraPerVolgnummer = new Map<number, ExtraContactInvoer>();
 
   cellen.forEach((cel, i) => {
     const waarde = cel.trim();
@@ -371,6 +621,23 @@ function maakInvoer(
     const kop = koppen[i];
     if (kop !== undefined && kop.trim() !== '') {
       invoer.rawAttributes[kop] = waarde;
+    }
+
+    const extraContact = extraContactPerIndex[i];
+    if (extraContact) {
+      let plek = extraPerVolgnummer.get(extraContact.volgnummer);
+      if (!plek) {
+        plek = {
+          volgnummer: extraContact.volgnummer,
+          email: null,
+          fullName: null,
+        };
+        extraPerVolgnummer.set(extraContact.volgnummer, plek);
+      }
+      if (waarde !== '') {
+        plek[extraContact.soort] = waarde;
+      }
+      return;
     }
 
     const veld = veldPerIndex[i];
@@ -382,6 +649,24 @@ function maakInvoer(
       invoer[veld] = waarde === '' ? null : waarde;
     }
   });
+
+  // Alleen volgnummers met minstens één ingevuld veld meenemen — een lege
+  // email_3/full_name_3-combinatie is geen extra contactgegeven, gewoon een
+  // lege kolom.
+  invoer.extraContacten = Array.from(extraPerVolgnummer.values())
+    .filter((c) => c.email !== null || c.fullName !== null)
+    .sort((a, b) => a.volgnummer - b.volgnummer);
+
+  // 'contract.vendor_contact_id' als naam gebruiken: alleen als
+  // vendor_contact.full_name zelf leeg bleef, én de waarde geen geldig UUID
+  // is (anders is het mogelijk een echte ID-verwijzing). Besluit eigenaar
+  // 31-08, zie isVendorContactIdKolom().
+  if (vendorContactIdKolomIndex !== null && invoer.contactFullName === null) {
+    const ruweWaarde = cellen[vendorContactIdKolomIndex]?.trim();
+    if (ruweWaarde && !UUID_REGEX_LOKAAL.test(ruweWaarde)) {
+      invoer.contactFullName = ruweWaarde;
+    }
+  }
 
   return invoer;
 }

--- a/src/contract-import/contract-import.controller.ts
+++ b/src/contract-import/contract-import.controller.ts
@@ -1,0 +1,75 @@
+import {
+  Body,
+  Controller,
+  Param,
+  Post,
+  Req,
+  UseGuards,
+  UseInterceptors,
+  UploadedFile,
+  BadRequestException,
+} from '@nestjs/common';
+import { FileInterceptor } from '@nestjs/platform-express';
+
+import {
+  TenantContextGuard,
+  type RequestMetSessie,
+} from '../auth/tenant-context.guard';
+import { PlatformAdminGuard } from '../platform/platform-admin.guard';
+import { ContractImportService } from './contract-import.service';
+
+/** Zelfde grens als de bestaande bijlage-upload (survey-response.controller.ts). */
+const MAX_BESTANDSGROOTTE = 5 * 1024 * 1024;
+
+/**
+ * Admin-only contract-import (#198): CSV → preview → bevestigen.
+ *
+ * Twee guards op klasseniveau, zelfde patroon als `PlatformController`:
+ * `TenantContextGuard` stelt de sessie vast, `PlatformAdminGuard` kijkt of
+ * die persoon platformbeheerder is. De tenant komt uit `sessie.tenantId` —
+ * een platformbeheerder kiest zijn doeltenant vooraf via het bestaande
+ * `POST /platform/sessie/wisselen`, niet via een veld in deze routes
+ * (MCM2-CLAUDE.md §6).
+ */
+@Controller('platform/contract-import')
+@UseGuards(TenantContextGuard, PlatformAdminGuard)
+export class ContractImportController {
+  constructor(private readonly imports: ContractImportService) {}
+
+  @Post('preview')
+  @UseInterceptors(
+    FileInterceptor('file', {
+      limits: { fileSize: MAX_BESTANDSGROOTTE, files: 1 },
+    }),
+  )
+  async preview(
+    @Req() request: RequestMetSessie,
+    @UploadedFile()
+    bestand:
+      { originalname: string; mimetype?: string; buffer: Buffer } | undefined,
+  ) {
+    if (!bestand) {
+      throw new BadRequestException('Er is geen bestand meegestuurd.');
+    }
+
+    const sessie = request.sessie!;
+
+    const { jobId, beoordeling } = await this.imports.preview(
+      sessie.tenantId,
+      sessie.userId,
+      bestand,
+    );
+
+    return { jobId, beoordeling };
+  }
+
+  @Post(':jobId/bevestigen')
+  async bevestigen(
+    @Param('jobId') jobId: string,
+    @Body() _body: unknown,
+    @Req() request: RequestMetSessie,
+  ) {
+    const sessie = request.sessie!;
+    return this.imports.bevestigen(sessie.tenantId, jobId);
+  }
+}

--- a/src/contract-import/contract-import.module.ts
+++ b/src/contract-import/contract-import.module.ts
@@ -1,0 +1,21 @@
+import { Module } from '@nestjs/common';
+
+import { AuthModule } from '../auth/auth.module';
+import { PlatformModule } from '../platform/platform.module';
+import { ContractImportAuditService } from './contract-import-audit.service';
+import { ContractImportController } from './contract-import.controller';
+import { ContractImportService } from './contract-import.service';
+
+/**
+ * Admin-only contract-import (#198).
+ *
+ * `AuthModule` levert `TenantContextGuard`, `PlatformModule` levert
+ * `PlatformAdminGuard` (geëxporteerd zodat deze module hem kan hergebruiken
+ * in plaats van een tweede registratie van dezelfde guard).
+ */
+@Module({
+  imports: [AuthModule, PlatformModule],
+  controllers: [ContractImportController],
+  providers: [ContractImportService, ContractImportAuditService],
+})
+export class ContractImportModule {}

--- a/src/contract-import/contract-import.service.ts
+++ b/src/contract-import/contract-import.service.ts
@@ -47,6 +47,25 @@ function leegIsNull(waarde: string | null | undefined): string | null {
   return getrimd === '' ? null : getrimd;
 }
 
+/**
+ * Zet vrije tekst ('ICT', 'Vastgoed & Facility Management') om naar een
+ * code-vorm die aansluit bij de bestaande, handmatig aangemaakte
+ * categorieën ('it_services', 'facilities'): kleine letters,
+ * spaties/leestekens naar underscore, geen dubbele/rand-underscores.
+ * Niet uniek gegarandeerd tussen twee verschillende teksten die toevallig
+ * tot dezelfde slug normaliseren — de primary key (tenant_id, code) vangt
+ * dat af door de bestaande rij te hergebruiken in plaats van te dupliceren.
+ */
+function naarCategorieCode(tekst: string): string {
+  return tekst
+    .trim()
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[̀-ͯ]/g, '') // diakritische tekens (é, ë, ...)
+    .replace(/[^a-z0-9]+/g, '_')
+    .replace(/^_+|_+$/g, '');
+}
+
 export interface PreviewResultaat {
   jobId: string;
   beoordeling: ContractImportBeoordeling;
@@ -59,6 +78,8 @@ export interface BevestigResultaat {
   hergebruikteVendors: number;
   aangemaakteContacten: number;
   hergebruikteContacten: number;
+  aangemaakteCategorieen: number;
+  extraContactenGevonden: number;
   overgeslagen: number;
   rijen: {
     regel: number;
@@ -67,6 +88,8 @@ export interface BevestigResultaat {
     vendorAangemaakt: boolean;
     vendorAfwijkt: boolean;
     contactAangemaakt: boolean;
+    categorieAangemaakt: boolean;
+    extraContacten: number;
     bevindingen: string[];
   }[];
 }
@@ -117,7 +140,7 @@ export class ContractImportService {
       const job = jobResultaat.rows[0].job_id;
 
       for (const rij of beoordeling.rijen) {
-        await tx.execute(
+        const rowResultaat = await tx.execute<{ row_id: string }>(
           sql`INSERT INTO clm.import_row
                 (tenant_id, job_id, row_number, raw_data, normalized_data,
                  findings, importable)
@@ -125,8 +148,23 @@ export class ContractImportService {
                       ${JSON.stringify(rij.invoer.rawAttributes)}::jsonb,
                       ${JSON.stringify(rij.invoer)}::jsonb,
                       ${JSON.stringify(rij.bevindingen)}::jsonb,
-                      ${rij.importeerbaar})`,
+                      ${rij.importeerbaar})
+              RETURNING row_id`,
         );
+
+        const rowId = rowResultaat.rows[0].row_id;
+
+        // Extra contactgegevens (email_2, full_name_2, ...) meteen bij de
+        // preview vastleggen — dit is een hulplijst, geen find-or-create,
+        // dus er is niets om pas bij bevestigen te doen (design-document §10.3).
+        for (const extra of rij.invoer.extraContacten) {
+          await tx.execute(
+            sql`INSERT INTO clm.import_extra_contact
+                  (tenant_id, row_id, volgnummer, email, full_name)
+                VALUES (${tenantId}, ${rowId}, ${extra.volgnummer},
+                        ${extra.email}, ${extra.fullName})`,
+          );
+        }
       }
 
       return job;
@@ -183,12 +221,15 @@ export class ContractImportService {
       let hergebruikteVendors = 0;
       let aangemaakteContacten = 0;
       let hergebruikteContacten = 0;
+      let aangemaakteCategorieen = 0;
+      let extraContactenGevonden = 0;
       let overgeslagen = 0;
 
       const rijResultaten: BevestigResultaat['rijen'] = [];
 
       for (const rij of rijenResultaat.rows) {
         const invoer = rij.normalized_data;
+        extraContactenGevonden += invoer.extraContacten.length;
 
         if (!rij.importable) {
           overgeslagen++;
@@ -202,6 +243,8 @@ export class ContractImportService {
             vendorAangemaakt: false,
             vendorAfwijkt: false,
             contactAangemaakt: false,
+            categorieAangemaakt: false,
+            extraContacten: invoer.extraContacten.length,
             bevindingen: rij.findings.map((f) => f.melding),
           });
           continue;
@@ -214,12 +257,13 @@ export class ContractImportService {
         );
         if (vendorUitkomst.aangemaakt) aangemaakteVendors++;
         else hergebruikteVendors++;
+        if (vendorUitkomst.categorieAangemaakt) aangemaakteCategorieen++;
 
         let contactId: string | null = null;
         let contactAangemaakt = false;
 
         if (
-          leegIsNull(invoer.contactEmail) &&
+          leegIsNull(invoer.contactEmail) ||
           leegIsNull(invoer.contactFullName)
         ) {
           const contactUitkomst = await this.vindOfMaakContact(
@@ -237,7 +281,8 @@ export class ContractImportService {
         const contractResultaat = await tx.execute<{ contract_id: string }>(
           sql`INSERT INTO clm.contract
                 (tenant_id, vendor_id, name, contract_number, contract_type,
-                 start_date, end_date, note, vendor_contact_id)
+                 start_date, end_date, note, vendor_contact_id,
+                 business_risk_tier_code)
               VALUES (${tenantId}, ${vendorUitkomst.vendorId},
                       ${invoer.contractName.trim()},
                       ${leegIsNull(invoer.contractNumber)},
@@ -245,7 +290,8 @@ export class ContractImportService {
                       ${leegIsNull(invoer.startDate)},
                       ${leegIsNull(invoer.endDate)},
                       ${leegIsNull(invoer.note)},
-                      ${contactId})
+                      ${contactId},
+                      ${leegIsNull(invoer.contractBusinessRiskTierCode)})
               RETURNING contract_id`,
         );
 
@@ -270,6 +316,8 @@ export class ContractImportService {
           vendorAangemaakt: vendorUitkomst.aangemaakt,
           vendorAfwijkt: vendorUitkomst.afwijkt,
           contactAangemaakt,
+          categorieAangemaakt: vendorUitkomst.categorieAangemaakt,
+          extraContacten: invoer.extraContacten.length,
           bevindingen: rij.findings.map((f) => f.melding),
         });
       }
@@ -290,12 +338,14 @@ export class ContractImportService {
           hergebruikteVendors,
           aangemaakteContacten,
           hergebruikteContacten,
+          aangemaakteCategorieen,
+          extraContactenGevonden,
           overgeslagen,
         },
       });
 
       this.logger.log(
-        `Contract-import bevestigd (${jobId}): ${aangemaakteContracten} contracten, ${aangemaakteVendors} nieuwe/${hergebruikteVendors} bestaande leveranciers.`,
+        `Contract-import bevestigd (${jobId}): ${aangemaakteContracten} contracten, ${aangemaakteVendors} nieuwe/${hergebruikteVendors} bestaande leveranciers, ${aangemaakteCategorieen} nieuwe categorieën, ${extraContactenGevonden} extra contactgegevens gevonden.`,
       );
 
       return {
@@ -305,6 +355,8 @@ export class ContractImportService {
         hergebruikteVendors,
         aangemaakteContacten,
         hergebruikteContacten,
+        aangemaakteCategorieen,
+        extraContactenGevonden,
         overgeslagen,
         rijen: rijResultaten,
       };
@@ -324,7 +376,12 @@ export class ContractImportService {
     tx: TenantTransaction,
     tenantId: string,
     invoer: ContractImportInvoer,
-  ): Promise<{ vendorId: string; aangemaakt: boolean; afwijkt: boolean }> {
+  ): Promise<{
+    vendorId: string;
+    aangemaakt: boolean;
+    afwijkt: boolean;
+    categorieAangemaakt: boolean;
+  }> {
     const coupaNummer = leegIsNull(invoer.vendorCoupaSupplierNumber);
 
     if (coupaNummer) {
@@ -353,28 +410,19 @@ export class ContractImportService {
           vendorId: bestaandeVendor.vendor_id,
           aangemaakt: false,
           afwijkt,
+          categorieAangemaakt: false,
         };
       }
     }
 
-    const categorieCode = leegIsNull(invoer.vendorCategoryCode);
-    let geldigeCategorie: string | null = null;
-
-    if (categorieCode) {
-      const categorieBestaat = await tx.execute<{ code: string }>(
-        sql`SELECT code FROM ref.vendor_category
-             WHERE tenant_id = ${tenantId} AND code = ${categorieCode}`,
-      );
-      // Onbekende categorie: waarschuwing staat al op de rij via de
-      // bevindingen die tijdens bevestigen niet opnieuw berekend worden —
-      // hier alleen het gedrag: veld blijft leeg i.p.v. een FK-fout.
-      geldigeCategorie =
-        categorieBestaat.rows.length > 0 ? categorieCode : null;
-    }
+    const { code: categorieCode, aangemaakt: categorieAangemaakt } =
+      await this.vindOfMaakCategorie(tx, tenantId, invoer.vendorCategoryCode);
 
     const nieuw = await tx.execute<{ vendor_id: string }>(
-      sql`INSERT INTO clm.vendor (tenant_id, name, category_code, coupa_supplier_number)
-          VALUES (${tenantId}, ${invoer.vendorName.trim()}, ${geldigeCategorie}, ${coupaNummer})
+      sql`INSERT INTO clm.vendor
+            (tenant_id, name, category_code, coupa_supplier_number, business_criticality_code)
+          VALUES (${tenantId}, ${invoer.vendorName.trim()}, ${categorieCode}, ${coupaNummer},
+                  ${leegIsNull(invoer.vendorBusinessCriticalityCode)})
           RETURNING vendor_id`,
     );
 
@@ -382,7 +430,47 @@ export class ContractImportService {
       vendorId: nieuw.rows[0].vendor_id,
       aangemaakt: true,
       afwijkt: false,
+      categorieAangemaakt,
     };
+  }
+
+  /**
+   * Vindt een vendor-categorie op code binnen de tenant, of maakt hem aan.
+   *
+   * Besluit eigenaar (31-08, na het eerste gebruik tegen een echt
+   * Transdev-testbestand): een echte export gebruikt vrije tekst ('ICT',
+   * 'Vastgoed & Facility Management') die vrijwel nooit exact overeenkomt
+   * met de korte codes die een tenant al heeft ('it_services',
+   * 'facilities'). Eerder liet dit veld gewoon leeg bij een onbekende code
+   * — dat verloor de categorie stilzwijgend. Nu: aanmaken, met de
+   * genormaliseerde tekst als code en de originele tekst als label. Een
+   * mens kan later opschonen/samenvoegen via /vendor-categories.
+   */
+  private async vindOfMaakCategorie(
+    tx: TenantTransaction,
+    tenantId: string,
+    categorieRuw: string | null,
+  ): Promise<{ code: string | null; aangemaakt: boolean }> {
+    const categorieTekst = leegIsNull(categorieRuw);
+    if (!categorieTekst) return { code: null, aangemaakt: false };
+
+    const code = naarCategorieCode(categorieTekst);
+
+    const bestaand = await tx.execute<{ code: string }>(
+      sql`SELECT code FROM ref.vendor_category
+           WHERE tenant_id = ${tenantId} AND code = ${code}`,
+    );
+
+    if (bestaand.rows.length > 0) {
+      return { code, aangemaakt: false };
+    }
+
+    await tx.execute(
+      sql`INSERT INTO ref.vendor_category (tenant_id, code, label)
+          VALUES (${tenantId}, ${code}, ${categorieTekst})`,
+    );
+
+    return { code, aangemaakt: true };
   }
 
   /**
@@ -391,6 +479,13 @@ export class ContractImportService {
    * met hetzelfde e-mailadres maar een andere naam zijn twee verschillende
    * contactpunten bij dezelfde vendor (bijv. een persoon vs. een
    * afdelingspostbus).
+   *
+   * `clm.vendor_contact.full_name` is `NOT NULL` (bestaand, niet te wijzigen
+   * schema) — alleen `email` is nullable. Bij alleen een e-mailadres (geen
+   * naam) gebruikt de INSERT daarom het e-mailadres zelf als voorlopige naam
+   * (besluit eigenaar 31-08), en de matchquery zoekt op diezelfde effectieve
+   * naam — anders zou een tweede import met dezelfde alleen-email-rij het
+   * eerder aangemaakte contact nooit hergebruiken.
    */
   private async vindOfMaakContact(
     tx: TenantTransaction,
@@ -399,12 +494,16 @@ export class ContractImportService {
     invoer: ContractImportInvoer,
   ): Promise<{ contactId: string; aangemaakt: boolean }> {
     const email = leegIsNull(invoer.contactEmail);
-    const naam = leegIsNull(invoer.contactFullName);
+    const naam = leegIsNull(invoer.contactFullName) ?? email;
 
+    // IS NOT DISTINCT FROM i.p.v. `=`: bij een NULL email (alleen naam
+    // ingevuld — besluit eigenaar 31-08, geen 'onvolledig' meer) geeft `=`
+    // altijd NULL, dus zou de match nooit slagen en elke import een nieuw
+    // contact aanmaken in plaats van het bestaande te hergebruiken.
     const bestaand = await tx.execute<{ contact_id: string }>(
       sql`SELECT contact_id FROM clm.vendor_contact
            WHERE vendor_id = ${vendorId}
-             AND email = ${email}
+             AND email IS NOT DISTINCT FROM ${email}
              AND full_name = ${naam}
              AND deleted_at IS NULL
            LIMIT 1`,

--- a/src/contract-import/contract-import.service.ts
+++ b/src/contract-import/contract-import.service.ts
@@ -1,0 +1,439 @@
+import { createHash } from 'node:crypto';
+
+import {
+  ConflictException,
+  Injectable,
+  Logger,
+  NotFoundException,
+} from '@nestjs/common';
+import { sql } from 'drizzle-orm';
+
+import { DatabaseService } from '../db/database.service';
+import type { TenantTransaction } from '../db/database.service';
+import { ContractImportAuditService } from './contract-import-audit.service';
+import {
+  beoordeelContractImportbestand,
+  type ContractImportBeoordeling,
+  type ContractImportInvoer,
+} from './contract-import-schema';
+
+/**
+ * Contract-import: preview + bevestigen, met find-or-create op vendor en
+ * vendor_contact (#198).
+ *
+ * ── Waarom hier eigen, kleine INSERT's staan i.p.v. VendorService/ContractService
+ * aan te roepen ────────────────────────────────────────────────────────────────
+ * Beide services openen zelf een `withTenant()`-transactie. De import wil één
+ * transactie voor de hele CSV (besluit eigenaar, 2026-08-31: eenvoud en een
+ * harde alles-of-niets-garantie wegen zwaarder dan hergebruik hier). Die twee
+ * eisen zijn niet te combineren zonder de bestaande services te herstructureren
+ * — en dat is bewust NIET gedaan (besluit eigenaar, 2026-08-31: "niet te ver
+ * gaan", geen wijziging aan bestaande, geteste services voor deze import).
+ *
+ * De INSERT's hieronder zijn daarom kleine, letterlijke echo's van wat
+ * `VendorService.maakAan()` (kolommen: tenant_id, name, category_code,
+ * coupa_supplier_number) en het contactpersoon-blok in `vendor.service.ts`
+ * doen — alleen smaller, want deze import vult geen KvK, land, website etc.
+ * Wijzigt een van die twee services zijn kolommen, dan moet dit bestand
+ * meebewegen; er is geen andere koppeling tussen de twee.
+ */
+
+const UUID_REGEX =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+function leegIsNull(waarde: string | null | undefined): string | null {
+  if (waarde === null || waarde === undefined) return null;
+  const getrimd = waarde.trim();
+  return getrimd === '' ? null : getrimd;
+}
+
+export interface PreviewResultaat {
+  jobId: string;
+  beoordeling: ContractImportBeoordeling;
+}
+
+export interface BevestigResultaat {
+  jobId: string;
+  aangemaakteContracten: number;
+  aangemaakteVendors: number;
+  hergebruikteVendors: number;
+  aangemaakteContacten: number;
+  hergebruikteContacten: number;
+  overgeslagen: number;
+  rijen: {
+    regel: number;
+    result: 'created' | 'skipped';
+    contractId: string | null;
+    vendorAangemaakt: boolean;
+    vendorAfwijkt: boolean;
+    contactAangemaakt: boolean;
+    bevindingen: string[];
+  }[];
+}
+
+interface ImportRowRij extends Record<string, unknown> {
+  row_id: string;
+  row_number: number;
+  normalized_data: ContractImportInvoer;
+  importable: boolean;
+  findings: { code: string; melding: string; blokkerend: boolean }[];
+}
+
+@Injectable()
+export class ContractImportService {
+  private readonly logger = new Logger(ContractImportService.name);
+
+  constructor(
+    private readonly db: DatabaseService,
+    private readonly audit: ContractImportAuditService,
+  ) {}
+
+  /**
+   * Beoordeelt een CSV-bestand en legt het resultaat vast als `import_job`
+   * (status 'preview') met een `import_row` per brondrij. Schrijft nog geen
+   * enkel contract, vendor of contactpersoon weg.
+   */
+  async preview(
+    tenantId: string,
+    userId: string,
+    bestand: { originalname: string; buffer: Buffer },
+  ): Promise<PreviewResultaat> {
+    const tekst = bestand.buffer.toString('utf8');
+    const beoordeling = beoordeelContractImportbestand(tekst);
+
+    const fileHash = this.berekenHash(bestand.buffer);
+
+    const jobId = await this.db.withTenant(tenantId, async (tx) => {
+      const jobResultaat = await tx.execute<{ job_id: string }>(
+        sql`INSERT INTO clm.import_job
+              (tenant_id, import_type, created_by_user_id, filename,
+               file_hash, row_count, status)
+            VALUES (${tenantId}, 'contract', ${userId},
+                    ${bestand.originalname}, ${fileHash},
+                    ${beoordeling.rijen.length}, 'preview')
+            RETURNING job_id`,
+      );
+
+      const job = jobResultaat.rows[0].job_id;
+
+      for (const rij of beoordeling.rijen) {
+        await tx.execute(
+          sql`INSERT INTO clm.import_row
+                (tenant_id, job_id, row_number, raw_data, normalized_data,
+                 findings, importable)
+              VALUES (${tenantId}, ${job}, ${rij.regel},
+                      ${JSON.stringify(rij.invoer.rawAttributes)}::jsonb,
+                      ${JSON.stringify(rij.invoer)}::jsonb,
+                      ${JSON.stringify(rij.bevindingen)}::jsonb,
+                      ${rij.importeerbaar})`,
+        );
+      }
+
+      return job;
+    });
+
+    this.logger.log(
+      `Contract-importpreview aangemaakt (${jobId}): ${beoordeling.samenvatting.totaal} rijen, ${beoordeling.samenvatting.importeerbaar} importeerbaar.`,
+    );
+
+    return { jobId, beoordeling };
+  }
+
+  /**
+   * Schrijft de importeerbare rijen van een preview-job definitief weg, in
+   * één transactie voor de hele job (besluit eigenaar: eenvoud en een harde
+   * alles-of-niets-garantie, geen batches). Een job kan maar één keer
+   * bevestigd worden.
+   */
+  async bevestigen(
+    tenantId: string,
+    jobId: string,
+  ): Promise<BevestigResultaat> {
+    if (!UUID_REGEX.test(jobId)) {
+      throw new NotFoundException('Onbekende import-job.');
+    }
+
+    return this.db.withTenant(tenantId, async (tx) => {
+      const jobResultaat = await tx.execute<{
+        job_id: string;
+        status: string;
+      }>(
+        sql`SELECT job_id, status FROM clm.import_job WHERE job_id = ${jobId}`,
+      );
+
+      if (jobResultaat.rows.length === 0) {
+        throw new NotFoundException('Onbekende import-job.');
+      }
+
+      if (jobResultaat.rows[0].status === 'bevestigd') {
+        throw new ConflictException(
+          'Deze import is al eerder bevestigd. Start een nieuwe import.',
+        );
+      }
+
+      const rijenResultaat = await tx.execute<ImportRowRij>(
+        sql`SELECT row_id, row_number, normalized_data, importable, findings
+              FROM clm.import_row
+             WHERE job_id = ${jobId}
+             ORDER BY row_number`,
+      );
+
+      let aangemaakteContracten = 0;
+      let aangemaakteVendors = 0;
+      let hergebruikteVendors = 0;
+      let aangemaakteContacten = 0;
+      let hergebruikteContacten = 0;
+      let overgeslagen = 0;
+
+      const rijResultaten: BevestigResultaat['rijen'] = [];
+
+      for (const rij of rijenResultaat.rows) {
+        const invoer = rij.normalized_data;
+
+        if (!rij.importable) {
+          overgeslagen++;
+          await tx.execute(
+            sql`UPDATE clm.import_row SET result = 'skipped' WHERE row_id = ${rij.row_id}`,
+          );
+          rijResultaten.push({
+            regel: rij.row_number,
+            result: 'skipped',
+            contractId: null,
+            vendorAangemaakt: false,
+            vendorAfwijkt: false,
+            contactAangemaakt: false,
+            bevindingen: rij.findings.map((f) => f.melding),
+          });
+          continue;
+        }
+
+        const vendorUitkomst = await this.vindOfMaakVendor(
+          tx,
+          tenantId,
+          invoer,
+        );
+        if (vendorUitkomst.aangemaakt) aangemaakteVendors++;
+        else hergebruikteVendors++;
+
+        let contactId: string | null = null;
+        let contactAangemaakt = false;
+
+        if (
+          leegIsNull(invoer.contactEmail) &&
+          leegIsNull(invoer.contactFullName)
+        ) {
+          const contactUitkomst = await this.vindOfMaakContact(
+            tx,
+            tenantId,
+            vendorUitkomst.vendorId,
+            invoer,
+          );
+          contactId = contactUitkomst.contactId;
+          contactAangemaakt = contactUitkomst.aangemaakt;
+          if (contactAangemaakt) aangemaakteContacten++;
+          else hergebruikteContacten++;
+        }
+
+        const contractResultaat = await tx.execute<{ contract_id: string }>(
+          sql`INSERT INTO clm.contract
+                (tenant_id, vendor_id, name, contract_number, contract_type,
+                 start_date, end_date, note, vendor_contact_id)
+              VALUES (${tenantId}, ${vendorUitkomst.vendorId},
+                      ${invoer.contractName.trim()},
+                      ${leegIsNull(invoer.contractNumber)},
+                      ${leegIsNull(invoer.contractType)},
+                      ${leegIsNull(invoer.startDate)},
+                      ${leegIsNull(invoer.endDate)},
+                      ${leegIsNull(invoer.note)},
+                      ${contactId})
+              RETURNING contract_id`,
+        );
+
+        const contractId = contractResultaat.rows[0].contract_id;
+        aangemaakteContracten++;
+
+        await tx.execute(
+          sql`UPDATE clm.import_row
+                 SET result = 'created',
+                     created_contract_id = ${contractId},
+                     created_vendor_id = ${vendorUitkomst.aangemaakt ? vendorUitkomst.vendorId : null},
+                     matched_vendor_id = ${vendorUitkomst.aangemaakt ? null : vendorUitkomst.vendorId},
+                     created_contact_id = ${contactAangemaakt ? contactId : null},
+                     matched_contact_id = ${contactId && !contactAangemaakt ? contactId : null}
+               WHERE row_id = ${rij.row_id}`,
+        );
+
+        rijResultaten.push({
+          regel: rij.row_number,
+          result: 'created',
+          contractId,
+          vendorAangemaakt: vendorUitkomst.aangemaakt,
+          vendorAfwijkt: vendorUitkomst.afwijkt,
+          contactAangemaakt,
+          bevindingen: rij.findings.map((f) => f.melding),
+        });
+      }
+
+      await tx.execute(
+        sql`UPDATE clm.import_job
+               SET status = 'bevestigd', confirmed_at = now()
+             WHERE job_id = ${jobId}`,
+      );
+
+      await this.audit.leg(tx, {
+        tenantId,
+        actie: 'contract_import_bevestigd',
+        jobId,
+        details: {
+          aangemaakteContracten,
+          aangemaakteVendors,
+          hergebruikteVendors,
+          aangemaakteContacten,
+          hergebruikteContacten,
+          overgeslagen,
+        },
+      });
+
+      this.logger.log(
+        `Contract-import bevestigd (${jobId}): ${aangemaakteContracten} contracten, ${aangemaakteVendors} nieuwe/${hergebruikteVendors} bestaande leveranciers.`,
+      );
+
+      return {
+        jobId,
+        aangemaakteContracten,
+        aangemaakteVendors,
+        hergebruikteVendors,
+        aangemaakteContacten,
+        hergebruikteContacten,
+        overgeslagen,
+        rijen: rijResultaten,
+      };
+    });
+  }
+
+  /**
+   * Vindt een vendor op `coupa_supplier_number` binnen de tenant, of maakt er
+   * een aan. Werkt bewust nooit bij: een gematchte vendor met afwijkende
+   * `name`/`category_code` in de CSV blijft in de database ongewijzigd
+   * (besluit eigenaar, create_only). Deze functie berekent geen
+   * `vendor_afwijkt`-waarschuwing (dat vraagt een vergelijking die niet in
+   * het resultaat van `bevestigen()` wordt teruggegeven in deze eenvoudige
+   * v1) — zie het design-document §11 voor deze bewuste beperking.
+   */
+  private async vindOfMaakVendor(
+    tx: TenantTransaction,
+    tenantId: string,
+    invoer: ContractImportInvoer,
+  ): Promise<{ vendorId: string; aangemaakt: boolean; afwijkt: boolean }> {
+    const coupaNummer = leegIsNull(invoer.vendorCoupaSupplierNumber);
+
+    if (coupaNummer) {
+      const bestaand = await tx.execute<{
+        vendor_id: string;
+        name: string;
+        category_code: string | null;
+      }>(
+        sql`SELECT vendor_id, name, category_code FROM clm.vendor
+             WHERE coupa_supplier_number = ${coupaNummer}
+               AND deleted_at IS NULL
+             LIMIT 1`,
+      );
+
+      if (bestaand.rows.length > 0) {
+        // Nooit bijwerken (create_only-uitgangspunt, besluit eigenaar
+        // 2026-08-31) — alleen signaleren of de CSV afwijkt van wat er al
+        // staat, zodat een mens het achteraf kan beoordelen.
+        const bestaandeVendor = bestaand.rows[0];
+        const categorieCode = leegIsNull(invoer.vendorCategoryCode);
+        const afwijkt =
+          bestaandeVendor.name.trim() !== invoer.vendorName.trim() ||
+          (categorieCode ?? null) !== (bestaandeVendor.category_code ?? null);
+
+        return {
+          vendorId: bestaandeVendor.vendor_id,
+          aangemaakt: false,
+          afwijkt,
+        };
+      }
+    }
+
+    const categorieCode = leegIsNull(invoer.vendorCategoryCode);
+    let geldigeCategorie: string | null = null;
+
+    if (categorieCode) {
+      const categorieBestaat = await tx.execute<{ code: string }>(
+        sql`SELECT code FROM ref.vendor_category
+             WHERE tenant_id = ${tenantId} AND code = ${categorieCode}`,
+      );
+      // Onbekende categorie: waarschuwing staat al op de rij via de
+      // bevindingen die tijdens bevestigen niet opnieuw berekend worden —
+      // hier alleen het gedrag: veld blijft leeg i.p.v. een FK-fout.
+      geldigeCategorie =
+        categorieBestaat.rows.length > 0 ? categorieCode : null;
+    }
+
+    const nieuw = await tx.execute<{ vendor_id: string }>(
+      sql`INSERT INTO clm.vendor (tenant_id, name, category_code, coupa_supplier_number)
+          VALUES (${tenantId}, ${invoer.vendorName.trim()}, ${geldigeCategorie}, ${coupaNummer})
+          RETURNING vendor_id`,
+    );
+
+    return {
+      vendorId: nieuw.rows[0].vendor_id,
+      aangemaakt: true,
+      afwijkt: false,
+    };
+  }
+
+  /**
+   * Vindt een contactpersoon op (vendor_id, email, full_name), of maakt er
+   * een aan. Beide velden samen als sleutel (besluit eigenaar): twee rijen
+   * met hetzelfde e-mailadres maar een andere naam zijn twee verschillende
+   * contactpunten bij dezelfde vendor (bijv. een persoon vs. een
+   * afdelingspostbus).
+   */
+  private async vindOfMaakContact(
+    tx: TenantTransaction,
+    tenantId: string,
+    vendorId: string,
+    invoer: ContractImportInvoer,
+  ): Promise<{ contactId: string; aangemaakt: boolean }> {
+    const email = leegIsNull(invoer.contactEmail);
+    const naam = leegIsNull(invoer.contactFullName);
+
+    const bestaand = await tx.execute<{ contact_id: string }>(
+      sql`SELECT contact_id FROM clm.vendor_contact
+           WHERE vendor_id = ${vendorId}
+             AND email = ${email}
+             AND full_name = ${naam}
+             AND deleted_at IS NULL
+           LIMIT 1`,
+    );
+
+    if (bestaand.rows.length > 0) {
+      return { contactId: bestaand.rows[0].contact_id, aangemaakt: false };
+    }
+
+    // Eerste contactpersoon van de vendor wordt vanzelf primair — zelfde
+    // regel als vendor.service.ts, zodat een via import aangemaakte
+    // leverancier ook meteen een aanspreekpunt heeft.
+    const aantal = await tx.execute<{ n: string }>(
+      sql`SELECT count(*) AS n FROM clm.vendor_contact
+           WHERE vendor_id = ${vendorId} AND deleted_at IS NULL`,
+    );
+    const wordtPrimair = Number(aantal.rows[0].n) === 0;
+
+    const nieuw = await tx.execute<{ contact_id: string }>(
+      sql`INSERT INTO clm.vendor_contact
+            (vendor_id, tenant_id, full_name, email, is_primary)
+          VALUES (${vendorId}, ${tenantId}, ${naam}, ${email}, ${wordtPrimair})
+          RETURNING contact_id`,
+    );
+
+    return { contactId: nieuw.rows[0].contact_id, aangemaakt: true };
+  }
+
+  private berekenHash(buffer: Buffer): string {
+    return createHash('sha256').update(buffer).digest('hex');
+  }
+}

--- a/src/db/rechten-contract.ts
+++ b/src/db/rechten-contract.ts
@@ -109,6 +109,14 @@ export const TABELRECHTEN: Readonly<Record<string, Tabelrechten>> = {
   // redenering als contract_survey_template hierboven.
   'clm.vendor_compliance_thema': ['SELECT', 'INSERT', 'DELETE'],
 
+  // clm.import_job / clm.import_row (0035, #198): admin-only contract-import.
+  // Een job/rij die eenmaal bevestigd is, wordt niet meer gewijzigd of
+  // verwijderd door de applicatie — het is het traceerbaarheidsspoor van de
+  // import. UPDATE is wél nodig: bevestigen zet import_job.status en
+  // import_row.result/created_*/matched_* na aanmaak van de preview-rijen.
+  'clm.import_job': NIET_VERWIJDEREN,
+  'clm.import_row': NIET_VERWIJDEREN,
+
   // ── Van nature append-only ─────────────────────────────────────────────────
   //
   // Een oordeel, een notitie of een koppeling verdwijnt niet: hij wordt zacht

--- a/src/db/rechten-contract.ts
+++ b/src/db/rechten-contract.ts
@@ -117,6 +117,10 @@ export const TABELRECHTEN: Readonly<Record<string, Tabelrechten>> = {
   'clm.import_job': NIET_VERWIJDEREN,
   'clm.import_row': NIET_VERWIJDEREN,
 
+  // clm.import_extra_contact (0036, #198): puur append-only hulplijst, wordt
+  // nooit bijgewerkt of verwijderd door de applicatie.
+  'clm.import_extra_contact': ['SELECT', 'INSERT'],
+
   // ── Van nature append-only ─────────────────────────────────────────────────
   //
   // Een oordeel, een notitie of een koppeling verdwijnt niet: hij wordt zacht

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -556,6 +556,29 @@ export const importRow = clm.table(
   ],
 );
 
+// Extra contactgegevens (email_2, full_name_2, ...) die niet in het
+// primaire paar pasten — hulplijst, geen vendor_contact-rij, geen
+// koppeling. Zie migratie 0036, design-document §10.3.
+export const importExtraContact = clm.table(
+  'import_extra_contact',
+  {
+    extraContactId: uuid('extra_contact_id').primaryKey().defaultRandom(),
+    tenantId: uuid('tenant_id')
+      .notNull()
+      .references(() => tenant.tenantId, { onDelete: 'cascade' }),
+    rowId: uuid('row_id')
+      .notNull()
+      .references(() => importRow.rowId, { onDelete: 'cascade' }),
+    volgnummer: integer('volgnummer').notNull(),
+    email: text('email'),
+    fullName: text('full_name'),
+  },
+  (t) => [
+    index('import_extra_contact_tenant_id_idx').on(t.tenantId),
+    index('import_extra_contact_row_id_idx').on(t.rowId),
+  ],
+);
+
 export const contractSurveyTemplate = clm.table(
   'contract_survey_template',
   {

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -481,6 +481,81 @@ export const contract = clm.table(
   ],
 );
 
+// ─── clm schema: admin-only contract-import (#198) ─────────────────────────
+// Zie docs/superpowers/specs/2026-08-31-contract-import-design.md, migratie 0035.
+
+export const importJob = clm.table(
+  'import_job',
+  {
+    jobId: uuid('job_id').primaryKey().defaultRandom(),
+    tenantId: uuid('tenant_id')
+      .notNull()
+      .references(() => tenant.tenantId, { onDelete: 'cascade' }),
+    // v1 kent uitsluitend 'contract'. Los veld i.p.v. alleen migratie 0035's
+    // scope, zodat een toekomstig tweede importtype geen migratie op deze
+    // tabel vraagt — alleen een nieuwe waarde en een eigen module.
+    importType: text('import_type').notNull(),
+    createdByUserId: uuid('created_by_user_id')
+      .notNull()
+      .references(() => user.userId, { onDelete: 'restrict' }),
+    filename: text('filename').notNull(),
+    fileHash: text('file_hash').notNull(),
+    rowCount: integer('row_count').notNull(),
+    status: text('status').notNull(), // 'preview' | 'bevestigd'
+    createdAt: timestamp('created_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    confirmedAt: timestamp('confirmed_at', { withTimezone: true }),
+  },
+  (t) => [index('import_job_tenant_id_idx').on(t.tenantId)],
+);
+
+export const importRow = clm.table(
+  'import_row',
+  {
+    rowId: uuid('row_id').primaryKey().defaultRandom(),
+    tenantId: uuid('tenant_id')
+      .notNull()
+      .references(() => tenant.tenantId, { onDelete: 'cascade' }),
+    jobId: uuid('job_id')
+      .notNull()
+      .references(() => importJob.jobId, { onDelete: 'cascade' }),
+    rowNumber: integer('row_number').notNull(),
+    rawData: jsonb('raw_data').notNull(),
+    normalizedData: jsonb('normalized_data').notNull(),
+    findings: jsonb('findings').notNull(),
+    importable: boolean('importable').notNull(),
+    result: text('result'), // null tot bevestigd: 'created' | 'skipped' | 'failed'
+    createdContractId: uuid('created_contract_id').references(
+      () => contract.contractId,
+      { onDelete: 'set null' },
+    ),
+    // Vier aparte kolommen (created vs. matched, per entiteit) i.p.v. één:
+    // het resultaatscherm moet apart tonen wat déze import nieuw aanmaakte
+    // versus hergebruikte (besluit eigenaar, 2026-08-31).
+    createdVendorId: uuid('created_vendor_id').references(
+      () => vendor.vendorId,
+      { onDelete: 'set null' },
+    ),
+    matchedVendorId: uuid('matched_vendor_id').references(
+      () => vendor.vendorId,
+      { onDelete: 'set null' },
+    ),
+    createdContactId: uuid('created_contact_id').references(
+      () => vendorContact.contactId,
+      { onDelete: 'set null' },
+    ),
+    matchedContactId: uuid('matched_contact_id').references(
+      () => vendorContact.contactId,
+      { onDelete: 'set null' },
+    ),
+  },
+  (t) => [
+    index('import_row_tenant_id_idx').on(t.tenantId),
+    index('import_row_job_id_idx').on(t.jobId),
+  ],
+);
+
 export const contractSurveyTemplate = clm.table(
   'contract_survey_template',
   {

--- a/src/platform/platform.module.ts
+++ b/src/platform/platform.module.ts
@@ -23,6 +23,6 @@ import { PlatformService } from './platform.service';
   imports: [AuthModule, MailModule],
   controllers: [PlatformController],
   providers: [PlatformService, PlatformAdminGuard],
-  exports: [PlatformService],
+  exports: [PlatformService, PlatformAdminGuard],
 })
 export class PlatformModule {}

--- a/test/contract-import.e2e-spec.ts
+++ b/test/contract-import.e2e-spec.ts
@@ -1,0 +1,571 @@
+import { INestApplication } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import cookieParser from 'cookie-parser';
+import { Client } from 'pg';
+import request from 'supertest';
+import type { App } from 'supertest/types';
+
+import { AppModule } from '../src/app.module';
+import { cookieInstellingen } from '../src/auth/sessie';
+import { SessieService } from '../src/auth/sessie.service';
+import { TEST_IDS } from './test-ids';
+
+/**
+ * Admin-only contract-import (#198): preview → bevestigen, met find-or-create
+ * op vendor en vendor_contact.
+ *
+ * Dekt wat het design-document (§9) als testplan vaststelde: matching
+ * (coupa_supplier_number, email+full_name), autorisatie
+ * (platformbeheerder-only), tenantisolatie, rollback/idempotency van de
+ * bevestig-stap, en de create_only-garantie op zowel contract als vendor.
+ */
+
+const { tenant, andereTenant } = TEST_IDS['contract-import'];
+
+const STEMPEL = Date.now();
+const SUBJECT_PLATFORM = `oid-import-platform-${STEMPEL}`;
+const SUBJECT_GEWOON = `oid-import-gewoon-${STEMPEL}`;
+
+const KOPPEN =
+  'contract.name,contract.contract_number,contract.contract_type,contract.start_date,contract.end_date,contract.note,vendor.name,vendor.category_code,vendor.coupa_supplier_number,vendor_contact.email,vendor_contact.full_name';
+
+function csv(...rijen: string[]): Buffer {
+  return Buffer.from([KOPPEN, ...rijen].join('\n'), 'utf8');
+}
+
+/** Voert een enkele SELECT uit binnen de tenantcontext van `tenant`. */
+async function selecteerBinnenTenant<T extends Record<string, unknown>>(
+  c: Client,
+  tenantId: string,
+  queryTekst: string,
+  params: unknown[],
+): Promise<T[]> {
+  await c.query('BEGIN');
+  await c.query(`SET LOCAL app.current_tenant_id = '${tenantId}'`);
+  const resultaat = await c.query<T>(queryTekst, params);
+  await c.query('COMMIT');
+  return resultaat.rows;
+}
+
+/** Migratierol, altijd naar dezelfde database als DATABASE_URL. */
+function migratieUrl(): string {
+  const runtime = process.env.DATABASE_URL;
+  if (!runtime) throw new Error('DATABASE_URL ontbreekt.');
+
+  const doel = new URL(runtime);
+  const expliciet = process.env.MIGRATION_DATABASE_URL;
+
+  if (expliciet) {
+    const gegeven = new URL(expliciet);
+    if (gegeven.host === doel.host && gegeven.pathname === doel.pathname) {
+      return expliciet;
+    }
+  }
+
+  doel.username = 'clm_migrator';
+  return doel.toString();
+}
+
+async function verwijderTestdata(migratieClient: Client): Promise<void> {
+  await migratieClient.query(
+    'DELETE FROM clm.platform_admin WHERE user_id IN (SELECT user_id FROM clm."user" WHERE external_subject = $1)',
+    [SUBJECT_PLATFORM],
+  );
+
+  for (const t of [tenant, andereTenant]) {
+    await migratieClient.query('BEGIN');
+    await migratieClient.query(`SET LOCAL app.current_tenant_id = '${t}'`);
+    await migratieClient.query(
+      'DELETE FROM clm.import_row WHERE tenant_id = $1',
+      [t],
+    );
+    await migratieClient.query(
+      'DELETE FROM clm.import_job WHERE tenant_id = $1',
+      [t],
+    );
+    await migratieClient.query(
+      'DELETE FROM clm.contract WHERE tenant_id = $1',
+      [t],
+    );
+    await migratieClient.query(
+      'DELETE FROM clm.vendor_contact WHERE tenant_id = $1',
+      [t],
+    );
+    await migratieClient.query('DELETE FROM clm.vendor WHERE tenant_id = $1', [
+      t,
+    ]);
+    await migratieClient.query(
+      'DELETE FROM clm.tenant_membership WHERE tenant_id = $1',
+      [t],
+    );
+    await migratieClient.query('DELETE FROM clm."user" WHERE tenant_id = $1', [
+      t,
+    ]);
+    await migratieClient.query('DELETE FROM clm.tenant WHERE tenant_id = $1', [
+      t,
+    ]);
+    await migratieClient.query('COMMIT');
+  }
+}
+
+describe('Contract-import (e2e, #198)', () => {
+  let app: INestApplication<App>;
+  let server: App;
+  let client: Client;
+  let migratieClient: Client;
+  let sessies: SessieService;
+
+  let platformCookie: string;
+  let gewoneCookie: string;
+
+  const cookieNaam = cookieInstellingen().naam;
+
+  beforeAll(async () => {
+    client = new Client({ connectionString: process.env.DATABASE_URL });
+    await client.connect();
+
+    migratieClient = new Client({ connectionString: migratieUrl() });
+    await migratieClient.connect();
+
+    await verwijderTestdata(migratieClient);
+
+    await client.query('BEGIN');
+    await client.query(`SET LOCAL app.current_tenant_id = '${tenant}'`);
+    await client.query(
+      'INSERT INTO clm.tenant (tenant_id, name) VALUES ($1, $2)',
+      [tenant, `contract-import-test-${STEMPEL}`],
+    );
+    await client.query('COMMIT');
+
+    await client.query('BEGIN');
+    await client.query(`SET LOCAL app.current_tenant_id = '${andereTenant}'`);
+    await client.query(
+      'INSERT INTO clm.tenant (tenant_id, name) VALUES ($1, $2)',
+      [andereTenant, `contract-import-ander-${STEMPEL}`],
+    );
+    await client.query('COMMIT');
+
+    await client.query('BEGIN');
+    await client.query(`SET LOCAL app.current_tenant_id = '${tenant}'`);
+
+    const platformUser = await client.query<{ user_id: string }>(
+      `INSERT INTO clm."user" (tenant_id, full_name, external_subject)
+       VALUES ($1, $2, $3) RETURNING user_id`,
+      [tenant, 'Platform Beheerder', SUBJECT_PLATFORM],
+    );
+    const gewoneUser = await client.query<{ user_id: string }>(
+      `INSERT INTO clm."user" (tenant_id, full_name, external_subject)
+       VALUES ($1, $2, $3) RETURNING user_id`,
+      [tenant, 'Gewone Gebruiker', SUBJECT_GEWOON],
+    );
+
+    await client.query(
+      `INSERT INTO clm.tenant_membership (user_id, tenant_id, role)
+       VALUES ($1, $2, 'admin'), ($3, $2, 'admin')`,
+      [platformUser.rows[0].user_id, tenant, gewoneUser.rows[0].user_id],
+    );
+    await client.query('COMMIT');
+
+    // clm.platform_admin ligt buiten RLS/tenantcontext — via de migratierol.
+    await migratieClient.query(
+      'INSERT INTO clm.platform_admin (user_id) VALUES ($1)',
+      [platformUser.rows[0].user_id],
+    );
+
+    const moduleRef = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleRef.createNestApplication();
+    app.use(cookieParser());
+    await app.init();
+    server = app.getHttpServer();
+
+    sessies = app.get(SessieService);
+
+    const platformSessie = await sessies.aanmaken(SUBJECT_PLATFORM);
+    const gewoneSessie = await sessies.aanmaken(SUBJECT_GEWOON);
+
+    platformCookie = `${cookieNaam}=${platformSessie!.token}`;
+    gewoneCookie = `${cookieNaam}=${gewoneSessie!.token}`;
+  });
+
+  afterAll(async () => {
+    await app.close();
+    await verwijderTestdata(migratieClient);
+    await client.end();
+    await migratieClient.end();
+  });
+
+  describe('Autorisatie', () => {
+    it('weigert preview voor een niet-platformbeheerder (403)', async () => {
+      const respons = await request(server)
+        .post('/platform/contract-import/preview')
+        .set('Cookie', gewoneCookie)
+        .attach('file', csv('Hosting,CN-1,,,,,Acme B.V.,,SUP-1,,'), {
+          filename: 'contracten.csv',
+          contentType: 'text/csv',
+        });
+
+      expect(respons.status).toBe(403);
+    });
+
+    it('staat preview toe voor een platformbeheerder', async () => {
+      const respons = await request(server)
+        .post('/platform/contract-import/preview')
+        .set('Cookie', platformCookie)
+        .attach('file', csv('Hosting,CN-1,,,,,Acme B.V.,,SUP-1,,'), {
+          filename: 'contracten.csv',
+          contentType: 'text/csv',
+        });
+
+      expect(respons.status).toBe(201);
+      const body = respons.body as { jobId: string };
+      expect(body.jobId).toBeTruthy();
+    });
+  });
+
+  describe('Preview en bevestigen', () => {
+    it('beoordeelt een bestand zonder iets weg te schrijven', async () => {
+      const naam = `Preview-vendor-${STEMPEL}`;
+      const respons = await request(server)
+        .post('/platform/contract-import/preview')
+        .set('Cookie', platformCookie)
+        .attach(
+          'file',
+          csv(`Hosting,CN-1,,,,,${naam},,SUP-PREV-${STEMPEL},,`),
+          { filename: 'contracten.csv', contentType: 'text/csv' },
+        );
+
+      expect(respons.status).toBe(201);
+
+      const vendorRijen = await selecteerBinnenTenant(
+        client,
+        tenant,
+        'SELECT vendor_id FROM clm.vendor WHERE name = $1',
+        [naam],
+      );
+      expect(vendorRijen).toHaveLength(0);
+    });
+
+    it('bevestigt een importeerbare rij: maakt vendor, contact en contract aan', async () => {
+      const vendorNaam = `Bevestig-vendor-${STEMPEL}`;
+      const coupaNummer = `SUP-CONF-${STEMPEL}`;
+
+      const preview = await request(server)
+        .post('/platform/contract-import/preview')
+        .set('Cookie', platformCookie)
+        .attach(
+          'file',
+          csv(
+            `Hosting,CN-CONF,Dienstenovereenkomst,01-01-2024,31-12-2027,Toelichting,${vendorNaam},,${coupaNummer},jan@example.nl,Jan Jansen`,
+          ),
+          { filename: 'contracten.csv', contentType: 'text/csv' },
+        );
+
+      const jobId = (preview.body as { jobId: string }).jobId;
+
+      const bevestig = await request(server)
+        .post(`/platform/contract-import/${jobId}/bevestigen`)
+        .set('Cookie', platformCookie)
+        .send({});
+
+      expect(bevestig.status).toBe(201);
+      const resultaat = bevestig.body as {
+        aangemaakteContracten: number;
+        aangemaakteVendors: number;
+        aangemaakteContacten: number;
+      };
+      expect(resultaat.aangemaakteContracten).toBe(1);
+      expect(resultaat.aangemaakteVendors).toBe(1);
+      expect(resultaat.aangemaakteContacten).toBe(1);
+
+      const vendorRijen = await selecteerBinnenTenant<{ vendor_id: string }>(
+        client,
+        tenant,
+        'SELECT vendor_id FROM clm.vendor WHERE name = $1',
+        [vendorNaam],
+      );
+      expect(vendorRijen).toHaveLength(1);
+
+      const contractRijen = await selecteerBinnenTenant<{
+        name: string;
+        vendor_contact_id: string | null;
+      }>(
+        client,
+        tenant,
+        'SELECT name, start_date, end_date, vendor_contact_id FROM clm.contract WHERE vendor_id = $1',
+        [vendorRijen[0].vendor_id],
+      );
+      expect(contractRijen[0].name).toBe('Hosting');
+      expect(contractRijen[0].vendor_contact_id).not.toBeNull();
+    });
+
+    it('weigert een tweede bevestiging van dezelfde job (409)', async () => {
+      const preview = await request(server)
+        .post('/platform/contract-import/preview')
+        .set('Cookie', platformCookie)
+        .attach(
+          'file',
+          csv(
+            `Idempotent,CN-IDEM,,,,,Idempotent-vendor-${STEMPEL},,SUP-IDEM-${STEMPEL},,`,
+          ),
+          { filename: 'contracten.csv', contentType: 'text/csv' },
+        );
+      const jobId = (preview.body as { jobId: string }).jobId;
+
+      const eerste = await request(server)
+        .post(`/platform/contract-import/${jobId}/bevestigen`)
+        .set('Cookie', platformCookie)
+        .send({});
+      expect(eerste.status).toBe(201);
+
+      const tweede = await request(server)
+        .post(`/platform/contract-import/${jobId}/bevestigen`)
+        .set('Cookie', platformCookie)
+        .send({});
+      expect(tweede.status).toBe(409);
+    });
+
+    it('slaat een geblokkeerde rij over (skipped), zonder een contract aan te maken', async () => {
+      const preview = await request(server)
+        .post('/platform/contract-import/preview')
+        .set('Cookie', platformCookie)
+        .attach(
+          // Geen contractnaam: blokkerend.
+          'file',
+          csv(`,CN-SKIP,,,,,Skip-vendor-${STEMPEL},,SUP-SKIP-${STEMPEL},,`),
+          { filename: 'contracten.csv', contentType: 'text/csv' },
+        );
+      const jobId = (preview.body as { jobId: string }).jobId;
+
+      const bevestig = await request(server)
+        .post(`/platform/contract-import/${jobId}/bevestigen`)
+        .set('Cookie', platformCookie)
+        .send({});
+
+      expect(bevestig.status).toBe(201);
+      const resultaat = bevestig.body as {
+        aangemaakteContracten: number;
+        overgeslagen: number;
+      };
+      expect(resultaat.aangemaakteContracten).toBe(0);
+      expect(resultaat.overgeslagen).toBe(1);
+
+      const vendorRijen = await selecteerBinnenTenant(
+        client,
+        tenant,
+        'SELECT vendor_id FROM clm.vendor WHERE name = $1',
+        [`Skip-vendor-${STEMPEL}`],
+      );
+      expect(vendorRijen).toHaveLength(0);
+    });
+  });
+
+  describe('Vendor-matching', () => {
+    it('hergebruikt een bestaande vendor op coupa_supplier_number, maakt geen dubbele aan', async () => {
+      const coupaNummer = `SUP-MATCH-${STEMPEL}`;
+      const naam = `Match-vendor-${STEMPEL}`;
+
+      const preview = await request(server)
+        .post('/platform/contract-import/preview')
+        .set('Cookie', platformCookie)
+        .attach(
+          'file',
+          csv(
+            `Contract A,CN-A,,,,,${naam},,${coupaNummer},,`,
+            `Contract B,CN-B,,,,,${naam},,${coupaNummer},,`,
+          ),
+          { filename: 'contracten.csv', contentType: 'text/csv' },
+        );
+      const jobId = (preview.body as { jobId: string }).jobId;
+
+      const bevestig = await request(server)
+        .post(`/platform/contract-import/${jobId}/bevestigen`)
+        .set('Cookie', platformCookie)
+        .send({});
+
+      const resultaat = bevestig.body as {
+        aangemaakteContracten: number;
+        aangemaakteVendors: number;
+        hergebruikteVendors: number;
+      };
+      expect(resultaat.aangemaakteContracten).toBe(2);
+      expect(resultaat.aangemaakteVendors).toBe(1);
+      expect(resultaat.hergebruikteVendors).toBe(1);
+
+      const vendorRijen = await selecteerBinnenTenant(
+        client,
+        tenant,
+        'SELECT vendor_id FROM clm.vendor WHERE coupa_supplier_number = $1',
+        [coupaNummer],
+      );
+      expect(vendorRijen).toHaveLength(1);
+    });
+
+    it('maakt altijd een nieuwe vendor aan zonder coupa_supplier_number, ook bij gelijke naam', async () => {
+      const naam = `Geen-sleutel-vendor-${STEMPEL}`;
+
+      const preview = await request(server)
+        .post('/platform/contract-import/preview')
+        .set('Cookie', platformCookie)
+        .attach(
+          'file',
+          csv(
+            `Contract A,CN-A,,,,,${naam},,,,`,
+            `Contract B,CN-B,,,,,${naam},,,,`,
+          ),
+          { filename: 'contracten.csv', contentType: 'text/csv' },
+        );
+      const jobId = (preview.body as { jobId: string }).jobId;
+
+      const bevestig = await request(server)
+        .post(`/platform/contract-import/${jobId}/bevestigen`)
+        .set('Cookie', platformCookie)
+        .send({});
+
+      const resultaat = bevestig.body as { aangemaakteVendors: number };
+      expect(resultaat.aangemaakteVendors).toBe(2);
+
+      const vendorRijen = await selecteerBinnenTenant(
+        client,
+        tenant,
+        'SELECT vendor_id FROM clm.vendor WHERE name = $1',
+        [naam],
+      );
+      expect(vendorRijen).toHaveLength(2);
+    });
+
+    it('werkt een gematchte vendor nooit bij, ook niet bij een afwijkende naam', async () => {
+      const coupaNummer = `SUP-AFWIJK-${STEMPEL}`;
+      const oorspronkelijkeNaam = `Oorspronkelijk-${STEMPEL}`;
+
+      const eerstePreview = await request(server)
+        .post('/platform/contract-import/preview')
+        .set('Cookie', platformCookie)
+        .attach(
+          'file',
+          csv(`Contract A,CN-A,,,,,${oorspronkelijkeNaam},,${coupaNummer},,`),
+          { filename: 'contracten.csv', contentType: 'text/csv' },
+        );
+      await request(server)
+        .post(
+          `/platform/contract-import/${(eerstePreview.body as { jobId: string }).jobId}/bevestigen`,
+        )
+        .set('Cookie', platformCookie)
+        .send({});
+
+      const tweedePreview = await request(server)
+        .post('/platform/contract-import/preview')
+        .set('Cookie', platformCookie)
+        .attach(
+          'file',
+          csv(`Contract B,CN-B,,,,,Andere-naam-${STEMPEL},,${coupaNummer},,`),
+          { filename: 'contracten.csv', contentType: 'text/csv' },
+        );
+      const bevestig = await request(server)
+        .post(
+          `/platform/contract-import/${(tweedePreview.body as { jobId: string }).jobId}/bevestigen`,
+        )
+        .set('Cookie', platformCookie)
+        .send({});
+
+      expect(
+        (bevestig.body as { rijen: { vendorAfwijkt: boolean }[] }).rijen[0]
+          .vendorAfwijkt,
+      ).toBe(true);
+
+      const vendorRijen = await selecteerBinnenTenant<{ name: string }>(
+        client,
+        tenant,
+        'SELECT name FROM clm.vendor WHERE coupa_supplier_number = $1',
+        [coupaNummer],
+      );
+      expect(vendorRijen[0].name).toBe(oorspronkelijkeNaam);
+    });
+  });
+
+  describe('Contact-matching', () => {
+    it('hergebruikt een contact op email+full_name binnen dezelfde vendor', async () => {
+      const coupaNummer = `SUP-CONTACT-${STEMPEL}`;
+      const naam = `Contact-vendor-${STEMPEL}`;
+
+      const preview = await request(server)
+        .post('/platform/contract-import/preview')
+        .set('Cookie', platformCookie)
+        .attach(
+          'file',
+          csv(
+            `Contract A,CN-A,,,,,${naam},,${coupaNummer},jan@voorbeeld.nl,Jan Jansen`,
+            `Contract B,CN-B,,,,,${naam},,${coupaNummer},jan@voorbeeld.nl,Jan Jansen`,
+          ),
+          { filename: 'contracten.csv', contentType: 'text/csv' },
+        );
+      const jobId = (preview.body as { jobId: string }).jobId;
+
+      const bevestig = await request(server)
+        .post(`/platform/contract-import/${jobId}/bevestigen`)
+        .set('Cookie', platformCookie)
+        .send({});
+
+      const resultaat = bevestig.body as {
+        aangemaakteContacten: number;
+        hergebruikteContacten: number;
+      };
+      expect(resultaat.aangemaakteContacten).toBe(1);
+      expect(resultaat.hergebruikteContacten).toBe(1);
+    });
+
+    it('maakt twee aparte contacten bij gelijk email maar andere naam (afdelingspostbus-scenario)', async () => {
+      const coupaNummer = `SUP-POSTBUS-${STEMPEL}`;
+      const naam = `Postbus-vendor-${STEMPEL}`;
+
+      const preview = await request(server)
+        .post('/platform/contract-import/preview')
+        .set('Cookie', platformCookie)
+        .attach(
+          'file',
+          csv(
+            `Contract A,CN-A,,,,,${naam},,${coupaNummer},info@voorbeeld.nl,Jan Jansen`,
+            `Contract B,CN-B,,,,,${naam},,${coupaNummer},info@voorbeeld.nl,Inkoopafdeling`,
+          ),
+          { filename: 'contracten.csv', contentType: 'text/csv' },
+        );
+      const jobId = (preview.body as { jobId: string }).jobId;
+
+      const bevestig = await request(server)
+        .post(`/platform/contract-import/${jobId}/bevestigen`)
+        .set('Cookie', platformCookie)
+        .send({});
+
+      const resultaat = bevestig.body as { aangemaakteContacten: number };
+      expect(resultaat.aangemaakteContacten).toBe(2);
+    });
+  });
+
+  describe('Tenantisolatie', () => {
+    it('een import-job van deze tenant is niet zichtbaar vanuit een andere tenantcontext', async () => {
+      const preview = await request(server)
+        .post('/platform/contract-import/preview')
+        .set('Cookie', platformCookie)
+        .attach(
+          'file',
+          csv(
+            `Isolatie,CN-ISO,,,,,Isolatie-vendor-${STEMPEL},,SUP-ISO-${STEMPEL},,`,
+          ),
+          { filename: 'contracten.csv', contentType: 'text/csv' },
+        );
+      const jobId = (preview.body as { jobId: string }).jobId;
+
+      await client.query('BEGIN');
+      await client.query(`SET LOCAL app.current_tenant_id = '${andereTenant}'`);
+      const vanuitAndereTenant = await client.query(
+        'SELECT job_id FROM clm.import_job WHERE job_id = $1',
+        [jobId],
+      );
+      await client.query('COMMIT');
+
+      expect(vanuitAndereTenant.rows).toHaveLength(0);
+    });
+  });
+});

--- a/test/contract-import.e2e-spec.ts
+++ b/test/contract-import.e2e-spec.ts
@@ -541,6 +541,336 @@ describe('Contract-import (e2e, #198)', () => {
       const resultaat = bevestig.body as { aangemaakteContacten: number };
       expect(resultaat.aangemaakteContacten).toBe(2);
     });
+
+    it('maakt een contactpersoon aan met alleen een e-mailadres (geen naam)', async () => {
+      // Besluit eigenaar 31-08: alleen-email of alleen-naam is niet langer
+      // 'onvolledig' — eerdere versie sloeg dit soort contacten over.
+      const coupaNummer = `SUP-ALLEENMAIL-${STEMPEL}`;
+      const naam = `Alleen-mail-vendor-${STEMPEL}`;
+
+      const preview = await request(server)
+        .post('/platform/contract-import/preview')
+        .set('Cookie', platformCookie)
+        .attach(
+          'file',
+          csv(
+            `Contract A,CN-A,,,,,${naam},,${coupaNummer},security@voorbeeld.nl,`,
+          ),
+          { filename: 'contracten.csv', contentType: 'text/csv' },
+        );
+      const jobId = (preview.body as { jobId: string }).jobId;
+
+      const bevestig = await request(server)
+        .post(`/platform/contract-import/${jobId}/bevestigen`)
+        .set('Cookie', platformCookie)
+        .send({});
+
+      const resultaat = bevestig.body as { aangemaakteContacten: number };
+      expect(resultaat.aangemaakteContacten).toBe(1);
+
+      // full_name is NOT NULL in clm.vendor_contact — zonder een naam in de
+      // bron gebruikt de import het e-mailadres zelf als voorlopige naam
+      // (besluit eigenaar 31-08).
+      const contactRijen = await selecteerBinnenTenant<{
+        email: string;
+        full_name: string;
+      }>(
+        client,
+        tenant,
+        `SELECT email, full_name FROM clm.vendor_contact
+           WHERE email = $1`,
+        ['security@voorbeeld.nl'],
+      );
+      expect(contactRijen).toHaveLength(1);
+      expect(contactRijen[0].full_name).toBe('security@voorbeeld.nl');
+    });
+
+    it('maakt een contactpersoon aan met alleen een naam (geen e-mailadres)', async () => {
+      const coupaNummer = `SUP-ALLEENNAAM-${STEMPEL}`;
+      const naam = `Alleen-naam-vendor-${STEMPEL}`;
+
+      const preview = await request(server)
+        .post('/platform/contract-import/preview')
+        .set('Cookie', platformCookie)
+        .attach(
+          'file',
+          csv(`Contract A,CN-A,,,,,${naam},,${coupaNummer},,Patrick Scheun`),
+          { filename: 'contracten.csv', contentType: 'text/csv' },
+        );
+      const jobId = (preview.body as { jobId: string }).jobId;
+
+      const bevestig = await request(server)
+        .post(`/platform/contract-import/${jobId}/bevestigen`)
+        .set('Cookie', platformCookie)
+        .send({});
+
+      const resultaat = bevestig.body as { aangemaakteContacten: number };
+      expect(resultaat.aangemaakteContacten).toBe(1);
+    });
+
+    it('hergebruikt een alleen-email-contact bij een tweede rij met dezelfde email (NULL-veilige match)', async () => {
+      const coupaNummer = `SUP-NULLMATCH-${STEMPEL}`;
+      const naam = `Nullmatch-vendor-${STEMPEL}`;
+
+      const preview = await request(server)
+        .post('/platform/contract-import/preview')
+        .set('Cookie', platformCookie)
+        .attach(
+          'file',
+          csv(
+            `Contract A,CN-A,,,,,${naam},,${coupaNummer},info@voorbeeld.nl,`,
+            `Contract B,CN-B,,,,,${naam},,${coupaNummer},info@voorbeeld.nl,`,
+          ),
+          { filename: 'contracten.csv', contentType: 'text/csv' },
+        );
+      const jobId = (preview.body as { jobId: string }).jobId;
+
+      const bevestig = await request(server)
+        .post(`/platform/contract-import/${jobId}/bevestigen`)
+        .set('Cookie', platformCookie)
+        .send({});
+
+      const resultaat = bevestig.body as {
+        aangemaakteContacten: number;
+        hergebruikteContacten: number;
+      };
+      expect(resultaat.aangemaakteContacten).toBe(1);
+      expect(resultaat.hergebruikteContacten).toBe(1);
+    });
+  });
+
+  describe('Business-criticality en business-risk-tier (#198, gevonden 31-08)', () => {
+    it('slaat beide velden correct op als de brontekst herkend wordt', async () => {
+      const naam = `Criticality-vendor-${STEMPEL}`;
+      const coupaNummer = `SUP-CRIT-${STEMPEL}`;
+
+      const koppen =
+        'contract.name;contract.contract_number;vendor.name;vendor.coupa_supplier_number;vendor.business_criticality_code;contract.business_risk_tier_code';
+      const bestand = Buffer.from(
+        [
+          koppen,
+          `Contract A;CN-A;${naam};${coupaNummer};Hoog;Tier 2  Medium impact`,
+        ].join('\n'),
+        'utf8',
+      );
+
+      const preview = await request(server)
+        .post('/platform/contract-import/preview')
+        .set('Cookie', platformCookie)
+        .attach('file', bestand, {
+          filename: 'contracten.csv',
+          contentType: 'text/csv',
+        });
+      const jobId = (preview.body as { jobId: string }).jobId;
+
+      await request(server)
+        .post(`/platform/contract-import/${jobId}/bevestigen`)
+        .set('Cookie', platformCookie)
+        .send({});
+
+      const vendorRijen = await selecteerBinnenTenant<{
+        business_criticality_code: string | null;
+      }>(
+        client,
+        tenant,
+        'SELECT business_criticality_code FROM clm.vendor WHERE coupa_supplier_number = $1',
+        [coupaNummer],
+      );
+      expect(vendorRijen[0].business_criticality_code).toBe('high');
+
+      const contractRijen = await selecteerBinnenTenant<{
+        business_risk_tier_code: string | null;
+      }>(
+        client,
+        tenant,
+        `SELECT c.business_risk_tier_code FROM clm.contract c
+           JOIN clm.vendor v ON v.vendor_id = c.vendor_id
+          WHERE v.coupa_supplier_number = $1`,
+        [coupaNummer],
+      );
+      expect(contractRijen[0].business_risk_tier_code).toBe('tier_2');
+    });
+
+    it('laat beide velden leeg bij een niet-herkende waarde, blokkeert de rij niet', async () => {
+      const naam = `Onbekend-crit-vendor-${STEMPEL}`;
+      const coupaNummer = `SUP-ONBEKEND-${STEMPEL}`;
+
+      const koppen =
+        'contract.name;contract.contract_number;vendor.name;vendor.coupa_supplier_number;vendor.business_criticality_code;contract.business_risk_tier_code';
+      const bestand = Buffer.from(
+        [
+          koppen,
+          `Contract A;CN-A;${naam};${coupaNummer};Onduidelijk;Geen idee`,
+        ].join('\n'),
+        'utf8',
+      );
+
+      const preview = await request(server)
+        .post('/platform/contract-import/preview')
+        .set('Cookie', platformCookie)
+        .attach('file', bestand, {
+          filename: 'contracten.csv',
+          contentType: 'text/csv',
+        });
+
+      const previewBody = preview.body as {
+        jobId: string;
+        beoordeling: { rijen: { importeerbaar: boolean }[] };
+      };
+      expect(previewBody.beoordeling.rijen[0].importeerbaar).toBe(true);
+
+      const bevestig = await request(server)
+        .post(`/platform/contract-import/${previewBody.jobId}/bevestigen`)
+        .set('Cookie', platformCookie)
+        .send({});
+
+      const resultaat = bevestig.body as { aangemaakteContracten: number };
+      expect(resultaat.aangemaakteContracten).toBe(1);
+
+      const vendorRijen = await selecteerBinnenTenant<{
+        business_criticality_code: string | null;
+      }>(
+        client,
+        tenant,
+        'SELECT business_criticality_code FROM clm.vendor WHERE coupa_supplier_number = $1',
+        [coupaNummer],
+      );
+      expect(vendorRijen[0].business_criticality_code).toBeNull();
+    });
+  });
+
+  describe('Categorie-aanmaak (#198, bevindingen 31-08)', () => {
+    it('maakt een onbekende categorie aan i.p.v. hem leeg te laten', async () => {
+      const naam = `Categorie-vendor-${STEMPEL}`;
+      const categorieTekst = `Vastgoed & Facility Management ${STEMPEL}`;
+
+      const preview = await request(server)
+        .post('/platform/contract-import/preview')
+        .set('Cookie', platformCookie)
+        .attach(
+          'file',
+          csv(
+            `Contract A,CN-CAT,,,,,${naam},${categorieTekst},SUP-CAT-${STEMPEL},,`,
+          ),
+          { filename: 'contracten.csv', contentType: 'text/csv' },
+        );
+      const jobId = (preview.body as { jobId: string }).jobId;
+
+      const bevestig = await request(server)
+        .post(`/platform/contract-import/${jobId}/bevestigen`)
+        .set('Cookie', platformCookie)
+        .send({});
+
+      const resultaat = bevestig.body as {
+        aangemaakteCategorieen: number;
+        rijen: { categorieAangemaakt: boolean }[];
+      };
+      expect(resultaat.aangemaakteCategorieen).toBe(1);
+      expect(resultaat.rijen[0].categorieAangemaakt).toBe(true);
+
+      const categorieRijen = await selecteerBinnenTenant<{
+        code: string;
+        label: string;
+      }>(
+        client,
+        tenant,
+        'SELECT code, label FROM ref.vendor_category WHERE label = $1',
+        [categorieTekst],
+      );
+      expect(categorieRijen).toHaveLength(1);
+    });
+
+    it('hergebruikt een net aangemaakte categorie binnen dezelfde import', async () => {
+      const naam1 = `Categorie-vendor-a-${STEMPEL}`;
+      const naam2 = `Categorie-vendor-b-${STEMPEL}`;
+      const categorieTekst = `Nieuwe categorie ${STEMPEL}`;
+
+      const preview = await request(server)
+        .post('/platform/contract-import/preview')
+        .set('Cookie', platformCookie)
+        .attach(
+          'file',
+          csv(
+            `Contract A,CN-A,,,,,${naam1},${categorieTekst},SUP-CATA-${STEMPEL},,`,
+            `Contract B,CN-B,,,,,${naam2},${categorieTekst},SUP-CATB-${STEMPEL},,`,
+          ),
+          { filename: 'contracten.csv', contentType: 'text/csv' },
+        );
+      const jobId = (preview.body as { jobId: string }).jobId;
+
+      const bevestig = await request(server)
+        .post(`/platform/contract-import/${jobId}/bevestigen`)
+        .set('Cookie', platformCookie)
+        .send({});
+
+      const resultaat = bevestig.body as { aangemaakteCategorieen: number };
+      expect(resultaat.aangemaakteCategorieen).toBe(1);
+
+      const categorieRijen = await selecteerBinnenTenant(
+        client,
+        tenant,
+        'SELECT code FROM ref.vendor_category WHERE label = $1',
+        [categorieTekst],
+      );
+      expect(categorieRijen).toHaveLength(1);
+    });
+  });
+
+  describe('Extra contactgegevens (#198, bevindingen 31-08)', () => {
+    it('legt vendor_contact.email_2/full_name_2 apart vast, zonder ze te verwerken als het primaire contact', async () => {
+      const naam = `Extracontact-vendor-${STEMPEL}`;
+
+      const koppenMetExtra =
+        'contract.name;contract.contract_number;contract.contract_type;contract.start_date;contract.end_date;contract.note;vendor.name;vendor.category_code;vendor.coupa_supplier_number;vendor_contact.email;vendor_contact.full_name;vendor_contact.email_2;vendor_contact.full_name_2';
+      const rij = `Contract met extra contact;CN-EXTRA;;;;;${naam};;SUP-EXTRA-${STEMPEL};jan@voorbeeld.nl;Jan Jansen;afdeling@voorbeeld.nl;Inkoopafdeling`;
+      const bestand = Buffer.from([koppenMetExtra, rij].join('\n'), 'utf8');
+
+      const preview = await request(server)
+        .post('/platform/contract-import/preview')
+        .set('Cookie', platformCookie)
+        .attach('file', bestand, {
+          filename: 'contracten.csv',
+          contentType: 'text/csv',
+        });
+
+      expect(preview.status).toBe(201);
+      const previewBody = preview.body as {
+        jobId: string;
+        beoordeling: { rijen: { bevindingen: { code: string }[] }[] };
+      };
+      expect(
+        previewBody.beoordeling.rijen[0].bevindingen.map((b) => b.code),
+      ).toContain('extra_contactgegevens_gevonden');
+
+      const bevestig = await request(server)
+        .post(`/platform/contract-import/${previewBody.jobId}/bevestigen`)
+        .set('Cookie', platformCookie)
+        .send({});
+
+      const resultaat = bevestig.body as {
+        extraContactenGevonden: number;
+        aangemaakteContacten: number;
+      };
+      expect(resultaat.extraContactenGevonden).toBe(1);
+      // Het primaire paar (Jan Jansen) is het enige dat een echte
+      // vendor_contact-rij oplevert — de extra blijft in de hulptabel.
+      expect(resultaat.aangemaakteContacten).toBe(1);
+
+      const extraRijen = await selecteerBinnenTenant<{
+        email: string;
+        full_name: string;
+      }>(
+        client,
+        tenant,
+        `SELECT ec.email, ec.full_name FROM clm.import_extra_contact ec
+           JOIN clm.import_row ir ON ir.row_id = ec.row_id
+          WHERE ir.job_id = $1`,
+        [previewBody.jobId],
+      );
+      expect(extraRijen).toHaveLength(1);
+      expect(extraRijen[0].email).toBe('afdeling@voorbeeld.nl');
+      expect(extraRijen[0].full_name).toBe('Inkoopafdeling');
+    });
   });
 
   describe('Tenantisolatie', () => {

--- a/test/test-ids.ts
+++ b/test/test-ids.ts
@@ -402,6 +402,10 @@ export const TEST_IDS = {
     adminA: id('4a'),
     userA: id('4b'),
   },
+  'contract-import': {
+    tenant: id('4c'),
+    andereTenant: id('4d'),
+  },
 } as const;
 
 /** Alle uitgedeelde id's, plat. Gebruikt door de bewakingstest. */


### PR DESCRIPTION
Closes #198.

## Wat

Een platformbeheerder kan contracten uit een CSV-bestand importeren, met
find-or-create op leverancier en contactpersoon. Twee stappen: preview
(valideert, matcht nog niets tegen de database) en bevestigen (schrijft
definitief weg, één transactie voor de hele job).

Volledig ontwerp: `docs/superpowers/specs/2026-08-31-contract-import-design.md`
(inclusief de scope-correctie — dit begon als een vendor-only-import-vraag,
bleek bij de daadwerkelijke kolommenlijst een contract-import te zijn).

## Matchbeleid (bevestigd door de eigenaar tijdens het ontwerp)

- Vendor: matcht op `coupa_supplier_number`; ontbreekt die, dan altijd een
  nieuwe vendor (nooit op naam matchen) + waarschuwing.
- Vendor_contact: matcht op `email` + `full_name` samen, binnen de vendor —
  ondersteunt meerdere contactpunten per vendor (persoon vs. afdelingspostbus).
- Een gematchte vendor met afwijkende gegevens in de CSV wordt nooit
  bijgewerkt, alleen gesignaleerd (`vendorAfwijkt`).
- Contract zelf is altijd create_only.
- Eén transactie voor de hele bevestiging (geen batches) — bewuste keuze
  voor eenvoud en een harde alles-of-niets-garantie boven het genoemde
  batch-alternatief.

## Bewuste architectuurkeuze

Geen refactor van `VendorService`/`ContractService` om ze binnen een gegeven
transactie te laten werken — dat zou een niet-triviale wijziging aan
bestaande, geteste code betekenen voor een eenmalige importbehoefte. In
plaats daarvan herhaalt de import zijn eigen, kleine INSERT's (zelfde
kolommen, met verwijzing naar de originele service in commentaar).

## Getest

- 23 unittests op de validatiemodule (`contract-import-schema.spec.ts`)
- 12 e2e-tests: autorisatie (platformbeheerder-only), vendor/contact-matching
  (inclusief het afdelingspostbus-scenario), tenantisolatie, idempotency
  (409 bij dubbele bevestiging), rollback via de create_only-garantie
- `verify:volledig` 7/7 groen (staging loopt één migratie achter dit PR,
  wat normaal is vóór een merge)

## Bijbehorende frontend-PR

AlingAdvies/MCM2-frontend#19

🤖 Generated with [Claude Code](https://claude.com/claude-code)