### PR TITLE
docs(instap): CLAUDE.md §0/§0b herzien naar de werkelijke stand + TD/AA-advies in git

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,86 +9,80 @@
 
 # 0. HET DOEL — lees dit vóór al het andere
 
-*Vastgelegd 2026-08-12, samen met de eigenaar. Dit staat bovenaan omdat het op
-die dag drie keer misging: er werd gebouwd zonder eerst vast te stellen wat het
-doel was en wat er al stond. De eigenaar moest steeds bijsturen.*
+*Vastgelegd 2026-08-12; herzien 2026-09-02. Het oorspronkelijke doel —
+aantonen dat de geautomatiseerde OTAP en DevOps werkt — is **behaald**:
+meerdere features zijn aantoonbaar van code tot AWS-productie doorlopen, met
+remmen die afgaan als er iets niet klopt en een bewezen weg terug. De
+oorspronkelijke tekst staat in de git-historie van dit bestand.*
 
-**Wat we aan het bouwen zijn:**
+**Wat we nu aan het doen zijn:**
 
-> Een omgeving die de **eindsituatie zo goed mogelijk repliceert**, om daarop
-> vast te stellen dat de **geautomatiseerde OTAP en DevOps werkt**.
+> Een **multitenant vendor-compliance-platform dat in productie draait, met
+> echte klanten erop, betrouwbaar doorontwikkelen** via de bewezen OTAP-keten.
 
-Dat is het eigenlijke product van dit werk. De features zijn het middel, niet
-het doel.
+**Vijf punten, actuele stand:**
 
-**Vijf punten, letterlijk zoals afgesproken:**
+1. **Productie draait op AWS** (`clm.alingadvies.nl`, ECS Express Mode) en
+   wordt echt gebruikt — voor klanten én demo. Staging en acceptatie draaien
+   op `saxombp`.
+2. **Transdev Nederland is de eerste echte klant-tenant**, met echte
+   gebruikers. Daarnaast bestaan op productie: AlingAdvies (de eigenaar),
+   demo, Bizaline en Platformbeheer.
+3. **Productiedata is klantdata**: backup, RLS, `beschermd`-markering, geen
+   e2e-suites ertegen. Dit gold eerst voor mock data; inmiddels is het echt.
+4. **Elke wijziging loopt door de keten**: eerst staging + rookproef, daarna
+   productie via `productie-aws.yml` achter de vier remmen (verse backup,
+   migratiestand, staging-pariteit, menselijk akkoord).
+5. **Toekomstrichting — verkennend, géén besluit:** mogelijke splitsing in
+   twee producten: TD (Transdev-maatwerk, via Bizaline) en AA (AlingAdvies,
+   100% multitenant, verkoopbaar). Zie `docs/advies-td-aa-splitsing.md` en
+   `docs/evaluatie-advies-td-aa-splitsing.md`; de kernvraag daaruit (één of
+   twee productdeployments) staat nog open. **Bouw hier niet op vooruit.**
 
-1. Een omgeving die de eindsituatie (AWS) zo goed mogelijk repliceert.
-2. Daarop aantonen dat de geautomatiseerde OTAP en DevOps werkt.
-3. **Eén echte tenant: AlingAdvies — dat is de eigenaar zelf.** Gevuld met
-   **mock data die behandeld wordt als klantdata**: backup, RLS, `beschermd`,
-   geen e2e-suites erop.
-4. Die tenant dient tegelijk voor **demo**, **test** én **bewijs** dat de
-   keten werkt.
-5. Alles wat gebouwd wordt moet **eenvoudig naar AWS te migreren** zijn.
+**Waar het werkelijk om gaat is onveranderd het gedrag, niet de techniek.**
+Dat de eigenaar een wijziging kan doen en die met vertrouwen tot in productie
+ziet lopen, met remmen die afgaan als er iets niet klopt, en dat hij kan
+terugvallen als het misgaat. Dat is wat een klant verwacht — en er stáát nu
+een klant op.
 
-**Wat dit betekent voor een voorstel:** bouw je iets dat op AWS niet zou
-bestaan (een sub-pad in plaats van een eigen hostnaam, een omgevingsspecifiek
-image), dan beproef je een constructie die straks weg is. Dat is dezelfde fout
-die het plan over staging benoemt: *"een generale repetitie op ander toneel
-bewijst weinig."*
+**Besluiten van de eigenaar, bijgewerkt naar de huidige stand:**
 
-**Waar het werkelijk om gaat is het gedrag, niet de techniek.** Dat de eigenaar
-een wijziging kan doen en die met vertrouwen tot in productie ziet lopen, met
-remmen die afgaan als er iets niet klopt, en dat hij kan terugvallen als het
-misgaat. Dat is wat een klant straks verwacht, en dat is wat nu op de eigen
-tenant beproefd wordt. Volgorde die daaruit volgt: **eerst de keten aantoonbaar
-rond mét data erin, daarna pas de kosmetiek.**
-
-**Twee besluiten van de eigenaar (12-08), zodat ze niet opnieuw gesteld worden:**
-
-| Vraag | Besluit |
+| Vraag | Stand |
 |---|---|
-| Moet het starten van de applicatie ook automatisch? | **Nee — handmatig starten is OK.** Het besluit uit §3.3c van het OTAP-plan blijft staan. |
-| Moet productie inlog krijgen, tegen §4.1 in? | **Ja.** Zonder inloggen valt niet vast te stellen dát de keten werkt, en demo is een expliciet doel. §4.1 is op dit punt achterhaald. |
-| Moet het sub-pad `/productie` opgelost worden? | **Ja.** Een eigen hostnaam per omgeving is de AWS-vorm. |
+| Moet het starten van de applicatie automatisch? | **AWS-productie start sinds 19-08 automatisch** na het akkoord op GitHub. Op `saxombp` (staging/acceptatie) blijft starten handwerk. |
+| Heeft productie inlog? | **Ja** — bestaat en wordt gebruikt door echte klanten en voor demo. |
+| Het sub-pad `/productie`? | **Opgelost door AWS**: productie heeft een eigen hostnaam. Het sub-pad-probleem op saxombp wordt bewust NIET meer opgelost (besloten 23-08 — zie de memory `mcm2-sub-pad-breekt-relatieve-api-aanroepen`). |
 
-De tenant komt via de **platformroute**, niet rechtstreeks in de database — het
-auditspoor ís de opbrengst (§5.1 van het plan blijft dus staan).
+Een tenant komt via de **platformroute**, niet rechtstreeks in de database —
+het auditspoor ís de opbrengst (dat blijft onverkort staan).
 
 ---
 
 # 0b. DE MIDDELEN — wat er werkelijk is
 
-*Gemeten op 2026-08-12, niet aangenomen. Klopt iets niet meer? Meet opnieuw en
-werk dit bij — een verouderde inventaris is erger dan geen.*
+*Opnieuw gemeten/geverifieerd op 2026-09-02 (eerste meting 2026-08-12). Klopt
+iets niet meer? Meet opnieuw en werk dit bij — een verouderde inventaris is
+erger dan geen.*
 
-## AWS: er is GEEN account
+## AWS — account en productie-omgeving
 
-**AWS is een richting, geen middel.** De kans is groot dat we er komen, maar we
-**staan er nog niet**. Stel nooit iets voor dat een AWS-account veronderstelt
-zonder dat expliciet te benoemen.
+- Account **AlingAdvies** (`727732213368`), regio **eu-west-1**.
+- Productie draait sinds **19-08** op **ECS Express Mode**: services
+  `mcm2-api` en `mcm2-frontend`, eigen hostnaam **`clm.alingadvies.nl`**.
+- Uitrol via workflow **`productie-aws.yml`** — na het menselijke akkoord op
+  GitHub Environment `productie` volautomatisch, reken op 30–40 minuten.
+  Authenticatie via OIDC; er staat geen langlevende AWS-sleutel in GitHub.
 
-## Rekenlaag — één machine
+## saxombp — alleen nog staging en acceptatie
 
-**`saxombp`** — een MacBook Pro uit 2009 (`MacBookPro5,5`) met Ubuntu 22.04.5.
+**`saxombp`** — MacBook Pro 2009 met Ubuntu 22.04.5 (hardware zoals gemeten
+12-08: Core2 Duo, 2 cores, 7,5 GB, ~87 GB vrij; bereikbaar **alleen via
+Tailscale**, `100.99.51.53`). Draait de staging- en acceptatie-containers en
+de acceptatiedatabase, plus de Saxo-app — **productie draait hier sinds 19-08
+niet meer**. Capaciteit is het probleem niet; het één-machine-zijn wel — geen
+tweede, geen redundantie.
 
-| | |
-|---|---|
-| Processor | Intel Core2 Duo P7550, 2 cores |
-| Geheugen | 7,5 GB (6,3 GB vrij) |
-| Schijf | 106 GB (87 GB vrij) |
-| Belasting | load 0,06 — de machine verveelt zich |
-| Bereikbaar | **alleen via Tailscale** (`100.99.51.53`), tailnet only |
-
-Zes MCM2-containers (~300 MB samen) plus de acceptatiedatabase. Daarnaast
-draait er **alleen de Saxo-app** (poort 8080/8081) — niets anders.
-
-Publiek IP `80.114.79.142` is de thuisrouter, gedeeld met de laptop en
-vermoedelijk niet vast. **Capaciteit is het probleem niet; het feit dat het
-één machine is wel** — geen tweede, geen redundantie.
-
-## Databases — bij Supabase
+## Databases — bij Supabase, plus één container
 
 | Omgeving | Waar | Markering |
 |---|---|---|
@@ -97,32 +91,37 @@ vermoedelijk niet vast. **Capaciteit is het probleem niet; het feit dat het
 | productie | Supabase `agojesdo…`, eu-west-1 | `beschermd` |
 
 Beide Supabase-projecten draaien op het **gratis plan** en **pauzeren na 7
-dagen stilte**. Dat is een reëel risico zodra productie voor demo gebruikt
-wordt.
+dagen stilte** (issue #30). Daarom bestaat de wekelijkse
+"houd staging en productie wakker"-vraag in de devops-handleiding.
 
 ## Bouwstraat en identiteit — in de cloud
 
 - **GitHub** `AlingAdvies/MCM2` — **publiek**, hoofdbranch `main`
-- Workflows `ci.yml` en `productie.yml`; Environment `productie` met een
+- Workflows: `ci.yml` (elke merge), `productie-aws.yml` (AWS-productie) en
+  het oudere `productie.yml` (saxombp); Environment `productie` met een
   verplichte akkoordgever
 - **GHCR** voor images (token verloopt rond **8 november 2026**)
 - **Microsoft Entra External ID** — CIAM-domein `mcm2ciam.ciamlogin.com`, één
   app-registratie. Elke omgeving vraagt een eigen redirect-adres.
 
-## Backup en bewaking — op de laptop van de eigenaar
+## Backup en bewaking — laptop én saxombp
 
-Drie geplande taken op de Windows-laptop: `MCM2 databasebackup`,
-`MCM2 backupcontrole`, `MCM2 backupcontrole volledig`. Dumps gaan naar
-**OneDrive** (`BACKUP_DIR`). Meldingen via **Telegram**.
-
-**Gevolg:** staat die laptop uit, dan draait er geen backup. CI kan er niet bij
-— zie [[mcm2-backupbewijs-omkering]] en het runbook.
+- Geplande taken op de Windows-laptop: `MCM2 databasebackup`,
+  `MCM2 backupcontrole`, `MCM2 backupcontrole volledig`, en sinds 02-09
+  `MCM2 tenant-uitnodigingscontrole` (elk uur; Telegram-melding bij een nieuw
+  actief lid van Transdev Nederland). Dumps naar **OneDrive**, meldingen via
+  **Telegram**.
+- **saxombp haalt daarnaast zelf een productiedump** (issue #58, 25-08) — de
+  backup hangt niet meer uitsluitend aan de laptop.
+- CI kan niet bij de laptop-backup — zie [[mcm2-backupbewijs-omkering]] en het
+  runbook.
 
 ## Wat er NIET is
 
-Geen AWS-account. Geen tweede server. Geen bewaking of alarmering. Geen
-incidentplan. Geen sleutelrotatie. Geen eigen hostnaam per omgeving — en dat
-laatste is precies wat de proefopstelling nog niet AWS-vormig maakt.
+Geen tweede server of regio-redundantie. Geen volwaardige
+monitoring/alerting-laag (issue #17). Geen incidentplan. Geen sleutelrotatie
+(issue #1). Supabase op het gratis plan — het pauzeer-risico (issue #30)
+blijft staan zolang dat zo is.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,9 +25,12 @@ oorspronkelijke tekst staat in de git-historie van dit bestand.*
 1. **Productie draait op AWS** (`clm.alingadvies.nl`, ECS Express Mode) en
    wordt echt gebruikt — voor klanten én demo. Staging en acceptatie draaien
    op `saxombp`.
-2. **Transdev Nederland is de eerste echte klant-tenant**, met echte
-   gebruikers. Daarnaast bestaan op productie: AlingAdvies (de eigenaar),
-   demo, Bizaline en Platformbeheer.
+2. **Twee tenants met een eigen, blijvende rol naast elkaar op productie:**
+   **Transdev Nederland is de betalende klant**, met echte gebruikers.
+   **AlingAdvies is de tenant van de eigenaar en blijft bewust in gebruik
+   voor demonstratie én handmatig testen** — dat is een keuze, geen
+   overblijfsel. Daarnaast bestaan op productie: demo, Bizaline en
+   Platformbeheer.
 3. **Productiedata is klantdata**: backup, RLS, `beschermd`-markering, geen
    e2e-suites ertegen. Dit gold eerst voor mock data; inmiddels is het echt.
 4. **Elke wijziging loopt door de keten**: eerst staging + rookproef, daarna

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,9 +100,17 @@ dagen stilte** (issue #30). Daarom bestaat de wekelijkse
 ## Bouwstraat en identiteit — in de cloud
 
 - **GitHub** `AlingAdvies/MCM2` — **publiek**, hoofdbranch `main`
-- Workflows: `ci.yml` (elke merge), `productie-aws.yml` (AWS-productie) en
-  het oudere `productie.yml` (saxombp); Environment `productie` met een
-  verplichte akkoordgever
+- **Tweede repo, 1-op-1 gekoppeld: `AlingAdvies/MCM2-frontend`** (lokaal
+  `c:\DEV\Work\MCM2-frontend`) — de Next.js-frontend, met een **eigen
+  `ci.yml`** die het frontend-image naar GHCR publiceert en een **eigen
+  `CLAUDE.md`** (sinds 28-08). Een feature raakt vaak beide repo's: dan
+  horen beide gemerged te zijn vóór een uitrol, en meld je de
+  frontend-consequentie altijd expliciet. Het frontend-image kent bewust
+  geen backend-adres (dat komt bij het starten via `API_BASE_URL`) — zo
+  blijft één image promoveerbaar over alle omgevingen.
+- Workflows in deze repo: `ci.yml` (elke merge), `productie-aws.yml`
+  (AWS-productie — rolt api én frontend uit) en het oudere `productie.yml`
+  (saxombp); Environment `productie` met een verplichte akkoordgever
 - **GHCR** voor images (token verloopt rond **8 november 2026**)
 - **Microsoft Entra External ID** — CIAM-domein `mcm2ciam.ciamlogin.com`, één
   app-registratie. Elke omgeving vraagt een eigen redirect-adres.

--- a/docs/advies-td-aa-splitsing.md
+++ b/docs/advies-td-aa-splitsing.md
@@ -1,0 +1,172 @@
+# MCM2 als twee producten: TD en AA — technisch advies
+
+*Opgesteld 2026-09-01. Puur technische verkenning, geen besluit — input voor
+een keuze die de eigenaar zelf maakt. Geen juridische/aandeelhouders-aspecten
+(die zijn apart te behandelen).*
+
+---
+
+## 1. Probleemstelling
+
+MCM2 is vandaag één multitenant platform: één codebase, één database-model
+met tenant-isolatie via RLS, meerdere tenants (waaronder AlingAdvies en
+Transdev) op dezelfde applicatie.
+
+Er tekent zich een scenario af waarin dat niet meer volstaat:
+
+- **Bizaline** ontwikkelt MCM2 feitelijk door als maatwerk voor één klant
+  (Transdev), met klantspecifieke inrichting — vooral aan de voorkant.
+- **AlingAdvies** wil MCM2 juist als generiek, verkoopbaar multitenant-product
+  in de markt zetten, aan meerdere klanten, met een deels eigen roadmap.
+
+Dat zijn geen twee tenants op één roadmap meer, maar **twee producten met
+divergerende roadmaps**. De vraag is hoe je dat organiseert zonder dat de
+stack onbeheersbaar wordt: hoe voorkom je dat een wijziging voor de ene kant
+de andere kant breekt, en hoe voorkom je dubbel werk bij wat wél gedeeld
+hoort te zijn.
+
+---
+
+## 2. Omstandigheden
+
+**Voorziene roadmap-verdeling** (zoals door de eigenaar geschetst):
+
+| Feature | TD | AA |
+|---|---|---|
+| Notificatiefunctionaliteit | ✅ | ✅ |
+| Mailen vanuit TD-omgeving (eigen afzender/templates) | ✅ | — |
+| Mailen vanuit generieke omgeving (à la jouwcontractmanager) | — | ✅ |
+| NIS2-support (nis2-scaffold) | — | ✅ |
+| Freemium / proefabonnement | — | ✅ |
+| In-app vragenlijst-builder | — | ✅ |
+
+Dit is geen zuiver frontend-verschil: NIS2-support en de vragenlijst-builder
+zijn backend-features. Mail is een gedeeld concept met een verschillende
+invulling per kant (afzenderdomein, templates).
+
+**Bepalende randvoorwaarde**: de eigenaar voorziet dat hij zelf **de enige
+onderhouder** van beide kanten wordt. Dat verandert het afwegingskader
+wezenlijk — zie §4.
+
+**Bestaande architectuur die al in deze richting wijst**:
+- Drie-laags klantaanpassing (configuratie → feature flags → maatwerkmodule),
+  vastgelegd in `c:\dev\CLAUDE.md`.
+- `jouwcontractmanager` bestaat al als entry-tier sibling van `MVM_V2` — een
+  precedent voor "gedeelde kern, aparte frontend-app".
+- De NIS2-scaffold is al als losstaande module/ADR opgezet
+  (`mcm2-nis2-scaffold-label-fundament`), niet verweven in de kern.
+- Tenant-architectuur (RLS, `tenant_membership`, platformbeheerder-rol)
+  bestaat al en is bewezen.
+
+---
+
+## 3. Advies
+
+**Kernkeuze: één repository met een gedeelde backend-kern, AA-only
+functionaliteit als losse uitschakelbare modules, en twee aparte
+frontend-applicaties (TD en AA).**
+
+Niet: twee losse backends. Niet: een fork op één moment in de tijd die
+daarna zelfstandig verder leeft.
+
+### 3.1 Backend: kern + modules, geen fork
+
+- De **kern** bevat wat gedeeld is: tenant-model, sessie/RLS, en gedeelde
+  features zoals notificaties.
+- **AA-only functionaliteit** (NIS2, freemium/proefabbo, vragenlijst-builder)
+  wordt gebouwd als losse modules naast de kern:
+  - eigen schema-namespace (zoals NIS2 al deels heeft),
+  - eigen routes onder een duidelijk, apart prefix,
+  - eigen migratiebestanden, niet vermengd met kern-migraties,
+  - een feature-vlag die de module voor een tenant/omgeving volledig
+    uitschakelt — niet alleen een UI-element verbergen, maar de route/tabel
+    ook daadwerkelijk niet actief.
+- **Mail** krijgt een abstracte provider-interface in de kern
+  (`MailProvider` o.i.d.); TD en AA hangen elk hun eigen implementatie
+  erachter (eigen afzenderdomein, eigen templates). Zo wordt de
+  mail-pijplijn één keer gebouwd, niet twee keer.
+
+### 3.2 Frontend: twee aparte apps
+
+- **TD-frontend**: Transdev-specifieke inrichting, blijft praten tegen
+  dezelfde kern-API.
+- **AA-frontend**: generiek, multitenant, roept ook de AA-only
+  backend-modules aan.
+- Precedent: dezelfde verhouding als `MVM_V2` ↔ `jouwcontractmanager`.
+
+### 3.3 Eén repo, niet twee
+
+Met één backend-kern en modulegrenzen is er geen technische noodzaak voor
+een aparte TD-backend-repo. Eén repo betekent:
+- een kern-bugfix (bijv. een RLS-fix) geldt voor beide kanten zonder dat hij
+  handmatig overgezet moet worden,
+- TD deployt eenvoudigweg een subset (kern + notificaties + TD-mail,
+  zonder de AA-only modules).
+
+Een aparte repo per kant is pas de betere keuze zodra een tweede partij
+zelfstandig in de kern gaat schrijven met eigen, niet-afgestemde wijzigingen
+— dat scenario is hier niet aan de orde (zie §4).
+
+---
+
+## 4. Waarom de "één onderhouder"-omstandigheid het advies verstevigt
+
+Het risico dat normaal tegen "één repo, gedeelde kern" pleit, is een
+**coördinatieprobleem tussen partijen**: fixes die niet consequent worden
+overgezet, een team dat de modulegrens niet respecteert. Dat risico bestaat
+vooral wanneer meerdere, onafhankelijke partijen aan dezelfde code werken.
+
+Als de eigenaar zelf beide kanten onderhoudt, vervalt dat risico grotendeels
+— er is niemand anders om mee af te stemmen. Wat overblijft is geen
+coördinatie-, maar een **cognitieve-lastvraag**: kan één persoon onthouden
+wat waar hangt, en voorkomen dat een TD-wijziging per ongeluk een AA-only
+aanname raakt (of omgekeerd)?
+
+Dat pleit er juist vóór om de modulegrenzen (schema-namespace, aparte
+routes, aparte migraties, feature-vlaggen) net zo strikt te bewaken als
+wanneer er wél een tweede partij zou zijn — niet als bescherming tussen
+mensen, maar als bescherming tegen een toekomstige versie van jezelf die de
+context niet meer scherp heeft. Discipline en tests vervangen hier wat een
+aparte repo anders zou afdwingen.
+
+---
+
+## 5. Voorwaarden voor succes
+
+1. **Elke AA-only module moet volledig uitschakelbaar zijn zonder de kern
+   te raken.** Test dit letterlijk: een TD-deploy met de module uitgezet
+   mag nergens een foutmelding, dode route, of ontbrekende tabel opleveren.
+2. **Eigen migratiebestanden per module.** Een TD-deploy draait nooit een
+   migratie die alleen voor een AA-only module bestaat.
+3. **Architectuurgrens-tests zoals nu al bestaan** (bijv.
+   `test/actor-context.e2e-spec.ts` dat het leverancierspad bewaakt) worden
+   het patroon voor elke nieuwe modulegrens: een geautomatiseerde test die
+   *bewijst* dat de grens niet doorbroken is, in plaats van vertrouwen op
+   het eigen geheugen.
+4. **Mail als interface, niet als kopie.** Vóór er een tweede
+   mail-implementatie bijkomt, eerst de abstractie bouwen — niet twee keer
+   dezelfde pijplijn met een andere afzender.
+5. **Eigenaarschap per module expliciet vastleggen**, ook met één
+   onderhouder — een korte notitie per module (waarvoor, welke tenant/kant,
+   welke aannames) zodat een toekomstige sessie (van jou, of van Claude
+   Code) niet hoeft te reconstrueren waarom een module bestaat.
+6. **`verify:volledig` (of een equivalent) moet beide deploy-varianten
+   dekken** — een testrun die alleen de AA-configuratie test, bewijst niets
+   over de TD-configuratie met uitgeschakelde modules, en omgekeerd.
+7. **Geen stilzwijgende kern-wijzigingen vanuit één kant.** Een wijziging in
+   de kern (niet in een module) raakt per definitie beide producten — die
+   wijziging verdient bewuste aandacht voor beide kanten, ook als er maar
+   één onderhouder is.
+
+---
+
+## 6. Wat dit advies niet beslist
+
+- De domeinnaam/merkkeuze (`clm.alingadvies.nl` vs. `clm.bizaline.com` vs.
+  iets nieuws) — dat is een aparte DNS/Entra/certificaat-vraag.
+- Eigenaarschap van IP en aandeelhoudersverhouding tussen Bizaline en
+  AlingAdvies bij deze productsplitsing — een juridische vraag, geen
+  technische.
+- Het exacte moment en de volgorde waarin bestaande AA-only functionaliteit
+  (NIS2-scaffold, andere) daadwerkelijk als losse module wordt
+  losgetrokken uit de huidige kern.

--- a/docs/evaluatie-advies-td-aa-splitsing.md
+++ b/docs/evaluatie-advies-td-aa-splitsing.md
@@ -1,0 +1,95 @@
+# Evaluatie: MCM2 als twee producten (TD en AA)
+
+## Eindoordeel
+
+Het document is inhoudelijk sterk en pragmatisch. De hoofdkeuze — een gedeelde kern met twee afzonderlijke frontends en strak afgebakende productmodules — past goed bij twee divergerende roadmaps die nog substantiële technische fundamenten delen.
+
+De analyse benoemt terecht dat dit geen gewone tenant-customization meer is, maar een ontwikkeling naar twee producten: een Transdev-specifiek product en een generiek, verkoopbaar AA-product. Dat onderscheid voorkomt de klassieke fout om productverschillen steeds verder weg te stoppen in tenantconfiguratie en feature flags.
+
+## Sterke punten
+
+- **Heldere probleemdefinitie.** Het document maakt terecht onderscheid tussen twee tenants en twee producten met divergerende roadmaps.
+- **Geen premature fork.** Bij één technische onderhouder zou een fork vooral dubbel onderhoud, handmatig overzetten van bugfixes en geleidelijke technische divergentie veroorzaken.
+- **Passende architectuurgrenzen.** Een gedeelde kern voor identiteit, tenantcontext, RLS en werkelijk gedeelde domeinfunctionaliteit; AA-functionaliteit als afgebakende modules; twee zelfstandige frontends.
+- **Goed mail-principe.** Een gedeelde mail-capability met product-specifieke provider-implementaties voorkomt twee gekopieerde mailflows.
+- **Realistische onderhouderanalyse.** Bij één maintainer is de kernuitdaging niet teamcoördinatie, maar de cognitieve last voor je toekomstige zelf. Strikte grenzen, documentatie en geautomatiseerde tests zijn daarvoor effectiever dan een kunstmatige repo-scheiding.
+
+## Belangrijkste aanscherping
+
+De combinatie van “één gedeelde backend-kern”, “TD deployt een subset” en “TD draait nooit een AA-only migratie” is alleen tegelijk goed uitvoerbaar wanneer TD en AA een gescheiden runtime- en waarschijnlijk database-topologie krijgen.
+
+| Onderwerp | Gedeelde runtime/database | Gescheiden productdeployments |
+|---|---|---|
+| Backend | Eén draaiende API voor alle tenants | Zelfde code, apart uitgerold voor TD en AA |
+| Database | Eén database met tenantisolatie | Eigen database of minimaal eigen database-omgeving per product |
+| Modulemigraties | Worden technisch uitgevoerd, ook als een module voor TD niet actief is | Kunnen uitsluitend bij AA worden uitgevoerd |
+| Risico | Grote blast radius en zwakkere productgrens | Meer deployment- en operationeel beheer |
+| Passend bij het advies | Minder goed passend | Beter passend bij TD-subset en module-exclusiviteit |
+
+### Advies
+
+Maak dit expliciet als architectuurbesluit. Als Transdev werkelijk een afzonderlijk product wordt met een eigen lifecycle, branding, maildomein en mogelijk afwijkende klant- of beveiligingseisen, kies dan voor **één codebase, maar twee onafhankelijke deployments**.
+
+De gedeelde kern is dan een gedeelde code- en testbasis, niet noodzakelijk één gedeelde productie-runtime. Dit maakt rollback, releaseplanning, incidentafhandeling en een eventuele latere ontvlechting veiliger.
+
+## Feature flags
+
+Het document gebruikt feature flags verstandig als productschakelaar, maar “route/tabel niet actief” verdient technische precisering. Een feature flag is primair een gedrags- en productentitlementmechanisme, geen harde beveiligings- of isolatiegrens.
+
+Hanteer daarom drie afzonderlijke concepten:
+
+- **Build/deployment-selectie:** welke modules fysiek zijn opgenomen en geactiveerd in TD respectievelijk AA.
+- **Productentitlements:** welke modules een AA-tenant mag gebruiken, bijvoorbeeld freemium versus betaald.
+- **Autorisatie:** welke gebruiker binnen een tenant bepaalde acties mag uitvoeren.
+
+Zo voorkom je dat een flag per ongeluk als autorisatiecontrole wordt gebruikt. Route-autorisatie en database-RLS moeten onafhankelijk blijven van de zichtbaarheid in de interface, vooral bij NIS2-functionaliteit, leveranciersinformatie en vragenlijsten.
+
+## Modulegrenzen
+
+Een eigen schema, router-prefix en migraties zijn nuttig, maar vormen nog geen echte module als de kern alsnog direct tabellen of interne services van de module aanroept.
+
+Leg per module minimaal vast:
+
+- **Publieke interface:** API-routes, service-contracten en events die andere onderdelen mogen gebruiken.
+- **Eigendom van data:** de module is exclusief eigenaar van haar tabellen; andere onderdelen lezen of muteren die data niet direct.
+- **Afhankelijkheidsrichting:** modules mogen van core afhankelijk zijn; core hoort niet afhankelijk te worden van een optionele AA-module.
+- **Lifecycle:** deployment waarin de module actief is, benodigde configuratie en veilige uitschakel- of migratiestrategie.
+- **Acceptatietests:** zowel AA mét module als TD zónder module moeten deel zijn van CI.
+
+Vertaal “module” in deze fase niet naar microservices. Voor één onderhouder is een goed gestructureerde modulaire monolith waarschijnlijk de beste balans tussen ontwikkelsnelheid, betrouwbaarheid en latere ontvlechtingsmogelijkheid.
+
+## Mailontwerp
+
+De `MailProvider`-gedachte is juist, maar houd de abstractie klein. Vermijd een generiek model dat alle toekomstige verschillen probeert te voorspellen; dat wordt snel ingewikkelder dan twee duidelijke adapters.
+
+Een bruikbare scheiding is:
+
+- **Kern:** verzendopdracht, ontvanger, berichttype, business-event, auditlog en retry-status.
+- **Productadapter:** afzenderdomein, providerconfiguratie, templates, huisstijl, reply-to en eventuele compliance- of bewaartermijnen.
+- **Productfrontend:** de gebruikersflow waarmee een medewerker de actie initieert.
+
+Zo blijft de betrouwbaarheidslogica gedeeld, terwijl Transdev en AA zelfstandig hun uitstraling en verzendbeleid beheren.
+
+## Nog vast te leggen besluiten
+
+Hoewel IP, aandeelhouderschap en domeinkeuze terecht buiten de scope van het technische advies vallen, zijn de volgende operationele besluiten nodig voor uitvoerbaarheid:
+
+1. **Deploymentgrens:** één of twee productieomgevingen, en één of twee databases?
+2. **Releasebeleid:** kan AA vaker releasen dan TD, en hoe verloopt acceptatie bij TD?
+3. **Versiebeheer:** hoe lang blijft een TD-deployment compatibel met wijzigingen aan de gedeelde kern?
+4. **Observability:** aparte logs, foutmeldingen, audittrails, back-ups en dashboards per product/klantcontext.
+5. **Herstelstrategie:** kan een TD-release zelfstandig worden teruggedraaid zonder AA te raken?
+6. **Kosten- en beheergrens:** welke extra cloudcomponenten zijn acceptabel voor productisolatie?
+
+## Aanbevolen vervolg
+
+1. Leg de gewenste **runtime-topologie** vast; voorkeur: twee productdeployments vanuit één repository.
+2. Definieer een `core`-contract: wat hoort er expliciet wel en niet thuis.
+3. Bouw eerst de mail-capability als interface met twee adapters, omdat daar nu al concreet productverschil bestaat.
+4. Breng NIS2, freemium en vragenlijsten onder in expliciete AA-modules, zonder directe afhankelijkheid vanuit core.
+5. Richt CI in als matrix: TD-configuratie, AA-configuratie en minimaal één test op kerncompatibiliteit.
+6. Voeg per module een korte ADR toe met doel, data-eigenaarschap, interfaces, configuratie en rollback-impact.
+
+## Slot
+
+De gekozen richting is goed onderbouwd en passend bij de situatie met één maintainer. Maak vooral de impliciete sprong van “gedeelde backend” naar “subset-deployment zonder AA-migraties” expliciet; daar wordt bepaald of de oplossing in de praktijk beheersbaar en veilig blijft.


### PR DESCRIPTION
**Ter beoordeling door de eigenaar — bewust NIET gemerged tot expliciet akkoord.**

`CLAUDE.md` §0/§0b (het bestand dat elke sessie als eerste stuurt) was gemeten op 12-08 en aantoonbaar achterhaald:

- §0: "Eén echte tenant: AlingAdvies, mock data" → Transdev Nederland is inmiddels een echte klant-tenant op productie, met echte gebruikers.
- §0b: "AWS: er is GEEN account" → productie draait sinds 19-08 op AWS ECS (`clm.alingadvies.nl`); vandaag nog twee volledige productie-uitrollen doorlopen.

Herzien in deze PR:

- **§0** — het oorspronkelijke doel (OTAP-keten aantoonbaar maken) gemarkeerd als behaald; nieuw doel: het multitenant productieplatform met echte klanten betrouwbaar doorontwikkelen. De TD/AA-productsplitsing opgenomen als **verkennende richting, géén besluit** ("bouw hier niet op vooruit"), met verwijzing naar advies én evaluatie.
- **§0b** — middeleninventaris opnieuw gemeten per 02-09: AWS-account + ECS-productie, saxombp alleen nog staging/acceptatie, backup ook vanaf saxombp zelf, de nieuwe uurlijkse tenant-uitnodigingscontrole, en een geactualiseerde "wat er NIET is"-lijst met issuenummers.
- **`docs/advies-td-aa-splitsing.md` + `docs/evaluatie-advies-td-aa-splitsing.md`** stonden ongetrackt op de laptop en gaan nu ongewijzigd mee in git, zodat ze niet verloren kunnen gaan.

Aanleiding: het memory-/documentatie-onderzoek van 02-09 (documentatie-drift voorkomen). De oorspronkelijke §0/§0b-tekst blijft beschikbaar in de git-historie.

🤖 Generated with [Claude Code](https://claude.com/claude-code)