### PR TITLE
chore(uitnodigingscontrole): Taakplanner-wrapper voor de uurlijkse controle

### DIFF
--- a/docs/runbooks/uitnodigingscontrole.md
+++ b/docs/runbooks/uitnodigingscontrole.md
@@ -19,21 +19,34 @@ omgevingen worden bewust niet gemeld.
 
 Beproefd tegen productie op 2026-09-02: een geaccepteerde testuitnodiging
 leverde correct één Telegram-bericht op, een herhaalde run zonder wijziging
-gaf terecht niets.
+gaf terecht niets. De geplande taak zelf is diezelfde dag aangemaakt en
+handmatig getest (`Start-ScheduledTask`, resultaat 0, logregel bevestigd).
 
-## Taakplanner instellen (eenmalig)
+## Taakplanner
 
-1. Open Taakplanner → **Taak maken** (niet "Eenvoudige taak").
-2. **Algemeen:** naam `MCM2 tenant-uitnodigingscontrole`. "Uitvoeren of de
-   gebruiker nu is aangemeld of niet" — zelfde keuze als de bestaande
-   backup-taken.
-3. **Triggers:** nieuw → Elke dag herhalen, Herhaal taak elke: **1 uur**,
-   gedurende: **onbeperkt**.
-4. **Acties:** nieuw → Programma: `node`, Argumenten:
-   `scripts/uitnodiging-controle.js`, Starten in:
-   `C:\DEV\Work\MCM2` (of het actuele pad van deze repository).
-5. **Voorwaarden:** "Alleen starten indien op netvoeding" uitzetten (laptop
-   draait ook op batterij), zelfde als de backup-taken.
+De taak **"MCM2 tenant-uitnodigingscontrole"** staat al ingesteld — elk uur,
+via `scripts/uitnodiging-controle-taak.cmd` (zelfde wrapper-vorm als
+`backup-controle-taak.cmd`: vast node-pad, logt naar
+`%USERPROFILE%\.mcm2-uitnodigingscontrole\taak.log`, `cd` naar de projectmap
+vóór het script draait). `StartWhenAvailable` staat aan en er is geen
+batterij-restrictie — zelfde instellingen als de bestaande backup-taken, zodat
+een gemiste cyclus (laptop uit) later alsnog ingehaald wordt zodra de laptop
+weer aan staat, en de taak niet stopt zodra hij van netvoeding naar batterij
+gaat.
+
+Mocht de taak ooit opnieuw ingericht moeten worden:
+
+```powershell
+schtasks /Create /TN "MCM2 tenant-uitnodigingscontrole" /TR "C:\DEV\Work\MCM2\scripts\uitnodiging-controle-taak.cmd" /SC HOURLY /MO 1 /RL LIMITED /F
+```
+
+gevolgd door (`StartWhenAvailable`/batterij-instellingen zet `schtasks /Create`
+niet goed):
+
+```powershell
+$settings = New-ScheduledTaskSettingsSet -StartWhenAvailable -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries -MultipleInstances IgnoreNew -ExecutionTimeLimit (New-TimeSpan -Minutes 15)
+Set-ScheduledTask -TaskName "MCM2 tenant-uitnodigingscontrole" -Settings $settings
+```
 
 ## Wat je ziet
 

--- a/scripts/uitnodiging-controle-taak.cmd
+++ b/scripts/uitnodiging-controle-taak.cmd
@@ -1,0 +1,40 @@
+@echo off
+REM ============================================================================
+REM  Uurlijkse controle - aangeroepen door de Windows-taak
+REM  "MCM2 tenant-uitnodigingscontrole".
+REM
+REM  Zelfde wrapper-vorm als backup-controle-taak.cmd: vast node-pad, logging
+REM  naar bestand, cd naar de projectmap voor het script draait.
+REM
+REM  LET OP: dit bestand moet in ANSI/ASCII staan, niet UTF-8. cmd.exe leest
+REM  UTF-8 met BOM verkeerd en voert dan elke regel als los commando uit.
+REM  Daarom staan er geen accenten of speciale tekens in dit bestand.
+REM ============================================================================
+
+setlocal
+
+set "LOG=%USERPROFILE%\.mcm2-uitnodigingscontrole\taak.log"
+set "PROJECT=C:\DEV\Work\MCM2"
+set "NODE=C:\Program Files\nodejs\node.exe"
+
+if not exist "%USERPROFILE%\.mcm2-uitnodigingscontrole" mkdir "%USERPROFILE%\.mcm2-uitnodigingscontrole"
+
+echo. >> "%LOG%"
+echo ===== %DATE% %TIME% - start >> "%LOG%"
+
+cd /d "%PROJECT%"
+if errorlevel 1 (
+    echo FOUT: projectmap niet bereikbaar. >> "%LOG%"
+    exit /b 1
+)
+
+"%NODE%" scripts\uitnodiging-controle.js >> "%LOG%" 2>&1
+set UITKOMST=%ERRORLEVEL%
+
+if "%UITKOMST%"=="0" (
+    echo ===== %DATE% %TIME% - OK >> "%LOG%"
+) else (
+    echo ===== %DATE% %TIME% - FOUT, code %UITKOMST% >> "%LOG%"
+)
+
+exit /b 0


### PR DESCRIPTION
Voegt `scripts/uitnodiging-controle-taak.cmd` toe — de wrapper die de Windows-taak "MCM2 tenant-uitnodigingscontrole" aanroept, zelfde vorm als `backup-controle-taak.cmd`.

De taak zelf staat al aangemaakt en handmatig getest op de laptop van de eigenaar: elk uur, `StartWhenAvailable` aan, geen batterij-restrictie (zelfde instellingen als de bestaande backup-taken). Het runbook is bijgewerkt naar wat er daadwerkelijk staat, inclusief het `schtasks`/`Set-ScheduledTask`-commando om de taak opnieuw in te richten mocht dat ooit nodig zijn.

## Testplan
- `npm run verify:volledig` groen (94 passed)
- `Start-ScheduledTask` handmatig gedraaid: `LastTaskResult 0`, logregel bevestigt een geslaagde run tegen productie

🤖 Generated with [Claude Code](https://claude.com/claude-code)