### PR TITLE
feat(veldkoppeling): 5 frontend-backend veldgaten gedicht na de veldcheck

### DIFF
--- a/src/contract/contract.service.ts
+++ b/src/contract/contract.service.ts
@@ -41,6 +41,8 @@ export interface ContractTenantBreed extends ContractSamenvatting {
   vendorId: string;
   vendorNaam: string;
   valueEur: string | null;
+  vendorCategoryCode: string | null;
+  vendorBusinessCriticalityCode: string | null;
 }
 
 export interface NieuwContract {
@@ -233,6 +235,8 @@ export class ContractService {
             vendor_id: string;
             vendor_naam: string;
             value_eur: string | null;
+            vendor_category_code: string | null;
+            vendor_business_criticality_code: string | null;
           }
         >(
           sql`SELECT c.contract_id, c.vendor_id, c.name, c.contract_number,
@@ -242,7 +246,9 @@ export class ContractService {
                      c.contract_type, c.dpa_aanwezig, c.business_risk_tier_code,
                      vc.full_name AS vendor_contact_naam,
                      u.full_name AS owner_naam,
-                     v.name AS vendor_naam
+                     v.name AS vendor_naam,
+                     v.category_code AS vendor_category_code,
+                     v.business_criticality_code AS vendor_business_criticality_code
                 FROM clm.contract c
                 LEFT JOIN clm.vendor_contact vc ON vc.contact_id = c.vendor_contact_id
                 LEFT JOIN clm."user" u ON u.user_id = c.owner_user_id
@@ -272,6 +278,8 @@ export class ContractService {
           contractType: r.contract_type,
           dpaAanwezig: r.dpa_aanwezig,
           businessRiskTierCode: r.business_risk_tier_code,
+          vendorCategoryCode: r.vendor_category_code,
+          vendorBusinessCriticalityCode: r.vendor_business_criticality_code,
         }));
       },
       'medewerker',

--- a/src/survey/vragenlijst-beheer.service.ts
+++ b/src/survey/vragenlijst-beheer.service.ts
@@ -85,6 +85,9 @@ export interface RondeSamenvatting {
   startedAt: string | null;
   closesAt: string | null;
   revokedAt: string | null;
+  /** Null wanneer deze ronde bij het starten niet aan een contract gekoppeld is. */
+  contractId: string | null;
+  contractNaam: string | null;
   /** Hoeveel deelnemers er zijn uitgenodigd. */
   aantalDeelnemers: number;
   /** Hoeveel daarvan hebben ingediend. */
@@ -234,6 +237,8 @@ interface RondeRij extends Record<string, unknown> {
   started_at: Date | string | null;
   closes_at: Date | string | null;
   revoked_at: Date | string | null;
+  contract_id: string | null;
+  contract_naam: string | null;
   aantal_deelnemers: string | number;
   aantal_ingediend: string | number;
 }
@@ -463,6 +468,8 @@ export class VragenlijstBeheerService {
                      r.started_at,
                      r.closes_at,
                      r.revoked_at,
+                     r.contract_id,
+                     c.name AS contract_naam,
                      (SELECT count(*) FROM clm.survey_response s
                        WHERE s.run_id = r.run_id)              AS aantal_deelnemers,
                      (SELECT count(*) FROM clm.survey_response s
@@ -470,6 +477,7 @@ export class VragenlijstBeheerService {
                          AND s.submitted_at IS NOT NULL)       AS aantal_ingediend
                 FROM clm.survey_run r
                 JOIN clm.survey_template t ON t.template_id = r.template_id
+                LEFT JOIN clm.contract c ON c.contract_id = r.contract_id
                ORDER BY r.started_at DESC NULLS FIRST, t.name`,
         );
 
@@ -575,6 +583,8 @@ export class VragenlijstBeheerService {
                      r.started_at,
                      r.closes_at,
                      r.revoked_at,
+                     r.contract_id,
+                     c.name AS contract_naam,
                      (SELECT count(*) FROM clm.survey_response s
                        WHERE s.run_id = r.run_id)              AS aantal_deelnemers,
                      (SELECT count(*) FROM clm.survey_response s
@@ -582,6 +592,7 @@ export class VragenlijstBeheerService {
                          AND s.submitted_at IS NOT NULL)       AS aantal_ingediend
                 FROM clm.survey_run r
                 JOIN clm.survey_template t ON t.template_id = r.template_id
+                LEFT JOIN clm.contract c ON c.contract_id = r.contract_id
                WHERE r.run_id = ${runId}`,
         );
 
@@ -794,6 +805,8 @@ export class VragenlijstBeheerService {
       startedAt: iso(r.started_at),
       closesAt: iso(r.closes_at),
       revokedAt: iso(r.revoked_at),
+      contractId: r.contract_id,
+      contractNaam: r.contract_naam,
       aantalDeelnemers: getal(r.aantal_deelnemers),
       aantalIngediend: getal(r.aantal_ingediend),
     };

--- a/src/tenant/tenant-leden-invoer.ts
+++ b/src/tenant/tenant-leden-invoer.ts
@@ -29,6 +29,11 @@ export interface RolWijziging {
   rol: ToegestaneRol;
 }
 
+export interface GegevensWijziging {
+  naam: string;
+  email: string;
+}
+
 function leesRol(waarde: unknown): ToegestaneRol {
   if (
     typeof waarde !== 'string' ||
@@ -72,4 +77,17 @@ export function leesRolWijziging(body: unknown): RolWijziging {
   }
   const { rol } = body as Record<string, unknown>;
   return { rol: leesRol(rol) };
+}
+
+export function leesGegevensWijziging(body: unknown): GegevensWijziging {
+  if (typeof body !== 'object' || body === null) {
+    throw new InvoerFout('email', 'Verwacht een JSON-object.');
+  }
+  const { email, naam } = body as Record<string, unknown>;
+
+  if (typeof email !== 'string' || !isGeldigMailadres(email)) {
+    throw new InvoerFout('email', 'Vul een geldig e-mailadres in.');
+  }
+
+  return { email, naam: leesNaam(naam) };
 }

--- a/src/tenant/tenant-leden.controller.ts
+++ b/src/tenant/tenant-leden.controller.ts
@@ -17,7 +17,11 @@ import {
   type RequestMetSessie,
 } from '../auth/tenant-context.guard';
 import { InvoerFout } from '../vendor/vendor-invoer';
-import { leesNieuwLid, leesRolWijziging } from './tenant-leden-invoer';
+import {
+  leesGegevensWijziging,
+  leesNieuwLid,
+  leesRolWijziging,
+} from './tenant-leden-invoer';
 import { TenantLedenService } from './tenant-leden.service';
 
 /**
@@ -82,6 +86,31 @@ export class TenantLedenController {
         request.sessie!.tenantId,
         userId,
         leesRolWijziging(body).rol,
+      );
+    } catch (fout) {
+      if (fout instanceof InvoerFout) {
+        throw new BadRequestException({
+          veld: fout.veld,
+          melding: fout.message,
+        });
+      }
+      throw fout;
+    }
+  }
+
+  @Put(':userId')
+  @VereistRol('admin', 'support')
+  @HttpCode(204)
+  async gegevensWijzigen(
+    @Req() request: RequestMetSessie,
+    @Param('userId') userId: string,
+    @Body() body: unknown,
+  ) {
+    try {
+      await this.leden.gegevensWijzigen(
+        request.sessie!.tenantId,
+        userId,
+        leesGegevensWijziging(body),
       );
     } catch (fout) {
       if (fout instanceof InvoerFout) {

--- a/src/tenant/tenant-leden.service.ts
+++ b/src/tenant/tenant-leden.service.ts
@@ -246,6 +246,41 @@ export class TenantLedenService {
     });
   }
 
+  /**
+   * Naam en e-mailadres van een bestaand lid wijzigen (echte UPDATE — geen
+   * verwijderen/opnieuw-aanmaken, zie het besluit van de eigenaar 31-08:
+   * rol en 'sinds'-datum van het lidmaatschap blijven intact).
+   */
+  async gegevensWijzigen(
+    tenantId: string,
+    userId: string,
+    wijziging: { naam: string; email: string },
+  ): Promise<void> {
+    return this.db.withTenant(tenantId, async (tx) => {
+      const dubbel = await tx.execute<{ aantal: string }>(
+        sql`SELECT count(*) AS aantal
+              FROM clm."user" u
+              JOIN clm.tenant_membership m ON m.user_id = u.user_id
+             WHERE m.tenant_id = ${tenantId}
+               AND m.deleted_at IS NULL
+               AND u.user_id <> ${userId}
+               AND u.email = ${wijziging.email}`,
+      );
+
+      if (Number(dubbel.rows[0].aantal) > 0) {
+        throw new ConflictException(
+          'Dit e-mailadres is al in gebruik door een ander lid van deze tenant.',
+        );
+      }
+
+      await tx.execute(
+        sql`UPDATE clm."user"
+               SET full_name = ${wijziging.naam}, email = ${wijziging.email}
+             WHERE user_id = ${userId}`,
+      );
+    });
+  }
+
   async intrekken(tenantId: string, userId: string): Promise<void> {
     return this.db.withTenant(tenantId, async (tx) => {
       await this.weigerAlsLaatsteAdmin(tx, tenantId, userId);


### PR DESCRIPTION
## Wat
5 concrete fixes uit de systematische veldcheck (31-08) van alle beheerschermen (frontend↔backend↔database).

- **Telefoonnummer bij contactpersoon**: `vendor_contact.phone` bestond al overal, nu ook in de contact-modal/lijst
- **Contract read-only weergave**: `contractType`, `businessRiskTierCode`, `dpaAanwezig` nu ook zichtbaar zonder te bewerken
- **Tenant-gebruiker wijzigen**: nieuwe route `PUT /tenant/leden/:userId` — echte UPDATE van naam/e-mail, geen verwijderen+opnieuw-aanmaken
- **Ronde → contract zichtbaar**: `survey_run.contract_id` + naam nu ook in `rondes()`/`ronde()`, niet alleen bij het starten
- **Contractenscherm**: 3 nieuwe kolommen (Categorie, Business-risk-tier, Cyber Criticaliteit) + filters, zelfde patroon als het leveranciersscherm

## Getest
`npm run verify:volledig` groen — 94/99 e2e-tests (5 bekend skipped), schema-conformiteit klopt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)