### PR TITLE
docs(seeds): intro-tekst vragenlijst aangevuld met geldigheid en indienen

### DIFF
--- a/db/seeds/transdev-annual-vendor-it-risk-v1.json
+++ b/db/seeds/transdev-annual-vendor-it-risk-v1.json
@@ -1,14 +1,14 @@
 {
   "schema_version": 1,
   "name": "transdev-annual-vendor-it-risk",
-  "version": 1,
+  "version": 2,
   "categories": [],
   "questions": [
     {
       "question_key": "intro",
       "position": 1,
       "title": "2026 Transdev ICT contract vendor compliance",
-      "body": "You have been invited to complete the following compliance survey: \"2026 Transdev ICT contract vendor compliance\". Your participation is requested to ensure vendor compliance and security standards.",
+      "body": "You have been invited to complete the following compliance survey: \"2026 Transdev ICT contract vendor compliance\". Your participation is requested to ensure vendor compliance and security standards.\n\nThis survey link is valid for 30 days. You can forward it to a colleague if someone else should complete or finish it. Once you click 'Submit' (Indienen), your answers can no longer be changed or added to.",
       "answer_type": "instruction",
       "is_required": false,
       "allows_upload": false,


### PR DESCRIPTION
Versie van `transdev-annual-vendor-it-risk` opgehoogd naar 2. De intro-vraag noemde alleen het doel van de vragenlijst. Toegevoegd aan de intro:

- de link is 30 dagen geldig
- kan doorgestuurd worden naar een collega om (af) te maken
- na klikken op 'Submit' (Indienen) kunnen antwoorden niet meer gewijzigd worden

Alleen `db/seeds/transdev-annual-vendor-it-risk-v1.json` gewijzigd. `transdev-leveranciersbeoordeling-v1` is ongemoeid.

`npm run verify:volledig` groen (93 passed).

Let op: dit bestand is alleen de bron. Om versie 2 in een omgeving zichtbaar te krijgen moet na merge `node scripts/seed-vragenlijsten.js <tenant-uuid>` gedraaid worden tegen die omgeving — dat gebeurt niet automatisch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)