### PR TITLE
feat(survey): beheerder kan een bijlage namens de leverancier toevoegen

### DIFF
--- a/docs/runbooks/backup-verwachting.json
+++ b/docs/runbooks/backup-verwachting.json
@@ -73,10 +73,16 @@
     "backupcontrole van 01-09 09:00 draaide tegen een dump van ná die uitrol",
     "en meldde de drie import-tabellen terecht als 'onbekend' omdat deze",
     "lijst toen nog op 0034 stond — dat was een vergeten opruimstap, geen",
-    "probleem met de backup zelf. Deze lijst is nu bijgewerkt."
+    "probleem met de backup zelf. Deze lijst is nu bijgewerkt.",
+    "",
+    "Migratie 0037 (01-09, beheerder uploadt namens leverancier) voegt GEEN",
+    "tabel toe — alleen uploaded_by_user_id en uploaded_by_admin op de",
+    "bestaande clm.survey_attachment, plus een herziene RLS-policy op die",
+    "tabel. Migratiestand bijgewerkt, tabellenlijst niet — zelfde soort",
+    "wijziging als migratie 0032/0033 hierboven."
   ],
   "bijgewerkt": "2026-09-01",
-  "migratiestand": "0036_contract_import_extra_contact",
+  "migratiestand": "0037_bijlage_namens_leverancier",
   "tabellen": [
     "audit.audit_event",
     "clm.contract",

--- a/drizzle/0037_bijlage_namens_leverancier.sql
+++ b/drizzle/0037_bijlage_namens_leverancier.sql
@@ -1,0 +1,60 @@
+-- ── 0037 — Beheerder kan een bijlage namens de leverancier toevoegen ────────
+--
+-- Aanleiding: een leverancier publiceert een certificaat (bv. ISO 27001) op
+-- zijn eigen website in plaats van het te uploaden. De contractbeheerder wil
+-- dat certificaat dan zelf ophalen en vastleggen bij de betreffende vraag,
+-- zodat het auditspoor compleet is — zonder dat dit lijkt alsof de
+-- leverancier het zelf heeft aangeleverd.
+--
+-- Twee kolommen op de bestaande tabel, geen nieuwe. NULL/false (de default)
+-- is het bestaande gedrag: een bijlage die de leverancier zelf uploadde via
+-- het portaal. Gevuld betekent: een medewerker heeft dit namens de
+-- leverancier toegevoegd — dat onderscheid moet zichtbaar blijven op de
+-- bijlage zelf, niet alleen af te leiden uit een los audit-logboek.
+
+ALTER TABLE clm.survey_attachment
+    ADD COLUMN uploaded_by_user_id uuid REFERENCES clm."user"(user_id) ON DELETE SET NULL;--> statement-breakpoint
+
+ALTER TABLE clm.survey_attachment
+    ADD COLUMN uploaded_by_admin boolean NOT NULL DEFAULT false;--> statement-breakpoint
+
+COMMENT ON COLUMN clm.survey_attachment.uploaded_by_user_id IS
+    'NULL = de leverancier heeft dit bestand zelf geüpload via het portaal (bestaand gedrag). Gevuld: welke medewerker het namens de leverancier heeft toegevoegd (migratie 0037). ON DELETE SET NULL: het bewijsstuk zelf blijft bestaan als de medewerker later wordt verwijderd — alleen het "wie" vervalt dan.';--> statement-breakpoint
+
+COMMENT ON COLUMN clm.survey_attachment.uploaded_by_admin IS
+    'true wanneer een medewerker dit bestand namens de leverancier heeft toegevoegd (migratie 0037) — het onderscheid tussen "leverancier zegt het zelf" en "beheerder heeft het extern geverifieerd en vastgelegd". Losse kolom naast uploaded_by_user_id (in plaats van alleen NULL-check) omdat een toekomstige achtergrondtaak ooit ook namens de leverancier zou kunnen uploaden zonder een user_id te hebben — dat moet dan nog steeds als "niet de leverancier zelf" herkenbaar zijn.';--> statement-breakpoint
+
+-- ── RLS-policy herzien: de bestaande WITH CHECK eiste r.status = 'pending' ──
+--
+-- Dat klopt nog steeds voor de leverancier (migratie 0005: een ingediende
+-- respons is dicht, geen nieuwe bijlagen meer). Het klopt niet meer voor een
+-- medewerker die namens de leverancier iets toevoegt — dat mag júist ook ná
+-- indienen, dat is het hele scenario van deze migratie.
+--
+-- clm.current_actor() (migratie 0013) maakt het onderscheid: BijlageService
+-- zet de actor op 'medewerker' voor voegToeAlsBeheer() en op 'leverancier'
+-- voor het bestaande voegToe(). De status-eis geldt daarom alleen nog voor
+-- de leverancier; een medewerker mag altijd toevoegen (mits de applicatielaag
+-- zelf allows_upload/max_files al gecontroleerd heeft — die controle stond
+-- en staat in BijlageService, niet in deze policy).
+
+DROP POLICY IF EXISTS survey_attachment_isolation ON clm.survey_attachment;--> statement-breakpoint
+
+CREATE POLICY survey_attachment_isolation ON clm.survey_attachment
+    USING (tenant_id = clm.current_tenant_id())
+    WITH CHECK (
+        tenant_id = clm.current_tenant_id()
+        AND EXISTS (
+            SELECT 1
+              FROM clm.survey_response r
+             WHERE r.response_id = survey_attachment.response_id
+               AND r.tenant_id   = clm.current_tenant_id()
+               AND (
+                   clm.current_actor() = 'medewerker'
+                   OR r.status = 'pending'
+               )
+        )
+    );--> statement-breakpoint
+
+COMMENT ON POLICY survey_attachment_isolation ON clm.survey_attachment IS
+    'Tenant-isolatie plus: een leverancier (of onbekende actor) mag alleen toevoegen aan een respons die nog pending is (migratie 0005); een medewerker mag ook toevoegen aan een al ingediende respons (migratie 0037, namens de leverancier). BijlageService.voegToeAlsBeheer() zet de actor op medewerker, voegToe() op leverancier.';

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -260,6 +260,13 @@
       "when": 1787068800010,
       "tag": "0036_contract_import_extra_contact",
       "breakpoints": true
+    },
+    {
+      "idx": 37,
+      "version": "7",
+      "when": 1787068800011,
+      "tag": "0037_bijlage_namens_leverancier",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -895,6 +895,15 @@ export const surveyAttachment = clm.table(
     // bestand niet gewijzigd is sinds indiening. Zelfde redenering als achter
     // de append-only audit trail.
     sha256: text('sha256').notNull(),
+    // NULL = de leverancier uploadde dit zelf via het portaal (bestaand
+    // gedrag). Gevuld: welke medewerker het namens de leverancier heeft
+    // toegevoegd (migratie 0037). Zie de kolomcommentaren in die migratie
+    // voor waarom dit twee kolommen zijn i.p.v. één NULL-check.
+    uploadedByUserId: uuid('uploaded_by_user_id').references(
+      () => user.userId,
+      { onDelete: 'set null' },
+    ),
+    uploadedByAdmin: boolean('uploaded_by_admin').notNull().default(false),
     createdAt: timestamp('created_at', { withTimezone: true })
       .notNull()
       .defaultNow(),

--- a/src/survey/bijlage-beheer.service.ts
+++ b/src/survey/bijlage-beheer.service.ts
@@ -1,0 +1,190 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { sql } from 'drizzle-orm';
+
+import { DatabaseService } from '../db/database.service';
+import { BestandOpslagService } from './bestand-opslag.service';
+import type { BijlageUitkomst } from './bijlage.service';
+import {
+  maakOpslagsleutel,
+  valideerBestand,
+  veiligeWeergavenaam,
+} from './bestand-validatie';
+
+interface VraagRij extends Record<string, unknown> {
+  question_id: string;
+  allows_upload: boolean;
+  max_files: number;
+}
+
+/**
+ * Voegt een bijlage toe namens de leverancier (besluit eigenaar, 01-09) —
+ * een medewerker die zelf bewijs heeft opgehaald (bv. een certificaat dat de
+ * leverancier op zijn eigen website publiceert in plaats van te uploaden)
+ * legt dat hier vast bij de betreffende vraag.
+ *
+ * ── Eigen bestand, niet een methode op BijlageService ───────────────────────
+ *
+ * `test/actor-context.e2e-spec.ts` bewaakt dat elk bestand op het
+ * leverancierspad (waaronder bijlage.service.ts) het letterlijke token
+ * 'medewerker' nergens in zijn broncode heeft — dat voorkomt precies de fout
+ * van 2026-08-03, waarbij een leverancierspad per ongeluk medewerkersrechten
+ * kreeg zonder dat één test het merkte. Deze klasse hoort bewust bij het
+ * medewerkerspad (net als VragenlijstBeheerService/RondeBeheerService,
+ * gescheiden van het leverancierspad om dezelfde reden), en staat daarom in
+ * een eigen bestand.
+ *
+ * Twee bewuste verschillen met `BijlageService.voegToe()`:
+ *
+ *   - Geen status-check op 'pending'. Dit mag ook nadat de leverancier al
+ *     heeft ingediend — dat is precies het scenario: het bewijs komt later
+ *     boven water, het antwoord staat er al. De RLS-policy op
+ *     survey_attachment (migratie 0037) staat dit voor actor 'medewerker'
+ *     toe, ongeacht de status van de respons.
+ *   - `uploadedByUserId`/`uploadedByAdmin` markeren dat dit niet de
+ *     leverancier zelf was. Dat onderscheid moet op de bijlage zelf
+ *     zichtbaar blijven, niet alleen in het audit-logboek.
+ *
+ * `allows_upload`/`max_files` gelden onverkort: die zijn een eigenschap van
+ * de vraag, niet van wie uploadt.
+ */
+@Injectable()
+export class BijlageBeheerService {
+  private readonly logger = new Logger(BijlageBeheerService.name);
+
+  constructor(
+    private readonly db: DatabaseService,
+    private readonly opslag: BestandOpslagService,
+  ) {}
+
+  async voegToeAlsBeheer(
+    tenantId: string,
+    responseId: string,
+    questionKey: string,
+    uploadedByUserId: string,
+    bestand: { originalname: string; mimetype?: string; buffer: Buffer },
+  ): Promise<BijlageUitkomst> {
+    const gecontroleerd = valideerBestand(bestand.buffer, bestand.mimetype);
+
+    if (!gecontroleerd.geldig) {
+      return { status: 'afgekeurd', reden: gecontroleerd.reden };
+    }
+
+    const storageKey = maakOpslagsleutel(tenantId, responseId);
+
+    await this.opslag.bewaar(storageKey, bestand.buffer);
+
+    try {
+      return await this.db.withTenant<BijlageUitkomst>(
+        tenantId,
+        async (tx) => {
+          // Vergrendelt de responserij zodat twee overlappende toevoegingen
+          // niet allebei over max_files heen tellen — zelfde plek als
+          // BijlageService.voegToe() (FOR UPDATE op de rij zelf, niet op de
+          // aggregate-count hieronder: PostgreSQL staat FOR UPDATE niet toe
+          // samen met count(*)). Geen statuscheck hier: dit mag juist ook
+          // ná 'submitted', dat is het hele scenario van deze methode.
+          const response = await tx.execute<{ response_id: string }>(
+            sql`SELECT response_id FROM clm.survey_response
+                 WHERE response_id = ${responseId}
+                 FOR UPDATE`,
+          );
+
+          // Bestaat de respons binnen deze tenant überhaupt? RLS regelt de
+          // tenantgrens; deze check onderscheidt "bestaat niet" niet apart —
+          // net als bij voegToe() levert een niet-gevonden vraag hieronder
+          // 'onbekende-vraag' op, wat voor de aanroeper hetzelfde effect
+          // heeft (404).
+          if (!response.rows[0]) {
+            return { status: 'onbekende-vraag' };
+          }
+
+          const vraag = await tx.execute<VraagRij>(
+            sql`SELECT q.question_id, q.allows_upload, q.max_files
+                  FROM clm.survey_response r
+                  JOIN clm.survey_run      run ON run.run_id    = r.run_id
+                  JOIN clm.survey_question q   ON q.template_id = run.template_id
+                 WHERE r.response_id = ${responseId}
+                   AND q.question_key = ${questionKey}`,
+          );
+
+          const rij = vraag.rows[0];
+
+          if (!rij) {
+            return { status: 'onbekende-vraag' };
+          }
+
+          if (!rij.allows_upload || rij.max_files < 1) {
+            return { status: 'geen-upload-vraag' };
+          }
+
+          const aantal = await tx.execute<{ n: string }>(
+            sql`SELECT count(*)::text AS n FROM clm.survey_attachment
+                 WHERE response_id = ${responseId}
+                   AND question_id = ${rij.question_id}`,
+          );
+
+          if (Number(aantal.rows[0].n) >= rij.max_files) {
+            return { status: 'te-veel-bestanden', maximum: rij.max_files };
+          }
+
+          const bijlage = await tx.execute<{ attachment_id: string }>(
+            sql`INSERT INTO clm.survey_attachment
+                    (tenant_id, response_id, question_id, original_name,
+                     storage_key, content_type, byte_size, sha256,
+                     uploaded_by_user_id, uploaded_by_admin)
+                VALUES (${tenantId}, ${responseId}, ${rij.question_id},
+                        ${veiligeWeergavenaam(bestand.originalname)},
+                        ${storageKey}, ${gecontroleerd.contentType},
+                        ${bestand.buffer.length}, ${gecontroleerd.sha256},
+                        ${uploadedByUserId}, true)
+                RETURNING attachment_id`,
+          );
+
+          this.logger.log(
+            `Bijlage namens leverancier toegevoegd aan response ${responseId} door gebruiker ${uploadedByUserId} (${gecontroleerd.contentType}, ${bestand.buffer.length} bytes).`,
+          );
+
+          return {
+            status: 'opgeslagen',
+            attachmentId: bijlage.rows[0].attachment_id,
+            contentType: gecontroleerd.contentType,
+          };
+        },
+        'medewerker',
+      );
+    } finally {
+      // Elke uitkomst behalve 'opgeslagen' laat een bestand achter zonder
+      // rij. Eigen kleine kopie i.p.v. BijlageService.ruimOpIndienNodig()
+      // hergebruiken: die is private, en dit stukje is te klein om er een
+      // gedeelde utility voor te maken.
+      await this.ruimOpIndienNodig(tenantId, storageKey);
+    }
+  }
+
+  private async ruimOpIndienNodig(
+    tenantId: string,
+    storageKey: string,
+  ): Promise<void> {
+    try {
+      const bestaat = await this.db.withTenant(
+        tenantId,
+        (tx) =>
+          tx.execute<{ n: string }>(
+            sql`SELECT count(*)::text AS n FROM clm.survey_attachment
+               WHERE storage_key = ${storageKey}`,
+          ),
+        'medewerker',
+      );
+
+      if (Number(bestaat.rows[0].n) === 0) {
+        await this.opslag.verwijder(storageKey);
+      }
+    } catch (fout) {
+      this.logger.warn(
+        `Opruimen van '${storageKey}' mislukt: ${
+          fout instanceof Error ? fout.message : String(fout)
+        }`,
+      );
+    }
+  }
+}

--- a/src/survey/survey.module.ts
+++ b/src/survey/survey.module.ts
@@ -10,6 +10,7 @@ import { SurveyTokenService } from './survey-token.service';
 import { AntwoordConceptService } from './antwoord-concept.service';
 import { AntwoordIndienService } from './antwoord-indienen.service';
 import { BestandOpslagService } from './bestand-opslag.service';
+import { BijlageBeheerService } from './bijlage-beheer.service';
 import { BijlageService } from './bijlage.service';
 import { BeoordelaarService } from './beoordelaar.service';
 import { BeoordelingService } from './beoordeling.service';
@@ -59,6 +60,7 @@ import { VragenlijstLeesService } from './vragenlijst-lezen.service';
     AntwoordConceptService,
     BestandOpslagService,
     BijlageService,
+    BijlageBeheerService,
   ],
   exports: [
     SurveyAuditService,
@@ -76,6 +78,7 @@ import { VragenlijstLeesService } from './vragenlijst-lezen.service';
     AntwoordConceptService,
     BestandOpslagService,
     BijlageService,
+    BijlageBeheerService,
   ],
 })
 export class SurveyModule {}

--- a/src/survey/vragenlijst-beheer.controller.ts
+++ b/src/survey/vragenlijst-beheer.controller.ts
@@ -5,14 +5,20 @@ import {
   Delete,
   Get,
   HttpCode,
+  NotFoundException,
   Param,
   Patch,
+  PayloadTooLargeException,
   Post,
   Query,
   Req,
   Res,
+  UnprocessableEntityException,
+  UploadedFile,
   UseGuards,
+  UseInterceptors,
 } from '@nestjs/common';
+import { FileInterceptor } from '@nestjs/platform-express';
 import type { Response } from 'express';
 
 import { UitnodigingVerzender } from '../mail/uitnodiging-verzender.service';
@@ -23,6 +29,8 @@ import {
 } from '../auth/tenant-context.guard';
 import { ContractService } from '../contract/contract.service';
 import { BestandOpslagService } from './bestand-opslag.service';
+import { BijlageBeheerService } from './bijlage-beheer.service';
+import { MAX_BESTANDSGROOTTE } from './bestand-validatie';
 import { ContractmanagerService } from './contractmanager.service';
 import { NotitieService } from './notitie.service';
 import { RondeBeheerService } from './ronde-beheer.service';
@@ -93,6 +101,7 @@ export class VragenlijstBeheerController {
     private readonly contractmanagers: ContractmanagerService,
     private readonly contracten: ContractService,
     private readonly opslag: BestandOpslagService,
+    private readonly bijlagenBeheer: BijlageBeheerService,
   ) {}
 
   /** Alle vragenlijsten van deze tenant, met aantallen vragen en rondes. */
@@ -200,6 +209,91 @@ export class VragenlijstBeheerController {
       'Content-Length': String(inhoud.length),
     });
     res.send(inhoud);
+  }
+
+  /**
+   * Voegt een bijlage toe namens de leverancier (besluit van de eigenaar,
+   * 01-09): een leverancier publiceert een certificaat soms op zijn eigen
+   * website in plaats van het te uploaden, en de contractbeheerder wil dat
+   * bewijs dan zelf ophalen en vastleggen bij de vraag.
+   *
+   * `@VereistRol('admin')`: bewust strenger dan de leesroutes hierboven
+   * (waar een reviewer ook mag) — dit is een schrijfactie die de
+   * leverancier normaal zelf doet, en die bevoegdheid hoort bij dezelfde rol
+   * die ook contracten en leveranciers beheert.
+   *
+   * Geen `niet-meer-open`-status zoals bij het leverancierspad: dit mag
+   * juist ook ná indienen, dat is het hele scenario.
+   */
+  @Post('responses/:id/attachments')
+  @VereistRol('admin')
+  @HttpCode(201)
+  @UseInterceptors(
+    FileInterceptor('file', {
+      limits: { fileSize: MAX_BESTANDSGROOTTE, files: 1 },
+    }),
+  )
+  async bijlageToevoegen(
+    @Req() request: RequestMetSessie,
+    @Param('id') id: string,
+    @Query('question') questionKey: string | undefined,
+    @UploadedFile()
+    bestand:
+      { originalname: string; mimetype?: string; buffer: Buffer } | undefined,
+  ) {
+    const sessie = request.sessie!;
+
+    if (!questionKey) {
+      throw new BadRequestException(
+        'Geef met de parameter `question` aan bij welke vraag dit bestand hoort.',
+      );
+    }
+
+    if (!bestand) {
+      throw new BadRequestException('Er is geen bestand meegestuurd.');
+    }
+
+    const uitkomst = await this.bijlagenBeheer.voegToeAlsBeheer(
+      sessie.tenantId,
+      id,
+      questionKey,
+      sessie.userId,
+      bestand,
+    );
+
+    switch (uitkomst.status) {
+      case 'opgeslagen':
+        return {
+          status: 'opgeslagen' as const,
+          attachmentId: uitkomst.attachmentId,
+          contentType: uitkomst.contentType,
+        };
+
+      case 'afgekeurd':
+        if (uitkomst.reden === 'te-groot') {
+          throw new PayloadTooLargeException('Dit bestand is groter dan 5 MB.');
+        }
+        throw new UnprocessableEntityException({
+          status: 'invalid_file',
+          reason: uitkomst.reden,
+        });
+
+      case 'onbekende-vraag':
+        throw new NotFoundException('Deze vraag hoort niet bij deze respons.');
+
+      case 'geen-upload-vraag':
+        throw new UnprocessableEntityException({
+          status: 'invalid_file',
+          reason: 'question_accepts_no_files',
+        });
+
+      case 'te-veel-bestanden':
+        throw new UnprocessableEntityException({
+          status: 'invalid_file',
+          reason: 'too_many_files',
+          maximum: uitkomst.maximum,
+        });
+    }
   }
 
   /** Alle oordelen over één respons, nieuwste eerst. */

--- a/src/survey/vragenlijst-beheer.service.ts
+++ b/src/survey/vragenlijst-beheer.service.ts
@@ -138,6 +138,10 @@ export interface BijlageSamenvatting {
   contentType: string;
   byteSize: number;
   createdAt: string;
+  /** true wanneer een medewerker dit namens de leverancier heeft toegevoegd
+   * (migratie 0037) — false voor een bestaande bijlage die de leverancier
+   * zelf uploadde. */
+  uploadedByAdmin: boolean;
 }
 
 /**
@@ -160,6 +164,8 @@ export interface AntwoordDetail {
   body: string;
   answerType: string;
   isRequired: boolean;
+  allowsUpload: boolean;
+  maxFiles: number;
   categoryId: string | null;
   categorieNaam: string | null;
   /** Null wanneer deze vraag niet is beantwoord. */
@@ -251,6 +257,8 @@ interface AntwoordRij extends Record<string, unknown> {
   body: string;
   answer_type: string;
   is_required: boolean;
+  allows_upload: boolean;
+  max_files: number;
   category_id: string | null;
   categorie_naam: string | null;
   answer_id: string | null;
@@ -270,6 +278,7 @@ interface BijlageRij extends Record<string, unknown> {
   content_type: string;
   byte_size: number;
   created_at: Date | string;
+  uploaded_by_admin: boolean;
 }
 
 interface ResponsRij extends Record<string, unknown> {
@@ -696,6 +705,8 @@ export class VragenlijstBeheerService {
                      q.body,
                      q.answer_type,
                      q.is_required,
+                     q.allows_upload,
+                     q.max_files,
                      q.category_id,
                      c.name AS categorie_naam,
                      a.answer_id,
@@ -721,7 +732,8 @@ export class VragenlijstBeheerService {
                      original_name,
                      content_type,
                      byte_size,
-                     created_at
+                     created_at,
+                     uploaded_by_admin
                 FROM clm.survey_attachment
                WHERE response_id = ${responseId}
                ORDER BY created_at`,
@@ -736,6 +748,7 @@ export class VragenlijstBeheerService {
             contentType: b.content_type,
             byteSize: b.byte_size,
             createdAt: iso(b.created_at) ?? '',
+            uploadedByAdmin: b.uploaded_by_admin,
           });
           perVraag.set(b.question_id, lijst);
         }
@@ -748,6 +761,8 @@ export class VragenlijstBeheerService {
           body: r.body,
           answerType: r.answer_type,
           isRequired: r.is_required,
+          allowsUpload: r.allows_upload,
+          maxFiles: r.max_files,
           categoryId: r.category_id,
           categorieNaam: r.categorie_naam,
           antwoord: r.answer_id

--- a/test/vragenlijst-beheer-routes.e2e-spec.ts
+++ b/test/vragenlijst-beheer-routes.e2e-spec.ts
@@ -59,6 +59,18 @@ const ATTACHMENT_A = randomUUID();
 const ATTACHMENT_STORAGE_KEY = `beheer-test/${ATTACHMENT_A}.pdf`;
 const ATTACHMENT_INHOUD = Buffer.from('%PDF-1.7\ntest-certificaat');
 
+// Eigen fixture voor 'namens leverancier toevoegen' — zie de toelichting bij
+// de insert in beforeAll().
+const TEMPLATE_UPLOAD = randomUUID();
+const QUESTION_UPLOAD = randomUUID();
+const RUN_UPLOAD = randomUUID();
+const RESPONSE_UPLOAD = randomUUID();
+const TOKEN_HASH_UPLOAD = `${'1'.repeat(48)}deadbeefcafe1234`;
+const PDF_BESTAND = Buffer.concat([
+  Buffer.from('%PDF-1.7\n'),
+  Buffer.from('door-de-beheerder-opgehaald'),
+]);
+
 interface LijstAntwoord {
   vragenlijsten: Array<{
     templateId: string;
@@ -271,6 +283,40 @@ describe('Vragenlijst-beheerroutes (e2e)', () => {
     );
     await client.query('COMMIT');
 
+    // Eigen, geïsoleerde fixture voor 'namens leverancier toevoegen'
+    // (hieronder): een aparte template/run/response met een upload-vraag.
+    // Los van TEMPLATE_A/RESPONSE_A, want v1/v2 daar staan bewust op
+    // allows_upload=false en de bestaande aantalVragen/aantalItems-tests
+    // rekenen op precies die twee vragen.
+    await client.query('BEGIN');
+    await client.query(`SET LOCAL app.current_tenant_id = '${tenantA}'`);
+    await client.query(
+      `INSERT INTO clm.survey_template (template_id, tenant_id, name, version)
+       VALUES ($1, $2, 'upload-test-lijst', 1)`,
+      [TEMPLATE_UPLOAD, tenantA],
+    );
+    await client.query(
+      `INSERT INTO clm.survey_question
+         (question_id, tenant_id, template_id, position, question_key, title,
+          body, answer_type, is_required, allows_upload, max_files, config)
+       VALUES ($1, $2, $3, 1, 'uv1', 'Upload-vraag', 'Toelichting', 'confirmation',
+               false, true, 1, '{}'::jsonb)`,
+      [QUESTION_UPLOAD, tenantA, TEMPLATE_UPLOAD],
+    );
+    await client.query(
+      `INSERT INTO clm.survey_run (run_id, tenant_id, template_id, status, survey_kind, is_test)
+       VALUES ($1, $2, $3, 'active', 'vendor_compliance', true)`,
+      [RUN_UPLOAD, tenantA, TEMPLATE_UPLOAD],
+    );
+    await client.query(
+      `INSERT INTO clm.survey_response
+         (response_id, tenant_id, run_id, vendor_id, subject_vendor_id,
+          token_hash, status, expires_at, submitted_at)
+       VALUES ($1, $2, $3, $4, $4, $5, 'submitted', now() + interval '30 days', now())`,
+      [RESPONSE_UPLOAD, tenantA, RUN_UPLOAD, VENDOR_A, TOKEN_HASH_UPLOAD],
+    );
+    await client.query('COMMIT');
+
     // Vragenlijst in B, zodat de tenantgrens iets te verbergen heeft.
     await client.query('BEGIN');
     await client.query(`SET LOCAL app.current_tenant_id = '${tenantB}'`);
@@ -407,12 +453,15 @@ describe('Vragenlijst-beheerroutes (e2e)', () => {
         .expect(200);
 
       const rondes = (antwoord.body as RondesAntwoord).rondes;
+      // filter i.p.v. toHaveLength(1): de upload-fixture (zie beforeAll)
+      // heeft ook een eigen ronde in tenant A.
+      const ronde = rondes.find((r) => r.runId === RUN_A);
 
-      expect(rondes).toHaveLength(1);
-      expect(rondes[0].templateNaam).toBe('beheer-test-lijst');
-      expect(rondes[0].status).toBe('active');
-      expect(rondes[0].aantalDeelnemers).toBe(1);
-      expect(rondes[0].aantalIngediend).toBe(0);
+      expect(ronde).toBeDefined();
+      expect(ronde!.templateNaam).toBe('beheer-test-lijst');
+      expect(ronde!.status).toBe('active');
+      expect(ronde!.aantalDeelnemers).toBe(1);
+      expect(ronde!.aantalIngediend).toBe(0);
     });
 
     it('toont de deelnemer met leveranciersnaam', async () => {
@@ -665,6 +714,103 @@ describe('Vragenlijst-beheerroutes (e2e)', () => {
     });
   });
 
+  describe('een bijlage toevoegen namens de leverancier', () => {
+    const upload = () =>
+      request(server)
+        .post(`/admin/survey/responses/${RESPONSE_UPLOAD}/attachments`)
+        .query({ question: 'uv1' })
+        .set('Cookie', cookieA);
+
+    it('slaat het bestand op, ook al is de respons al ingediend', async () => {
+      // RESPONSE_UPLOAD staat op 'submitted' — dat is precies het scenario:
+      // het bewijs komt later boven water dan de indiening zelf.
+      const res = await upload()
+        .attach('file', PDF_BESTAND, 'van-website-gehaald.pdf')
+        .expect(201);
+
+      expect((res.body as { contentType: string }).contentType).toBe(
+        'application/pdf',
+      );
+
+      // RLS: survey_attachment eist app.current_tenant_id, dus lezen (en
+      // opruimen) gebeurt binnen dezelfde tenant-context als de fixture.
+      await client.query('BEGIN');
+      await client.query(`SET LOCAL app.current_tenant_id = '${tenantA}'`);
+
+      const rij = await client.query<{
+        uploaded_by_admin: boolean;
+        uploaded_by_user_id: string;
+        original_name: string;
+      }>(
+        `SELECT uploaded_by_admin, uploaded_by_user_id, original_name
+           FROM clm.survey_attachment
+          WHERE response_id = $1`,
+        [RESPONSE_UPLOAD],
+      );
+
+      expect(rij.rows).toHaveLength(1);
+      expect(rij.rows[0].uploaded_by_admin).toBe(true);
+      expect(rij.rows[0].uploaded_by_user_id).toBe(userA);
+      expect(rij.rows[0].original_name).toBe('van-website-gehaald.pdf');
+
+      // Opruimen: de volgende test in dit blok verwacht een lege staat.
+      await client.query(
+        'DELETE FROM clm.survey_attachment WHERE response_id = $1',
+        [RESPONSE_UPLOAD],
+      );
+      await client.query('COMMIT');
+    });
+
+    it('respecteert max_files, ook voor de beheerder', async () => {
+      // uv1 staat op max_files = 1 (besluit eigenaar 01-09: dezelfde
+      // limiet geldt, ongeacht wie uploadt).
+      await upload().attach('file', PDF_BESTAND, 'eerste.pdf').expect(201);
+
+      await upload()
+        .attach('file', PDF_BESTAND, 'tweede.pdf')
+        .expect(422)
+        .expect((res) => {
+          expect((res.body as { reason: string }).reason).toBe(
+            'too_many_files',
+          );
+        });
+
+      await client.query('BEGIN');
+      await client.query(`SET LOCAL app.current_tenant_id = '${tenantA}'`);
+      await client.query(
+        'DELETE FROM clm.survey_attachment WHERE response_id = $1',
+        [RESPONSE_UPLOAD],
+      );
+      await client.query('COMMIT');
+    });
+
+    it('weigert een reviewer — dit is een schrijfactie, geen leesroute', async () => {
+      await request(server)
+        .post(`/admin/survey/responses/${RESPONSE_UPLOAD}/attachments`)
+        .query({ question: 'uv1' })
+        .set('Cookie', cookieReviewer)
+        .attach('file', PDF_BESTAND, 'certificaat.pdf')
+        .expect(403);
+    });
+
+    it('geeft 404 bij een vraag die niet bij deze respons hoort', async () => {
+      await request(server)
+        .post(`/admin/survey/responses/${RESPONSE_UPLOAD}/attachments`)
+        .query({ question: 'onbestaand' })
+        .set('Cookie', cookieA)
+        .attach('file', PDF_BESTAND, 'certificaat.pdf')
+        .expect(404);
+    });
+
+    it('geeft 400 zonder de question-parameter', async () => {
+      await request(server)
+        .post(`/admin/survey/responses/${RESPONSE_UPLOAD}/attachments`)
+        .set('Cookie', cookieA)
+        .attach('file', PDF_BESTAND, 'certificaat.pdf')
+        .expect(400);
+    });
+  });
+
   describe('de uitvragen van één leverancier', () => {
     /**
      * ── Waarom deze route bestaat ─────────────────────────────────────────
@@ -684,13 +830,15 @@ describe('Vragenlijst-beheerroutes (e2e)', () => {
       const { uitvragen } = antwoord.body as {
         uitvragen: Array<Record<string, unknown>>;
       };
+      // find i.p.v. toHaveLength(1): de upload-fixture (zie beforeAll) zit
+      // op dezelfde vendor.
+      const uitvraag = uitvragen.find((u) => u.responseId === RESPONSE_A);
 
-      expect(uitvragen).toHaveLength(1);
-      expect(uitvragen[0].responseId).toBe(RESPONSE_A);
-      expect(uitvragen[0].runId).toBe(RUN_A);
-      expect(uitvragen[0].status).toBe('pending');
-      expect(uitvragen[0].ingediendOp).toBeNull();
-      expect(uitvragen[0].templateNaam).toBeTruthy();
+      expect(uitvraag).toBeDefined();
+      expect(uitvraag!.runId).toBe(RUN_A);
+      expect(uitvraag!.status).toBe('pending');
+      expect(uitvraag!.ingediendOp).toBeNull();
+      expect(uitvraag!.templateNaam).toBeTruthy();
     });
 
     it('lekt het token niet', async () => {


### PR DESCRIPTION
## Wat
Een leverancier publiceert een certificaat (bv. ISO 27001) soms op zijn eigen website in plaats van het te uploaden. De contractbeheerder wil dat bewijs dan zelf ophalen en vastleggen bij de betreffende vraag, zodat het auditspoor compleet blijft.

- **Migratie 0037**: `uploaded_by_user_id`/`uploaded_by_admin` op `clm.survey_attachment`, en de RLS-policy herzien zodat een medewerker (actor `medewerker`) ook mag toevoegen aan een al ingediende respons — de leverancier zelf blijft beperkt tot `pending`, zoals altijd.
- **Nieuwe route** `POST /admin/survey/responses/:id/attachments`, `@VereistRol('admin')`, zelfde `allows_upload`/`max_files`-grenzen als het leverancierspad.
- **`BijlageBeheerService` in een eigen bestand**, niet als methode op `BijlageService`: `test/actor-context.e2e-spec.ts` bewaakt dat elk leverancierspad-bestand het token `'medewerker'` nergens in de broncode heeft (voorkomt de architectuurfout van 2026-08-03). Deze scheiding is dus geen stijlkeuze maar een bewaakte grens — de eerste versie schond hem, gecorrigeerd na een falende `actor-context.e2e-spec.ts`.
- 5 nieuwe e2e-tests: gelukkige weg (ook ná indienen), `max_files` geldt ook voor de beheerder, een reviewer mag niet (403), 404 op een vraag die niet bij de respons hoort, 400 zonder `question`-parameter.

Hoort bij frontend-PR AlingAdvies/MCM2-frontend#23.

## Getest
`npm run verify:volledig` groen — 95/99 e2e-tests (4 bekend skipped), 617 unittests, RLS-isolatietest groen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)