### PR TITLE
fix(survey): downloadroute voor bijlagen bij een antwoord

### DIFF
--- a/src/survey/vragenlijst-beheer.controller.ts
+++ b/src/survey/vragenlijst-beheer.controller.ts
@@ -10,8 +10,10 @@ import {
   Post,
   Query,
   Req,
+  Res,
   UseGuards,
 } from '@nestjs/common';
+import type { Response } from 'express';
 
 import { UitnodigingVerzender } from '../mail/uitnodiging-verzender.service';
 import { RolGuard, VereistRol } from '../auth/rol.guard';
@@ -20,6 +22,7 @@ import {
   type RequestMetSessie,
 } from '../auth/tenant-context.guard';
 import { ContractService } from '../contract/contract.service';
+import { BestandOpslagService } from './bestand-opslag.service';
 import { ContractmanagerService } from './contractmanager.service';
 import { NotitieService } from './notitie.service';
 import { RondeBeheerService } from './ronde-beheer.service';
@@ -89,6 +92,7 @@ export class VragenlijstBeheerController {
     private readonly notities_: NotitieService,
     private readonly contractmanagers: ContractmanagerService,
     private readonly contracten: ContractService,
+    private readonly opslag: BestandOpslagService,
   ) {}
 
   /** Alle vragenlijsten van deze tenant, met aantallen vragen en rondes. */
@@ -161,6 +165,41 @@ export class VragenlijstBeheerController {
     const sessie = request.sessie!;
 
     return this.beheer.antwoorden(sessie.tenantId, id);
+  }
+
+  /**
+   * Downloadt één bijlage bij een antwoord.
+   *
+   * Geen `@VereistRol`: zelfde regel als `antwoorden()` hierboven — een
+   * reviewer moet een geüpload certificaat kunnen openen om te kunnen
+   * beoordelen.
+   *
+   * `storage_key` verlaat de service nooit naar de client (zie de toelichting
+   * bij `VragenlijstBeheerService.bijlageOpzoeken()`) — deze route leest hem
+   * op, geeft hem meteen door aan `BestandOpslagService.lees()`, en stuurt
+   * alleen de bytes terug.
+   */
+  @Get('attachments/:id')
+  async bijlageDownloaden(
+    @Req() request: RequestMetSessie,
+    @Param('id') id: string,
+    @Res() res: Response,
+  ) {
+    const sessie = request.sessie!;
+
+    const bijlage = await this.beheer.bijlageOpzoeken(sessie.tenantId, id);
+    const inhoud = await this.opslag.lees(bijlage.storageKey);
+
+    res.set({
+      'Content-Type': bijlage.contentType,
+      // 'attachment' i.p.v. 'inline': een geüpload PDF/afbeelding hoort
+      // gedownload te worden, niet in de browser te renderen naast de
+      // beheerinterface. encodeURIComponent voorkomt problemen met
+      // aanhalingstekens of niet-ASCII-tekens in de oorspronkelijke naam.
+      'Content-Disposition': `attachment; filename="${encodeURIComponent(bijlage.originalName)}"`,
+      'Content-Length': String(inhoud.length),
+    });
+    res.send(inhoud);
   }
 
   /** Alle oordelen over één respons, nieuwste eerst. */

--- a/src/survey/vragenlijst-beheer.service.ts
+++ b/src/survey/vragenlijst-beheer.service.ts
@@ -794,6 +794,49 @@ export class VragenlijstBeheerService {
     );
   }
 
+  /**
+   * Zoekt één bijlage op voor download — tenant-gescoped, net als elke andere
+   * methode hier. Geeft `storage_key` bewust wél terug: dat mag hier, in
+   * tegenstelling tot een lijstroute (zie `ronde()`), omdat de aanroeper
+   * (`GET .../attachments/:id`, hieronder) het meteen doorgeeft aan
+   * `BestandOpslagService.lees()` en nooit naar de client stuurt.
+   */
+  async bijlageOpzoeken(
+    tenantId: string,
+    attachmentId: string,
+  ): Promise<{
+    storageKey: string;
+    originalName: string;
+    contentType: string;
+  }> {
+    return this.db.withTenant(
+      tenantId,
+      async (tx) => {
+        const { rows } = await tx.execute<{
+          storage_key: string;
+          original_name: string;
+          content_type: string;
+        }>(
+          sql`SELECT storage_key, original_name, content_type
+                FROM clm.survey_attachment
+               WHERE attachment_id = ${attachmentId}`,
+        );
+
+        const rij = rows[0];
+        if (!rij) {
+          throw new NotFoundException('Deze bijlage bestaat niet.');
+        }
+
+        return {
+          storageKey: rij.storage_key,
+          originalName: rij.original_name,
+          contentType: rij.content_type,
+        };
+      },
+      'medewerker',
+    );
+  }
+
   private naarRonde(r: RondeRij): RondeSamenvatting {
     return {
       runId: r.run_id,

--- a/test/vragenlijst-beheer-routes.e2e-spec.ts
+++ b/test/vragenlijst-beheer-routes.e2e-spec.ts
@@ -1,6 +1,11 @@
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
 import { INestApplication } from '@nestjs/common';
 import { Test } from '@nestjs/testing';
 import cookieParser from 'cookie-parser';
+import { randomUUID } from 'node:crypto';
 import { Client } from 'pg';
 import request from 'supertest';
 import type { App } from 'supertest/types';
@@ -50,6 +55,10 @@ const SUBJECT_REVIEWER = `oid-vlb-r-${Date.now()}`;
  */
 const TOKEN_HASH = `${'0'.repeat(48)}deadbeefcafe1234`;
 
+const ATTACHMENT_A = randomUUID();
+const ATTACHMENT_STORAGE_KEY = `beheer-test/${ATTACHMENT_A}.pdf`;
+const ATTACHMENT_INHOUD = Buffer.from('%PDF-1.7\ntest-certificaat');
+
 interface LijstAntwoord {
   vragenlijsten: Array<{
     templateId: string;
@@ -93,8 +102,9 @@ async function verwijderTestdata(client: Client): Promise<void> {
     await client.query('BEGIN');
     await client.query(`SET LOCAL app.current_tenant_id = '${tenant}'`);
     for (const tabel of [
-      // Antwoorden vóór de respons: survey_answer heeft een FK naar
+      // Bijlagen en antwoorden vóór de respons: beide hebben een FK naar
       // survey_response, dus andersom weigert Postgres de DELETE.
+      'clm.survey_attachment',
       'clm.survey_answer',
       'clm.survey_response',
       'clm.survey_run',
@@ -120,9 +130,17 @@ describe('Vragenlijst-beheerroutes (e2e)', () => {
   let cookieA: string;
   let cookieB: string;
   let cookieReviewer: string;
+  let uploadMap: string;
   const cookieNaam = cookieInstellingen().naam;
 
   beforeAll(async () => {
+    // Eigen tijdelijke map, zelfde patroon als bijlage-upload.e2e-spec.ts:
+    // de downloadroute leest een echt bestand van schijf.
+    uploadMap = await mkdtemp(join(tmpdir(), 'mcm2-vlb-uploads-'));
+    process.env.UPLOAD_DIR = uploadMap;
+    await mkdir(join(uploadMap, 'beheer-test'), { recursive: true });
+    await writeFile(join(uploadMap, ATTACHMENT_STORAGE_KEY), ATTACHMENT_INHOUD);
+
     client = new Client({ connectionString: process.env.DATABASE_URL });
     await client.connect();
     await verwijderTestdata(client);
@@ -231,6 +249,26 @@ describe('Vragenlijst-beheerroutes (e2e)', () => {
         WHERE q.template_id = $3 AND q.question_key = 'v1'`,
       [tenantA, RESPONSE_A, TEMPLATE_A],
     );
+
+    // Eén bijlage bij v1, voor de downloadroute-tests hieronder.
+    await client.query(
+      `INSERT INTO clm.survey_attachment
+         (attachment_id, tenant_id, response_id, question_id, original_name,
+          storage_key, content_type, byte_size, sha256)
+       SELECT $1, $2, $3, q.question_id, 'certificaat.pdf', $4,
+              'application/pdf', $5, $6
+         FROM clm.survey_question q
+        WHERE q.template_id = $7 AND q.question_key = 'v1'`,
+      [
+        ATTACHMENT_A,
+        tenantA,
+        RESPONSE_A,
+        ATTACHMENT_STORAGE_KEY,
+        ATTACHMENT_INHOUD.length,
+        '0'.repeat(64),
+        TEMPLATE_A,
+      ],
+    );
     await client.query('COMMIT');
 
     // Vragenlijst in B, zodat de tenantgrens iets te verbergen heeft.
@@ -270,6 +308,8 @@ describe('Vragenlijst-beheerroutes (e2e)', () => {
     await app.close();
     await verwijderTestdata(client);
     await client.end();
+    await rm(uploadMap, { recursive: true, force: true });
+    delete process.env.UPLOAD_DIR;
   }, 30000);
 
   describe('zonder geldige sessie is er geen toegang', () => {
@@ -534,6 +574,25 @@ describe('Vragenlijst-beheerroutes (e2e)', () => {
       expect(alsTekst).not.toContain('storageKey');
     });
 
+    it('geeft de bijlage terug in het antwoord, met de juiste naam en grootte', async () => {
+      const body = await haalAntwoorden(cookieA);
+
+      const v1 = body.antwoorden.find((a) => a.questionKey === 'v1') as {
+        bijlagen: Array<{
+          attachmentId: string;
+          originalName: string;
+          byteSize: number;
+          contentType: string;
+        }>;
+      };
+
+      expect(v1.bijlagen).toHaveLength(1);
+      expect(v1.bijlagen[0].attachmentId).toBe(ATTACHMENT_A);
+      expect(v1.bijlagen[0].originalName).toBe('certificaat.pdf');
+      expect(v1.bijlagen[0].byteSize).toBe(ATTACHMENT_INHOUD.length);
+      expect(v1.bijlagen[0].contentType).toBe('application/pdf');
+    });
+
     it('laat een reviewer de antwoorden lezen', async () => {
       // Voor een reviewer is dit de kernroute: beoordelen kan niet zonder de
       // antwoorden te zien.
@@ -559,6 +618,50 @@ describe('Vragenlijst-beheerroutes (e2e)', () => {
         )
         .set('Cookie', cookieA)
         .expect(404);
+    });
+  });
+
+  describe('het downloaden van een bijlage', () => {
+    it('geeft de bytes van het bestand terug, met de juiste headers', async () => {
+      const res = await request(server)
+        .get(`/admin/survey/attachments/${ATTACHMENT_A}`)
+        .set('Cookie', cookieA)
+        .expect(200);
+
+      expect(res.headers['content-type']).toBe('application/pdf');
+      expect(res.headers['content-disposition']).toContain('certificaat.pdf');
+      expect(Buffer.compare(res.body as Buffer, ATTACHMENT_INHOUD)).toBe(0);
+    });
+
+    it('laat een reviewer de bijlage ook downloaden', async () => {
+      // Zelfde regel als bij de antwoordenroute: beoordelen kan niet zonder
+      // het geüploade bewijs te kunnen openen.
+      await request(server)
+        .get(`/admin/survey/attachments/${ATTACHMENT_A}`)
+        .set('Cookie', cookieReviewer)
+        .expect(200);
+    });
+
+    it('geeft tenant B een 404 op de bijlage van A', async () => {
+      // RLS maakt de rij onzichtbaar — zelfde patroon als de andere
+      // tenantgrens-tests hierboven.
+      await request(server)
+        .get(`/admin/survey/attachments/${ATTACHMENT_A}`)
+        .set('Cookie', cookieB)
+        .expect(404);
+    });
+
+    it('geeft 404 op een niet-bestaande bijlage', async () => {
+      await request(server)
+        .get('/admin/survey/attachments/00000000-0000-0000-0000-00000000dead')
+        .set('Cookie', cookieA)
+        .expect(404);
+    });
+
+    it('geeft geen toegang zonder geldige sessie', async () => {
+      await request(server)
+        .get(`/admin/survey/attachments/${ATTACHMENT_A}`)
+        .expect(401);
     });
   });
 


### PR DESCRIPTION
## Wat
Gevonden op productie: het beoordelingsscherm toonde "NaN MB" bij een geüpload certificaat en er was geen manier om het bestand te openen.

- Nieuwe route `GET /admin/survey/attachments/:id` — tenant-gescoped via `withTenant()`/RLS, `storage_key` verlaat de service nooit naar de client (zelfde regel als de bestaande `answers`-route)
- e2e-tests: gelukkige weg, reviewer mag ook downloaden, tenantgrens (404), 404 op onbekende bijlage, 401 zonder sessie
- Bijvangst: `verwijderTestdata()` in de e2e-suite miste `survey_attachment` in de opruimvolgorde (FK-schending) — gefixt

Hoort bij frontend-PR AlingAdvies/MCM2-frontend#22.

## Getest
`npm run verify:volledig` groen — 95/99 e2e-tests (4 bekend skipped). Nieuwe testsuite lokaal: 40/40 geslaagd.

🤖 Generated with [Claude Code](https://claude.com/claude-code)